### PR TITLE
fix(proxy): release the socket after a rejected CONNECT tunnel request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 - The loopback DNS proxy that gives musl binaries working name resolution now requires a per-boot token. Binding to `127.0.0.1` is not access control on Android — loopback is not isolated per app — so any installed app could previously have used it as an open forwarder for arbitrary outbound connections attributed to VSCodroid
+- A rejected tunnel request through that proxy no longer leaves a connection pinned open. Any app on the device could previously open them in a loop and hold file descriptors in VSCodroid's server for as long as it kept running — without a token, without reaching the network, and without leaving a trace in the log
 
 ### Fixed
 - An emergency port picked when the usual range is full is no longer remembered. It came from the range the kernel hands to outgoing connections, so a later launch would often find it taken and move the workbench to a new address — emptying secret storage and every extension's saved state, and never moving back once the congestion cleared

--- a/android/app/src/main/assets/dns-proxy.js
+++ b/android/app/src/main/assets/dns-proxy.js
@@ -121,6 +121,27 @@ function start(log) {
 
     const CHALLENGE = 'Basic realm="vscodroid"';
 
+    /**
+     * Writes a final response on a CONNECT socket and then releases it.
+     *
+     * end() on its own does not release anything here. http.Server constructs
+     * its sockets with allowHalfOpen -- measured true on the bundled runtime --
+     * so end() sends our FIN and then waits for the peer's. A client that
+     * simply stops talking never sends one, and the descriptor stays pinned for
+     * the life of the process: measured, 100 rejected CONNECTs held 100
+     * server-side sockets, still held at 65 seconds. Nothing reaps them,
+     * because none of the HTTP timeouts govern a socket once 'connect' has
+     * fired -- also measured, against a server whose timeouts demonstrably
+     * still reap an ordinary request.
+     *
+     * The callback runs once writableFinished is set, so the response is fully
+     * handed to the kernel before the descriptor closes; a challenge-response
+     * client such as git still reads the whole 407 and retries with
+     * credentials. It is also called on a socket that was already destroyed,
+     * so there is no path where this silently does nothing.
+     */
+    const closeWith = (socket, response) => socket.end(response, () => socket.destroy());
+
     return new Promise((resolve) => {
         let settled = false;
         const done = (env) => {
@@ -220,7 +241,8 @@ function start(log) {
                 // The plain-HTTP 407 above needs no equivalent: it goes through
                 // Node's own response framing, which keeps that connection
                 // alive for the retry.
-                clientSocket.end(
+                closeWith(
+                    clientSocket,
                     `HTTP/1.1 407 Proxy Authentication Required\r\n` +
                         `Proxy-Authenticate: ${CHALLENGE}\r\n` +
                         `Connection: close\r\n\r\n`,
@@ -266,7 +288,7 @@ function start(log) {
                     throw new Error('no host in CONNECT target');
                 }
             } catch {
-                clientSocket.end('HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n');
+                closeWith(clientSocket, 'HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n');
                 return;
             }
             upstream = net.connect(port, host, () => {
@@ -279,7 +301,7 @@ function start(log) {
             });
             upstream.on('error', (err) => {
                 log('warn', `dns-proxy: CONNECT ${host}:${port} failed: ${reason(err)}`);
-                clientSocket.end('HTTP/1.1 502 Bad Gateway\r\n\r\n');
+                closeWith(clientSocket, 'HTTP/1.1 502 Bad Gateway\r\nConnection: close\r\n\r\n');
             });
         });
 

--- a/scripts/test-dns-proxy.js
+++ b/scripts/test-dns-proxy.js
@@ -367,6 +367,48 @@ async function main() {
     const stillAlive = await proxiedGet(proxyPort, `http://127.0.0.1:${originPort}/`, goodCredentials);
     assert.strictEqual(stillAlive.status, 200, 'the proxy died after a client aborted mid-transfer');
 
+    // --- a rejected CONNECT must not pin a descriptor ---------------------
+    // The response text is identical whether or not the socket is released, so
+    // this is the one case in the file that has to be asserted by counting.
+    // http.Server builds its sockets with allowHalfOpen, so end() sends our FIN
+    // and waits for a peer FIN that a client with no interest in replying never
+    // sends; and no HTTP timeout governs a socket once 'connect' has fired. A
+    // co-installed app could otherwise hold descriptors in this process for
+    // free, without a token and without a single line in the log.
+    //
+    // _getActiveHandles is private, and used deliberately: both ends live in
+    // this process, so it is the only vantage point that sees the server side
+    // at all.
+    const liveSockets = () =>
+        process._getActiveHandles().filter((h) => h.constructor && h.constructor.name === 'Socket' && !h.destroyed)
+            .length;
+
+    const PROBES = 40;
+    const baseline = liveSockets();
+    const probes = [];
+    for (let i = 0; i < PROBES; i++) {
+        await new Promise((resolve) => {
+            const socket = net.connect(proxyPort, '127.0.0.1', () => {
+                socket.write(`${connectHead}\r\n`);
+                probes.push(socket);
+                resolve();
+            });
+            socket.on('error', resolve);
+        });
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    // Every probe still holds its own client socket on purpose -- a peer that
+    // hangs up is exactly the case that already worked. What must not survive
+    // is the server's half.
+    const held = liveSockets() - baseline - probes.length;
+    assert.ok(
+        held <= 0,
+        `${held} of ${PROBES} rejected CONNECTs left a server-side socket pinned; ` +
+            'end() without a release leaves them half-open and nothing reaps them',
+    );
+    probes.forEach((socket) => socket.destroy());
+
     // --- the token must not escape into any log ---------------------------
     const secret = decodeURIComponent(proxy.password);
     for (const line of logLines) {


### PR DESCRIPTION
A CONNECT request the loopback proxy rejects left its client socket half-open instead of closing it. The rejection wrote its response with `end()`, which sends our FIN and then waits for the peer's — a peer that never sends it holds the socket open, and once a CONNECT has been received the HTTP server's timeouts no longer govern that socket, so nothing reaps it.

Measured on the current code: 100 rejected CONNECTs left 100 server-side sockets pinned, still held past the 60-second header timeout.

This is not new — the same shape existed before the proxy required a token, at its 502 path. What changed is the cost: previously parking a descriptor meant forcing an outbound dial to fail, which also logged a line per socket; the unauthenticated 407 parks for free, with no network activity and no log entry. Any app on the device could hold file descriptors in VSCodroid's server in a loop.

The three rejection sites now close through a single helper that destroys the socket once the response has been flushed to the kernel, so the response is still delivered in full — a well-behaved client's authentication retry is unaffected — while a client that walks away no longer leaves anything behind. The regression test measures the pinned descriptors directly rather than asserting on the response text, since the two states are byte-identical.