### PR TITLE
fix: issue #3 follow-ups — restart test coverage, folder restore, launch resilience

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,11 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Install system dependencies
-        run: sudo apt-get install -y --no-install-recommends libarchive-tools zstd zip
+        # See build.yml: the runner's baked apt index goes stale as Ubuntu drops
+        # superseded versions from the pool, so refresh it before installing.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libarchive-tools zstd zip
 
       # Cache downloaded tarballs/debs
       - name: Cache download intermediates
@@ -174,7 +178,9 @@ jobs:
           path: artifacts
 
       - name: Install packaging dependencies
-        run: sudo apt-get install -y --no-install-recommends libarchive-tools zstd zip
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libarchive-tools zstd zip
 
       - name: Download toolchain assets
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Terminal profile picker was empty, leaving no way to switch terminals ([#3](https://github.com/rmyndharis/VSCodroid/issues/3))
+- App froze and had to be force-restarted after the server process was killed — automatic recovery never actually ran
+- A server restart now returns to the folder you had open instead of the default projects directory
+- A WebView rebuilt after a renderer crash no longer comes back without its Android bridge
+- Launching no longer crashes outright if refreshing tool paths fails
+- Comments and formatting in `settings.json` now survive the refresh of bundled tool paths
+- Build and release workflows no longer fail when the runner's package index is out of date
+
 ## [1.0.0] - 2026-04-21
 
 ### 🎉 First Production Release on Google Play Store!

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -50,9 +50,6 @@ class MainActivity : AppCompatActivity() {
     private var backgroundedAt = 0L
     private var bridgeInitialized = false
 
-    /** Folder the WebView is currently showing, so a server restart can return to it. */
-    private var activeFolder: String? = null
-
     private var pendingFileUri: Uri? = null
     private lateinit var securityManager: SecurityManager
     private lateinit var safManager: SafStorageManager
@@ -444,8 +441,20 @@ class MainActivity : AppCompatActivity() {
         // onServerReady routes a restart through here without a folder. Falling back
         // to the folder already on screen keeps the user's workspace instead of
         // dropping them back into the default projects directory.
-        navigateToFolder(port, folderPath ?: activeFolder ?: Environment.getProjectsDir(this))
+        navigateToFolder(port, folderPath ?: folderFromUrl(webView?.url) ?: Environment.getProjectsDir(this))
     }
+
+    /**
+     * The folder encoded in a workbench URL, if it still exists on disk.
+     *
+     * VS Code opens a folder by navigating this same WebView without going
+     * through Kotlin, so the URL is the only record of the open workspace that
+     * stays truthful. A folder that has since disappeared — a cleared SAF
+     * mirror, unmounted storage — is dropped so the caller falls back to the
+     * default rather than pinning the WebView to a dead path.
+     */
+    private fun folderFromUrl(url: String?): String? =
+        url?.let { Uri.parse(it).getQueryParameter("folder") }?.takeIf { File(it).isDirectory }
 
     /**
      * Initializes the WebView bridge, security manager, and clients.
@@ -494,7 +503,6 @@ class MainActivity : AppCompatActivity() {
      */
     private fun navigateToFolder(port: Int, folderPath: String) {
         val wv = webView ?: return
-        activeFolder = folderPath
         val url = "http://127.0.0.1:$port/?folder=${Uri.encode(folderPath)}"
         Logger.i(tag, "Loading VS Code at $url")
         wv.loadUrl(url)
@@ -992,7 +1000,7 @@ class MainActivity : AppCompatActivity() {
     private fun recreateWebView() {
         Logger.w(tag, "Recreating WebView after crash")
         val wv = webView ?: return
-        // Fix #4: Preserve last URL for folder context restoration
+        // Read the open folder off the dying WebView before it goes away
         val lastUrl = wv.url
         val container = findViewById<android.widget.FrameLayout>(R.id.webViewContainer)
         container.removeView(wv)
@@ -1008,12 +1016,10 @@ class MainActivity : AppCompatActivity() {
 
         setupWebView()
         if (serverPort > 0) {
-            // Restore last URL if it was a localhost VS Code URL (preserves folder context)
-            if (lastUrl != null && lastUrl.startsWith("http://127.0.0.1")) {
-                webView?.loadUrl(lastUrl)
-            } else {
-                loadVSCode(serverPort)
-            }
+            // Always via loadVSCode so initBridge re-registers on the new WebView;
+            // loading the old URL directly would leave it without the bridge. The
+            // folder is carried over from the URL the destroyed WebView was showing.
+            loadVSCode(serverPort, folderFromUrl(lastUrl))
         }
     }
 

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -50,6 +50,9 @@ class MainActivity : AppCompatActivity() {
     private var backgroundedAt = 0L
     private var bridgeInitialized = false
 
+    /** Folder the WebView is currently showing, so a server restart can return to it. */
+    private var activeFolder: String? = null
+
     private var pendingFileUri: Uri? = null
     private lateinit var securityManager: SecurityManager
     private lateinit var safManager: SafStorageManager
@@ -438,7 +441,10 @@ class MainActivity : AppCompatActivity() {
 
     private fun loadVSCode(port: Int, folderPath: String? = null) {
         initBridge(port)
-        navigateToFolder(port, folderPath ?: Environment.getProjectsDir(this))
+        // onServerReady routes a restart through here without a folder. Falling back
+        // to the folder already on screen keeps the user's workspace instead of
+        // dropping them back into the default projects directory.
+        navigateToFolder(port, folderPath ?: activeFolder ?: Environment.getProjectsDir(this))
     }
 
     /**
@@ -488,6 +494,7 @@ class MainActivity : AppCompatActivity() {
      */
     private fun navigateToFolder(port: Int, folderPath: String) {
         val wv = webView ?: return
+        activeFolder = folderPath
         val url = "http://127.0.0.1:$port/?folder=${Uri.encode(folderPath)}"
         Logger.i(tag, "Loading VS Code at $url")
         wv.loadUrl(url)

--- a/android/app/src/main/kotlin/com/vscodroid/SplashActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/SplashActivity.kt
@@ -47,11 +47,20 @@ class SplashActivity : AppCompatActivity() {
 
         // Always validate tool symlinks — Android changes nativeLibraryDir
         // path on every reinstall, which breaks absolute symlinks in usr/bin/.
-        setup.setupToolSymlinks()
-        setup.setupRipgrepVscodeSymlink()
-        setup.createNpmWrappers()
-        setup.ensureToolchainEnvSourcing()
-        setup.updateSettingsNativeLibPaths()
+        //
+        // These touch the filesystem on the main thread at launch. Letting one
+        // throw would crash the app before it ever draws, leaving the user with a
+        // launch loop and no explanation; a genuinely broken install still surfaces
+        // later as a server error that says so.
+        try {
+            setup.setupToolSymlinks()
+            setup.setupRipgrepVscodeSymlink()
+            setup.createNpmWrappers()
+            setup.ensureToolchainEnvSourcing()
+            setup.updateSettingsNativeLibPaths()
+        } catch (e: Exception) {
+            Logger.e(tag, "Launch-time setup refresh failed", e)
+        }
 
         if (!setup.isFirstRun()) {
             Logger.i(tag, "Not first run, launching main activity")

--- a/android/app/src/main/kotlin/com/vscodroid/SplashActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/SplashActivity.kt
@@ -49,9 +49,10 @@ class SplashActivity : AppCompatActivity() {
         // path on every reinstall, which breaks absolute symlinks in usr/bin/.
         //
         // These touch the filesystem on the main thread at launch. Letting one
-        // throw would crash the app before it ever draws, leaving the user with a
-        // launch loop and no explanation; a genuinely broken install still surfaces
-        // later as a server error that says so.
+        // throw would crash the app before it ever draws, leaving a launch loop
+        // with no explanation. What survives a failure here is degraded rather
+        // than dead — tools missing from PATH, a stale terminal profile — and
+        // logcat is the only trace, so keep the message specific.
         try {
             setup.setupToolSymlinks()
             setup.setupRipgrepVscodeSymlink()

--- a/android/app/src/main/kotlin/com/vscodroid/service/ProcessManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/service/ProcessManager.kt
@@ -211,6 +211,10 @@ class ProcessManager(private val context: Context) {
                 (pidMethod.invoke(process) as? Long)
             } else {
                 // Fallback for runtimes that only expose an internal pid field.
+                // This is the branch Android takes: its java.lang.Process has no
+                // pid(). On a desktop JVM the method is found but belongs to the
+                // package-private ProcessImpl, so invoking it fails and this
+                // returns null — do not assert on it from a JVM unit test.
                 val pidField = process.javaClass.getDeclaredField("pid")
                 pidField.isAccessible = true
                 pidField.getInt(process).toLong()

--- a/android/app/src/test/kotlin/com/vscodroid/service/ProcessManagerTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/service/ProcessManagerTest.kt
@@ -18,6 +18,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 /**
  * Tests for [ProcessManager]'s start guard and port allocation.
@@ -81,11 +83,11 @@ class ProcessManagerTest {
     @Test
     fun `starts again after the process has died`() {
         // The crash path leaves this reference in place; it must not block a restart.
-        manager.serverProcessField = mockk<Process>(relaxed = true) {
-            every { isAlive } returns false
-        }
+        val dead = mockk<Process>(relaxed = true) { every { isAlive } returns false }
+        manager.serverProcessField = dead
 
-        assertTrue(manager.startServer(), "a dead server must be restartable")
+        assertTrue(startAndAwaitWatchdog(), "a dead server must be restartable")
+        assertNotEquals(dead, manager.serverProcessField, "the dead reference must be replaced")
     }
 
     @Test
@@ -97,14 +99,31 @@ class ProcessManagerTest {
             every { isAlive } returns false
         }
 
-        assertTrue(manager.startServer())
+        assertTrue(startAndAwaitWatchdog())
         assertEquals(45678, manager.port, "restart must reuse the original port")
     }
 
     @Test
     fun `allocates a port on the first start`() {
-        assertTrue(manager.startServer())
+        assertTrue(startAndAwaitWatchdog())
         assertNotEquals(0, manager.port, "the first start must allocate a port")
+    }
+
+    /**
+     * Starts the server and waits for the watchdog to report `/bin/echo` exiting.
+     *
+     * Waiting is what keeps the watchdog thread from outliving the test and
+     * logging through the Logger mock after `unmockkAll()` has torn it down,
+     * which collides with the next test class re-mocking the same object in this
+     * JVM. It also pins the watchdog itself: without it the latch never fires,
+     * and the watchdog is the mechanism the whole restart depends on.
+     */
+    private fun startAndAwaitWatchdog(): Boolean {
+        val exited = CountDownLatch(1)
+        manager.onServerCrashed = { exited.countDown() }
+        val started = manager.startServer()
+        assertTrue(exited.await(5, TimeUnit.SECONDS), "watchdog never reported the exit")
+        return started
     }
 }
 

--- a/android/app/src/test/kotlin/com/vscodroid/service/ProcessManagerTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/service/ProcessManagerTest.kt
@@ -1,0 +1,122 @@
+package com.vscodroid.service
+
+import android.content.Context
+import com.vscodroid.util.Environment
+import com.vscodroid.util.Logger
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.Runs
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+/**
+ * Tests for [ProcessManager]'s start guard and port allocation.
+ *
+ * Regression coverage for issue #3: the guard tested `serverProcess != null`,
+ * but only `stopServer()` ever cleared that field — the crash path left the
+ * dead Process referenced. Every automatic restart after an unexpected exit
+ * was therefore refused, and the app stayed wedged until it was relaunched.
+ *
+ * [Environment] is stubbed so the spawned command is `/bin/echo`, which lets a
+ * start actually succeed without the bundled Node binary. The private state is
+ * reached by reflection rather than widening the production API for a test.
+ */
+class ProcessManagerTest {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    private lateinit var manager: ProcessManager
+
+    @BeforeEach
+    fun setUp() {
+        // Mock Logger to avoid android.util.Log crashes in JVM tests
+        mockkObject(Logger)
+        every { Logger.w(any(), any(), any()) } just Runs
+        every { Logger.i(any(), any()) } just Runs
+        every { Logger.d(any(), any()) } just Runs
+        every { Logger.e(any(), any(), any()) } just Runs
+
+        mockkObject(Environment)
+        every { Environment.getNodePath(any()) } returns "/bin/echo"
+        every { Environment.getServerScript(any()) } returns "server.js"
+        every { Environment.buildProcessEnvironment(any(), any()) } returns emptyMap()
+        every { Environment.getExtensionsDir(any()) } returns "extensions"
+        every { Environment.getUserDataDir(any()) } returns "data"
+        every { Environment.getLogsDir(any()) } returns "logs"
+
+        val context = mockk<Context>(relaxed = true)
+        every { context.cacheDir } returns tempDir
+        every { context.filesDir } returns tempDir
+
+        manager = ProcessManager(context)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        manager.stopServer()
+        unmockkAll()
+    }
+
+    @Test
+    fun `refuses to start while the process is alive`() {
+        manager.serverProcessField = mockk<Process>(relaxed = true) {
+            every { isAlive } returns true
+        }
+
+        assertFalse(manager.startServer(), "a live server must not be started twice")
+        assertEquals(0, manager.port, "the guard must reject before a port is taken")
+    }
+
+    @Test
+    fun `starts again after the process has died`() {
+        // The crash path leaves this reference in place; it must not block a restart.
+        manager.serverProcessField = mockk<Process>(relaxed = true) {
+            every { isAlive } returns false
+        }
+
+        assertTrue(manager.startServer(), "a dead server must be restartable")
+    }
+
+    @Test
+    fun `keeps the port across a restart`() {
+        // The WebView's loaded URL and the bridge's allowed-origin check are bound
+        // to the port and are not rebuilt on restart, so it has to stay put.
+        manager.portField = 45678
+        manager.serverProcessField = mockk<Process>(relaxed = true) {
+            every { isAlive } returns false
+        }
+
+        assertTrue(manager.startServer())
+        assertEquals(45678, manager.port, "restart must reuse the original port")
+    }
+
+    @Test
+    fun `allocates a port on the first start`() {
+        assertTrue(manager.startServer())
+        assertNotEquals(0, manager.port, "the first start must allocate a port")
+    }
+}
+
+/** Reaches [ProcessManager.serverProcess], which is private production state. */
+private var ProcessManager.serverProcessField: Process?
+    get() = field("serverProcess").get(this) as Process?
+    set(value) = field("serverProcess").set(this, value)
+
+/** Reaches [ProcessManager._port], which is private production state. */
+private var ProcessManager.portField: Int
+    get() = field("_port").getInt(this)
+    set(value) = field("_port").setInt(this, value)
+
+private fun field(name: String) =
+    ProcessManager::class.java.getDeclaredField(name).apply { isAccessible = true }


### PR DESCRIPTION
Follows #4, now merged. Picks up the four items that PR deliberately left out, plus the same CI defect in the release workflow. Three more surfaced while working through these changes, fixed in the later commits.

## Test coverage for the restart fix

The start guard was the riskiest change in #4 and the only one without a test. Exercising it needs a live process, which is why it was deferred.

`Environment` is stubbed so the spawned command is `/bin/echo`, which lets a start actually succeed without the bundled Node binary, and the private fields are reached by reflection rather than widening the production API for a test.

Every behaviour the tests claim to protect fails a test when removed:

| Mutation | Tests that fail |
| --- | --- |
| guard back to `serverProcess != null` | `starts again after the process has died`, `keeps the port across a restart` |
| drop the `_port == 0` guard | `keeps the port across a restart` |
| delete `startWatchdog()` | all three spawning tests |

The tests also wait for the watchdog to report the exit before finishing. Without that the thread outlived the test and logged through the Logger mock after teardown had removed it, colliding with the next test class re-mocking the same object in the same JVM — reproduced in 4 of 18 runs, and clean in 12 of 12 after.

## Returning to the open folder after a restart

`onServerReady` routes a restart through `loadVSCode()` with no folder argument, so the WebView reloaded the default projects directory and a user who had opened a project lost their workspace on every recovery. Only reachable once the restart itself started working, so it belongs with that change.

The folder is read back from the WebView's URL rather than tracked in a field. VS Code opens a folder by navigating the same WebView through `location.href` without going through Kotlin, so File > Open Folder, Open Recent and the Welcome page all move the workbench — a field updated only by the Kotlin side would miss exactly the cases users hit most. Paths that no longer exist are dropped, so a cleared SAF mirror falls back to the default instead of pinning the WebView to a dead directory.

`recreateWebView` no longer reloads the old URL directly either. That branch skipped `initBridge`, so a WebView rebuilt after a renderer crash came back without the Android bridge. It now goes through `loadVSCode` and carries the folder across explicitly.

## Surviving a failed launch-time setup refresh

The symlink, npm wrapper and settings refreshes run on the main thread in `onCreate` with nothing catching them, so any I/O failure crashed the app before it drew anything — a launch loop with no explanation. They are now wrapped and logged. What survives a failure there is a degraded install (tools missing from PATH, a stale terminal profile), with logcat as the only trace.

## Release workflow apt index

Same defect fixed for the build workflow in #4, in both jobs of the release workflow. Neither is guarded by a cache hit, so both run on every release and would fail the same way once the indexed package version is superseded.

## Changelog

`[Unreleased]` now records the user-facing effect of this work and of #4.

## Tests

205 tests, 0 failures, repeated 12 times. `assembleDebug` succeeds.