### PR TITLE
ci: check the patches against the tree, not the table against itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- The build now refuses a server tree that is missing any of the Android adaptations, instead of checking only the ones someone remembered to list. A patch added without its check used to produce a clean-looking build that quietly shipped without it
 - npm upgraded 10.8.2 → 11.16.0, the version the bundled Node runtime actually ships with. The app had been packaging npm taken from an older Node release it no longer runs, left behind when the runtime was replaced
 - The release now checks the app bundle against the store's size limits before publishing anything, rather than measuring it and carrying on. A bundle that has grown too large previously failed at store upload with the download release already public, leaving one version shipping through two channels with different contents
 - The on-device test suite now checks that what shipped actually runs: Python has to import the ten modules that need a bundled library behind them, the shell has to start, and git's HTTPS helper has to be executable. Five Python modules were dead on shipped builds for months while every check passed. The suite also stopped expecting a Node version the app replaced two releases ago — the versions it checks are now read from what was built rather than written down

--- a/patches/fingerprints.txt
+++ b/patches/fingerprints.txt
@@ -1,0 +1,34 @@
+# How each patch is proven to have reached the packaged output.
+#
+# Applying a patch to the source proves nothing about the package: the file may
+# not be in this target's graph, or the build may inline an older copy. So each
+# patch leaves a fingerprint that survives minification, and the packaged tree is
+# searched for it.
+#
+# Format, one line per patch in patches/:
+#
+#   NNNN label|bundle|pattern      the bundle must contain the pattern
+#   NNNN label|-|why               no fingerprint is possible; how it is proven instead
+#
+# Every patch needs a line. A patch with no line fails the check rather than
+# passing silently, which is the whole point: an absent line used to be
+# indistinguishable from a forgotten one.
+#
+# Choosing a pattern: match something the patch introduces that minification
+# cannot rewrite -- a string literal, an HTML attribute, a comparison against a
+# literal. Never a variable name; those are mangled. Verify the pattern appears
+# zero times in an unpatched bundle before trusting it, because a pattern that
+# already matched proves nothing at all.
+
+0001 platform|out/server-main.js|platform==="android"
+0002 userDataPath|out/vs/platform/terminal/node/ptyHostMain.js|case"android"
+0003 ptyHost worker|out/server-main.js|__vsc_disconnect
+0004 extHost worker|out/server-main.js|worker_thread Extension Host
+0005 webview csp|out/vs/workbench/contrib/webview/browser/pre/index.html|script-src 'unsafe-inline'
+0006 callback relay|out/vs/code/browser/workbench/callback.html|intent://callback
+0007 persist secrets|-|flips a single boolean, and its only distinctive text is a comment that minification strips
+0008 activitybar height|out/vs/code/browser/workbench/workbench.js|.activitybar .composite-bar
+0009 alpine target|out/server-main.js|Android: requesting the alpine target platform
+0010 moduleignore keep|-|edits build/.moduleignore, so its proof is the file surviving into the tree; verify-server-tree.py requires that path
+0011 walkthrough brand|out/nls.messages.js|Get Started with VSCodroid
+0012 callback route|out/server-main.js|==="/callback"

--- a/scripts/build-vscode-oss.sh
+++ b/scripts/build-vscode-oss.sh
@@ -353,37 +353,21 @@ fail=0
 # because only this side has the patches and the expectation file.
 python3 "$SCRIPT_DIR/verify-server-tree.py" "$OUT" || fail=1
 
-# Applying a patch to the source proves nothing about the package: the file may
-# not be in this target's graph, or the build may inline an older copy. Each
-# patch therefore leaves a fingerprint that has to survive minification, and the
-# packaged output is searched for it.
+# Every patch has to be proven present in the packaged output, not merely
+# applied to the source. The expectations and the reasoning live in
+# patches/fingerprints.txt; this runs them.
+#
+# It takes the tree as an argument on purpose, the way verify-server-tree.py
+# does, so the same check can run on the fetch side against a downloaded
+# tarball. That case is the one with no other signal: a tarball predating a
+# patch has the same name, the same version, and a digest that verifies,
+# because a digest proves the file is intact rather than that it is the right
+# file.
+# Skipped for a deliberately unadapted build, the same condition that governs
+# whether the patches were applied at all -- checking a tree for patches nobody
+# applied would fail it for doing exactly what was asked.
 if [ -d "$PATCHES" ] && [ -n "$(ls -A "$PATCHES"/*.patch 2>/dev/null)" ]; then
