### PR TITLE
build: fail the Python download when the runtime is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - VS Code upgraded 1.96.4 → 1.133.0
 - Node.js runtime upgraded to 24.18.0, now taken from Termux's `nodejs-lts` package — the previous hand-cross-compiled 20.18.1 segfaulted inside several CLI tools
 - Every bundled executable and shared library — the shell, git, tmux, make, ssh and the libraries they load — is now checked before packaging for the right architecture, dependencies that are actually present, and the page alignment Android 16 requires. Previously only the Node runtime and the native addons were, so a tool whose dependency had gone missing produced a successful build and an install where the terminal would not start
+- The Python bundling step now fails the build when the interpreter's runtime library is absent, installs that runtime under the exact name the launcher links against, and runs the same architecture, dependency and page-alignment check as every other bundled binary — the one it did not yet cover. It previously printed a note and carried on, which could ship a build where `python` failed on first use with a missing-library error
 
 ### Added
 - **GitHub Copilot Chat now works on device**: the bundled extension's platform packages are aliased under the name Android resolves, its SDK entry ships again, and `@vscode/sqlite3` is rebuilt for Bionic so model selection completes end to end

--- a/scripts/download-python.sh
+++ b/scripts/download-python.sh
@@ -266,20 +266,26 @@ for pkg in "${LIB_PACKAGES[@]}"; do
     done
 done
 
-# Also need libpython shared library
-# Binary links against versioned SONAME (libpython3.12.so.1.0), not unversioned
+# Also need the libpython runtime the launcher links against. readelf -d on the
+# placed libpython.so needs the unversioned name (libpython3.x.so), not the
+# versioned .so.1.0 -- so the runtime must land under that unversioned name
+# whichever file the package ships. Termux currently ships only the unversioned
+# file; copying the versioned one to the unversioned name covers a package that
+# ever flips to versioned-only. A launcher with no runtime is a broken build, so
+# fail here rather than emit a note and ship an APK where python cannot start.
 LIBPYTHON_SRC="extracted/python/data/data/com.termux/files/usr/lib"
 LIBPYTHON_VERSIONED="libpython${PYTHON_MAJOR_MINOR}.so.1.0"
 LIBPYTHON_UNVERSIONED="libpython${PYTHON_MAJOR_MINOR}.so"
-if [ -f "$LIBPYTHON_SRC/$LIBPYTHON_VERSIONED" ] || [ -L "$LIBPYTHON_SRC/$LIBPYTHON_VERSIONED" ]; then
-    cp -L "$LIBPYTHON_SRC/$LIBPYTHON_VERSIONED" "$ASSETS_DIR/usr/lib/$LIBPYTHON_VERSIONED"
-    echo "  $LIBPYTHON_VERSIONED ($(du -sh "$ASSETS_DIR/usr/lib/$LIBPYTHON_VERSIONED" | cut -f1))"
-elif [ -f "$LIBPYTHON_SRC/$LIBPYTHON_UNVERSIONED" ] || [ -L "$LIBPYTHON_SRC/$LIBPYTHON_UNVERSIONED" ]; then
-    cp -L "$LIBPYTHON_SRC/$LIBPYTHON_UNVERSIONED" "$ASSETS_DIR/usr/lib/$LIBPYTHON_UNVERSIONED"
-    echo "  $LIBPYTHON_UNVERSIONED ($(du -sh "$ASSETS_DIR/usr/lib/$LIBPYTHON_UNVERSIONED" | cut -f1))"
+LIBPYTHON_DST="$ASSETS_DIR/usr/lib/$LIBPYTHON_UNVERSIONED"
+if [ -e "$LIBPYTHON_SRC/$LIBPYTHON_UNVERSIONED" ]; then
+    cp -L "$LIBPYTHON_SRC/$LIBPYTHON_UNVERSIONED" "$LIBPYTHON_DST"
+elif [ -e "$LIBPYTHON_SRC/$LIBPYTHON_VERSIONED" ]; then
+    cp -L "$LIBPYTHON_SRC/$LIBPYTHON_VERSIONED" "$LIBPYTHON_DST"
 else
