### PR TITLE
fix: proxy IPv6 tunnelling, port persistence, and cleanup of superseded plumbing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - An emergency port picked when the usual range is full is no longer remembered. It came from the range the kernel hands to outgoing connections, so a later launch would often find it taken and move the workbench to a new address — emptying secret storage and every extension's saved state, and never moving back once the congestion cleared
 - Tunnelling to an IPv6 address through the local proxy failed: the target was split on every colon, so `[::1]:443` was read as a host named `[`. A malformed port in the same position could take the server down at startup instead of being refused
+- Closing a tab or cancelling a download mid-transfer left the local proxy still pulling the rest of it from the network, with nothing on the other end to receive it. Each abandoned transfer held a connection open until the far side gave up
 - The placeholder page shown before the editor is installed pointed at a build script that no longer exists
 - Legal notices listed fixed versions for Node.js, Python, Bash, tmux and Make, none of which this repository pins — they come from the package index at build time, so the numbers had been wrong since the runtime changed
 - Chat panels were unusable: the extra key row covered the bottom of the page — exactly where VS Code anchors the chat toolbar — so the model picker and Send button could be seen but never tapped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The loopback DNS proxy that gives musl binaries working name resolution now requires a per-boot token. Binding to `127.0.0.1` is not access control on Android — loopback is not isolated per app — so any installed app could previously have used it as an open forwarder for arbitrary outbound connections attributed to VSCodroid
 
 ### Fixed
+- An emergency port picked when the usual range is full is no longer remembered. It came from the range the kernel hands to outgoing connections, so a later launch would often find it taken and move the workbench to a new address — emptying secret storage and every extension's saved state, and never moving back once the congestion cleared
+- Tunnelling to an IPv6 address through the local proxy failed: the target was split on every colon, so `[::1]:443` was read as a host named `[`. A malformed port in the same position could take the server down at startup instead of being refused
+- The placeholder page shown before the editor is installed pointed at a build script that no longer exists
+- Legal notices listed fixed versions for Node.js, Python, Bash, tmux and Make, none of which this repository pins — they come from the package index at build time, so the numbers had been wrong since the runtime changed
 - Chat panels were unusable: the extra key row covered the bottom of the page — exactly where VS Code anchors the chat toolbar — so the model picker and Send button could be seen but never tapped
 - Claude Code sign-in died with "Socket is closed": Node abandoned each connection attempt after 250 ms, which the API's handshake regularly exceeded from a phone
 - The glibc shim's ctype table misclassified five of twelve character classes, and its `environ`/`stdout`/`stderr` exports loaded as NULL

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -59,15 +59,6 @@
                 <data android:mimeType="application/json" />
             </intent-filter>
 
-            <!-- OAuth callback deep link: vscodroid://oauth/github?code=...&state=... -->
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <data android:scheme="vscodroid" android:host="oauth" />
-            </intent-filter>
-
             <!-- Extension callback relay: vscodroid://callback?data=... -->
             <!-- Bridges localStorage gap between Chrome (callback.html) and WebView -->
             <intent-filter>

--- a/android/app/src/main/assets/dns-proxy.js
+++ b/android/app/src/main/assets/dns-proxy.js
@@ -183,6 +183,12 @@ function start(log) {
             // CONNECT handler below.
             req.on('error', () => upstream.destroy());
             res.on('error', () => upstream.destroy());
+            // 'error' is not enough on its own. A client that simply goes away
+            // mid-response produces no failed write, so Node reports it as
+            // 'close' and nothing else -- leaving this leg to drain the origin
+            // into a socket nobody is reading. Firing on normal completion too
+            // is harmless: the request is finished by then.
+            res.on('close', () => upstream.destroy());
             req.pipe(upstream);
         });
 
