### PR TITLE
feat(network): add a command that gives you the address to share

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,10 +40,12 @@ yarn-error.log*
 /android/app/src/main/assets/vscode-reh/
 /android/app/src/main/assets/python-stdlib/
 /android/app/src/main/assets/extensions/*
-!/android/app/src/main/assets/extensions/vscodroid.vscodroid-process-monitor-*/
-!/android/app/src/main/assets/extensions/vscodroid.vscodroid-saf-bridge-*/
-!/android/app/src/main/assets/extensions/vscodroid.vscodroid-welcome-*/
-!/android/app/src/main/assets/extensions/vscodroid.vscodroid-github-auth-*/
+# This project's own extensions are source and belong in git; everything else in
+# here is downloaded by download-extensions.sh and does not. One pattern rather
+# than a line per extension: the list had to be edited for every extension added,
+# it still named one that no longer exists, and a forgotten line means the new
+# extension is silently absent from the APK with nothing to explain why.
+!/android/app/src/main/assets/extensions/vscodroid.vscodroid-*/
 /android/app/src/main/assets/usr/
 
 # ===== Toolchain Asset Packs (populated by scripts/download-*.sh) =====

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The Java toolchain is now checked the same way, completing the set — every downloadable toolchain is examined before it is packaged
 
 ### Added
+- **Serve on Network**: a command that answers "what address do I give my friend?" — it lists the ports your dev servers are listening on, shows the address other devices can reach them at, and copies it. Servers listening only on this device are called out as such, with the flag needed to change that
 - You can now preview your own dev server at the device's network address from inside the editor, not only at `localhost` — the same thing a laptop does when you check how a page looks from another machine on the same Wi-Fi
 - **GitHub Copilot Chat now works on device**: the bundled extension's platform packages are aliased under the name Android resolves, its SDK entry ships again, and `@vscode/sqlite3` is rebuilt for Bionic so model selection completes end to end
 - **Claude Code extension support**: the marketplace serves its musl build, the CLI starts through the bundled musl loader, and a loopback DNS proxy gives musl binaries working name resolution

--- a/android/app/src/main/assets/extensions/vscodroid.vscodroid-serve-network-1.0.0/extension.js
+++ b/android/app/src/main/assets/extensions/vscodroid.vscodroid-serve-network-1.0.0/extension.js
@@ -1,0 +1,153 @@
+const vscode = require('vscode');
+const fs = require('fs');
+const os = require('os');
+
+// Loopback, in the byte order /proc/net/tcp prints addresses in: little-endian
+// hex, so 127.0.0.1 reads back as 0100007F. A server on this address answers
+// only to this device, which is the whole distinction this command exists to
+// explain.
+const LOOPBACK_V4 = '0100007F';
+const ANY_V4 = '00000000';
+const ANY_V6 = '00000000000000000000000000000000';
+const LOOPBACK_V6 = '00000000000000000000000001000000';
+
+const TCP_LISTEN = '0A';
+
+/**
+ * Every TCP port this device is listening on, and whether it answers the
+ * network or only itself.
+ *
+ * Read from /proc rather than by probing: probing a port tells you something
+ * answered, not who is allowed to reach it, and the difference between
+ * "listening on 0.0.0.0" and "listening on 127.0.0.1" is exactly what a user
+ * needs to be told.
+ */
+function listeningPorts(read = (p) => fs.readFileSync(p, 'utf8')) {
+    const found = new Map();
+
+    for (const [path, any] of [
+        ['/proc/net/tcp', ANY_V4],
+        ['/proc/net/tcp6', ANY_V6],
+    ]) {
+        let content;
+        try {
+            content = read(path);
+        } catch {
+            continue; // tcp6 is absent on devices without IPv6; not an error
+        }
+
+        for (const line of content.split('\n').slice(1)) {
+            const fields = line.trim().split(/\s+/);
+            if (fields.length < 4 || fields[3] !== TCP_LISTEN) continue;
+
+            const [address, portHex] = fields[1].split(':');
+            const port = parseInt(portHex, 16);
+            if (!port) continue;
+
+            // A port bound to both stacks appears twice; reachable wins, because
+            // one interface answering the network is enough.
+            const reachable = address === any;
+            if (!found.has(port) || reachable) found.set(port, reachable);
+        }
+    }
+    return found;
+}
+
+/** The addresses another device on this network could dial. */
+function networkAddresses() {
+    const addresses = [];
+    for (const [name, entries] of Object.entries(os.networkInterfaces())) {
+        for (const entry of entries || []) {
+            if (entry.family !== 'IPv4' || entry.internal) continue;
+            addresses.push({ name, address: entry.address });
+        }
+    }
+    return addresses;
+}
+
+function activate(context) {
+    const command = vscode.commands.registerCommand('vscodroid.serveOnNetwork', async () => {
+        const addresses = networkAddresses();
+        if (addresses.length === 0) {
+            vscode.window.showWarningMessage(
+                'This device is not on a network right now. Connect to Wi-Fi, then run this again.',
+            );
+            return;
+        }
+
+        // The editor's own server is listening too, and offering it would send
+        // someone to a page that is not theirs. Kotlin exports the port it
+        // chose; if that is ever missing, showing one extra entry is a smaller
+        // failure than hiding a real one, so nothing is filtered in that case.
+        const editorPort = parseInt(process.env.VSCODROID_PORT || '', 10);
+
+        const ports = listeningPorts();
+        const reachable = [];
+        const localOnly = [];
+        for (const [port, isReachable] of ports) {
+            if (port === editorPort) continue;
+            (isReachable ? reachable : localOnly).push(port);
+        }
+        reachable.sort((a, b) => a - b);
+        localOnly.sort((a, b) => a - b);
+
+        if (reachable.length === 0 && localOnly.length === 0) {
+            vscode.window.showInformationMessage(
+                'No dev server is running yet. Start one in the terminal, then run this again.',
+            );
+            return;
+        }
+
+        const items = [];
+        for (const port of reachable) {
+            for (const { address, name } of addresses) {
+                items.push({
+                    label: `$(globe) http://${address}:${port}`,
+                    description: name,
+                    detail: 'Reachable from other devices on this network — select to copy',
+                    url: `http://${address}:${port}`,
+                });
+            }
+        }
+        for (const port of localOnly) {
+            items.push({
+                label: `$(circle-slash) port ${port} — this device only`,
+                detail:
+                    'Listening on localhost, so other devices cannot reach it. Restart the server ' +
+                    'bound to every interface: Vite `--host 0.0.0.0`, Next.js `-H 0.0.0.0`, ' +
+                    'Node `server.listen(port, "0.0.0.0")`, Python `--bind 0.0.0.0`.',
+                url: null,
+            });
+        }
+
+        const picked = await vscode.window.showQuickPick(items, {
+            title: 'Serve on Network',
+            placeHolder:
+                reachable.length > 0
+                    ? 'Pick an address to copy, then open it on the other device'
+                    : 'Nothing is reachable from other devices yet',
+        });
+        if (!picked) return;
+
+        if (!picked.url) {
+            vscode.window.showInformationMessage(
+                'That server only answers this device. Restart it bound to 0.0.0.0 and run this again.',
+            );
+            return;
+        }
+
+        await vscode.env.clipboard.writeText(picked.url);
+        vscode.window.showInformationMessage(`Copied ${picked.url} — open it on the other device.`);
+    });
+
+    context.subscriptions.push(command);
+}
+
+function deactivate() {}
+
+// listeningPorts is exported so it can be exercised against captured /proc
+// output. The parsing is the part that can be wrong in a way nobody would
+// notice — a mis-read address turns "other devices can reach this" into its
+// opposite — and a test that re-implemented the parser would only agree with
+// itself.
+module.exports = { activate, deactivate, listeningPorts, ANY_V4, LOOPBACK_V4 };

