### PR TITLE
fix: restore server auto-restart and terminal profile (#3)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,12 @@ jobs:
 
       - name: Install system dependencies
         if: steps.cache-assets.outputs.cache-hit != 'true'
-        run: sudo apt-get install -y --no-install-recommends libarchive-tools
+        # The runner image ships a baked apt index. Ubuntu keeps only the current
+        # version of a package in the pool, so once the indexed one is superseded
+        # the download 404s. Refresh the index before installing.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libarchive-tools
 
       # Download and prepare all assets (only if not cached)
       - name: Download VS Code Server

--- a/android/app/src/main/kotlin/com/vscodroid/service/NodeService.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/service/NodeService.kt
@@ -15,6 +15,7 @@ import com.vscodroid.MainActivity
 import com.vscodroid.util.Logger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
@@ -43,6 +44,7 @@ class NodeService : Service() {
     private lateinit var processManager: ProcessManager
     private var restartCount = 0
     private var isServiceRunning = false
+    private var launchJob: Job? = null
 
     /** Invoked when the server is healthy and accepting connections. */
     var onServerReady: ((port: Int) -> Unit)? = null
@@ -115,7 +117,11 @@ class NodeService : Service() {
      * Notifies [onServerReady] on success or [onServerError] on failure/timeout.
      */
     private fun launchServer() {
-        serviceScope.launch(Dispatchers.IO) {
+        // A crash during startup restarts the server while the previous attempt is
+        // still inside waitForReady()'s 30s poll. Without this the two overlap and
+        // both report readiness for the same server.
+        launchJob?.cancel()
+        launchJob = serviceScope.launch(Dispatchers.IO) {
             val started = processManager.startServer()
             if (!started) {
                 Logger.e(tag, "Failed to start server process")

--- a/android/app/src/main/kotlin/com/vscodroid/service/ProcessManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/service/ProcessManager.kt
@@ -57,20 +57,27 @@ class ProcessManager(private val context: Context) {
     /**
      * Starts the Node.js code-server process.
      *
-     * Allocates an available port, builds the command line from [Environment] paths,
-     * spawns the process, and begins output reading and watchdog monitoring.
+     * Allocates a port on the first call and keeps it for the lifetime of this
+     * instance, builds the command line from [Environment] paths, spawns the
+     * process, and begins output reading and watchdog monitoring.
      *
      * @return `true` if the process was spawned successfully, `false` on error or
-     *         if a process is already running.
+     *         if a live process is already running.
      */
     fun startServer(): Boolean {
-        if (serverProcess != null) {
+        // Liveness, not nullity: the crash path leaves the dead Process referenced,
+        // so a null check here refused every automatic restart attempt (issue #3).
+        if (isRunning()) {
             Logger.w(tag, "Server already running")
             return false
         }
 
         isShuttingDown = false
-        _port = PortFinder.findAvailablePort()
+        // Keep the port across restarts. The WebView's loaded URL and the bridge's
+        // allowed-origin check are both bound to it, and neither is rebuilt on restart.
+        if (_port == 0) {
+            _port = PortFinder.findAvailablePort()
+        }
         Logger.i(tag, "Starting server on port $_port")
 
         // Ensure TMPDIR exists — Android may clear cache between launches

--- a/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
@@ -424,19 +424,17 @@ npx() { VSCODROID_PLATFORM_FIX=1 node "${'$'}PREFIX/lib/node_modules/npm/bin/npx
      * reference this directory, so they must be refreshed on each launch.
      */
     fun updateSettingsNativeLibPaths() {
-        val nativeLibDir = context.applicationInfo.nativeLibraryDir
         val settingsFile = File(context.filesDir, "home/.vscodroid/User/settings.json")
         if (!settingsFile.exists()) return
 
-        val content = settingsFile.readText()
-        // Match any /data/app/<random>/<pkg-random>/lib/<arch> prefix
-        val pattern = Regex("""/data/app/[^"]+/lib/[^"]+""")
-        val updated = pattern.replace(content, nativeLibDir)
+        val updated = refreshManagedPaths(
+            settingsFile.readText(),
+            Environment.getBashPath(context),
+            Environment.getGitPath(context),
+        ) ?: return
 
-        if (updated != content) {
-            settingsFile.writeText(updated)
-            Logger.i(tag, "Updated nativeLibDir paths in settings.json")
-        }
+        settingsFile.writeText(updated)
+        Logger.i(tag, "Refreshed managed paths in settings.json")
     }
 
     private fun createWelcomeProject() {
@@ -753,4 +751,39 @@ npx() { VSCODROID_PLATFORM_FIX=1 node "${'$'}PREFIX/lib/node_modules/npm/bin/npx
         private const val KEY_VERSION = "setup_version"
         private const val KEY_VERSION_CODE = "setup_version_code"
     }
+}
+
+/**
+ * The bundled bash inside the terminal profile, and the bundled git. Both are
+ * anchored on their key and match only a nativeLibraryDir value, so a path the
+ * user chose themselves is left alone.
+ *
+ * The character class excludes braces deliberately: an earlier release used
+ * `/data/app/[^"]+/lib/[^"]+`, whose tail ran straight past the directory and
+ * swallowed the binary filename, leaving the terminal profile pointing at a
+ * directory (issue #3). Every quantifier here is fenced by the delimiter it
+ * must not cross.
+ */
+private val BASH_PROFILE_PATH = Regex(
+    """("terminal\.integrated\.profiles\.linux"\s*:\s*\{\s*"bash"\s*:\s*\{[^{}]*?"path"\s*:\s*)"/data/app/[^"]*["]"""
+)
+private val GIT_PATH = Regex("""("git\.path"\s*:\s*)"/data/app/[^"]*["]""")
+
+/**
+ * Points the two settings.json values that embed nativeLibraryDir back at the
+ * current install, returning the updated document or `null` when nothing needed
+ * changing.
+ *
+ * Substitutes the two values in place and leaves every other byte untouched.
+ * settings.json is JSONC: comments and trailing commas are legal there, so
+ * parsing the document to re-serialise it would strip the user's comments,
+ * escape every slash, and turn `["-i",]` into `["-i", null]`.
+ *
+ * A pattern that does not match changes nothing, so a file the user has
+ * restructured is left as they wrote it rather than mangled.
+ */
+internal fun refreshManagedPaths(content: String, bashPath: String, gitPath: String): String? {
+    var updated = BASH_PROFILE_PATH.replace(content) { "${it.groupValues[1]}\"$bashPath\"" }
+    updated = GIT_PATH.replace(updated) { "${it.groupValues[1]}\"$gitPath\"" }
+    return updated.takeIf { it != content }
 }

--- a/android/app/src/test/kotlin/com/vscodroid/setup/SettingsPathsTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/SettingsPathsTest.kt
@@ -1,0 +1,156 @@
+package com.vscodroid.setup
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for [refreshManagedPaths] — the settings.json values that embed
+ * nativeLibraryDir and therefore go stale on every APK reinstall.
+ *
+ * Regression coverage for issue #3: a greedy regex used to rewrite these paths
+ * swallowed the binary filename, leaving the terminal profile pointing at a
+ * directory. VS Code validates profile paths with isFile(), so the profile was
+ * silently dropped and the terminal profile picker went empty.
+ *
+ * settings.json is JSONC and belongs to the user, so these tests assert on the
+ * document text rather than on parsed values: everything outside the two managed
+ * values must survive byte for byte.
+ */
+class SettingsPathsTest {
+
+    private val bash = "/data/app/~~new==/com.vscodroid-new==/lib/arm64/libbash.so"
+    private val git = "/data/app/~~new==/com.vscodroid-new==/lib/arm64/libgit.so"
+
+    private val oldDir = "/data/app/~~old==/com.vscodroid-old==/lib/arm64"
+
+    private fun settings(
+        bashPath: String,
+        gitPath: String,
+        args: String = """["-i"]""",
+        preamble: String = "",
+    ) = """
+        {
+        $preamble    "editor.fontSize": 14,
+            "terminal.integrated.profiles.linux": {
+                "bash": {
+                    "path": "$bashPath",
+                    "args": $args,
+                    "icon": "terminal-bash"
+                }
+            },
+            "git.path": "$gitPath",
+            "workbench.colorTheme": "Monokai"
+        }
+    """.trimIndent()
+
+    @Nested
+    inner class Repair {
+
+        @Test
+        fun `restores a profile path truncated to a directory`() {
+            // Exactly what shipped in v1.0.0: the binary filename stripped off.
+            val result = refreshManagedPaths(settings(oldDir, oldDir), bash, git)
+
+            requireNotNull(result) { "corrupted settings must be rewritten" }
+            assertTrue(result.contains(""""path": "$bash""""), "bash path not restored:\n$result")
+            assertTrue(result.contains(""""git.path": "$git""""), "git path not restored:\n$result")
+        }
+
+        @Test
+        fun `refreshes paths left stale by a reinstall`() {
+            val result = refreshManagedPaths(
+                settings("$oldDir/libbash.so", "$oldDir/libgit.so"), bash, git,
+            )
+
+            requireNotNull(result)
+            assertTrue(result.contains(""""path": "$bash""""))
+            assertTrue(result.contains(""""git.path": "$git""""))
+        }
+
+        @Test
+        fun `rewrites the terminal profile even when git path is already current`() {
+            // The two values must be tracked independently: an implementation that
+            // decided "changed" from git.path alone would leave the terminal broken,
+            // which is the reported bug.
+            val result = refreshManagedPaths(settings(oldDir, git), bash, git)
+
+            requireNotNull(result) { "a stale bash path alone must trigger a rewrite" }
+            assertTrue(result.contains(""""path": "$bash""""))
+        }
+
+        @Test
+        fun `rewrites git path even when the terminal profile is already current`() {
+            val result = refreshManagedPaths(settings(bash, oldDir), bash, git)
+
+            requireNotNull(result) { "a stale git path alone must trigger a rewrite" }
+            assertTrue(result.contains(""""git.path": "$git""""))
+        }
+    }
+
+    @Nested
+    inner class LeavesAlone {
+
+        @Test
+        fun `returns null when both paths are already correct`() {
+            // Guards against rewriting the file on every launch, which is how the old
+            // regex corrupted a healthy install on its second run.
+            assertNull(refreshManagedPaths(settings(bash, git), bash, git))
+        }
+
+        @Test
+        fun `preserves comments and the rest of the document verbatim`() {
+            val notes = "    // my own notes\n    /* and a block */\n"
+
+            val result = refreshManagedPaths(settings(oldDir, oldDir, preamble = notes), bash, git)
+
+            // The whole document, byte for byte, with only the two managed values moved on.
+            assertEquals(settings(bash, git, preamble = notes), result)
+        }
+
+        @Test
+        fun `preserves a trailing comma in the profile args`() {
+            // Legal JSONC. Re-serialising through a JSON object model would turn this
+            // into ["-i", null] on Android and break the terminal it exists to fix.
+            val result = refreshManagedPaths(
+                settings(oldDir, oldDir, args = """["-i",]"""), bash, git,
+            )
+
+            requireNotNull(result)
+            assertTrue(result.contains("""["-i",]"""), "args were reformatted:\n$result")
+        }
+
+        @Test
+        fun `does not touch a git path the user chose themselves`() {
+            val custom = "/data/user/0/com.vscodroid/files/usr/bin/git"
+
+            val result = refreshManagedPaths(settings(oldDir, custom), bash, git)
+
+            requireNotNull(result) { "the bash path still needed repairing" }
+            assertTrue(result.contains(""""git.path": "$custom""""), "user git.path overwritten")
+        }
+
+        @Test
+        fun `returns null when git path is absent rather than inventing one`() {
+            val noGit = """{ "editor.fontSize": 14 }"""
+
+            assertNull(refreshManagedPaths(noGit, bash, git))
+        }
+
+        @Test
+        fun `returns null when the profile has been restructured`() {
+            // A shape we do not recognise is left as the user wrote it.
+            val restructured = """
+                {
+                    "terminal.integrated.profiles.linux": {
+                        "zsh": { "path": "$oldDir/libzsh.so" }
+                    }
+                }
+            """.trimIndent()
+
+            assertNull(refreshManagedPaths(restructured, bash, git))
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3.

The report described three symptoms: the app freezing when changing the terminal, no way to switch terminals at all, and being unable to type. Tracing them found two independent defects, both shipped in v1.0.0.

## Server auto-restart was unreachable

`startServer()` refused to start while `serverProcess` was non-null, but only `stopServer()` ever cleared that field. The crash path left the dead `Process` referenced, so `NodeService`'s restart-with-backoff always hit the stale reference, logged `Server already running`, and returned false. The user got a single toast and a permanently wedged app: the WebView held a dead WebSocket and only relaunching recovered it.

The guard now tests liveness instead of nullity, using the `isRunning()` accessor that already existed.

The port is also kept across restarts. `SecurityManager`, `VSCodroidWebViewClient` and the service-worker interception are all constructed once behind the `bridgeInitialized` guard and are never rebuilt, so a new port on restart would silently break the allowed-origin check and every CDN rewrite. Reuse is scoped to a single `ProcessManager` instance, which lives exactly as long as one service instance.

This is the likely trigger on the reporter's device: creating or switching a terminal spawns another shell, which on a 4 GB device is precisely when the low-memory killer takes the Node process. `ProcessManager` already anticipates that case — it logs exit 137 as `Server killed (OOM or phantom limit)`.

## Terminal profiles disappeared from the picker

The settings.json path refresh matched `/data/app/[^"]+/lib/[^"]+` and replaced the match with `nativeLibraryDir`. Since `[^"]` does not exclude `/`, the greedy tail ran past the directory and swallowed the binary filename:

```
"path": ".../lib/arm64/libbash.so"  ->  "path": ".../lib/arm64"
```

Profile paths are validated with `isFile()`, so a directory failed validation and the profile was dropped with only a trace-level log. The `+` dropdown and `Select Default Profile` are both built from settings-declared profiles, so both ended up empty — there was genuinely nothing to switch to. VS Code fell back to `$SHELL`, which is computed fresh at launch and stays correct, so a working shell still spawned.

This fired on the second launch of every install, because the substitution result always differed from the original. It never healed, since the defaults are only written when the file is absent.

The refresh now substitutes the two managed values in place and leaves the rest of the document untouched. settings.json is JSONC: parsing it to re-serialise would strip the user's comments, escape every slash, and turn `["-i",]` into `["-i", null]`. Anchoring on the key and matching only `nativeLibraryDir` values also means a path the user chose themselves is no longer overwritten, and an absent key is no longer invented. A pattern that does not match changes nothing, so a restructured file is left as written rather than mangled.

## Also included

Restarting while a previous launch was still inside `waitForReady()`'s 30-second poll left two readiness watchers running for the same server. The launch coroutine is now cancelled before a new one starts.

## Tests

Adds 10 regression tests for the path refresh — repair, staleness, the no-op case the old regex got wrong, comment and trailing-comma preservation, and the unmatched structures that must be left alone. Full suite: 201 tests, 0 failures. Reintroducing the truncation defect fails 5 of the 10 new tests.

`ProcessManager` remains without a unit test; exercising the restart path needs a live process. It should be confirmed on a device by killing the Node process and checking that the log reads `Starting server on port <same port>` where it previously read `Server already running`.