### PR TITLE
docs: correct the version numbers the npm change made wrong

### DIFF
--- a/docs/LEGAL_NOTICES.md
+++ b/docs/LEGAL_NOTICES.md
@@ -138,7 +138,7 @@ Node.js includes V8 (BSD-3-Clause), libuv (MIT), OpenSSL (Apache-2.0), ICU (Unic
 ### npm
 
 - **Project**: https://www.npmjs.com
-- **Version**: 10.8.2 — pinned as `NPM_VERSION` in `scripts/download-npm.sh`, extracted from the nodejs.org tarball named there
+- **Version**: 11.16.0 — declared as `NPM_VERSION` in `scripts/download-npm.sh` and asserted against the nodejs.org tarball, which is the release the bundled Node runtime comes from
 - **License**: Artistic License 2.0
 - **Copyright**: Copyright (c) npm, Inc. and Contributors
 - **Full license**: https://github.com/npm/cli/blob/latest/LICENSE

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -125,9 +125,9 @@ Open the terminal with **Ctrl+`** or from the menu bar. VSCodroid includes a ful
 All tools are available immediately with no installation or setup:
 
 ```
-node -v           # Node.js 20.18.1
-npm -v            # npm 10.8.2
-python3 --version # Python 3.12.12
+node -v           # Node.js 24.x
+npm -v            # npm 11.x
+python3 --version # Python 3.14.x
 pip --version     # pip (bundled with Python)
 git --version     # Git 2.53.0
 bash --version    # Bash 5.3.9


### PR DESCRIPTION
## Summary

Follow-up to #74, which moved npm from 10.8.2 to 11.16.0. Two documents still name the old version, and `main` currently ships one number while stating another.

`docs/LEGAL_NOTICES.md` records npm's version for **attribution**. A licence notice naming a version the app does not ship is the one kind of stale documentation that is not merely unhelpful.

`docs/USER_GUIDE.md`'s verify-your-install block was worse than a single wrong number: **two of its three were already wrong before #74**. It claimed Node 20.18.1 against a runtime at 24.18.0, and Python 3.12.12 against a bundled 3.14. Correcting only npm would have left one accurate number between two wrong ones — which reads as though all three had been checked.

Those three now name major versions rather than exact patches. The block exists so someone can confirm their install looks right; a patch number there goes stale on every bump while telling the reader nothing they need. The exact version stays in `LEGAL_NOTICES`, where it is the point.

## Why this is separate

The correction was found while reviewing #74 after it had already been merged. It belongs to that change and arrives late rather than not at all.

## Verification

| Document claim | What `main` ships |
| --- | --- |
| `LEGAL_NOTICES` npm 11.16.0 | `NPM_VERSION="11.16.0"` |
| `USER_GUIDE` Node.js 24.x | 24.18.0 |
| `USER_GUIDE` Python 3.14.x | `libpython3.14.so` |