### PR TITLE
build: verify the Node headers against the published digest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- The Node.js headers the native components are compiled against are now checked against the digest nodejs.org publishes, the last download in the build that was still taken on trust
 - The build now checks that the bundled SQLite database engine was compiled from the same version as the JavaScript shipped beside it, the last of the three native components without that check. A mismatch there shows up on device as chat failing to pick a model, an error several layers from its cause
 - The build now checks every binary the Python bundling step installs — the runtime, the shared libraries and all 75 extension modules — rather than the launcher alone, and refuses to continue when a library is missing or pip did not install. It also removes standard libraries left over from an earlier Python version instead of shipping them alongside the current one
 - Contributing guide's repository map matches the shipped binaries again: the Python runtime never lived in `jniLibs` (and its version is not pinned), while git's HTTPS helper and the musl loader do live there and were missing

--- a/scripts/build-native-addons.sh
+++ b/scripts/build-native-addons.sh
@@ -79,9 +79,44 @@ NODE_INCLUDE="$WORK_DIR/node-v$NODE_VERSION/include/node"
 if [ ! -d "$NODE_INCLUDE" ]; then
     echo ""
     echo "Downloading Node v$NODE_VERSION headers..."
-    curl -fsSL --show-error \
-        "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-headers.tar.gz" \
-        | tar xz -C "$WORK_DIR"
+    # Downloaded to a file rather than piped into tar, because a pipe leaves
+    # nothing to hash. These headers define the ABI every addon here is compiled
+    # against, so a substituted archive is a substituted ABI -- and this was the
+    # last fetch in the tree still taking bytes on trust after every other one
+    # was made to verify.
+    #
+    # Same shape as download-npm.sh: nodejs.org publishes SHASUMS256.txt per
+    # release, and the digest is kept in a sidecar so an offline rebuild against
+    # an already-verified archive still verifies rather than dying in the fetch.
+    # With neither the network nor a sidecar, fail closed.
+    HEADERS_TARBALL="node-v$NODE_VERSION-headers.tar.gz"
+    HEADERS_PATH="$WORK_DIR/$HEADERS_TARBALL"
+    HEADERS_SIDECAR="$HEADERS_PATH.sha256"
+    [ -f "$HEADERS_PATH" ] || curl -fsSL --show-error \
+        "https://nodejs.org/dist/v$NODE_VERSION/$HEADERS_TARBALL" -o "$HEADERS_PATH"
+
+    expected=$(curl -sL "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt" 2>/dev/null \
+        | awk -v f="$HEADERS_TARBALL" '$2 == f { print $1; exit }' || true)
+    if [ -n "$expected" ]; then
+        printf '%s\n' "$expected" > "$HEADERS_SIDECAR"
+    elif [ -f "$HEADERS_SIDECAR" ]; then
+        expected=$(cat "$HEADERS_SIDECAR")
+        echo "  sha256: using cached digest (SHASUMS256.txt unreachable)"
+    fi
+    if [ -z "$expected" ]; then
+        echo "  ERROR: no digest for $HEADERS_TARBALL (SHASUMS256.txt unreachable, no cached sidecar)" >&2
+        exit 1
+    fi
+    actual=$( (sha256sum "$HEADERS_PATH" 2>/dev/null || shasum -a 256 "$HEADERS_PATH") | cut -d' ' -f1)
+    if [ "$actual" != "$expected" ]; then
+        echo "  ERROR: $HEADERS_TARBALL does not match SHASUMS256.txt" >&2
+        echo "    published : $expected" >&2
+        echo "    downloaded: $actual" >&2
+        rm -f "$HEADERS_PATH"
+        exit 1
+    fi
+    echo "  sha256  : verified"
+    tar xz -C "$WORK_DIR" -f "$HEADERS_PATH"
 fi
 [ -d "$NODE_INCLUDE" ] || { echo "ERROR: headers missing at $NODE_INCLUDE" >&2; exit 1; }
 


### PR DESCRIPTION
Fixes #45

## Why

Every other download in the tree verifies a digest and fails closed on a mismatch. This one was missed, and it is easy to see why — it predates that sweep under a different filename, and it never looked like a download:

```sh
curl -fsSL --show-error \
    "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-headers.tar.gz" \
    | tar xz -C "$WORK_DIR"
```

A pipe leaves nothing to hash.

These headers define the ABI every native addon here is compiled against, so a substituted archive is a substituted ABI. That would not fail in the build — it would fail at `dlopen` on a device, which is the failure mode this project has spent the most effort learning to prevent.

## What changed

The archive is downloaded to a file, verified, then extracted. Same shape as `download-npm.sh`, which fetches from the same host: the digest comes from the `SHASUMS256.txt` nodejs.org publishes per release, kept in a sidecar so an offline rebuild against an already-verified archive still verifies rather than dying in the fetch. With neither the network nor a sidecar, it fails closed.

## Verification

The block run in isolation against a scratch work directory, both directions:

```
=== clean run ===
Downloading Node v24.18.0 headers...
  sha256  : verified
exit=0
  -> node-v24.18.0/include/node/ extracted

=== byte appended to the archive, network blocked ===
  sha256: using cached digest (SHASUMS256.txt unreachable)
  ERROR: node-v24.18.0-headers.tar.gz does not match SHASUMS256.txt
    published : 6c7d41d8...37887
    downloaded: be767599...b7f81
```

The second case also exercises the sidecar path, which is the offline-rebuild reason it exists.
