### PR TITLE
fix(build): source npm from the Node release the app actually runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- npm upgraded 10.8.2 → 11.16.0, the version the bundled Node runtime actually ships with. The app had been packaging npm taken from an older Node release it no longer runs, left behind when the runtime was replaced
 - The release now checks the app bundle against the store's size limits before publishing anything, rather than measuring it and carrying on. A bundle that has grown too large previously failed at store upload with the download release already public, leaving one version shipping through two channels with different contents
 - The on-device test suite now checks that what shipped actually runs: Python has to import the ten modules that need a bundled library behind them, the shell has to start, and git's HTTPS helper has to be executable. Five Python modules were dead on shipped builds for months while every check passed. The suite also stopped expecting a Node version the app replaced two releases ago — the versions it checks are now read from what was built rather than written down
 - Extensions dropped from the bundled set are now removed from the build tree instead of lingering and shipping in development builds

--- a/scripts/download-npm.sh
+++ b/scripts/download-npm.sh
@@ -5,15 +5,39 @@ set -euo pipefail
 # Extracts lib/node_modules/npm/ to assets/usr/lib/node_modules/npm/.
 # Strips docs, man pages, and test files to minimize size.
 #
-# npm version is locked to the one bundled with Node.js 20.18.1 (npm 10.8.2).
+# npm comes from the Node release the app actually runs, not from a number of
+# its own.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 ASSETS_DIR="$ROOT_DIR/android/app/src/main/assets"
 WORK_DIR="$ROOT_DIR/toolchains/build/npm"
 
-NODE_VERSION="v20.18.1"
-NPM_VERSION="10.8.2"
+# Read from the version the native addons are compiled against. The runtime has
+# to equal that -- an addon built for one Node and loaded by another is the
+# defect check_pair exists for -- so it is the one place this repository states
+# which Node this app is.
+#
+# This was pinned to v20.18.1 on its own, a leftover from the hand-cross-compiled
+# runtime abandoned for segfaulting inside several CLI tools. The app therefore
+# shipped npm from a Node release it no longer ran, and nothing compared the two.
+# Nothing was broken by it -- npm 10 supports Node >=20.5.0 -- which is exactly
+# why it survived a runtime bump unnoticed.
+NODE_MAJOR_MINOR_PATCH=$(sed -n 's/^NODE_VERSION="${NODE_VERSION:-\([0-9.]*\)}".*/\1/p' \
+    "$SCRIPT_DIR/build-native-addons.sh" | head -1)
+if [ -z "$NODE_MAJOR_MINOR_PATCH" ]; then
+    echo "ERROR: could not read NODE_VERSION from build-native-addons.sh." >&2
+    echo "       npm is sourced from the Node release the app runs; without that" >&2
+    echo "       number there is nothing to source it from." >&2
+    exit 1
+fi
+NODE_VERSION="v$NODE_MAJOR_MINOR_PATCH"
+
+# What that release carries. Declared rather than derived because scripts/
+# consumers read it without downloading anything -- device-test.sh falls back to
+# it when a checkout has no assets tree -- and it is asserted against the tarball
+# below, so it cannot quietly disagree with what ships.
+NPM_VERSION="11.16.0"
 NODE_TARBALL="node-${NODE_VERSION}-linux-arm64.tar.xz"
 NODE_URL="https://nodejs.org/dist/${NODE_VERSION}/${NODE_TARBALL}"
 
@@ -87,7 +111,13 @@ EXTRACTED_VERSION=$(node -e "console.log(require('$NPM_SRC/package.json').versio
 
 echo "  npm version: $EXTRACTED_VERSION"
 if [ "$EXTRACTED_VERSION" != "$NPM_VERSION" ]; then
-    echo "  WARNING: Expected npm $NPM_VERSION but got $EXTRACTED_VERSION"
+    # Fatal, not a warning. NPM_VERSION is read by other scripts as the answer to
+    # "which npm ships", so a warning here means they answer with a number the
+    # build already knew was wrong -- and the build carries on and ships the
+    # other one.
+    echo "  ERROR: NPM_VERSION says $NPM_VERSION but $NODE_VERSION carries $EXTRACTED_VERSION." >&2
+    echo "         Update NPM_VERSION in this script to $EXTRACTED_VERSION." >&2
+    exit 1
 fi
 
 # --- Step 3: Strip unnecessary files ---


### PR DESCRIPTION
## Summary

`download-npm.sh` pinned `NODE_VERSION` to `v20.18.1` and took npm from that tarball. The runtime is Termux's `nodejs-lts` at **24.18.0** — the pin was a leftover from the hand-cross-compiled build that was abandoned for segfaulting inside several CLI tools. The app shipped npm from a Node release it no longer runs.

Nothing was broken by it: npm 10 supports Node `>=20.5.0`, so the combination worked. That is exactly why it survived a runtime bump unnoticed — the two numbers lived in different files, maintained by hand, with nothing relating them.

## What changes

The Node release is now **read from the version the native addons are compiled against**. The runtime has to equal that — an addon built for one Node and loaded by another is the defect `check_pair` exists for — so it is the one place this repository states which Node this app is. npm follows the runtime from here without anyone having to remember.

**This moves npm 10.8.2 → 11.16.0.** Measured, not assumed:

| Check | Result |
| --- | --- |
| `index.json` npm for v24.18.0 | `11.16.0` |
| `node-v24.18.0-linux-arm64.tar.xz` | HTTP 200 |
| `SHASUMS256.txt` entry | present (`58c95205…`) |

The last row matters because the script fails closed without a digest; a release missing one would stop the build rather than ship unverified bytes.

The post-extraction version assertion was a **warning** and is now fatal. `NPM_VERSION` is read by other scripts as the answer to "which npm ships" — `device-test.sh` falls back to it when a checkout has no assets tree — so a warning meant they could answer with a number the build already knew was wrong while it shipped the other one.

## Verification

- Derivation resolves: `build-native-addons.sh` → `24.18.0` → `NODE_VERSION=v24.18.0`.
- Failing direction: with the version unreadable, the derivation yields an empty string and the script exits rather than downloading whatever `v` resolves to.
- `device-test.sh`'s fallback still finds `NPM_VERSION` and now reads `11.16.0`.
- `bash -n` clean.

## What I could not verify

npm 11 has **not been exercised on a device by me** — I have no device available; both emulators are in use by other work. npm 11 requires Node `^20.17.0 || >=22.9.0` and the runtime is 24.18.0, so the combination is supported upstream, but "supported" and "exercised here" are different claims and only the first is established.

`device-test.sh`'s `tool_npm` derives its expectation from the shipped tree, so whoever next runs that suite against a device exercises this without needing to update anything.

Fixes #67