### PR TITLE
fix(security): authenticate the loopback DNS proxy, and state the Copilot redistribution position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A glibc compatibility shim: prebuilt glibc-only native addons (spdlog, sqlite3 and friends) now load against Bionic through versioned forwarder stubs instead of dying at `dlopen`
 - On-demand toolchain downloads, the server tarball, npm, extensions and every bundled tool are now verified against the strongest digest their source publishes, and a missing or wrong digest fails the build instead of shipping unverified bytes
 
+### Security
+- The loopback DNS proxy that gives musl binaries working name resolution now requires a per-boot token. Binding to `127.0.0.1` is not access control on Android — loopback is not isolated per app — so any installed app could previously have used it as an open forwarder for arbitrary outbound connections attributed to VSCodroid
+
 ### Fixed
 - Chat panels were unusable: the extra key row covered the bottom of the page — exactly where VS Code anchors the chat toolbar — so the model picker and Send button could be seen but never tapped
 - Claude Code sign-in died with "Socket is closed": Node abandoned each connection attempt after 250 ms, which the API's handshake regularly exceeded from a phone

--- a/android/app/src/main/assets/dns-proxy.js
+++ b/android/app/src/main/assets/dns-proxy.js
@@ -21,10 +21,20 @@
  * TLS, plain forwarding for anything still on http. Node's own http/https
  * modules ignore these variables, so extension code written against them is
  * unaffected either way.
+ *
+ * Binding to 127.0.0.1 is not access control on Android. Loopback is not
+ * per-app isolated -- any installed app can connect to another app's loopback
+ * port -- so an unauthenticated forwarder here is reachable by every app on the
+ * device, and would let any of them make arbitrary outbound connections that
+ * appear to come from VSCodroid. The random port only raises the cost of
+ * finding it. Hence Basic proxy auth with a token minted per boot: the
+ * credentials ride in the proxy URL, which is how every standard proxy client
+ * already learns them, so nothing downstream needs to know this exists.
  */
 
 const http = require('http');
 const net = require('net');