-    # patch | bundle it must reach | fingerprint that survives minification
-    # Not every patch leaves one: 0007 flips a single boolean and its only
-    # distinctive text is a comment, which minification strips. 0010 edits
-    # build/.moduleignore, so its proof is a file surviving into the tree,
-    # which verify-server-tree.py checks as a required path. An absent row is
-    # deliberate, not an oversight.
-    while IFS='|' read -r id bundle pattern; do
-        [ -z "$id" ] && continue
-        if [ -f "$OUT/$bundle" ] && grep -q "$pattern" "$OUT/$bundle"; then
-            echo "  ok      $id reached $(basename "$bundle")"
-        else
-            echo "  FAIL    $id did not reach $bundle"
-            fail=1
-        fi
-    done <<'FINGERPRINTS'
-0001 platform|out/server-main.js|platform==="android"
-0002 userDataPath|out/vs/platform/terminal/node/ptyHostMain.js|case"android"
-0003 ptyHost worker|out/server-main.js|__vsc_disconnect
-0004 extHost worker|out/server-main.js|worker_thread Extension Host
-0005 webview csp|out/vs/workbench/contrib/webview/browser/pre/index.html|script-src 'unsafe-inline'
-0006 callback relay|out/vs/code/browser/workbench/callback.html|intent://callback
-0008 activitybar height|out/vs/code/browser/workbench/workbench.js|.activitybar .composite-bar
-0009 alpine target|out/server-main.js|Android: requesting the alpine target platform
-0011 walkthrough brand|out/nls.messages.js|Get Started with VSCodroid
-0012 callback route|out/server-main.js|==="/callback"
-FINGERPRINTS
+    python3 "$SCRIPT_DIR/check-patch-fingerprints.py" "$OUT" "$PATCHES" || fail=1
 fi
 
 if [ -d "$BRANDING" ]; then

