### PR TITLE
docs: give unresolved follow-ups a tracked home

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - README brought back in line with how the project actually builds and installs: local builds fetch the prebuilt server rather than needing Node and Yarn to build VS Code, SSH ships as the bundled OpenSSH client and `ssh-keygen` rather than a command-palette flow, toolchains install on sideloaded devices too (direct download) rather than Play-only, and the size table now carries figures measured from the release AAB
+- Contributing guide: review findings that are not fixed in the same pull request now get an issue, and rejected ones a stated reason, so nothing is left referenced only by its position in a discussion
 - **The VS Code server is now built from the MIT-licensed Code - OSS source** instead of downloading Microsoft's proprietary pre-built server, which could not legally be modified and redistributed inside an APK. The build applies this repository's patches and branding to readable source, is verified for tree shape, architecture and branding before it ships, and is published once per VS Code version
 - VS Code upgraded 1.96.4 → 1.133.0
 - Node.js runtime upgraded to 24.18.0, now taken from Termux's `nodejs-lts` package — the previous hand-cross-compiled 20.18.1 segfaulted inside several CLI tools

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -448,12 +448,32 @@ generated identifiers, broke on every version bump, and printed `SKIP` on a miss
    - Reference related issues (e.g., `Fixes #123`).
 3. Address review feedback and push updates.
 
+### Review Findings
+
+A review often turns up more than the change can carry: something adjacent, something
+pre-existing, something real but out of scope. Give every one of those a home before the
+PR merges.
+
+- **Fixed in the same PR** — nothing more to do.
+- **Not fixed** — open an issue, and link it from the review thread. One issue per finding,
+  titled so it can be found by name.
+- **Rejected** — say so in the thread, with the reason. "Checked, does not apply because X"
+  is a resolution; silence is not.
+
+The rule is that no finding leaves review referenced only by something ephemeral — a position
+in a list, "the second one", a number that exists nowhere in this repository. Those references
+stop meaning anything the moment the discussion scrolls away, and the finding is then either
+rediscovered at full cost or quietly assumed to be handled.
+
+An issue is cheap. Re-deriving a defect someone already found is not.
+
 ### PR Checklist
 
 - [ ] Tested on physical ARM64 device (if applicable)
 - [ ] No unrelated changes included
 - [ ] Commit messages follow Conventional Commits format
 - [ ] Documentation updated (if behavior changes)
+- [ ] Review findings left unfixed have issues, and rejected ones have a reason in the thread
 - [ ] Download scripts still work (if assets changed)
 - [ ] App builds without errors (`./gradlew assembleDebug`)
 


### PR DESCRIPTION
Fixes #19

## Why

Work turns up more than a change can carry: something adjacent, something pre-existing, something real but out of scope. Nothing in the guide said what happens to those, so in practice they were referenced by whatever was at hand — a position in a list, "the second one", a number that exists nowhere in this repository. Such a reference stops meaning anything as soon as the discussion scrolls away, and the finding is then either rediscovered at full cost or quietly assumed to be handled.

Two recent costs, both concrete:

- Work was carried out, reviewed and merged under a label that pointed at no issue anyone could open. It was twice called closed without the original text being read beside the code, because the original text was not anywhere it could be read.
- A defect raised during review was set aside with a reason that did not hold, left no trace, and had to be found again from scratch. Written down when first raised, re-examining it would have been minutes.

## What changed

A short section in `CONTRIBUTING.md` stating the three outcomes a finding can have — fixed in the same PR, an issue opened, or rejected with a reason in the thread — and one checklist item asking for them.

No tooling. The gap is a habit of using ephemeral identifiers, not a missing feature.