-    echo "  NOTE: libpython shared lib not found (Python may be statically linked)"
+    echo "  ERROR: no libpython runtime ($LIBPYTHON_UNVERSIONED or $LIBPYTHON_VERSIONED) in $LIBPYTHON_SRC" >&2
+    exit 1
 fi
+echo "  $LIBPYTHON_UNVERSIONED ($(du -sh "$LIBPYTHON_DST" | cut -f1))"
 
 # --- Step 8: Size summary ---
 echo ""
@@ -300,8 +306,18 @@ for pkg in "${LIB_PACKAGES[@]}"; do
         [ -f "$ASSETS_DIR/usr/lib/$soname" ] && echo "  $soname: $(du -sh "$ASSETS_DIR/usr/lib/$soname" | cut -f1)"
     done
 done
-[ -f "$ASSETS_DIR/usr/lib/$LIBPYTHON_VERSIONED" ] && echo "  $LIBPYTHON_VERSIONED: $(du -sh "$ASSETS_DIR/usr/lib/$LIBPYTHON_VERSIONED" | cut -f1)"
 [ -f "$ASSETS_DIR/usr/lib/$LIBPYTHON_UNVERSIONED" ] && echo "  $LIBPYTHON_UNVERSIONED: $(du -sh "$ASSETS_DIR/usr/lib/$LIBPYTHON_UNVERSIONED" | cut -f1)"
+
+echo ""
+echo "=== Verify ==="
+# The launcher's DT_NEEDED names its runtime and every other lib it loads; this
+# fails the build if one is missing, the wrong arch, or not 16 KB-aligned -- the
+# check the old silent NOTE skipped. It also proves the runtime landed under the
+# name the launcher links: a mismatch shows up here as an unresolved DT_NEEDED,
+# not as a broken python on someone's device.
+python3 "$SCRIPT_DIR/verify-android-elf.py" "$JNILIBS_DIR/libpython.so" \
+    --lib-dir "$ASSETS_DIR/usr/lib" \
+    --lib-dir "$JNILIBS_DIR"
 
 echo ""
 echo "=== Python download complete ==="


### PR DESCRIPTION
## Summary

`scripts/download-python.sh` was the one download script still able to succeed while leaving the build broken: when the libpython runtime was not where it expected, it printed a note ("Python may be statically linked" — never true for this package) and carried on. The resulting APK carries an interpreter with nothing to link against, and the failure surfaces as `CANNOT LINK EXECUTABLE ... library "libpython3.x.so" not found` on a user's device.

CI is currently healthy — the latest `main` build places the runtime correctly — so this is latent hardening, not an active outage. It closes the gap before an upstream layout shift turns it into one.

## Changes

- **Fail closed.** A missing runtime now exits the build with an error instead of a note.
- **Ship the name the launcher links.** `readelf -d` on the placed `libpython.so` needs the unversioned `libpython3.x.so`. The copy now always lands under that name, whichever of the two candidate files the package ships. Previously a versioned-only package would have been copied under `.so.1.0` — a name nothing looks for, with no symlink bridging the two.
- **Run the ELF gate.** The same `verify-android-elf.py` check every other bundled binary gets now runs on the Python launcher: architecture, 16 KB alignment, and every `DT_NEEDED` resolvable from Bionic or the bundle. This doubles as proof the runtime landed under the right name — a mismatch fails the build as an unresolved `DT_NEEDED` rather than surfacing on a device.

The stale comment claiming the binary links the *versioned* name is corrected; the launcher's actual `DT_NEEDED` set is `libandroid-support.so`, `libpython3.x.so`, `libc.so`, all of which resolve at the point in the workflow where this script runs (`download-termux-tools.sh` has already placed `libandroid-support.so`).

## Verification

- `bash -n` passes.
- The gate was exercised against a tree with the runtime deliberately absent: it fails with the unresolved `libpython3.x.so`, which is exactly the condition the old note waved through.
- Both CI cache keys hash this script, so this PR's CI run re-executes the download path in full rather than restoring a cached tree — the new gate runs for real before merge.

Fixes #17
