### PR TITLE
build: pair the SQLite addon with the JavaScript it ships beside

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- The build now checks that the bundled SQLite database engine was compiled from the same version as the JavaScript shipped beside it, the last of the three native components without that check. A mismatch there shows up on device as chat failing to pick a model, an error several layers from its cause
 - Contributing guide's repository map matches the shipped binaries again: the Python runtime never lived in `jniLibs` (and its version is not pinned), while git's HTTPS helper and the musl loader do live there and were missing
 - README brought back in line with how the project actually builds and installs: local builds fetch the prebuilt server rather than needing Node and Yarn to build VS Code, SSH ships as the bundled OpenSSH client and `ssh-keygen` rather than a command-palette flow, toolchains install on sideloaded devices too (direct download) rather than Play-only, and the size table now carries figures measured from the release AAB
 - Contributing guide: review findings that are not fixed in the same pull request now get an issue, and rejected ones a stated reason, so nothing is left referenced only by its position in a discussion

--- a/scripts/build-native-addons.sh
+++ b/scripts/build-native-addons.sh
@@ -237,7 +237,8 @@ check_pair @parcel/watcher "$WATCHER_VERSION" "$OUTPUT_ROOT/node_modules/@parcel
 # are one call.
 echo ""
 echo "@vscode/sqlite3..."
-SQLITE_SRC=$(fetch @vscode/sqlite3 5.1.12-vscode)
+SQLITE_VERSION=5.1.12-vscode
+SQLITE_SRC=$(fetch @vscode/sqlite3 "$SQLITE_VERSION")
 SQLITE_AMALGAMATION="$SQLITE_SRC/sqlite-autoconf-3390400"
 if [ ! -d "$SQLITE_AMALGAMATION" ]; then
     tar xzf "$SQLITE_SRC/deps/sqlite-autoconf-3390400.tar.gz" -C "$SQLITE_SRC"
@@ -271,6 +272,8 @@ mkdir -p "$(dirname "$SQLITE_OUT")"
     "$WORK_DIR/sqlite3.o"
 "$STRIP" "$SQLITE_OUT"
 verify "$SQLITE_OUT" @vscode/sqlite3 || failed=1
+check_pair @vscode/sqlite3 "$SQLITE_VERSION" \
+    "$OUTPUT_ROOT/node_modules/@vscode/sqlite3/package.json" || failed=1
 
 echo ""
 [ "$failed" -eq 0 ] || { echo "=== FAILED ==="; exit 1; }


### PR DESCRIPTION
Fixes #35

## Why

`check_pair` exists because a native addon and the JavaScript it binds to are one unit. Between prerelease versions the private binding surface moves, so a mismatch is not a build failure here — it is a runtime failure on device.

`node-pty` and `@parcel/watcher` have been through that gate since it was written. `@vscode/sqlite3` was not, and its version was spelled inline at the fetch rather than named:

```sh
SQLITE_SRC=$(fetch @vscode/sqlite3 5.1.12-vscode)
```

A version with no name is a version nothing can be compared against, which is how it stayed the exception.

Its failure mode is also the least legible of the three. The addon is the workbench's storage engine and what the Copilot CLI session store opens through the embedder, so a mismatch surfaces as chat failing to pick a model — an error three layers from its cause, and the reason that block already carries a comment saying so.

## What changed

The version becomes `SQLITE_VERSION` and the block gains the same `check_pair` line the other two have, against the `package.json` in the server tree.

## Verification

Both directions, against the tree this repository actually ships, without building anything:

```
--- versions match (must pass) ---
  pairing: @vscode/sqlite3 JS matches native (5.1.12-vscode)          exit=0

--- version poisoned one patch off (must fail) ---
  ERROR: @vscode/sqlite3 native is built from 5.1.11-vscode
         but the shipped JS is 5.1.12-vscode                          exit=1

--- JS absent entirely (must fail closed) ---
  ERROR: @vscode/sqlite3 JS not present at ...; cannot verify pairing  exit=1
```

`bash -n` clean. Nothing else in the script changed.
