### PR TITLE
docs: make the repository map match the shipped binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Contributing guide's repository map matches the shipped binaries again: the Python runtime never lived in `jniLibs` (and its version is not pinned), while git's HTTPS helper and the musl loader do live there and were missing
 - README brought back in line with how the project actually builds and installs: local builds fetch the prebuilt server rather than needing Node and Yarn to build VS Code, SSH ships as the bundled OpenSSH client and `ssh-keygen` rather than a command-palette flow, toolchains install on sideloaded devices too (direct download) rather than Play-only, and the size table now carries figures measured from the release AAB
 - Contributing guide: review findings that are not fixed in the same pull request now get an issue, and rejected ones a stated reason, so nothing is left referenced only by its position in a discussion
 - **The VS Code server is now built from the MIT-licensed Code - OSS source** instead of downloading Microsoft's proprietary pre-built server, which could not legally be modified and redistributed inside an APK. The build applies this repository's patches and branding to readable source, is verified for tree shape, architecture and branding before it ships, and is published once per VS Code version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,16 +130,17 @@ VSCodroid/
 │   │   │   │   └── extensions/           # Pre-bundled extensions
 │   │   │   ├── jniLibs/arm64-v8a/     # Native binaries (.so trick for exec permission)
 │   │   │   │   ├── libnode.so            # Node.js (~48 MB)
-│   │   │   │   ├── libpython.so          # Python launcher
-│   │   │   │   ├── libpython3.12.so      # Python shared library
+│   │   │   │   ├── libpython.so          # Python launcher (its libpython3.x.so
+│   │   │   │   │                         #   runtime lives in assets/usr/lib)
 │   │   │   │   ├── libgit.so             # Git
+│   │   │   │   ├── libgit-remote-curl.so # Git's HTTPS transport helper
 │   │   │   │   ├── libbash.so            # Bash
 │   │   │   │   ├── libtmux.so            # tmux
 │   │   │   │   ├── libmake.so            # make
 │   │   │   │   ├── libssh.so             # OpenSSH client
 │   │   │   │   ├── libssh-keygen.so      # ssh-keygen
 │   │   │   │   ├── libripgrep.so         # ripgrep (for VS Code Search)
-│   │   │   │   └── libc++_shared.so      # NDK C++ stdlib
+│   │   │   │   └── libldmusl.so          # musl loader (runs the Claude Code CLI)
 │   │   │   └── res/                   # Android resources, layouts
 │   │   └── build.gradle.kts
 │   ├── toolchain_go/              # Go on-demand asset pack


### PR DESCRIPTION
## Summary

The repository map in CONTRIBUTING.md drifted from the actual contents of `jniLibs/arm64-v8a/`. Verified against `ls` of the directory:

- **`libpython3.12.so` removed** — it has never lived in jniLibs. The Python runtime is extracted from `assets/usr/lib`, and its version is resolved from the package index at build time rather than pinned, so naming a versioned file in a document guarantees rot. The launcher's entry now points at where the runtime actually lives.
- **`libc++_shared.so` removed** — it ships in `assets/usr/lib` with the other shared libraries, not in jniLibs.
- **`libgit-remote-curl.so` added** — the HTTPS transport helper git executes for `https://` remotes.
- **`libldmusl.so` added** — the musl loader.

Documentation only.