### PR TITLE
docs: correct README claims that drifted from the implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- README brought back in line with how the project actually builds and installs: local builds fetch the prebuilt server rather than needing Node and Yarn to build VS Code, SSH ships as the bundled OpenSSH client and `ssh-keygen` rather than a command-palette flow, toolchains install on sideloaded devices too (direct download) rather than Play-only, and the size table now carries figures measured from the release AAB
 - **The VS Code server is now built from the MIT-licensed Code - OSS source** instead of downloading Microsoft's proprietary pre-built server, which could not legally be modified and redistributed inside an APK. The build applies this repository's patches and branding to readable source, is verified for tree shape, architecture and branding before it ships, and is published once per VS Code version
 - VS Code upgraded 1.96.4 → 1.133.0
 - Node.js runtime upgraded to 24.18.0, now taken from Termux's `nodejs-lts` package — the previous hand-cross-compiled 20.18.1 segfaulted inside several CLI tools

--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ If you are **ready to learn**, you should be able to **start today**.
 - **Batteries Included** — Node.js, Python 3, Git, npm, SSH, and essential tools bundled out of the box.
 - **Offline-First** — Code without an internet connection. Everything runs locally on your device.
 - **Mobile-Optimized** — Extra Key Row (Ctrl, Alt, Tab, Esc, arrows), touch-friendly UI, clipboard bridge.
-- **SSH Key Management** — Generate ed25519 keys and copy public keys from the command palette.
-- **Language Picker** — Select your languages, Go/Ruby/Java auto-install via Play Store.
+- **SSH Out of the Box** — Bundled OpenSSH client and `ssh-keygen`, preconfigured with sane defaults (ed25519, keepalive, `accept-new`).
+- **Language Picker** — Select your languages; Go/Ruby/Java install on demand — via Play Asset Delivery on Play installs, or direct download on sideloaded installs.
 - **Dev Server Preview** — Open localhost URLs in your device's browser for web app testing.
 
 ## 📸 Screenshots
@@ -186,7 +186,7 @@ flowchart TD
 
 1. **Install** from [Google Play](https://play.google.com/store/apps/details?id=com.vscodroid).
 2. Open the app. Core binaries extract automatically (~5-10 seconds).
-3. Pick your languages (Go, Ruby, Java, etc.). They install automatically.
+3. Pick your languages (Go, Ruby, Java). They install automatically.
 4. Start coding. Editor, terminal, and tools are ready.
 
 > You can also download APKs directly from [GitHub Releases](https://github.com/rmyndharis/VSCodroid/releases).
@@ -196,18 +196,19 @@ flowchart TD
 | Tier                         | What                                                        | How                                                      |
 | ---------------------------- | ----------------------------------------------------------- | -------------------------------------------------------- |
 | **Core (Base APK)**          | Node.js, npm, Python 3, Git, Bash, SSH, tmux, make, ripgrep | Available immediately                                    |
-| **Toolchains (Asset Packs)** | Go, Ruby, Java                                              | Select in Language Picker, auto-installed via Play Store |
+| **Toolchains (Asset Packs)** | Go, Ruby, Java                                              | Select in Language Picker — Play Asset Delivery, or direct download on sideloaded installs |
 
 ## 🔨 Building from Source
 
 ### Prerequisites
 
 - **Android Studio** latest stable version with Android API 36 support.
-- **Android NDK** r27+.
-- **Node.js** 20 LTS (for building VS Code).
-- **Yarn** 1.x Classic (for VS Code build).
-- **Python** 3.x (for node-gyp).
+- **Android NDK** r27+ (for cross-compiling the native addons).
+- **Python** 3.x (used by the download and verification scripts).
 - **Git**.
+
+You do **not** build VS Code locally: the server tree is built once per VS Code version by a
+separate workflow and fetched as a verified tarball by `scripts/fetch-vscode-oss.sh`.
 
 ### Build Steps
 
@@ -233,10 +234,10 @@ adb install android/app/build/outputs/apk/debug/app-debug.apk
 
 | Metric                             | Size                   |
 | ---------------------------------- | ---------------------- |
-| Play Store download (core)         | ~150-200 MB            |
-| + Each toolchain (on-demand)       | 20-100 MB per language |
-| Installed storage (core)           | ~300-400 MB            |
-| Installed storage (all toolchains) | ~600-800 MB            |
+| Play Store download (core)         | ~135 MB                |
+| + Each toolchain (on-demand)       | 9-53 MB per language   |
+| Installed storage (core)           | ~400 MB                |
+| Installed storage (all toolchains) | ~750 MB                |
 | RAM usage (typical)                | ~400-700 MB            |
 
 ## 🤝 Contributing


### PR DESCRIPTION
## Summary

An audit of the README against the current implementation found four claims that had drifted. Each correction below was verified against the code or a measured artifact before being made; nothing else in the document was touched.

## Corrections

- **Build prerequisites.** The list still asked for Node 20 LTS and Yarn 1.x "for building VS Code". Since the Code - OSS pivot, the server tree is built once per VS Code version by a separate workflow and fetched as a digest-verified tarball by `scripts/fetch-vscode-oss.sh` — a local app build never builds VS Code. The list now names what a local build actually needs (NDK r27+ for the native addons, Python 3 for the scripts) and says so explicitly.
- **SSH feature bullet.** It promised key generation "from the command palette", which is not where the feature is reachable. The bullet now describes what ships: the bundled OpenSSH client and `ssh-keygen`, preconfigured with ed25519, keepalive and `accept-new` defaults.
- **Toolchain delivery.** Two places read as Play-only ("auto-installed via Play Store"). Delivery is chosen at runtime by install source: Play installs use Play Asset Delivery, sideloaded installs download the same toolchains from GitHub Releases. Both places now say so.
- **Size table.** The estimates (150-200 MB download, 20-100 MB per toolchain, 300-400 MB installed) predate the measured v1.0.0 AAB: base module 134.2 MiB compressed / 388.4 MiB raw, toolchains 8.8-52.7 MiB compressed. The table now carries figures rounded from those measurements.

Also trimmed "etc." from the language list in Getting Started — the picker offers exactly Go, Ruby and Java.

No behavior changes; documentation only.