@@ -194,6 +200,10 @@ function start(log) {
             // uncaught 'error' on a socket takes the whole bootstrap down.
             let upstream = null;
             clientSocket.on('error', () => upstream && upstream.destroy());
+            // Same reason as the plain-HTTP leg: an abrupt client is a 'close'
+            // here, not an 'error', and without this the tunnel's far half stays
+            // open with nothing on the near end.
+            clientSocket.on('close', () => upstream && upstream.destroy());
 
             if (!authorized(req)) {
                 // "Connection: close" is load-bearing, not decoration. git does
@@ -229,9 +239,32 @@ function start(log) {
             let host;
             let port;
             try {
-                const target = new URL(`http://${req.url}`);
-                host = target.hostname.startsWith('[') ? target.hostname.slice(1, -1) : target.hostname;
-                port = Number(target.port) || 443;
+                const authority = req.url;
+                // The port is read from the raw text, never from the parser. A
+                // WHATWG URL normalises away a port that equals the scheme
+                // default, so `host:80` parses to an empty .port and would then
+                // be dialled as 443 -- a wrong dial for a valid target. The
+                // authority-form of CONNECT always carries an explicit port
+                // (RFC 7231 4.3.6), so the last colon is the separator, and it
+                // has to fall outside any bracketed IPv6 address.
+                const sep = authority.lastIndexOf(':');
+                if (sep === -1 || sep < authority.lastIndexOf(']')) {
+                    throw new Error('no port in CONNECT target');
+                }
+                port = Number(authority.slice(sep + 1));
+                if (!Number.isInteger(port) || port < 1 || port > 65535) {
+                    throw new Error('port out of range');
+                }
+                // The host still comes from the parser, which is the part that
+                // gets the bracketed IPv6 form right; it keeps the brackets and
+                // net.connect wants them off.
+                host = new URL(`http://${authority}`).hostname;
+                if (host.startsWith('[')) {
+                    host = host.slice(1, -1);
+                }
+                if (!host) {
+                    throw new Error('no host in CONNECT target');
+                }
             } catch {
                 clientSocket.end('HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n');
                 return;
@@ -245,7 +278,7 @@ function start(log) {
                 clientSocket.pipe(upstream);
             });
             upstream.on('error', (err) => {
-                log('warn', `dns-proxy: CONNECT ${host} failed: ${reason(err)}`);
+                log('warn', `dns-proxy: CONNECT ${host}:${port} failed: ${reason(err)}`);
                 clientSocket.end('HTTP/1.1 502 Bad Gateway\r\n\r\n');
             });
         });

--- a/android/app/src/main/assets/dns-proxy.js
+++ b/android/app/src/main/assets/dns-proxy.js
@@ -218,8 +218,25 @@ function start(log) {
                 return;
             }
 
-            const [host, rawPort] = req.url.split(':');
-            upstream = net.connect(Number(rawPort) || 443, host, () => {
+            // Parsed rather than split on ':' because a CONNECT target may be an
+            // IPv6 literal: "[::1]:443".split(':') yields ["[", "", "1]", "443"],
+            // so the old form dialled a host named "[". The WHATWG parser gets
+            // this right and rejects a malformed authority outright, which also
+            // closes a second hole -- "host:99999999" used to reach net.connect
+            // and throw ERR_SOCKET_BAD_PORT synchronously, taking the bootstrap
+            // down with it. It keeps the brackets on an IPv6 hostname; net.connect
+            // wants the bare address.
+            let host;
+            let port;
+            try {
+                const target = new URL(`http://${req.url}`);
+                host = target.hostname.startsWith('[') ? target.hostname.slice(1, -1) : target.hostname;
+                port = Number(target.port) || 443;
+            } catch {
+                clientSocket.end('HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n');
+                return;
+            }
+            upstream = net.connect(port, host, () => {
                 clientSocket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
                 if (head && head.length) {
                     upstream.write(head);

--- a/android/app/src/main/assets/server.js
+++ b/android/app/src/main/assets/server.js
@@ -74,7 +74,10 @@ if (!fs.existsSync(rehEntryPoint)) {
             <body style="background:#1e1e1e;color:#ccc;font-family:monospace;padding:40px;text-align:center;">
                 <h1>VSCodroid</h1>
                 <p>Server is running, but VS Code is not yet built.</p>
-                <p>Run: <code>./scripts/build-vscode.sh && ./scripts/package-assets.sh</code></p>
+                <p>Run: <code>./scripts/fetch-vscode-oss.sh && ./scripts/package-assets.sh</code></p>
+                <p style="color:#666;">The fetch pulls the server tree from the <code>server-&lt;version&gt;</code>
+                release for the version pinned in <code>VSCODE_VERSION</code>. If no such release exists,
+                build it first with the <code>build-vscode-oss</code> workflow.</p>
                 <p style="color:#666;">Node.js ${process.version} on ${process.platform} ${process.arch}</p>
             </body>
             </html>

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -132,10 +132,6 @@ class MainActivity : AppCompatActivity() {
             handleExtensionCallback(uri)
             return
         }
-        if (uri?.scheme == "vscodroid" && uri.host == "oauth") {
-            handleOAuthCallback(uri)
-            return
-        }
         handleIntent(intent)
     }
 
@@ -876,9 +872,6 @@ class MainActivity : AppCompatActivity() {
                         } else if (d.cmd === 'generateBugReport') {
                             result = AndroidBridge.generateBugReport(token);
                             ch.postMessage({id: d.id, ok: true, data: result});
-                        } else if (d.cmd === 'startGitHubAuth') {
-                            AndroidBridge.startGitHubAuth(d.url, token);
-                            ch.postMessage({id: d.id, ok: true});
                         } else if (d.cmd === 'openToolchainSettings') {
                             AndroidBridge.openToolchainSettings(token);
                             ch.postMessage({id: d.id, ok: true});
@@ -1077,27 +1070,6 @@ class MainActivity : AppCompatActivity() {
                 }
             })();
         """.trimIndent(), null)
-    }
-
-    /**
-     * Forwards an OAuth callback deep link to VS Code's authentication handler.
-     * URL format: vscodroid://oauth/github?code=XXX&state=YYY
-     */
-    private fun handleOAuthCallback(uri: Uri) {
-        val code = uri.getQueryParameter("code")
-        val state = uri.getQueryParameter("state")
-        if (code == null || state == null) {
-            Logger.w(tag, "OAuth callback missing code or state: $uri")
-            return
-        }
-        Logger.i(tag, "OAuth callback received (state=$state)")
-        // Forward to VS Code's auth handler via JS.
-        // Use JSONObject.quote() for complete escaping (handles \u2028, \u2029, etc.)
-        val escapedCode = org.json.JSONObject.quote(code)
-        val escapedState = org.json.JSONObject.quote(state)
-        webView?.evaluateJavascript(
-            "window.__vscodroid?.onOAuthCallback?.($escapedCode, $escapedState)", null
-        )
     }
 
     /**

--- a/android/app/src/main/kotlin/com/vscodroid/bridge/AndroidBridge.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/bridge/AndroidBridge.kt
@@ -220,34 +220,6 @@ class AndroidBridge(
         CrashReporter.clearCrashLogs()
     }
 
-    // -- GitHub OAuth --
-
-    /**
-     * Opens a GitHub OAuth URL via Chrome Custom Tabs.
-     * The callback deep link (vscodroid://oauth/github?code=...&state=...)
-     * is handled by MainActivity and forwarded to VS Code via JS callback.
-     */
-    @JavascriptInterface
-    fun startGitHubAuth(authUrl: String, authToken: String) {
-        if (!security.validateToken(authToken)) return
-        try {
-            val uri = Uri.parse(authUrl)
-            // Only allow GitHub OAuth URLs to prevent misuse
-            if (uri.scheme != "https" || uri.host != "github.com") {
-                Logger.w(tag, "Blocked non-GitHub OAuth URL: ${uri.host}")
-                return
-            }
-            val customTabsIntent = CustomTabsIntent.Builder()
-                .setShowTitle(true)
-                .build()
-            customTabsIntent.intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            customTabsIntent.launchUrl(context, uri)
-            Logger.i(tag, "GitHub OAuth started")
-        } catch (e: Exception) {
-            Logger.e(tag, "Failed to start GitHub OAuth", e)
-        }
-    }
-
     // -- Toolchain Settings --
 
     /**

--- a/android/app/src/main/kotlin/com/vscodroid/util/Environment.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/util/Environment.kt
@@ -176,20 +176,6 @@ object Environment {
     fun getTerminalShellPath(context: Context): String =
         "${context.filesDir}/usr/bin/bash"
 
-    /**
-     * The node the Claude Code extension launches its CLI with.
-     *
-     * Names the symlink rather than nativeLibraryDir/libnode.so, and the
-     * difference matters twice. Android hands out a new nativeLibraryDir on every
-     * reinstall, so a path recorded in settings.json goes stale — the symlink
-     * lives under filesDir, which does not move, and setupToolSymlinks() re-points
-     * it at every launch. And SELinux denies execve on app_data_file, so the
-     * script could not be made executable itself; execve resolves the symlink and
-     * checks the target, which is in nativeLibraryDir and allowed.
-     */
-    fun getNodeSymlinkPath(context: Context): String =
-        "${context.filesDir}/usr/bin/node"
-
     fun getGitPath(context: Context): String =
         "${context.applicationInfo.nativeLibraryDir}/libgit.so"
 

--- a/android/app/src/main/kotlin/com/vscodroid/util/PortFinder.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/util/PortFinder.kt
@@ -49,7 +49,23 @@ object PortFinder {
                     "Workbench storage keyed to the old origin is lost.",
             )
         }
-        prefs.edit().putInt(KEY_PORT, port).apply()
+        // Only a port from the scan range is worth remembering. The fallback in
+        // findAvailablePort() returns one from the kernel's ephemeral range, and
+        // the comment on DEFAULT_PORT explains why that is the wrong thing to
+        // write here: an unrelated outbound socket can be holding such a port at
+        // the moment of the next launch, which sends the workbench to a new
+        // origin and drops the IndexedDB behind the old one. Persisting it would
+        // also be one-way -- once remembered, the port never migrates back to the
+        // stable range even after the congestion that forced it has cleared.
+        //
+        // Leaving the previous value in place is deliberate: the next cold start
+        // retries the port this install has been using, which is exactly right if
+        // the range was only briefly full. This is persistence only; the port is
+        // still returned and still reused for the whole process lifetime through
+        // ProcessManager's cached _port.
+        if (port in DEFAULT_PORT until DEFAULT_PORT + SCAN_RANGE) {
+            prefs.edit().putInt(KEY_PORT, port).apply()
+        }
         return port
     }
 

--- a/android/app/src/test/kotlin/com/vscodroid/util/PortFinderTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/util/PortFinderTest.kt
@@ -91,6 +91,43 @@ class PortFinderTest {
         }
 
         @Test
+        fun `does not remember a port from the ephemeral range`() {
+            // Exhaust the scan range so allocation has to fall through to
+            // ServerSocket(0). That port comes out of the kernel's volatile range,
+            // where an unrelated outbound socket can be holding it by the next
+            // launch -- remembering it would re-arm the very storage loss the fixed
+            // scan base exists to avoid, and it would never migrate back once the
+            // congestion clears.
+            val held = (13337 until 13337 + 64).mapNotNull {
+                runCatching { ServerSocket(it) }.getOrNull()
+            }
+            try {
+                val port = PortFinder.getOrAllocatePort(context)
+                assertTrue(port >= 32768, "precondition failed: the scan range was not exhausted")
+                assertEquals(0, stored, "an ephemeral port must not be persisted")
+            } finally {
+                held.forEach { it.close() }
+            }
+        }
+
+        @Test
+        fun `keeps the previously remembered port when it falls back to an ephemeral one`() {
+            // The old value is worth more than the emergency port: if the range was
+            // only briefly full, the next cold start returns to the origin this
+            // install has been using, with its IndexedDB intact.
+            stored = 13350
+            val held = (13337 until 13337 + 64).mapNotNull {
+                runCatching { ServerSocket(it) }.getOrNull()
+            }
+            try {
+                PortFinder.getOrAllocatePort(context)
+                assertEquals(13350, stored, "the remembered port must survive an ephemeral fallback")
+            } finally {
+                held.forEach { it.close() }
+            }
+        }
+
+        @Test
         fun `returns the same port on the next cold start`() {
             // The workbench keys IndexedDB by origin, and the port is part of the
             // origin: a different port here empties secret storage and every

--- a/docs/LEGAL_NOTICES.md
+++ b/docs/LEGAL_NOTICES.md
@@ -16,6 +16,8 @@ VSCodroid uses the **Open VSX** extension registry (https://open-vsx.org), not t
 
 VSCodroid incorporates the following open source projects. We are grateful to the developers and communities behind each of them.
 
+Versions are given only where this repository actually pins one. Most bundled tools are installed from the Termux package index at build time, so the version a given release shipped is a property of that build, not of this file — stating a number here would only go stale silently. Where a version is pinned, the entry names the file that pins it.
+
 ### Code - OSS (VS Code)
 
 - **Project**: https://github.com/microsoft/vscode
@@ -47,7 +49,7 @@ SOFTWARE.
 ### Node.js
 
 - **Project**: https://nodejs.org
-- **Version**: 20.18.1 (cross-compiled for ARM64 Android using Termux patches)
+- **Version**: not pinned here — the `nodejs-lts` package from the Termux index, installed by `scripts/download-node.sh`. The line it must track is set by `remote/.npmrc` at the VS Code tag in `VSCODE_VERSION`, since that is what the server's native modules are built against
 - **License**: MIT License (Node.js core), with additional licenses for bundled dependencies
 - **Copyright**: Copyright Node.js contributors. All rights reserved.
 - **Full license**: https://github.com/nodejs/node/blob/main/LICENSE
@@ -57,7 +59,7 @@ Node.js includes V8 (BSD-3-Clause), libuv (MIT), OpenSSL (Apache-2.0), ICU (Unic
 ### Python
 
 - **Project**: https://www.python.org
-- **Version**: 3.12.12 (from Termux packages)
+- **Version**: not pinned here — resolved from the Termux package index at build time by `scripts/download-python.sh`
 - **License**: Python Software Foundation License (PSF-2.0)
 - **Copyright**: Copyright (c) 2001-2024 Python Software Foundation. All rights reserved.
 - **Full license**: https://docs.python.org/3/license.html
@@ -73,7 +75,7 @@ Node.js includes V8 (BSD-3-Clause), libuv (MIT), OpenSSL (Apache-2.0), ICU (Unic
 ### Bash
 
 - **Project**: https://www.gnu.org/software/bash/
-- **Version**: 5.3.9 (from Termux packages)
+- **Version**: not pinned here — from the Termux package index at build time (`scripts/download-termux-tools.sh`)
 - **License**: GNU General Public License v3.0 (GPL-3.0-or-later)
 - **Copyright**: Copyright (c) Free Software Foundation, Inc.
 - **Full license**: https://www.gnu.org/licenses/gpl-3.0.html
@@ -89,7 +91,7 @@ Node.js includes V8 (BSD-3-Clause), libuv (MIT), OpenSSL (Apache-2.0), ICU (Unic
 ### tmux
 
 - **Project**: https://github.com/tmux/tmux
-- **Version**: 3.6a (from Termux packages)
+- **Version**: not pinned here — from the Termux package index at build time (`scripts/download-termux-tools.sh`)
 - **License**: ISC License
 - **Copyright**: Copyright (c) Nicholas Marriott and contributors
 - **Full license**: https://github.com/tmux/tmux/blob/master/COPYING
@@ -97,7 +99,7 @@ Node.js includes V8 (BSD-3-Clause), libuv (MIT), OpenSSL (Apache-2.0), ICU (Unic
 ### GNU Make
 
 - **Project**: https://www.gnu.org/software/make/
-- **Version**: 4.4.1 (from Termux packages)
+- **Version**: not pinned here — from the Termux package index at build time (`scripts/download-termux-tools.sh`)
 - **License**: GNU General Public License v3.0 (GPL-3.0-or-later)
 - **Copyright**: Copyright (c) Free Software Foundation, Inc.
 - **Full license**: https://www.gnu.org/licenses/gpl-3.0.html
@@ -136,7 +138,7 @@ Node.js includes V8 (BSD-3-Clause), libuv (MIT), OpenSSL (Apache-2.0), ICU (Unic
 ### npm
 
 - **Project**: https://www.npmjs.com
-- **Version**: 10.8.2
+- **Version**: 10.8.2 — pinned as `NPM_VERSION` in `scripts/download-npm.sh`, extracted from the nodejs.org tarball named there
 - **License**: Artistic License 2.0
 - **Copyright**: Copyright (c) npm, Inc. and Contributors
 - **Full license**: https://github.com/npm/cli/blob/latest/LICENSE

--- a/patches/0003-ptyhost-as-worker-thread.patch
+++ b/patches/0003-ptyhost-as-worker-thread.patch
@@ -29,7 +29,6 @@ ipc.cp.ts picks between them on serverName. Only the Pty Host moves in this
 change; the file watcher keeps forking, and the Extension Host is a separate step
 because it also has to stop passing sockets over its channel.
 
-  ipc.cp.ts: situs fork dikondisikan
 diff --git a/src/bootstrap-fork.ts b/src/bootstrap-fork.ts
 index a92290a..282873b 100644
 --- a/src/bootstrap-fork.ts

--- a/scripts/test-dns-proxy.js
+++ b/scripts/test-dns-proxy.js
@@ -26,9 +26,30 @@ function listen(server) {
     return new Promise((resolve) => server.listen(0, '127.0.0.1', () => resolve(server.address().port)));
 }
 
-/** An origin server that reports back exactly which headers reached it. */
+/**
+ * An origin that reports which headers reached it, and on /big streams a body
+ * far larger than any socket buffer so a client can abort mid-response.
+ */
 function originServer() {
     return http.createServer((req, res) => {
+        if (req.url === '/big') {
+            res.writeHead(200, { 'content-type': 'application/octet-stream' });
+            const chunk = Buffer.alloc(1 << 16, 0x61);
+            let sent = 0;
+            const pump = () => {
+                while (sent < 64) {
+                    sent++;
+                    if (!res.write(chunk)) {
+                        res.once('drain', pump);
+                        return;
+                    }
+                }
+                res.end();
+            };
+            res.on('error', () => {});
+            pump();
+            return;
+        }
         res.writeHead(200, { 'content-type': 'application/json' });
         res.end(JSON.stringify(req.headers));
     });
@@ -116,7 +137,21 @@ async function main() {
 
     const origin = originServer();
     const originPort = await listen(origin);
-    const echo = net.createServer((socket) => socket.pipe(socket));
+    // The echo sockets need their own error handler: these tests deliberately
+    // RST the client, and a bare socket.pipe(socket) would die of the
+    // ECONNRESET that arrives here -- a crash in the harness, mistakable for a
+    // crash in the proxy.
+    // Tracked so teardown can close them: the abort tests deliberately leave the
+    // proxy's upstream leg open, and server.close() waits on live connections,
+    // which would hang this script after every assertion had already passed.
+    const echoSockets = new Set();
+    const echoHandler = (socket) => {
+        echoSockets.add(socket);
+        socket.on('close', () => echoSockets.delete(socket));
+        socket.on('error', () => {});
+        socket.pipe(socket);
+    };
+    const echo = net.createServer(echoHandler);
     const echoPort = await listen(echo);
 
     // The four env vars must agree; a client that reads http_proxy and one that
@@ -214,7 +249,7 @@ async function main() {
     // --- IPv6 literals ----------------------------------------------------
     // "[::1]:443".split(':') yields ["[", "", "1]", "443"], so the pre-parser
     // form dialled a host named "[". Skipped where the loopback has no IPv6.
-    const echo6 = net.createServer((socket) => socket.pipe(socket));
+    const echo6 = net.createServer(echoHandler);
     const echo6Port = await new Promise((resolve) => {
         echo6.once('error', () => resolve(null));
         echo6.listen(0, '::1', () => resolve(echo6.address().port));
@@ -231,6 +266,36 @@ async function main() {
         console.log('note -- no IPv6 loopback here, skipped the IPv6 CONNECT case');
     }
 
+    // A URL parser normalises away a port that matches the scheme default, so
+    // reading the port back from it turns "host:80" into an empty string and
+    // then, via `|| 443`, into a dial to the wrong port entirely. The port must
+    // come from the raw target text. Only 80 can trigger this, so the check
+    // needs port 80 to be closed here to be meaningful.
+    const port80Closed = await new Promise((resolve) => {
+        const probe = net.connect(80, '127.0.0.1');
+        probe.on('connect', () => {
+            probe.destroy();
+            resolve(false);
+        });
+        probe.on('error', () => resolve(true));
+    });
+    if (port80Closed) {
+        const before = logLines.length;
+        await rawExchange(
+            proxyPort,
+            `CONNECT 127.0.0.1:80 HTTP/1.1\r\nHost: 127.0.0.1:80\r\n` +
+                `Proxy-Authorization: Basic ${Buffer.from(goodCredentials).toString('base64')}\r\n\r\n`,
+        );
+        const logged = logLines.slice(before).join('\n');
+        assert.match(
+            logged,
+            /CONNECT 127\.0\.0\.1:80 failed/,
+            `a CONNECT to port 80 was not dialled on port 80: ${logged || '(nothing logged)'}`,
+        );
+    } else {
+        console.log('note -- something is listening on port 80 here, skipped the default-port case');
+    }
+
     // A port outside the valid range used to reach net.connect and throw
     // ERR_SOCKET_BAD_PORT synchronously, which took the whole bootstrap down.
     const badPort = await rawExchange(
@@ -242,26 +307,65 @@ async function main() {
 
     // --- a client that walks away mid-flight ------------------------------
     // The error listeners in both handlers exist so an aborted client cannot
-    // raise an unhandled 'error' and kill the bootstrap. Nothing exercised them.
-    await new Promise((resolve) => {
-        const socket = net.connect(proxyPort, '127.0.0.1', () => {
-            socket.write(`${connectHead}Proxy-Authorization: Basic ${Buffer.from(goodCredentials).toString('base64')}\r\n\r\n`);
-            socket.destroy();
-            resolve();
+    // raise an unhandled 'error' and take the bootstrap down with it.
+    //
+    // Aborting has to be done carefully to exercise them at all. A destroy()
+    // issued after the write has drained closes the connection cleanly, and a
+    // clean close reaches the proxy as 'end', never 'error' -- an earlier
+    // version of this test did exactly that and passed with every listener
+    // deleted. Leaving unread data in the receive buffer at close turns the
+    // FIN into an RST, which is what the proxy sees as an error on a socket it
+    // is still writing to.
+    const abortMidTunnel = () =>
+        new Promise((resolve) => {
+            const socket = net.connect(proxyPort, '127.0.0.1', () => {
+                socket.write(
+                    `${connectHead}Proxy-Authorization: Basic ${Buffer.from(goodCredentials).toString('base64')}\r\n\r\n`,
+                );
+            });
+            let armed = false;
+            socket.on('data', () => {
+                if (armed) return;
+                armed = true;
+                // Flood the echo server, then vanish without reading a byte of
+                // what comes back.
+                socket.write('x'.repeat(1 << 20));
+                setImmediate(() => {
+                    socket.resume = () => {};
+                    socket.destroy();
+                    resolve();
+                });
+            });
+            socket.on('error', resolve);
+            socket.setTimeout(3000, () => {
+                socket.destroy();
+                resolve();
+            });
         });
-        socket.on('error', resolve);
-    });
-    await new Promise((resolve) => {
-        const socket = net.connect(proxyPort, '127.0.0.1', () => {
-            socket.write(`GET http://127.0.0.1:${originPort}/ HTTP/1.1\r\nHost: x\r\n\r\n`);
-            socket.destroy();
-            resolve();
+
+    const abortMidResponse = () =>
+        new Promise((resolve) => {
+            const socket = net.connect(proxyPort, '127.0.0.1', () => {
+                socket.write(
+                    `GET http://127.0.0.1:${originPort}/big HTTP/1.1\r\nHost: x\r\n` +
+                        `Proxy-Authorization: Basic ${Buffer.from(goodCredentials).toString('base64')}\r\n\r\n`,
+                );
+            });
+            socket.on('data', () => socket.destroy());
+            socket.on('error', resolve);
+            socket.on('close', resolve);
+            socket.setTimeout(3000, () => {
+                socket.destroy();
+                resolve();
+            });
         });
-        socket.on('error', resolve);
-    });
+
+    await abortMidTunnel();
+    await abortMidResponse();
+
     // If either abort had killed the proxy, this would not answer.
     const stillAlive = await proxiedGet(proxyPort, `http://127.0.0.1:${originPort}/`, goodCredentials);
-    assert.strictEqual(stillAlive.status, 200, 'the proxy died after a client aborted mid-request');
+    assert.strictEqual(stillAlive.status, 200, 'the proxy died after a client aborted mid-transfer');
 
     // --- the token must not escape into any log ---------------------------
     const secret = decodeURIComponent(proxy.password);
@@ -269,12 +373,30 @@ async function main() {
         assert.ok(!line.includes(secret), `the token reached the log: ${line}`);
     }
 
+    echoSockets.forEach((socket) => socket.destroy());
     origin.close();
     echo.close();
     console.log(`ok -- ${logLines.length} log line(s), none carrying the token`);
 }
 
-main().catch((err) => {
-    console.error(err);
-    process.exit(1);
-});
+main()
+    .then(() => {
+        // The abort cases above leave nothing behind only if the proxy tears
+        // down the far half of each connection. When it does not, every
+        // assertion still passes and the process simply never exits -- which is
+        // how that leak hid in the first place. This turns the hang into a named
+        // failure instead of a timeout someone has to interpret.
+        const bail = setTimeout(() => {
+            console.error(
+                'FAIL: assertions passed but the event loop is still busy.\n' +
+                    'Something the proxy opened was never closed -- most likely an upstream\n' +
+                    'leg left draining after a client went away.',
+            );
+            process.exit(1);
+        }, 2000);
+        bail.unref();
+    })
+    .catch((err) => {
+        console.error(err);
+        process.exit(1);
+    });

--- a/scripts/test-dns-proxy.js
+++ b/scripts/test-dns-proxy.js
@@ -53,6 +53,29 @@ function rawExchange(port, request) {
     });
 }
 
+/**
+ * Like rawExchange, but lets the server close the connection instead of
+ * destroying it at the first CRLFCRLF. That distinction is the whole point of
+ * the Connection: close test below -- reading the header text only proves the
+ * proxy claimed it would close, not that it did.
+ */
+function rawExchangeUntilClose(port, request) {
+    return new Promise((resolve, reject) => {
+        const socket = net.connect(port, '127.0.0.1', () => socket.write(request));
+        let received = '';
+        let sawFin = false;
+        socket.on('data', (chunk) => (received += chunk));
+        socket.on('end', () => (sawFin = true));
+        socket.on('error', reject);
+        socket.on('close', () => resolve({ received, sawFin }));
+        // A tunnel that stays open would hang this forever; fail loudly instead.
+        socket.setTimeout(3000, () => {
+            socket.destroy();
+            resolve({ received, sawFin });
+        });
+    });
+}
+
 /** Issues a proxied GET with the Proxy-Authorization header set verbatim. */
 function proxiedGetRaw(proxyPort, targetUrl, headerValue) {
     return new Promise((resolve, reject) => {
@@ -180,6 +203,65 @@ async function main() {
         `${connectHead}Proxy-Authorization: Basic ${Buffer.from(goodCredentials).toString('base64')}\r\n\r\n`,
     );
     assert.match(goodTunnel, /^HTTP\/1\.1 200 /, `a correct token was refused a tunnel: ${goodTunnel}`);
+
+    // The header text above only proves the proxy said it would close. This
+    // proves it did: a challenge-response client retries on this connection, and
+    // if the FIN never arrives it waits on a socket that is already gone.
+    const closed = await rawExchangeUntilClose(proxyPort, `${connectHead}\r\n`);
+    assert.match(closed.received, /^HTTP\/1\.1 407 /, 'unauthenticated CONNECT was not rejected');
+    assert.ok(closed.sawFin, 'the proxy announced Connection: close but never closed the connection');
+
+    // --- IPv6 literals ----------------------------------------------------
+    // "[::1]:443".split(':') yields ["[", "", "1]", "443"], so the pre-parser
+    // form dialled a host named "[". Skipped where the loopback has no IPv6.
+    const echo6 = net.createServer((socket) => socket.pipe(socket));
+    const echo6Port = await new Promise((resolve) => {
+        echo6.once('error', () => resolve(null));
+        echo6.listen(0, '::1', () => resolve(echo6.address().port));
+    });
+    if (echo6Port) {
+        const tunnel6 = await rawExchange(
+            proxyPort,
+            `CONNECT [::1]:${echo6Port} HTTP/1.1\r\nHost: [::1]:${echo6Port}\r\n` +
+                `Proxy-Authorization: Basic ${Buffer.from(goodCredentials).toString('base64')}\r\n\r\n`,
+        );
+        assert.match(tunnel6, /^HTTP\/1\.1 200 /, `an IPv6 CONNECT target was refused: ${tunnel6}`);
+        echo6.close();
+    } else {
+        console.log('note -- no IPv6 loopback here, skipped the IPv6 CONNECT case');
+    }
+
+    // A port outside the valid range used to reach net.connect and throw
+    // ERR_SOCKET_BAD_PORT synchronously, which took the whole bootstrap down.
+    const badPort = await rawExchange(
+        proxyPort,
+        `CONNECT example.com:99999999 HTTP/1.1\r\nHost: example.com\r\n` +
+            `Proxy-Authorization: Basic ${Buffer.from(goodCredentials).toString('base64')}\r\n\r\n`,
+    );
+    assert.match(badPort, /^HTTP\/1\.1 400 /, `a malformed CONNECT target was not rejected: ${badPort}`);
+
+    // --- a client that walks away mid-flight ------------------------------
+    // The error listeners in both handlers exist so an aborted client cannot
+    // raise an unhandled 'error' and kill the bootstrap. Nothing exercised them.
+    await new Promise((resolve) => {
+        const socket = net.connect(proxyPort, '127.0.0.1', () => {
+            socket.write(`${connectHead}Proxy-Authorization: Basic ${Buffer.from(goodCredentials).toString('base64')}\r\n\r\n`);
+            socket.destroy();
+            resolve();
+        });
+        socket.on('error', resolve);
+    });
+    await new Promise((resolve) => {
+        const socket = net.connect(proxyPort, '127.0.0.1', () => {
+            socket.write(`GET http://127.0.0.1:${originPort}/ HTTP/1.1\r\nHost: x\r\n\r\n`);
+            socket.destroy();
+            resolve();
+        });
+        socket.on('error', resolve);
+    });
+    // If either abort had killed the proxy, this would not answer.
+    const stillAlive = await proxiedGet(proxyPort, `http://127.0.0.1:${originPort}/`, goodCredentials);
+    assert.strictEqual(stillAlive.status, 200, 'the proxy died after a client aborted mid-request');
 
     // --- the token must not escape into any log ---------------------------
     const secret = decodeURIComponent(proxy.password);


### PR DESCRIPTION
A sweep of smaller correctness fixes and dead-code removal.

## Fixed
- **IPv6 CONNECT tunnelling**: the loopback proxy split the CONNECT target on every colon, so `[::1]:443` was read as a host named `[`. It now parses the target with the URL API for the host and reads the port from the raw authority, and a malformed or out-of-range port is refused with 400 instead of crashing the bootstrap at startup.
- **Abandoned-transfer socket leak** (pre-existing): closing a tab or cancelling a download mid-transfer left the proxy pulling the rest from the network with nothing receiving it, holding a connection open until the far side gave up. The upstream leg is now released when the client goes away, not only on a write error.
- **Ephemeral port persistence**: when the usual port range is full, the emergency port the kernel hands out is no longer remembered — a later launch would often find it taken and move the workbench to a new address, emptying secret storage and saved extension state and never moving back.

## Removed
- The `startGitHubAuth` bridge method, its relay, `handleOAuthCallback`, and the `vscodroid://oauth` intent filter — all reachable only from an extension stub that was removed earlier. The live extension OAuth callback (`vscodroid://callback`), which handles GitHub and Claude sign-in, is untouched.
- An unused environment path helper left behind when the loader path resolution changed.

## Docs
- The pre-install placeholder page no longer points at a deleted build script, and the legal notices no longer list fixed versions for tools whose versions come from the package index at build time.

Tests: unit suite (231) and lint pass; the proxy self-check exercises IPv6 tunnelling, the port guard, client aborts, and the abandoned-leg release.