### PR TITLE
docs: retire three claims the code has moved past

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.
 | Python            | 3.x                            | For node-gyp (native module compilation)     |
 | Git               | Any recent version             | -                                            |
 | adb               | Via Android SDK platform-tools | For deploying to device                      |
-| Physical ARM64 device | Android 13+ (API 33+)      | Emulators will not work (ARM64 binaries)     |
+| ARM64 device or emulator | Android 13+ (API 33+)   | The bundled binaries are arm64-only, so an x86_64 emulator will not work; an arm64 emulator (the default on Apple Silicon) works fine |
 
 ### Clone and Initial Setup
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -503,19 +503,9 @@ VSCodroid typically uses 400-700 MB of RAM. On devices with 4 GB or less, you ma
 
 `os.cpus()` returns an empty array on Android. This is cosmetic -- tools that display CPU core counts may show 0, but actual performance is unaffected.
 
-### @parcel/watcher Error
-
-You may see a warning about `@parcel/watcher` not having a native build for Android.
-
-The shipped `@parcel/watcher/build/Release/watcher.node` is a glibc ARM64 binary, which Android's Bionic loader cannot load, and `watcherMain.js` imports the module with a static ESM import. Treat automatic recursive file watching as **not working**, rather than degraded: an extension that expects to be told when a file changes somewhere below the workspace root may simply never hear about it.
-
-Saving and editing in the editor is unaffected. If something looks stale, reload the window.
-
-This is on the list to fix by cross-compiling the addon for Bionic. The exact runtime behaviour after the load fails has not been confirmed on a device — this note describes what the binary and the import site show, not an observed failure mode.
-
 ### Microsoft-only Extensions
 
-Extensions exclusive to the Microsoft Marketplace (such as GitHub Copilot, Microsoft C/C++, and some Microsoft-published extensions) are not available on Open VSX. Check Open VSX for community-maintained alternatives.
+Extensions exclusive to the Microsoft Marketplace (such as Microsoft C/C++ and some other Microsoft-published extensions) are not available on Open VSX. Check Open VSX for community-maintained alternatives. GitHub Copilot Chat is not affected: it ships built in and works on device.
 
 ### No Multi-window
 


### PR DESCRIPTION
Follow-up documentation sweep after PR #8: the emulator prohibition in CONTRIBUTING (arm64 emulators work — today's verification ran in one), the USER_GUIDE known-issue entry for @parcel/watcher (the addon is Bionic-built now), and the claim that GitHub Copilot is unavailable (it ships built in and works).

Documentation only.