### PR TITLE
fix(ci): sweep bundled extensions the build no longer manages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,12 @@ jobs:
             android/app/src/main/assets/extensions/
             android/app/src/main/jniLibs/arm64-v8a/
             server/vscode-reh/
-          key: assets-${{ hashFiles('VSCODE_VERSION', 'patches/**', 'branding/**', 'scripts/build-vscode-oss.sh', '.github/workflows/build-vscode-oss.yml', 'scripts/fetch-vscode-oss.sh', 'scripts/verify-server-tree.py', 'scripts/download-termux-tools.sh', 'scripts/download-node.sh', 'scripts/download-npm.sh', 'scripts/download-python.sh', 'scripts/download-extensions.sh', 'scripts/download-musl-loader.sh', 'scripts/build-native-addons.sh', 'scripts/build-glibc-shim.sh', 'scripts/glibc-shim.c', 'scripts/gen-glibc-forwarders.py') }}
+          key: assets-${{ hashFiles('VSCODE_VERSION', 'patches/**', 'branding/**', 'scripts/build-vscode-oss.sh', '.github/workflows/build-vscode-oss.yml', 'scripts/fetch-vscode-oss.sh', 'scripts/verify-server-tree.py', 'scripts/download-termux-tools.sh', 'scripts/download-node.sh', 'scripts/download-npm.sh', 'scripts/download-python.sh', 'scripts/download-extensions.sh', 'scripts/download-musl-loader.sh', 'scripts/build-native-addons.sh', 'scripts/build-glibc-shim.sh', 'scripts/glibc-shim.c', 'scripts/gen-glibc-forwarders.py', 'android/app/src/main/assets/extensions/**') }}
+          # The fallback is what let a removed extension come back: it restores
+          # any earlier tree, and the run then saves that tree forward under its
+          # own key. It stays, because a partial hit still saves most of a build
+          # -- download-extensions.sh now sweeps what it no longer manages, so a
+          # restored tree is corrected rather than inherited.
           restore-keys: |
             assets-
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Extensions dropped from the bundled set are now removed from the build tree instead of lingering and shipping in development builds
 - The Node.js headers the native components are compiled against are now checked against the digest nodejs.org publishes, the last download in the build that was still taken on trust
 - The build now checks that the bundled SQLite database engine was compiled from the same version as the JavaScript shipped beside it, the last of the three native components without that check. A mismatch there shows up on device as chat failing to pick a model, an error several layers from its cause
 - The build now checks every binary the Python bundling step installs — the runtime, the shared libraries and all 75 extension modules — rather than the launcher alone, and refuses to continue when a library is missing or pip did not install. It also removes standard libraries left over from an earlier Python version instead of shipping them alongside the current one

--- a/scripts/download-extensions.sh
+++ b/scripts/download-extensions.sh
@@ -46,6 +46,37 @@ OPENVSX_API="https://open-vsx.org/api"
 echo "=== Downloading bundled extensions from Open VSX ==="
 
 mkdir -p "$ASSETS_DIR"
+
+# Remove extensions this script no longer manages, before placing the ones it
+# does. Nothing here ever deleted, and the loop below skips a directory that
+# already exists -- so an extension dropped from the list above stayed in the
+# tree and shipped, which is how a removed 22 MB extension kept appearing in
+# APKs long after it was taken out. In CI it also came back from the assets
+# cache: restore-keys falls back to any earlier tree, and without this sweep
+# the run then saved that tree forward under its own key.
+#
+# The discriminator is git, not a name pattern: this project's own extensions
+# are committed here, downloaded ones are not. Where git cannot answer, keep
+# everything -- a sweep that guesses is worse than no sweep at all.
+if git -C "$ROOT_DIR" rev-parse --git-dir >/dev/null 2>&1; then
+    managed=""
+    for entry in "${EXTENSIONS[@]}"; do
+        managed="$managed ${entry%@*}-${entry##*@}"
+    done
+    for dir in "$ASSETS_DIR"/*/; do
+        [ -d "$dir" ] || continue
+        name=$(basename "$dir")
+        case " $managed " in *" $name "*) continue ;; esac
+        if git -C "$ROOT_DIR" ls-files --error-unmatch \
+            "android/app/src/main/assets/extensions/$name" >/dev/null 2>&1; then
+            continue
+        fi
+        echo "  Removing extension no longer bundled: $name ($(du -sh "$dir" | cut -f1))"
+        rm -rf "$dir"
+    done
+else
+    echo "  NOTE: not a git checkout; leaving existing extension directories alone"
+fi
 mkdir -p "$WORK_DIR"
 
 for EXT_SPEC in "${EXTENSIONS[@]}"; do


### PR DESCRIPTION
Fixes #42

## Why

Nothing removed extension directories, and the download loop skips one that already exists:

```sh
if [ -d "$DEST_DIR" ] && [ -f "$DEST_DIR/package.json" ]; then
    echo "  Already extracted: $DIR_NAME (skipping)"
    continue
fi
```

So an extension dropped from the list stayed in the tree and shipped. A 22 MB extension removed months ago kept turning up in development builds for exactly this reason, along with five superseded version pins sitting beside their replacements.

CI made it durable rather than transient. The assets cache falls back through `restore-keys: assets-` to any earlier tree, and the run then saved that tree forward under its own key — so a removal had to survive not just one build but every cached ancestor of it.

The device side does not rescue this: reconciliation keeps whatever the APK carries.

Release builds were never affected — `release.yml` has no assets cache. The cost was PR builds and device testing, which is where most looking happens.

## What changed

A sweep before placement, using **git as the discriminator rather than a name pattern**: this project's own extensions are committed under `assets/extensions/`, downloaded ones are not. Where git cannot answer — a source tree without a checkout — it keeps everything and says so, because a sweep that guesses is worse than no sweep.

`restore-keys` stays. A partial hit still saves most of a build, and a restored tree is now corrected rather than inherited. The committed extension sources join the cache key so a change to one of the three misses rather than resolving to a stale neighbour.

## Verification

Seeded a tree with both shapes this produces — an extension removed from the list, and a superseded pin beside its replacement:

```
before:  PKief.material-icon-theme-5.35.0
         eamodio.gitlens-2026.3.1505
         vscodroid.vscodroid-process-monitor-1.0.0
         vscodroid.vscodroid-saf-bridge-1.0.0
         vscodroid.vscodroid-welcome-1.0.0

  Removing extension no longer bundled: PKief.material-icon-theme-5.35.0
  Removing extension no longer bundled: eamodio.gitlens-2026.3.1505

after:   vscodroid.vscodroid-process-monitor-1.0.0
         vscodroid.vscodroid-saf-bridge-1.0.0
         vscodroid.vscodroid-welcome-1.0.0
```

Both removed, all three committed extensions untouched. `bash -n` and YAML parse clean.
