### PR TITLE
fix(android): guard folderFromUrl against opaque WebView URLs

### DIFF
--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -454,7 +454,10 @@ class MainActivity : AppCompatActivity() {
      * default rather than pinning the WebView to a dead path.
      */
     private fun folderFromUrl(url: String?): String? =
-        url?.let { Uri.parse(it).getQueryParameter("folder") }?.takeIf { File(it).isDirectory }
+        // A WebView that has not navigated yet reports an opaque URL
+        // (about:blank); getQueryParameter throws on non-hierarchical URIs.
+        url?.let { Uri.parse(it) }?.takeIf { it.isHierarchical }
+            ?.getQueryParameter("folder")?.takeIf { File(it).isDirectory }
 
     /**
      * Initializes the WebView bridge, security manager, and clients.


### PR DESCRIPTION
# fix(android): guard folderFromUrl against opaque WebView URLs

## Summary

Fixes a startup crash loop introduced by 3525f61 ("fix: derive the open folder from the WebView URL", part of the #3 fixes). `MainActivity.folderFromUrl` calls `Uri.getQueryParameter("folder")` on `webView.url`, but a WebView that has not navigated yet reports `about:blank` — an opaque (non-hierarchical) URI, on which `getQueryParameter` throws by contract:

```
java.lang.UnsupportedOperationException: This isn't a hierarchical URI.
    at android.net.Uri.getQueryParameter(Uri.java:1723)
    at com.vscodroid.MainActivity.folderFromUrl(MainActivity.kt:457)
    at com.vscodroid.MainActivity.loadVSCode(MainActivity.kt:444)
    at com.vscodroid.MainActivity.setupServiceCallbacks(MainActivity.kt:435)
    at com.vscodroid.MainActivity$serviceConnection$1.onServiceConnected(MainActivity.kt:80)
```

## Reproduction

1. Launch the app so the Node server service is running, then let the activity die while the service survives (recreation, or the crash itself).
2. Relaunch: `onServiceConnected` takes the "server already running" path and calls `loadVSCode(port)` with no folder.
3. `loadVSCode` falls back to `folderFromUrl(webView?.url)` before the WebView has navigated → `about:blank` → crash.

Because the service outlives the activity, every subsequent launch hits the same branch immediately, so the app crash-loops and never recovers on its own.

## Fix

Skip the query lookup unless the parsed URI is hierarchical:

```kotlin
private fun folderFromUrl(url: String?): String? =
    url?.let { Uri.parse(it) }?.takeIf { it.isHierarchical }
        ?.getQueryParameter("folder")?.takeIf { File(it).isDirectory }
```

The caller's existing fallback chain (`folderPath ?: folderFromUrl(...) ?: Environment.getProjectsDir(this)`) then lands on the default projects directory, which is the pre-3525f61 behavior for a fresh WebView.

## Testing

- `./gradlew testDebugUnitTest` — passes.
- On-device (Samsung SM-F956B, Android 14): reproduced the crash loop on master (`426e8fa`), installed the patched build over it, cold-started and relaunched with the server still running — no crash, server comes up and the workbench loads.
- No regression test added: `folderFromUrl` is a private Activity method and the test setup is plain JUnit 5 + MockK (no Robolectric), so `Uri.parse` is unavailable off-device. Happy to add one if you'd rather pull in Robolectric.
