### PR TITLE
feat(webview): allow previewing a dev server at its network address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The Java toolchain is now checked the same way, completing the set — every downloadable toolchain is examined before it is packaged
 
 ### Added
+- You can now preview your own dev server at the device's network address from inside the editor, not only at `localhost` — the same thing a laptop does when you check how a page looks from another machine on the same Wi-Fi
 - **GitHub Copilot Chat now works on device**: the bundled extension's platform packages are aliased under the name Android resolves, its SDK entry ships again, and `@vscode/sqlite3` is rebuilt for Bionic so model selection completes end to end
 - **Claude Code extension support**: the marketplace serves its musl build, the CLI starts through the bundled musl loader, and a loopback DNS proxy gives musl binaries working name resolution
 - A glibc compatibility shim: prebuilt glibc-only native addons (spdlog, sqlite3 and friends) now load against Bionic through versioned forwarder stubs instead of dying at `dlopen`. It supplies what Bionic has no equivalent for — the `__isoc99_` scanf family, the `tolower`/`toupper` character tables, and `copy_file_range` on devices below Android 14 — and translates what the two libraries number differently, so `getaddrinfo` and `getnameinfo` answer the question the addon actually asked instead of a differently-numbered one

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,11 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <!-- Default: HTTPS only for all external traffic -->
-    <base-config cleartextTrafficPermitted="false" />
+    <!-- Cleartext is permitted because this app is a development environment, and
+         the thing being developed is served over plain HTTP by every framework
+         there is. A dev server on this device answers at the device's own network
+         address, and previewing it in the editor - or reaching it from a laptop on
+         the same Wi-Fi - is the point of the product, not an edge case.
 
-    <!-- Exception: allow cleartext HTTP for localhost only (VS Code Server) -->
-    <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="false">localhost</domain>
-        <domain includeSubdomains="false">127.0.0.1</domain>
-    </domain-config>
+         The obvious narrower rule cannot be written. Network security config
+         matches <domain> entries by hostname, an exact string with an optional
+         subdomain flag; it understands neither CIDR notation nor address ranges,
+         so "any private address" has no spelling here. The addresses in question
+         are also not known at build time - they change with the network the device
+         joins - and this file is static XML compiled into the APK, so they cannot
+         be added later either. The choice was between permitting cleartext and
+         telling users their own app is unreachable from the editor.
+
+         What this does not change: every remote service the editor talks to - the
+         extension marketplace, extension downloads, resource fetches - is HTTPS
+         and stays HTTPS. What changes is that the platform is no longer the thing
+         enforcing that.
+
+         Reachability from other devices is a separate matter: Android's local
+         network permission gates inbound connections from SDK 37 onward, and that
+         needs a manifest permission rather than anything in this file. -->
+    <base-config cleartextTrafficPermitted="true" />
 </network-security-config>


### PR DESCRIPTION
## Summary

The editor could only load a dev server at `localhost`. Opening the same server at the device's own network address — `http://192.168.1.42:5173`, the address a laptop on the same Wi-Fi would use — was refused by the platform before the request left the app.

Checking that your page renders correctly at the address someone else will reach it on is not an edge case for this project; on a laptop it is unremarkable.

## Why the narrow rule is not there

The obvious change is to permit the private address ranges. That cannot be written: Android's network security configuration matches `<domain>` entries by hostname — an exact string with an optional subdomain flag — and understands neither CIDR notation nor address ranges. The addresses are also unknown at build time, since they change with the network the device joins, and the file is static XML compiled into the APK.

So the choice was between permitting cleartext and telling users their own app is unreachable from the editor. The reasoning is written into the file rather than left in a commit message, because the next person to read that config will ask the same question.

## Cost, stated plainly

Every remote service the editor talks to — the extension marketplace, extension downloads, resource fetches — is HTTPS and stays HTTPS. What changes is that the platform is no longer the thing enforcing it.

## Verification

The configuration parses, and CI builds the APK with it. The behavioural check that matters — loading `http://<device-address>:<port>` in the editor — needs a device on a real network with a dev server running, and is worth doing before this ships rather than trusting the config alone.

## Related

Reachability from *other* devices depends on the local network permission, which is a manifest change and a separate concern — see #57. This PR only removes the restriction on the editor loading a plain-HTTP address.

Fixes #53