### PR TITLE
fix(build): refuse a bundle with no base module

### DIFF
--- a/scripts/check-bundle-size.py
+++ b/scripts/check-bundle-size.py
@@ -77,6 +77,14 @@ def main(argv) -> int:
     if not sizes:
         print(f"  FAIL   no modules found in {aab.name}; the bundle layout changed")
         return 1
+    # And so would a bundle with asset packs but no base module: every pack sits
+    # far under the larger per-pack cap, so the run prints nothing but "ok" while
+    # the one module carrying the 500 MB limit was never examined. The empty case
+    # above was guarded and this one, which is the same shape, was not.
+    if "base" not in sizes:
+        print(f"  FAIL   no base module in {aab.name}; "
+              f"found {', '.join(sorted(sizes))}")
+        return 1
 
     failed = False
     for module, (comp, raw) in sorted(sizes.items(), key=lambda kv: -kv[1][0]):


### PR DESCRIPTION
## Summary

The bundle size check guarded the empty-bundle case and missed the one immediately next to it.

A bundle carrying asset packs but **no base module** passed cleanly. Every pack sits far under the larger per-pack cap, so the run printed nothing but `ok` — while the single module that carries the 500 MB limit was never examined at all.

```
before:  ok     toolchain_go   0.0 MiB compressed  cap 1536 MiB
         exit 0

after:   FAIL   no base module in nobase.aab; found toolchain_go
         exit 1
```

This is the same shape as the case that was already fatal — a comparison with nothing on the left reads exactly like a comparison that passed. The empty bundle is the case you think of; this one is not.

## Verification

| Case | Before | After |
| --- | --- | --- |
| Asset packs, no base | exit 0 (silent pass) | exit 1, names what it found |
| Bundle with no modules at all | exit 1 | exit 1 |
| Real signed AAB | exit 0 | exit 0 |