### PR TITLE
fix(webview): keep the open workspace when resuming after a long background

### DIFF
--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -304,17 +304,19 @@ class MainActivity : AppCompatActivity() {
         when {
             bgMs > FORCE_RELOAD_THRESHOLD_MS -> {
                 Logger.i(tag, "Reloading after ${bgMs / 1000}s in background")
-                // Rebuilt rather than reload()ed, because this is the one reload
-                // that can outlive its own authentication: the cookie carrying the
-                // connection token is set for a week, and this branch exists
-                // precisely for a WebView that has been idle a long time. Going
-                // through loadVSCode() re-sends the token in the query, which the
-                // server turns into a fresh cookie. The JS-triggered reloads below
-                // stay as they are -- they run on a page that is demonstrably still
-                // authenticated, and reaching them would mean putting the token
-                // where page scripts can read it. loadVSCode() keeps the folder
-                // on screen by itself and initBridge() is already idempotent.
-                loadVSCode(serverPort)
+                // reload(), not a rebuilt URL. The WebView URL is the only
+                // truthful record of what is open, and rebuilding reads only
+                // `folder` back out of it — so a multi-root workspace
+                // (`?workspace=<file>`) or a closed folder (`?ew=true`), both of
+                // which the workbench navigates to on its own, would come back as
+                // the default projects directory instead.
+                //
+                // Authentication is not a reason to rebuild here: the cookie the
+                // connection token rides in lasts a week and this branch fires at
+                // five minutes. A process idle long enough for it to expire will
+                // have been killed by Android first, and a cold start mints a
+                // fresh token anyway.
+                webView?.reload()
             }
             bgMs > HEALTH_CHECK_THRESHOLD_MS -> {
                 checkConnectionHealth(bgMs)

--- a/docs/03-ARCHITECTURE.md
+++ b/docs/03-ARCHITECTURE.md
@@ -42,7 +42,7 @@ flowchart TD
 |-----------|-----------|
 | **Minimal modification to VS Code** | Less maintenance burden, easier to rebase on upstream updates |
 | **Process isolation** | WebView renderer and Node.js are separate processes; one crashing doesn't kill the other |
-| **Localhost-only communication** | No network exposure, no authentication needed, simplifies security |
+| **Localhost-only communication** | No network exposure; the server still requires a connection token, because loopback is not isolated per app on Android |
 | **Native shell for Android integration** | Kotlin handles platform-specific concerns (keyboard, clipboard, lifecycle) |
 | **Lazy resource loading** | Language servers, extensions, toolchains loaded on-demand to minimize resource usage |
 | **Graceful degradation** | App remains functional even if some components fail (e.g., extension marketplace offline) |


### PR DESCRIPTION
Three small corrections, all to code and comments added in #66.

## The workspace was lost on resume

`handleResumeFromBackground` rebuilt the workbench URL rather than reloading it. Rebuilding
goes through `folderFromUrl`, which reads only the `folder` query parameter and additionally
requires `File(it).isDirectory`. The workbench navigates itself to two other shapes:

| Shape | When | Survives a rebuild? |
|---|---|---|
| `?folder=<dir>` | opening a folder | yes |
| `?workspace=<file>` | opening a `.code-workspace` | no — not read, and would fail the isDirectory check anyway |
| `?ew=true` | File > Close Folder | no |

So after five minutes in the background, a multi-root workspace or a deliberately closed
folder came back as the default projects directory. `reload()` re-requests the exact current
URL and is faithful to whatever the workbench navigated to.

**The reason given for rebuilding does not hold.** It was to refresh the connection token
cookie — but that cookie lasts a week (`Max-Age=604800`) while this branch fires at five
minutes (`FORCE_RELOAD_THRESHOLD_MS = 300_000`). A process idle long enough for the cookie to
expire will have been killed by Android well before, and a cold start mints a fresh token
regardless.

## A comment that was wrong

The same block claimed the JS-triggered reloads were left alone because reaching them would
put the token "where page scripts can read it". Measured off the response headers:

```
Set-Cookie: vscode-tkn=<...>; Max-Age=604800; SameSite=Lax
```

No `HttpOnly`, so `document.cookie` already exposes it. The decision to leave those reloads
alone is still right — they run on a page that is demonstrably still authenticated — but the
stated reason was false, and a wrong comment is worse than none.

## A doc that stopped being true

`docs/03-ARCHITECTURE.md:45` still described the localhost design as needing no
authentication.

## Testing

`compileDebugKotlin` and `testDebugUnitTest` pass. The changed branch has no unit coverage and
cannot easily get any — `folderFromUrl` calls `Uri.parse`, which throws "not mocked" in this
project's JVM tests, and there is no Robolectric.