--- a/scripts/check-patch-fingerprints.py
+++ b/scripts/check-patch-fingerprints.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Check a packaged tree carries every patch this repository applies.
+
+    check-patch-fingerprints.py <tree> [patches-dir]
+
+Applying a patch to the source proves nothing about the package: the file may
+not be in the target's graph, or the build may inline an older copy. Each patch
+therefore leaves a fingerprint that survives minification, and this searches the
+packaged tree for it. The expectations live in patches/fingerprints.txt.
+
+Two things this fixes about the check it replaces, which was a heredoc inside
+build-vscode-oss.sh:
+
+  * It walks patches/, not the table. The old loop iterated its own rows, so a
+    patch added without a row produced a run of "ok" lines and passed. Two
+    patches legitimately have no fingerprint, and their absence looked identical
+    to an oversight -- the gate could not tell deliberate from forgotten, so
+    exemptions are now written down as lines that say how the patch is proven
+    instead.
+
+  * It takes the tree as an argument, like verify-server-tree.py, which is what
+    lets the same check run on both sides. build-vscode-oss.sh checks what it
+    built; fetch-vscode-oss.sh can check what it downloaded, and that second
+    caller is the one that matters: a server tarball predating a patch has the
+    same name, the same version, and a digest that verifies, because a digest
+    proves the tarball is intact rather than that it is the right tarball.
+"""
+
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+# The patches directory is an argument rather than a fixed path because
+# build-vscode-oss.sh takes PATCHES from the environment: a local Docker run
+# mounts it at /patches. Resolving it here from this file's own location would
+# check the repository's patches while the build applied the mounted ones, and
+# the two would disagree without saying so. The table lives inside that
+# directory, so it follows whichever one is in use.
+DEFAULT_PATCHES = ROOT / "patches"
+
+# 0001-platform-treat-android-as-linux.patch -> 0001
+PATCH_ID = re.compile(r"^(\d{4})-.*\.patch$")
+
+failed = False
+
+
+def check(ok, label, detail=""):
+    global failed
+    print(f"  {'ok     ' if ok else 'FAIL   '} {label}{'' if ok else '  ' + detail}")
+    if not ok:
+        failed = True
+
+
+def read_table(TABLE):
+    """{id: (label, bundle, pattern)}; bundle '-' means an explicit exemption."""
+    rows = {}
+    for lineno, raw in enumerate(TABLE.read_text().splitlines(), 1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        head, _, rest = line.partition("|")
+        bundle, _, pattern = rest.partition("|")
+        ident = head.split(None, 1)[0] if head.split() else ""
+        if not re.fullmatch(r"\d{4}", ident) or not bundle or not pattern:
+            print(f"  FAIL   {TABLE.name}:{lineno} is not "
+                  f"'NNNN label|bundle|pattern': {line}")
+            return None
+        rows[ident] = (head.split(None, 1)[1] if " " in head else "", bundle, pattern)
+    return rows
+
+
+def main(tree, patches_dir):
+    TABLE = patches_dir / "fingerprints.txt"
+    if not TABLE.is_file():
+        print(f"  FAIL   no fingerprint table at {TABLE}")
+        return 1
+
+    rows = read_table(TABLE)
+    if rows is None:
+        return 1
+
+    patches = {}
+    for path in sorted(patches_dir.glob("*.patch")):
+        m = PATCH_ID.match(path.name)
+        if m:
+            patches[m.group(1)] = path.name
+
+    # An empty left-hand side would make every comparison below vacuously true.
+    if not patches:
+        print(f"  FAIL   no patches found in {patches_dir}; the naming changed")
+        return 1
+
+    for ident, name in sorted(patches.items()):
+        if ident not in rows:
+            check(False, f"{name} has no line in {TABLE.name}",
+                  "add its fingerprint, or a line saying how it is proven instead")
+            continue
+        label, bundle, pattern = rows[ident]
+        if bundle == "-":
+            # Not a pass by omission: the line states the reason, and it had to be
+            # written for the patch to get here at all.
+            print(f"  ok      {ident} {label} has no fingerprint -- {pattern}")
+            continue
+        target = tree / bundle
+        if not target.is_file():
+            check(False, f"{ident} {label}: {bundle} is not in the tree")
+        else:
+            check(pattern in target.read_text(errors="ignore"),
+                  f"{ident} {label} reached {pathlib.Path(bundle).name}",
+                  f"{bundle} does not contain {pattern!r}")
+
+    # A row naming a patch that no longer exists is stale rather than harmless:
+    # it is the only remaining place someone would look to learn the patch is
+    # gone, and it would keep asserting against a tree forever.
+    for ident in sorted(set(rows) - set(patches)):
+        check(False, f"{TABLE.name} has a line for {ident}, which is not in patches/",
+              "remove the line, or restore the patch")
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) not in (2, 3):
+        print("usage: check-patch-fingerprints.py <tree> [patches-dir]", file=sys.stderr)
+        sys.exit(2)
+    root = pathlib.Path(sys.argv[1])
+    patches = pathlib.Path(sys.argv[2]) if len(sys.argv) == 3 else DEFAULT_PATCHES
+    for label, path in (("tree", root), ("patches directory", patches)):
+        if not path.is_dir():
+            print(f"  FAIL    {path} is not a directory ({label})", file=sys.stderr)
+            sys.exit(1)
+    sys.exit(main(root, patches))


### PR DESCRIPTION
## Summary

The fingerprint check walked its own rows. A patch added without a row produced a run of `ok` lines and passed — which is exactly the failure the check exists to prevent: applying a patch to the source proves nothing about the package, since the file may not be in the target's graph or the build may inline an older copy.

Twelve patches, ten rows, and nothing walked `patches/`.

## Exemptions become statements

Two patches legitimately have no fingerprint:

- **0007** flips a single boolean whose only distinctive text is a comment that minification strips.
- **0010** edits `build/.moduleignore`, so its proof is a file surviving into the tree — one `verify-server-tree.py` already requires.

Both were sound, and both were invisible: **an absent row looked exactly like a forgotten one.** They are now lines that say how the patch is proven instead, so an exemption has to be *written* rather than merely not written.

## Why it takes the tree as an argument

The table moved to `patches/fingerprints.txt` and the check to `scripts/check-patch-fingerprints.py`, taking the tree as an argument the way `verify-server-tree.py` does. That is what lets the same check run on the **fetch** side — and that caller is the one with no other signal:

> A server tarball predating a patch carries the same name, the same version, and a digest that verifies. A digest proves a file is intact, not that it is the right file.

**This is not hypothetical.** As this was written, patch 0012 was on `main` while the server release had not been rebuilt — so every app build was fetching a pre-0012 tarball and producing an APK without the OAuth fix, with nothing anywhere reporting it.

Wiring up the fetch side changes behaviour (trees that pass today would start failing), so it belongs to its own change rather than riding along with a change of shape.

## The patches directory is passed in

`build-vscode-oss.sh` takes `PATCHES` from the environment, and a local Docker run mounts it at `/patches`. Resolving it from the script's own location would check the repository's patches while the build applied the mounted ones — and neither would say so. The table lives inside that directory, so it follows whichever is in use.

The unadapted-build guard was kept: checking a tree for patches nobody applied would fail it for doing exactly what `ALLOW_UNADAPTED` asked.

## Verification

| Case | Result |
| --- | --- |
| Tree carrying all twelve | exit 0 |
| New patch with no line | fails, **names the file** |
| Line for a patch that no longer exists | fails, **names the id** |
| Malformed line | fails, **with its line number** |
| Tree with 0012's fingerprint removed (the live scenario) | fails, **names the bundle** |
| Patches directory passed explicitly with an extra patch | that set is checked, not the repository's |

Fixes #71