### PR TITLE
build: refuse a bundle Play would reject for size

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,6 +242,14 @@ jobs:
           VSCODROID_KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         run: ./gradlew bundleRelease
 
+      # Before the release is published, because the alternative is finding out
+      # at Play upload with the GitHub release already public -- one version
+      # shipping through two channels with different contents.
+      - name: Check the bundle against Play's size limits
+        run: |
+          python3 scripts/check-bundle-size.py \
+            android/app/build/outputs/bundle/release/app-release.aab
+
       - name: Package toolchain ZIPs
         run: |
           bash scripts/package-toolchains.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- The release now checks the app bundle against the store's size limits before publishing anything, rather than measuring it and carrying on. A bundle that has grown too large previously failed at store upload with the download release already public, leaving one version shipping through two channels with different contents
 - Extensions dropped from the bundled set are now removed from the build tree instead of lingering and shipping in development builds
 - The Node.js headers the native components are compiled against are now checked against the digest nodejs.org publishes, the last download in the build that was still taken on trust
 - The build now checks that the bundled SQLite database engine was compiled from the same version as the JavaScript shipped beside it, the last of the three native components without that check. A mismatch there shows up on device as chat failing to pick a model, an error several layers from its cause

--- a/scripts/check-bundle-size.py
+++ b/scripts/check-bundle-size.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Refuse a bundle that Play would reject for size.
+
+    check-bundle-size.py <app.aab>
+
+The release workflow measured the artifacts and gated nothing, so a base module
+grown past Play's cap failed at upload -- after the GitHub release was already
+public. One version then ships through two channels with different contents:
+sideloaders get the new APK and toolchain ZIPs, Play still serves the previous
+version.
+
+What this measures, and why it is safe in the direction that matters
+--------------------------------------------------------------------
+Play's limit applies to the compressed download for one device configuration.
+A bundle carries every configuration, so a per-module total taken from it is
+greater than or equal to any single device's download. This check can therefore
+be stricter than Play but never more permissive: a bundle it passes cannot be
+one Play rejects for module size. It does not reproduce Play's own number and
+does not try to.
+
+What it does not cover -- stated rather than implied
+----------------------------------------------------
+Delivery mode (install-time, fast-follow, on-demand) lives in each module's
+binary AndroidManifest and BundleConfig.pb, neither of which is read here. So:
+
+  * the 4 GB cumulative cap on modules plus install-time packs is NOT checked,
+    because which packs are install-time is not visible without parsing those;
+  * the 30 GB on-demand budget is NOT checked and cannot be -- it is
+    account-wide, not a property of one bundle.
+
+Both are printed as uncovered every run. A gate that lists only what it checked
+reads as though it checked everything, which is the failure this repository has
+already shipped once.
+"""
+
+import pathlib
+import sys
+import zipfile
+
+MIB = 1024 * 1024
+
+# support.google.com/googleplay/android-developer/answer/9859372
+BASE_CAP_MIB = 500
+PACK_CAP_MIB = 1536
+
+# Not modules: bundle-level metadata and the config protobuf.
+NOT_A_MODULE = {"BUNDLE-METADATA", "META-INF", "BundleConfig.pb"}
+
+
+def module_sizes(aab):
+    """Compressed and uncompressed bytes per top-level module."""
+    sizes = {}
+    with zipfile.ZipFile(aab) as z:
+        for info in z.infolist():
+            if info.is_dir():
+                continue
+            module = info.filename.split("/")[0]
+            if module in NOT_A_MODULE:
+                continue
+            comp, raw = sizes.get(module, (0, 0))
+            sizes[module] = (comp + info.compress_size, raw + info.file_size)
+    return sizes
+
+
+def main(argv) -> int:
+    if len(argv) != 2:
+        print("usage: check-bundle-size.py <app.aab>", file=sys.stderr)
+        return 2
+    aab = pathlib.Path(argv[1])
+    if not aab.is_file():
+        print(f"  FAIL   {aab} is not a file", file=sys.stderr)
+        return 1
+
+    sizes = module_sizes(aab)
+    # An empty result would pass every comparison below. That is the shape this
+    # gate exists to remove, so it is fatal rather than a silent success.
+    if not sizes:
+        print(f"  FAIL   no modules found in {aab.name}; the bundle layout changed")
+        return 1
+
+    failed = False
+    for module, (comp, raw) in sorted(sizes.items(), key=lambda kv: -kv[1][0]):
+        cap = BASE_CAP_MIB if module == "base" else PACK_CAP_MIB
+        over = comp / MIB > cap
+        status = "FAIL  " if over else "ok    "
+        print(f"  {status} {module:<18} {comp / MIB:8.1f} MiB compressed "
+              f"({raw / MIB:7.1f} MiB raw)  cap {cap} MiB")
+        if over:
+            print(f"         Play refuses this at upload. Reduce {module} or move "
+                  f"content into an on-demand pack.")
+            failed = True
+
+    print()
+    print("  not covered by this check:")
+    print("    - the 4 GB cumulative cap on modules plus install-time packs")
+    print("      (delivery mode is not readable without parsing binary manifests)")
+    print("    - the 30 GB on-demand pack budget (account-wide, not in a bundle)")
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
## Summary

The release workflow measured the artifacts and gated nothing. A base module grown past Play's compressed-download cap fails at upload — **after** the GitHub release is already public. One version then ships through two channels with different contents: sideloaders get the new APK and toolchain ZIPs, while Play still serves the previous version.

The margin is not obviously large: `base` measured 134.2 MiB compressed at v1.0.0 against a 500 MB cap, and the server tree has moved from VS Code 1.96.4 to 1.133.0 since.

## What it measures

Sizes come from the bundle rather than being written down, so the check cannot drift from what ships. Against the current signed AAB it reproduces the figures already recorded elsewhere exactly:

```
ok     base                  134.2 MiB compressed (  388.4 MiB raw)  cap 500 MiB
ok     toolchain_java         52.7 MiB compressed (  146.0 MiB raw)  cap 1536 MiB
ok     toolchain_go           48.8 MiB compressed (  162.9 MiB raw)  cap 1536 MiB
ok     toolchain_ruby          8.8 MiB compressed (   28.6 MiB raw)  cap 1536 MiB
```

## What it deliberately is not

This does not reproduce Play's own number. Play's limit applies to the compressed download for **one device configuration**, while a bundle carries every configuration — so a per-module total taken from the bundle is greater than or equal to any single device's download. The check can therefore be stricter than Play and **never more permissive**: a bundle it passes cannot be one Play rejects for module size.

It prints what it does not cover on every run, rather than letting the reader assume:

- the **4 GB cumulative cap** on modules plus install-time packs is not checked — delivery mode lives in each module's binary manifest and `BundleConfig.pb`, neither of which is parsed here;
- the **30 GB on-demand budget** is account-wide and not a property of a bundle at all.

A gate that lists only what it checked reads as though it checked everything.

## Verification

| Case | Result |
| --- | --- |
| Module over its cap | fails, **names the module**, exit 1 |
| Bundle with no modules | fatal — not a vacuous pass |
| `BUNDLE-METADATA` holding a 2 MiB blob | excluded from module totals |
| Real signed AAB, real caps | exit 0 |

The over-cap case was tested with a synthetic bundle and a copy of the script carrying tiny caps, so the comparison logic is what is under test rather than the constants — and no test-only knob had to be added to the shipped script.

Fixes #62