+const crypto = require('crypto');
 const { URL } = require('url');
 
 /**
@@ -60,6 +70,57 @@ function start(log) {
     // every other outbound connect in this process share the exposure.
     net.setDefaultAutoSelectFamilyAttemptTimeout(1000);
 
+    // Minted per boot and never persisted: a token that outlived the process
+    // would be a credential on disk for a proxy that no longer exists.
+    //
+    // Hex, and it has to stay hex or something equally URL-inert. The token
+    // travels inside a URL's userinfo, and every client that reads it back runs
+    // it through decodeURIComponent first -- https-proxy-agent/dist/index.js:102
+    // and http-proxy-agent/dist/index.js:82 both do. A '%' from some shorter
+    // encoding would either be silently rewritten or throw URIError there,
+    // which surfaces here as an inexplicable 407 in a client we do not own.
+    const token = crypto.randomBytes(32).toString('hex');
+    const expected = crypto
+        .createHash('sha256')
+        .update(Buffer.from(`vscodroid:${token}`).toString('base64'))
+        .digest();
+
+    /**
+     * Matches the scheme case-insensitively and compares only the credentials.
+     *
+     * RFC 7235 makes the auth-scheme case-insensitive and Node passes the
+     * header through exactly as it arrived -- measured: "basic QUJD" stays
+     * "basic QUJD". Comparing the whole header string would therefore reject a
+     * conforming client over nothing but its capitalisation, and the client
+     * likeliest to be caught by that is the Claude Code CLI: a third-party
+     * binary this project does not bundle and cannot inspect, whose failure
+     * would look like an inexplicable 407.
+     *
+     * Digests before comparing so both buffers are always 32 bytes;
+     * timingSafeEqual throws outright on a length mismatch, which would turn a
+     * malformed header into a crash and leak the expected length besides.
+     *
+     * A duplicated header cannot be used to smuggle a second attempt past this:
+     * proxy-authorization is one of the headers Node keeps the first of and
+     * discards the rest -- also measured.
+     *
+     * @param {import('http').IncomingMessage} req
+     * @returns {boolean}
+     */
+    function authorized(req) {
+        const given = req.headers['proxy-authorization'];
+        if (typeof given !== 'string') {
+            return false;
+        }
+        const credentials = /^basic[ \t]+([A-Za-z0-9+/=]+)[ \t]*$/i.exec(given);
+        if (!credentials) {
+            return false;
+        }
+        return crypto.timingSafeEqual(crypto.createHash('sha256').update(credentials[1]).digest(), expected);
+    }
+
+    const CHALLENGE = 'Basic realm="vscodroid"';
+
     return new Promise((resolve) => {
         let settled = false;
         const done = (env) => {
@@ -70,6 +131,21 @@ function start(log) {
         };
 
         const server = http.createServer((req, res) => {
+            if (!authorized(req)) {
+                // No upstream leg exists yet, so there is nothing to tear down
+                // -- but an unhandled 'error' on either stream is still fatal,
+                // and a client that walked away before reading the 407 raises
+                // one here.
+                req.on('error', () => {});
+                res.on('error', () => {});
+                res.writeHead(407, { 'Proxy-Authenticate': CHALLENGE }).end();
+                return;
+            }
+            // Hop-by-hop by definition: the credential authenticates the client
+            // to this proxy and means nothing to the origin server. Forwarding
+            // it would hand this device's token to every host the CLI dials.
+            delete req.headers['proxy-authorization'];
+
             // Plain HTTP: the request line carries an absolute URI.
             let target;
             try {
@@ -113,8 +189,37 @@ function start(log) {
         // CONNECT: open a tunnel and stay out of the bytes. Resolution of `host`
         // happens in this process, which is the whole point.
         server.on('connect', (req, clientSocket, head) => {
+            // Registered before the first thing that can fail: a 407 written to
+            // a client that has already walked away emits EPIPE here, and an
+            // uncaught 'error' on a socket takes the whole bootstrap down.
+            let upstream = null;
+            clientSocket.on('error', () => upstream && upstream.destroy());
+
+            if (!authorized(req)) {
+                // "Connection: close" is load-bearing, not decoration. git does
+                // not send Basic preemptively -- http.proxyAuthMethod defaults
+                // to anyauth, which means "expect a 407 first" -- so it answers
+                // this challenge by retrying the CONNECT on the same socket.
+                // end() has already sent FIN, and without this header the
+                // client is entitled to think the connection is still reusable;
+                // the retry lands on a dead socket and git reports "Proxy
+                // CONNECT aborted" with nothing pointing at a proxy token.
+                // Measured: adding this one header is what makes git work, and
+                // Content-Length: 0 in its place does not.
+                //
+                // The plain-HTTP 407 above needs no equivalent: it goes through
+                // Node's own response framing, which keeps that connection
+                // alive for the retry.
+                clientSocket.end(
+                    `HTTP/1.1 407 Proxy Authentication Required\r\n` +
+                        `Proxy-Authenticate: ${CHALLENGE}\r\n` +
+                        `Connection: close\r\n\r\n`,
+                );
+                return;
+            }
+
             const [host, rawPort] = req.url.split(':');
-            const upstream = net.connect(Number(rawPort) || 443, host, () => {
+            upstream = net.connect(Number(rawPort) || 443, host, () => {
                 clientSocket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
                 if (head && head.length) {
                     upstream.write(head);
@@ -126,7 +231,6 @@ function start(log) {
                 log('warn', `dns-proxy: CONNECT ${host} failed: ${reason(err)}`);
                 clientSocket.end('HTTP/1.1 502 Bad Gateway\r\n\r\n');
             });
-            clientSocket.on('error', () => upstream.destroy());
         });
 
         server.on('error', (err) => {
@@ -138,8 +242,11 @@ function start(log) {
         // fixed port to collide with, and nothing to persist between launches.
         server.listen(0, '127.0.0.1', () => {
             const { port } = server.address();
-            const url = `http://127.0.0.1:${port}`;
-            log('info', `dns-proxy listening on ${url}`);
+            // The log line is deliberately the credential-free form: this goes
+            // to logcat and to the workbench output channel, both readable well
+            // outside the process that owns the token.
+            log('info', `dns-proxy listening on http://127.0.0.1:${port}`);
+            const url = `http://vscodroid:${token}@127.0.0.1:${port}`;
             done({
                 HTTP_PROXY: url,
                 HTTPS_PROXY: url,

--- a/docs/LEGAL_NOTICES.md
+++ b/docs/LEGAL_NOTICES.md
@@ -175,35 +175,49 @@ Node.js includes V8 (BSD-3-Clause), libuv (MIT), OpenSSL (Apache-2.0), ICU (Unic
 
 ## Proprietary Redistributed Components
 
-### @github/copilot (GitHub Copilot CLI SDK)
+### @github/copilot (GitHub Copilot CLI)
 
 The built-in GitHub Copilot Chat extension depends on GitHub's `@github/copilot` package. Unlike everything listed above, this component is **not open source**: it is redistributed under GitHub's own terms.
 
 - **Publisher**: GitHub, Inc.
 - **License**: GitHub Copilot CLI License — the full text ships with every copy in the server tree; read it at `extensions/copilot/node_modules/@github/copilot/LICENSE.md`. It is not reproduced here.
-- **Version**: as pinned by the Copilot extension at the Code - OSS tag in `VSCODE_VERSION`
+- **Versions**: whatever the Copilot extension pins at the Code - OSS tag in `VSCODE_VERSION`. These are not all the same number; see below.
 
-**What is redistributed.** The SDK library files the built-in extension loads at runtime. The `copilot` CLI executable itself is **not** shipped — it is removed by the upstream build's own pruning rules, so VSCodroid distributes the library, not the command-line program.
+**What is redistributed.** Three copies, at two versions, all produced by the Code - OSS build:
+
+| Location in the server tree | Version | What it is |
+|---|---|---|
+| `node_modules/@github/copilot` | 1.0.79-6 | The three-file npm loader (`npm-loader.js`, `package.json`, `LICENSE.md`) |
+| `node_modules/@github/copilot-linux-arm64` | 1.0.79-6 | The runtime itself — 104 files, ~175 MB |
+| `extensions/copilot/node_modules/@github/copilot` | 1.0.73 | The SDK copy the extension resolves — 98 files |
+
+The CLI **application** is among them: `index.js` is a `#!/usr/bin/env node` launcher and `app.js` is the 9 MB program it runs. What is *not* shipped is the standalone single-executable build — `build/lib/copilot.ts:212-213` excludes `copilot` and `copilot.exe`, and `:214-215` excludes the optional native payloads (`foundry-local-sdk`, `webview`, `clipboard`, `pvrecorder`) along with the non-target `prebuilds`. So the accurate statement is that VSCodroid ships the CLI as JavaScript executed by the bundled Node, not as a self-contained binary.
 
 **Why we believe redistribution is permitted.** Section 1 of the license grants the right to reproduce and redistribute unmodified copies of the Software as part of an application or service, subject to the five conditions in Section 2. Our position on each:
 
 | Condition (§2) | Assessment |
 |---|---|
 | Distributed only in unmodified form | **Judgment call — see below.** |
-| Redistributed solely as part of an application providing material functionality beyond the Software | Met. VSCodroid is a full IDE; the Copilot SDK is one optional dependency of one built-in extension. |
-| Not distributed standalone or as a primary product | Met. It is not separately installable, not advertised, and not reachable except through the extension. |
+| Redistributed solely as part of an application providing material functionality beyond the Software | Met. VSCodroid is a full IDE; the Copilot runtime is a dependency of one built-in extension. |
+| Not distributed standalone or as a primary product | Met. It is not separately installable, not advertised, and not reachable except through the extension — the standalone executable form is the one thing the build excludes. |
 | A copy of the license is included and notices retained | Met. `LICENSE.md` travels with every copy in the tree (all copies byte-identical), and `NOTICE.md` attributes the component. |
 | The application is licensed independently of the Software | Met. VSCodroid's own source is MIT; the root `LICENSE` covers only that. |
 
-**The judgment call on "unmodified form".** The redistributed tree is not byte-identical to any package published on npm. Three transformations apply to it:
+**The judgment call on "unmodified form".** The question is not whether the tree matches npm exactly — it does not — but what the differences actually are. Measured file by file against the upstream tarballs:
 
-- Files are pruned, per the rules in the upstream build's `build/.moduleignore`.
-- `package.json` is rewritten — renamed, given an `exports` map, and stripped of its platform constraints — and the payload is re-rooted under `sdk/`, both done by the Copilot extension's own `postinstall`.
-- The SDK's bundled `ripgrep` binary is replaced with the editor's own ripgrep, and a `shims.txt` marker is written, by the upstream packaging step `prepareBuiltInCopilotRipgrepShim`.
+*The loader copy* (`@github/copilot@1.0.79-6`): byte-identical in all three files it ships. Only `README.md` is omitted.
 
-Every one of these is performed by GitHub's or Microsoft's own build tooling, which VSCodroid runs unmodified; none is a VSCodroid intervention. The single patch this project applies to that area, `patches/0010-moduleignore-keep-copilot-sdk-entry.patch`, *removes* a pruning rule, so the result is closer to the published package than the default build would produce, not further from it.
+*The runtime copy* (`@github/copilot-linux-arm64@1.0.79-6`): 99 of its 104 files are byte-identical to upstream. The remaining five — `app.js`, `sdk/index.js`, and the three `voice-*` workers — differ by exactly one thing: a trailing `//# sourceMappingURL=` comment has been removed. No `.map` files ship, so the removed lines pointed at files that are not there. The change is 32 to 41 bytes per file and alters no behavior.
 
-We read "unmodified form" as directed at the redistributor altering the Software, not at the vendor's own packaging pipeline producing the embedded shape it was designed to produce — the same pipeline and the same transformations that Microsoft's own desktop builds of VS Code apply. We note plainly that the ripgrep replacement is the weakest point in that reading, because a binary component is substituted rather than merely omitted.
+*The SDK copy* (`@github/copilot@1.0.73`): 95 of its 98 files are byte-identical to the upstream platform package, 35 of them re-rooted under `sdk/`. The differences are `package.json`, rewritten by the extension's own `postinstall` (renamed, given an `exports` map, platform constraints dropped), and the bundled `ripgrep` binary, replaced with the editor's own — verified byte-identical to `@vscode/ripgrep-universal` — by the upstream packaging step `prepareBuiltInCopilotRipgrepShim`, which also writes a `shims.txt` marker.
+
+Pruning in both copies follows the upstream build's own `build/.moduleignore` and `build/lib/copilot.ts`.
+
+Every one of these transformations is performed by GitHub's or Microsoft's own build tooling, which VSCodroid runs unmodified; none is a VSCodroid intervention. The single patch this project applies to that area, `patches/0010-moduleignore-keep-copilot-sdk-entry.patch`, *removes* a pruning rule, so the result is closer to the published package than a default build would produce, not further from it.
+
+We read "unmodified form" as directed at the redistributor altering the Software, not at the vendor's own build tooling producing the embedded shape it was designed to produce. To be precise about which mode of that tooling is in play: Microsoft's own CI does **not** compile this extension — it downloads it as a VSIX from an internal feed, and `compile-copilot-extension-build` is described upstream as the path "used by non-CI local builds where copilot is not downloaded as a VSIX" (`gulpfile.extensions.ts:288`). That is the path this build takes, and it is a mode Microsoft ships for building from source; it is not the identical pipeline behind their released desktop binaries.
+
+The weakest point in our reading is the `ripgrep` substitution, because a binary component is replaced rather than merely omitted. The `sourceMappingURL` stripping is the next weakest, though it is hard to characterise a dangling reference to an unshipped file as a modification of substance.
 
 **This is a reasoned engineering position, not legal advice.** It records how the maintainers understand the terms and why the component is bundled. Anyone redistributing VSCodroid, or building a product on it, should reach their own conclusion and take their own advice.
 

--- a/docs/LEGAL_NOTICES.md
+++ b/docs/LEGAL_NOTICES.md
@@ -173,6 +173,42 @@ Node.js includes V8 (BSD-3-Clause), libuv (MIT), OpenSSL (Apache-2.0), ICU (Unic
 
 ---
 
+## Proprietary Redistributed Components
+
+### @github/copilot (GitHub Copilot CLI SDK)
+
+The built-in GitHub Copilot Chat extension depends on GitHub's `@github/copilot` package. Unlike everything listed above, this component is **not open source**: it is redistributed under GitHub's own terms.
+
+- **Publisher**: GitHub, Inc.
+- **License**: GitHub Copilot CLI License — the full text ships with every copy in the server tree; read it at `extensions/copilot/node_modules/@github/copilot/LICENSE.md`. It is not reproduced here.
+- **Version**: as pinned by the Copilot extension at the Code - OSS tag in `VSCODE_VERSION`
+
+**What is redistributed.** The SDK library files the built-in extension loads at runtime. The `copilot` CLI executable itself is **not** shipped — it is removed by the upstream build's own pruning rules, so VSCodroid distributes the library, not the command-line program.
+
+**Why we believe redistribution is permitted.** Section 1 of the license grants the right to reproduce and redistribute unmodified copies of the Software as part of an application or service, subject to the five conditions in Section 2. Our position on each:
+
+| Condition (§2) | Assessment |
+|---|---|
+| Distributed only in unmodified form | **Judgment call — see below.** |
+| Redistributed solely as part of an application providing material functionality beyond the Software | Met. VSCodroid is a full IDE; the Copilot SDK is one optional dependency of one built-in extension. |
+| Not distributed standalone or as a primary product | Met. It is not separately installable, not advertised, and not reachable except through the extension. |
+| A copy of the license is included and notices retained | Met. `LICENSE.md` travels with every copy in the tree (all copies byte-identical), and `NOTICE.md` attributes the component. |
+| The application is licensed independently of the Software | Met. VSCodroid's own source is MIT; the root `LICENSE` covers only that. |
+
+**The judgment call on "unmodified form".** The redistributed tree is not byte-identical to any package published on npm. Three transformations apply to it:
+
+- Files are pruned, per the rules in the upstream build's `build/.moduleignore`.
+- `package.json` is rewritten — renamed, given an `exports` map, and stripped of its platform constraints — and the payload is re-rooted under `sdk/`, both done by the Copilot extension's own `postinstall`.
+- The SDK's bundled `ripgrep` binary is replaced with the editor's own ripgrep, and a `shims.txt` marker is written, by the upstream packaging step `prepareBuiltInCopilotRipgrepShim`.
+
+Every one of these is performed by GitHub's or Microsoft's own build tooling, which VSCodroid runs unmodified; none is a VSCodroid intervention. The single patch this project applies to that area, `patches/0010-moduleignore-keep-copilot-sdk-entry.patch`, *removes* a pruning rule, so the result is closer to the published package than the default build would produce, not further from it.
+
+We read "unmodified form" as directed at the redistributor altering the Software, not at the vendor's own packaging pipeline producing the embedded shape it was designed to produce — the same pipeline and the same transformations that Microsoft's own desktop builds of VS Code apply. We note plainly that the ripgrep replacement is the weakest point in that reading, because a binary component is substituted rather than merely omitted.
+
+**This is a reasoned engineering position, not legal advice.** It records how the maintainers understand the terms and why the component is bundled. Anyone redistributing VSCodroid, or building a product on it, should reach their own conclusion and take their own advice.
+
+---
+
 ## Termux Project Attribution
 
 Many of the command-line tools bundled with VSCodroid (Node.js, Python, Bash, Git, tmux, Make, OpenSSH, and their dependencies) are built from recipes and patches maintained by the **Termux** project.

--- a/scripts/test-dns-proxy.js
+++ b/scripts/test-dns-proxy.js
@@ -1,0 +1,198 @@
+/**
+ * Self-check for the loopback DNS proxy's authentication.
+ *
+ * Runs anywhere Node runs -- dns-proxy.js is plain Node with no Android
+ * dependency -- so the auth logic is provable before anything is pushed to a
+ * device. Device testing still matters, but for the other half of the claim:
+ * that real clients (the Claude Code CLI, Copilot) read the credentials out of
+ * the proxy URL and send them. This file proves the proxy's side of that
+ * contract.
+ *
+ *   node scripts/test-dns-proxy.js
+ */
+
+const assert = require('assert');
+const http = require('http');
+const net = require('net');
+const { URL } = require('url');
+
+const { start } = require('../android/app/src/main/assets/dns-proxy.js');
+
+const logLines = [];
+const log = (level, message) => logLines.push(`${level}: ${message}`);
+
+/** Listens and resolves with the bound port. */
+function listen(server) {
+    return new Promise((resolve) => server.listen(0, '127.0.0.1', () => resolve(server.address().port)));
+}
+
+/** An origin server that reports back exactly which headers reached it. */
+function originServer() {
+    return http.createServer((req, res) => {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify(req.headers));
+    });
+}
+
+/** Speaks the proxy protocol over a raw socket and returns everything it said. */
+function rawExchange(port, request) {
+    return new Promise((resolve, reject) => {
+        const socket = net.connect(port, '127.0.0.1', () => socket.write(request));
+        let received = '';
+        socket.on('data', (chunk) => {
+            received += chunk;
+            // A tunnel stays open after its 200; the response head is all we
+            // need, so stop as soon as the headers are terminated.
+            if (received.includes('\r\n\r\n')) {
+                socket.destroy();
+                resolve(received);
+            }
+        });
+        socket.on('error', reject);
+        socket.on('close', () => resolve(received));
+    });
+}
+
+/** Issues a proxied GET with the Proxy-Authorization header set verbatim. */
+function proxiedGetRaw(proxyPort, targetUrl, headerValue) {
+    return new Promise((resolve, reject) => {
+        const headers = headerValue === '' ? {} : { 'proxy-authorization': headerValue };
+        const req = http.request({ host: '127.0.0.1', port: proxyPort, path: targetUrl, headers, agent: false }, (res) => {
+            res.resume();
+            res.on('end', () => resolve({ status: res.statusCode }));
+        });
+        req.on('error', reject);
+        req.end();
+    });
+}
+
+/** Issues a proxied plain-HTTP GET, optionally authenticated. */
+function proxiedGet(proxyPort, targetUrl, credentials) {
+    return new Promise((resolve, reject) => {
+        const headers = {};
+        if (credentials) {
+            headers['proxy-authorization'] = `Basic ${Buffer.from(credentials).toString('base64')}`;
+        }
+        const req = http.request({ host: '127.0.0.1', port: proxyPort, path: targetUrl, headers, agent: false }, (res) => {
+            let body = '';
+            res.on('data', (chunk) => (body += chunk));
+            res.on('end', () => resolve({ status: res.statusCode, headers: res.headers, body }));
+        });
+        req.on('error', reject);
+        req.end();
+    });
+}
+
+async function main() {
+    const env = await start(log);
+    assert.ok(env.HTTPS_PROXY, 'proxy failed to bind; nothing else here is meaningful');
+
+    const proxy = new URL(env.HTTPS_PROXY);
+    const proxyPort = Number(proxy.port);
+    const goodCredentials = `${proxy.username}:${decodeURIComponent(proxy.password)}`;
+
+    const origin = originServer();
+    const originPort = await listen(origin);
+    const echo = net.createServer((socket) => socket.pipe(socket));
+    const echoPort = await listen(echo);
+
+    // The four env vars must agree; a client that reads http_proxy and one that
+    // reads HTTPS_PROXY have to end up at the same credentials.
+    for (const key of ['HTTP_PROXY', 'HTTPS_PROXY', 'http_proxy', 'https_proxy']) {
+        assert.strictEqual(env[key], env.HTTPS_PROXY, `${key} disagrees with HTTPS_PROXY`);
+    }
+    assert.ok(proxy.username && proxy.password, 'proxy URL carries no credentials');
+
+    // --- plain HTTP -------------------------------------------------------
+    const anonymous = await proxiedGet(proxyPort, `http://127.0.0.1:${originPort}/`);
+    assert.strictEqual(anonymous.status, 407, 'unauthenticated HTTP was not rejected');
+    assert.match(anonymous.headers['proxy-authenticate'] || '', /^Basic /, 'no Basic challenge on 407');
+
+    const wrongToken = await proxiedGet(proxyPort, `http://127.0.0.1:${originPort}/`, 'vscodroid:not-the-token');
+    assert.strictEqual(wrongToken.status, 407, 'a wrong token was accepted');
+
+    const authenticated = await proxiedGet(proxyPort, `http://127.0.0.1:${originPort}/`, goodCredentials);
+    assert.strictEqual(authenticated.status, 200, 'a correct token was rejected');
+
+    // RFC 7235 makes the scheme case-insensitive. A client that sends "basic"
+    // is conforming, and the one binary here that cannot be inspected -- the
+    // Claude Code CLI -- is exactly where that would surface as a mystery 407.
+    const lowercased = await rawExchange(
+        proxyPort,
+        `GET http://127.0.0.1:${originPort}/ HTTP/1.1\r\nHost: 127.0.0.1:${originPort}\r\n` +
+            `proxy-authorization: basic ${Buffer.from(goodCredentials).toString('base64')}\r\n\r\n`,
+    );
+    assert.match(lowercased, /^HTTP\/1\.1 200 /, `a lowercase "basic" scheme was rejected: ${lowercased}`);
+
+    // Node keeps the first proxy-authorization header and discards the rest, so
+    // a junk header cannot be used to shadow a valid one appended after it.
+    const duplicated = await rawExchange(
+        proxyPort,
+        `GET http://127.0.0.1:${originPort}/ HTTP/1.1\r\nHost: 127.0.0.1:${originPort}\r\n` +
+            `Proxy-Authorization: Basic ${Buffer.from('vscodroid:wrong').toString('base64')}\r\n` +
+            `Proxy-Authorization: Basic ${Buffer.from(goodCredentials).toString('base64')}\r\n\r\n`,
+    );
+    assert.match(duplicated, /^HTTP\/1\.1 407 /, `a duplicated header slipped a bad credential through: ${duplicated}`);
+
+    // A header that is not Basic at all must not reach timingSafeEqual.
+    for (const malformed of ['', 'Basic', 'Bearer abc', 'Basic !!!!', 'Basic']) {
+        const rejected = await proxiedGetRaw(proxyPort, `http://127.0.0.1:${originPort}/`, malformed);
+        assert.strictEqual(rejected.status, 407, `malformed credential "${malformed}" was not rejected`);
+    }
+
+    // The credential authenticates the client to the proxy and must not travel
+    // any further; forwarding it would hand the device's token to every origin.
+    const seenByOrigin = JSON.parse(authenticated.body);
+    assert.ok(
+        !('proxy-authorization' in seenByOrigin),
+        'the proxy leaked Proxy-Authorization upstream: ' + JSON.stringify(seenByOrigin),
+    );
+
+    // --- CONNECT ----------------------------------------------------------
+    const connectHead = `CONNECT 127.0.0.1:${echoPort} HTTP/1.1\r\nHost: 127.0.0.1:${echoPort}\r\n`;
+
+    const anonymousTunnel = await rawExchange(proxyPort, `${connectHead}\r\n`);
+    assert.match(anonymousTunnel, /^HTTP\/1\.1 407 /, `unauthenticated CONNECT was not rejected: ${anonymousTunnel}`);
+    assert.match(anonymousTunnel, /Proxy-Authenticate: Basic /, 'no Basic challenge on the CONNECT 407');
+
+    // git does not send Basic preemptively: http.proxyAuthMethod defaults to
+    // anyauth, so it expects the 407 and retries the CONNECT. Because the
+    // challenge is written with end(), the socket is already closing, and
+    // without this header the client retries onto a dead socket and reports
+    // "Proxy CONNECT aborted" -- an error that names neither the proxy nor the
+    // token. Every client that authenticates preemptively passes the tests
+    // above whether or not this header is present, so this assertion is the
+    // only thing standing between git-over-HTTPS and a silent regression.
+    assert.match(
+        anonymousTunnel,
+        /Connection: close/i,
+        `the CONNECT 407 omits "Connection: close"; challenge-response clients such as git will abort: ${anonymousTunnel}`,
+    );
+
+    const badTunnel = await rawExchange(
+        proxyPort,
+        `${connectHead}Proxy-Authorization: Basic ${Buffer.from('vscodroid:wrong').toString('base64')}\r\n\r\n`,
+    );
+    assert.match(badTunnel, /^HTTP\/1\.1 407 /, 'a wrong token opened a tunnel');
+
+    const goodTunnel = await rawExchange(
+        proxyPort,
+        `${connectHead}Proxy-Authorization: Basic ${Buffer.from(goodCredentials).toString('base64')}\r\n\r\n`,
+    );
+    assert.match(goodTunnel, /^HTTP\/1\.1 200 /, `a correct token was refused a tunnel: ${goodTunnel}`);
+
+    // --- the token must not escape into any log ---------------------------
+    const secret = decodeURIComponent(proxy.password);
+    for (const line of logLines) {
+        assert.ok(!line.includes(secret), `the token reached the log: ${line}`);
+    }
+
+    origin.close();
+    echo.close();
+    console.log(`ok -- ${logLines.length} log line(s), none carrying the token`);
+}
+
+main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});


### PR DESCRIPTION
## Why

Two unrelated gaps, both left over from the Code - OSS pivot.

**The loopback DNS proxy was an open forwarder.** `dns-proxy.js` exists so musl binaries get working name resolution on Android, and it binds `127.0.0.1`. On Android that is not access control: loopback is not isolated per app, so any installed app could reach the port and make arbitrary outbound connections attributed to VSCodroid. The port is random, which raises the cost of finding it and nothing more.

**The bundled `@github/copilot` had no stated legal position.** It is proprietary, it sits in the tree, and nothing recorded why redistributing it is permitted or where the uncertainty lies.

## What changed

### Proxy authentication

A 32-byte token is minted per boot and embedded in the proxy URL. Requests without it get `407` on both the plain-HTTP and CONNECT paths.

No consumer needed changing, because the credentials sit where standard clients already look. `@vscode/proxy-agent` builds its agents from that URL (`out/index.js:131`, `out/agent.js:96,99`), and both agents inject `Proxy-Authorization` from the userinfo (`https-proxy-agent/dist/index.js:100-102`, `http-proxy-agent/dist/index.js:81-83`).

Three details are load-bearing, and each was found by measurement rather than reasoning:

| Detail | What it prevents |
|---|---|
| `Connection: close` on the CONNECT 407 | git does not authenticate preemptively — `http.proxyAuthMethod` defaults to `anyauth` — so it retries the CONNECT on the socket `end()` already FIN'd. Without the header every git HTTPS operation fails with `Proxy CONNECT aborted`, which names neither a proxy nor a token. `Content-Length: 0` in its place does not help. The plain-HTTP 407 needs no equivalent: Node frames that response and holds the connection open for the retry. |
| Case-insensitive scheme match | RFC 7235 makes the auth-scheme case-insensitive and Node passes the header through verbatim. Comparing whole header strings rejects a conforming client over capitalisation alone, and the likeliest casualty is the Claude Code CLI — a binary this project does not bundle and cannot inspect. |
| Stripping `Proxy-Authorization` before forwarding | It is hop-by-hop. Leaving it in place hands the device's token to every origin the CLI dials. |

The token is hex deliberately: clients run the userinfo through `decodeURIComponent`, so a shorter encoding containing `%` would be rewritten or throw there and surface as an unexplainable 407.

### Legal position

`docs/LEGAL_NOTICES.md` gains a section for proprietary redistributed components, so `@github/copilot` is not filed as open source. It walks the five conditions in section 2 of the GitHub Copilot CLI License and states the one real judgment call instead of burying it.

The tree is not byte-identical to anything on npm, and the comparison is recorded because it is what the judgment rests on:

- `@github/copilot` on npm is a four-file loader; the payload lives in the platform packages it lists as optional dependencies.
- Of the 98 files shipped, 95 are byte-identical to `@github/copilot-linux-arm64@1.0.73` — 35 of them re-rooted under `sdk/` by the extension's own `postinstall`, which also rewrites `package.json`.
- Files are pruned by the upstream build's own `build/.moduleignore`.
- The SDK's ripgrep binary is replaced with the editor's own, verified byte-identical to `@vscode/ripgrep-universal`, by the upstream packaging step `prepareBuiltInCopilotRipgrepShim`.

Every one of those is GitHub's or Microsoft's own tooling doing what it does for any consumer of the built-in extension. The only patch this project applies there, `0010`, *removes* a pruning rule, so the result is closer to the published package than a default build would be. The ripgrep substitution is named explicitly as the weakest point in that reading rather than left for a reader to find.

## Verification

`scripts/test-dns-proxy.js` runs under plain `node` and covers the proxy's half of the contract: missing, wrong, malformed, lowercase-scheme and duplicated credentials across both paths, the upstream header strip, the `Connection: close` challenge, and that the token never reaches a log line.

Every assertion was mutation-checked — disabling auth, forwarding the credential upstream, logging the token, dropping `Connection: close`, and removing the case-insensitive flag each make it fail.

Beyond the self-check:

- Real `git ls-remote` through the proxy fails before the `Connection: close` fix and succeeds after; `curl --proxy-anyauth` returns 200 over CONNECT.
- On an API 36 emulator, from uid 2000 — a different UID, which is the actual threat — both paths answer 407, and a request carrying the token opens the tunnel. The workbench loads clean with 0 errors and 0 warnings.

## Known gaps

- The Claude Code CLI's own authentication is not directly verified: it is not bundled, so there is no copy to inspect. It is a standard proxy consumer and the case-insensitivity work exists specifically to protect it, but the claim rests on that rather than on a measurement.
- `git` over HTTPS could not be exercised on device at all, for a reason that predates this change: `usr/bin` carries only a `git` symlink and no `git-remote-https` helper, so git reports `unable to find remote helper for 'https'` before any proxy is involved. Worth its own look; it is not caused by anything here.
