### PR TITLE
build: verify bundled tools and libraries load on Android before packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The VS Code server is now built from the MIT-licensed Code - OSS source** instead of downloading Microsoft's proprietary pre-built server, which could not legally be modified and redistributed inside an APK. The build applies this repository's patches and branding to readable source, is verified for tree shape, architecture and branding before it ships, and is published once per VS Code version
 - VS Code upgraded 1.96.4 → 1.133.0
 - Node.js runtime upgraded to 24.18.0, now taken from Termux's `nodejs-lts` package — the previous hand-cross-compiled 20.18.1 segfaulted inside several CLI tools
+- Every bundled executable and shared library — the shell, git, tmux, make, ssh and the libraries they load — is now checked before packaging for the right architecture, dependencies that are actually present, and the page alignment Android 16 requires. Previously only the Node runtime and the native addons were, so a tool whose dependency had gone missing produced a successful build and an install where the terminal would not start
 
 ### Added
 - **GitHub Copilot Chat now works on device**: the bundled extension's platform packages are aliased under the name Android resolves, its SDK entry ships again, and `@vscode/sqlite3` is rebuilt for Bionic so model selection completes end to end

--- a/scripts/download-termux-tools.sh
+++ b/scripts/download-termux-tools.sh
@@ -507,7 +507,76 @@ else
     echo "  WARNING: terminfo not found in ncurses package"
 fi
 
-# --- Step 8: Size summary ---
+# --- Step 8: Verify everything placed can actually load on Android ---
+echo ""
+echo "=== Verifying placed binaries ==="
+# Every object above arrives pre-compiled from a third-party mirror and is then
+# either executed on the device or dlopen'd into a process there, and until now
+# nothing checked that any of it could load at all. That gap is not theoretical:
+# an install shipped a libbash.so whose libandroid-support.so was not beside it,
+# and the terminal died with "CANNOT LINK EXECUTABLE ... library
+# libandroid-support.so not found" -- at runtime, on a device, from a build that
+# had reported success. verify-android-elf.py answers exactly the three
+# questions that would have caught it: the right architecture, every DT_NEEDED
+# resolvable, and 16 KB segment alignment for Android 16.
+#
+# Both --lib-dir arguments are load-bearing. The executables here link against
+# the libraries this same script places, so a check without them would reject
+# every legitimate dependency and the gate would be useless in the other
+# direction.
+#
+# This runs last because step 5 empties assets/usr/lib before repopulating it:
+# verifying earlier would be verifying a directory still being built.
+
+JNILIBS_BINARIES=(libbash.so libgit.so libtmux.so libmake.so libssh.so libssh-keygen.so)
+
+# git-core holds shell scripts and a manifest beside its binaries, and the
+# verifier rejects a non-ELF file rather than skipping it.
+is_elf() {
+    [ "$(dd if="$1" bs=4 count=1 2>/dev/null | od -An -tx1 | tr -d ' \n')" = "7f454c46" ]
+}
+
+verify_failures=0
+verify_checked=0
+
+verify_object() {
+    local out
+    verify_checked=$((verify_checked + 1))
+    if ! out=$(python3 "$SCRIPT_DIR/verify-android-elf.py" "$1" \
+                   --lib-dir "$ASSETS_DIR/usr/lib" --lib-dir "$JNILIBS_DIR" 2>&1); then
+        echo "  FAILED  $(basename "$1")" >&2
+        # `|| true` because this file runs under pipefail: if grep ever matched
+        # nothing it would return 1, and the shell would exit right here --
+        # killing the build with no message at all, in the one branch whose job
+        # is to explain what went wrong. Measured, not assumed: a failing
+        # pipeline in this position aborts before the next line runs.
+        echo "$out" | grep -v '^  ok' | sed 's/^/     /' >&2 || true
+        verify_failures=$((verify_failures + 1))
+    fi
+}
+
+for name in "${JNILIBS_BINARIES[@]}"; do
+    verify_object "$JNILIBS_DIR/$name"
+done
+
+for lib in "$ASSETS_DIR/usr/lib"/*.so*; do
+    [ -f "$lib" ] && verify_object "$lib"
+done
+
+for helper in "$GIT_CORE_DST"/*; do
+    [ -f "$helper" ] && is_elf "$helper" && verify_object "$helper"
+done
+
+if [ "$verify_failures" -gt 0 ]; then
+    echo "" >&2
+    echo "  ERROR: $verify_failures of $verify_checked objects would fail to load" >&2
+    echo "         on a device. Shipping them produces a working build and a" >&2
+    echo "         broken install." >&2
+    exit 1
+fi
+echo "  $verify_checked objects verified: architecture, dependencies, 16 KB alignment"
+
+# --- Step 9: Size summary ---
 echo ""
 echo "=== Size Summary ==="
 


### PR DESCRIPTION
Until now only the Node runtime and the native addons were checked for Android loadability at build time. Every other bundled binary — the shell, git, tmux, make, ssh, and the shared libraries they link against — arrived pre-compiled from a third-party mirror and was packaged with no check that it could load at all.

That gap was not theoretical. An install once shipped a `libbash.so` whose `libandroid-support.so` was not beside it, and the terminal died on device with `CANNOT LINK EXECUTABLE ... library "libandroid-support.so" not found` — from a build that had reported success.

This adds a verification pass over everything the tools step places: the six jniLibs executables, the shared libraries in `usr/lib`, and the git-core helpers (ELF files only; the directory also holds shell scripts). Each is checked for the right architecture, that every declared dependency is actually present, and the 16 KB segment alignment Android 16 requires. A single missing dependency now fails the build with the full list of affected objects, instead of a green build and a broken install.

The check runs after the tools and libraries are in place, and both library search paths (`usr/lib` and jniLibs) are passed so a legitimate bundled dependency is not mistaken for a missing one.

Verified two ways: a full run passes all 51 objects, and removing one library that others depend on fails the build and names all ten affected — a reminder that the single runtime crash line only ever showed the first of them.