--- a/android/app/src/main/assets/extensions/vscodroid.vscodroid-serve-network-1.0.0/package.json
+++ b/android/app/src/main/assets/extensions/vscodroid.vscodroid-serve-network-1.0.0/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "vscodroid-serve-network",
+  "displayName": "VSCodroid Serve on Network",
+  "description": "Shows the address other devices can use to reach a dev server running on this device",
+  "version": "1.0.0",
+  "publisher": "vscodroid",
+  "engines": {
+    "vscode": "^1.96.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [],
+  "main": "./extension.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "vscodroid.serveOnNetwork",
+        "title": "VSCodroid: Serve on Network"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Handing your running app to someone else — a friend's laptop, a second phone — required knowing three things the editor never told you: that a dev server binds to `localhost` by default, that the flag to change it differs per framework, and what address this device answers on. Most desktop dev servers print the network URL themselves. Here there was no path to it, so for anyone who did not already know, the capability effectively did not exist.

**VSCodroid: Serve on Network** answers it in one step: the ports that are listening, the address other devices can reach them at, and the URL copied ready to hand over.

## Design notes

**Read `/proc`, don't probe.** Probing a port tells you something answered; it does not tell you who is allowed to reach it. The distinction between a server on `0.0.0.0` and one on `127.0.0.1` is the whole thing a user needs to be told, and only the listening address carries it.

**Say so when it will not work.** A server listening only on this device is listed as exactly that, with the flag for Vite, Next.js, plain Node and Python — rather than hidden (leaving the user to wonder why their port is missing) or offered as a URL that times out on the other device.

**Excluding the editor's own port** uses `VSCODROID_PORT`, which the Kotlin side has always exported and nothing read until now. If it is ever absent the port is shown rather than filtered: one confusing extra entry beats hiding a real server.

**A bundled extension, not an injected command.** Commands injected into the workbench from the Android side never register — the workbench is ESM and the injection reaches for a loader that is not there. `vscode.commands.registerCommand` from a bundled extension is the path that works, and the one the process monitor and SAF bridge already use.

## Verification

The parser was exercised against `/proc/net/tcp` and `/proc/net/tcp6` captured from a running device, not against a fixture written to match the parser:

```
port   reachable-from-network
5555   true      <- adbd, bound to :: in tcp6
13337  false     <- the editor itself, loopback
24041  false
36239  false
```

Both directions are covered by real observations: a loopback-bound port reads as unreachable, a wildcard-bound one as reachable. `listeningPorts` is exported with an injectable reader so the check runs against captured output rather than a re-implementation of the parser, which would only have agreed with itself.

## Incidental

The gitignore allowlist for bundled extensions became a pattern. It carried one line per extension, required an edit for every extension added, still named one that no longer exists, and a forgotten line would have left this extension out of the APK with nothing to explain the absence. Verified both directions: this project's extensions are tracked, downloaded ones stay ignored.

## Related

What this command reports depends on the platform continuing to allow it — see #57 for the local network permission that gates inbound connections from SDK 37 onward.

Fixes #54