### PR TITLE
ci: keep dev servers reachable across the targetSdk bump

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,6 +48,13 @@ jobs:
       - name: Check the documented build steps match the workflows
         run: python3 scripts/check-build-steps.py
 
+      # Reads two files and no assets, so it runs beside the other cheap check
+      # rather than inside the build. What it guards arrives a whole release
+      # after the change that causes it: raising targetSdk closes the local
+      # network, and the symptom is a friend's browser timing out.
+      - name: Check local network access survives the targetSdk in use
+        run: python3 scripts/check-local-network-permission.py
+
       - name: Run lint
         working-directory: android
         run: ./gradlew lint

--- a/scripts/check-local-network-permission.py
+++ b/scripts/check-local-network-permission.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Keep serving your app to other devices working across the targetSdk bump.
+
+    check-local-network-permission.py
+
+Running a dev server and handing the address to someone on the same Wi-Fi is
+what this project exists for. Android is closing that path behind a permission,
+and the closing is scheduled rather than hypothetical:
+
+  * Android 16 -- opt-in. Local network access is open by default, which is why
+    a server bound to 0.0.0.0 is reachable from another device today.
+  * Android 17, and any app targeting SDK 37 or later -- blocked by default.
+    ACCESS_LOCAL_NETWORK must be declared and granted at runtime. The platform
+    documentation lists "Accepting an incoming TCP connection" as requiring it,
+    so this covers a server running here being reached from elsewhere, not only
+    this app reaching out.
+
+Nothing announces that at build time. Raising targetSdk to 37 would produce a
+green build, a working editor, and dev servers that no other device can reach --
+with no error the user can act on, because their friend's browser simply times
+out. The failure would arrive one release after the change that caused it.
+
+So this asserts the pair: at targetSdk 37 or above, the manifest declares the
+permission. It is deliberately not a demand to declare it now. The permission
+would appear in the Play listing today for a capability the platform does not
+yet withhold, and asking for something before it is needed is its own cost.
+
+What this does not check, because it cannot: whether the runtime request is
+actually made and handled when refused. A declaration is necessary and not
+sufficient. Whoever raises targetSdk has to do that part, and this check exists
+to make sure they find out from the build rather than from a review.
+"""
+
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+GRADLE = ROOT / "android/app/build.gradle.kts"
+MANIFEST = ROOT / "android/app/src/main/AndroidManifest.xml"
+
+PERMISSION = "android.permission.ACCESS_LOCAL_NETWORK"
+ENFORCED_FROM_SDK = 37
+
+
+def fail(message: str) -> int:
+    print(f"  FAIL   {message}", file=sys.stderr)
+    return 1
+
+
+def main() -> int:
+    if not GRADLE.is_file():
+        return fail(f"{GRADLE.relative_to(ROOT)} is missing; this check cannot run")
+    if not MANIFEST.is_file():
+        return fail(f"{MANIFEST.relative_to(ROOT)} is missing; this check cannot run")
+
+    gradle = GRADLE.read_text()
+    match = re.search(r"^\s*targetSdk\s*=\s*(\d+)", gradle, re.MULTILINE)
+    if not match:
+        # Not "assume it is fine": a targetSdk that cannot be read is a check
+        # that cannot answer, and answering anyway is how a gate starts lying.
+        return fail(
+            f"no targetSdk found in {GRADLE.relative_to(ROOT)}; "
+            "the check cannot tell whether the permission is required"
+        )
+
+    target = int(match.group(1))
+    declared = PERMISSION in MANIFEST.read_text()
+
+    if target < ENFORCED_FROM_SDK:
+        state = "declared" if declared else "not declared"
+        print(f"  ok     targetSdk {target}: local network access is implicit "
+              f"({PERMISSION} {state})")
+        return 0
+
+    if not declared:
+        return fail(
+            f"targetSdk {target} withholds local network access, and "
+            f"{PERMISSION}\n"
+            "         is not declared in the manifest. Dev servers running on "
+            "this device would\n"
+            "         stop being reachable from other devices, with nothing to "
+            "tell the user why.\n"
+            "         Declare the permission, request it at runtime where the "
+            "user asks to serve\n"
+            "         on the network, and keep working when it is refused."
+        )
+
+    print(f"  ok     targetSdk {target}: {PERMISSION} is declared")
+    print("         (that it is also requested at runtime is not something "
+          "this check can see)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Running a dev server on the phone and handing the address to a friend's laptop is a core capability here. Android is closing that path behind a permission, on a fixed schedule:

- **Android 16** — opt-in; local network access is open by default, which is why a server bound to `0.0.0.0` is reachable from another device today.
- **Android 17, and any app targeting SDK 37+** — blocked by default. `ACCESS_LOCAL_NETWORK` must be declared and granted at runtime. The platform documentation lists *"Accepting an incoming TCP connection"* as requiring it, so this covers a server running here being reached from elsewhere, not only this app reaching out.

Nothing in the build would announce that. Raising `targetSdk` later would produce a green build, a working editor, and dev servers no other device can reach — with no error the user can act on, because their friend's browser simply times out. The failure would arrive a release after the change that caused it.

## What this changes

**No SDK level moves and no permission is added.** `minSdk`, `targetSdk` and `compileSdk` are untouched; the diff is one new check and one line wiring it into the lint workflow.

The check asserts a pair: *if* `targetSdk` ever reaches 37 or above, the manifest must declare the permission. Declaring it now was the alternative and is worse — it would appear in the Play listing for a capability the platform does not yet withhold.

## Verified in four directions

| Case | Result |
|---|---|
| targetSdk 36, permission absent (today) | `ok`, exit 0 |
| targetSdk 37, permission absent | **FAIL**, exit 1, naming the consequence |
| targetSdk 37, permission declared | `ok`, exit 0 |
| targetSdk unreadable | **FAIL**, exit 1 |

The last one is the point. A check that cannot answer and answers anyway is how a gate starts lying, and a vacuous pass on empty input is a shape this repository has been bitten by more than once.

## What it cannot see

Whether the runtime request is actually made, and whether refusal is handled so the editor and localhost development keep working. A declaration is necessary and not sufficient, and the passing message says so rather than letting it read as more than it is.

Runs in the lint workflow beside the existing build-step check: two files read, no assets, no build.

Fixes #57