### PR TITLE
fix(build): check the fetched server tree carries every patch, not just the built one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Builds now check that the downloaded server tree actually carries every patch this repository applies, instead of only checking that at build time. A tree built before a patch landed has the same filename, the same version and a digest that verifies, so nothing here could previously tell it apart -- and an app could ship a server missing a fix that the repository already contained
 - The build now refuses a server tree that is missing any of the Android adaptations, instead of checking only the ones someone remembered to list. A patch added without its check used to produce a clean-looking build that quietly shipped without it
 - npm upgraded 10.8.2 → 11.16.0, the version the bundled Node runtime actually ships with. The app had been packaging npm taken from an older Node release it no longer runs, left behind when the runtime was replaced
 - The on-device test suite now states when it is expected to be run, and the build checks that it can still read the versions it asserts. It had gone two releases expecting a Node version the app no longer shipped, because nothing ran it and nothing noticed

--- a/scripts/fetch-vscode-oss.sh
+++ b/scripts/fetch-vscode-oss.sh
@@ -108,6 +108,35 @@ echo "=== Verify ==="
 python3 "$ROOT_DIR/scripts/verify-server-tree.py" "$DEST"
 
 echo
+echo "=== Patches ==="
+# The same check build-vscode-oss.sh runs on its own output, here against the
+# tree that will actually ship.
+#
+# This is the gate nothing else on this side can stand in for. A server tarball
+# built before a patch landed has the same filename, the same version, and a
+# digest that verifies -- a digest proves the bytes are intact, not that they are
+# the right bytes. verify-server-tree.py does not help either: it checks the
+# shape of the tree, and a tree missing a patch has exactly the right shape.
+# Without this, a patch could sit in patches/ while every build quietly shipped a
+# server that predates it, and the first symptom would be on a user's device.
+if ! python3 "$ROOT_DIR/scripts/check-patch-fingerprints.py" "$DEST"; then
+    cat >&2 <<EOF
+
+  This server tree is missing at least one patch this checkout applies.
+
+  It is almost certainly older than patches/. The fix is to rebuild and publish
+  the server -- run the "Build Code - OSS server" workflow -- and then remove
+
+      $TARBALL
+
+  before running this again. A cached tarball is only refetched when the digest
+  on the release changes, so a rebuild that has not been published will not
+  reach you no matter how many times you retry.
+EOF
+    exit 1
+fi
+
+echo
 echo "=== ripgrep ==="
 # rg cannot run from where the rest of the tree lives. SELinux denies
 # execute_no_trans on app_data_file for targetSdk >= 29, so anything under


### PR DESCRIPTION
Closes the fetch-side half of #71.

`check-patch-fingerprints.py` was written to take the tree as an argument precisely so it could
run on both sides. Only one side called it: the build checked what it had just produced, and
nothing checked what an app build downloaded.

## Why nothing else on this side covers it

| Gate | What it proves | Why it misses this |
|---|---|---|
| Release digest | the bytes arrived intact | proves the tarball is *whole*, not that it is the *right* tarball |
| `verify-server-tree.py` | the tree has the right shape | a tree missing a patch has exactly the right shape |
| Filename / version | — | a tarball built before a patch has both identical |

So a patch could sit in `patches/` while every build quietly packaged a server that predates it,
and the first symptom would be on a device. That is not hypothetical — it is the shape of the
problem #76 was an instance of, and it is what would have let that fix silently not ship.

## The message is written for this side

At build time a missing fingerprint means the patch did not reach the output. Here it means the
tarball is older than the checkout, and the remedy is different — rebuild and publish, then
delete the cached tarball, because a cached one is only refetched when the digest on the release
changes. Retrying without that does nothing, so the message says so.

## Verified both directions, against real trees

Not contrived inputs — the actual tree from the current release, and the actual tree that was
packaged before 0012 landed.

**Passes** on the tree fetched from `server-1.133.0`, all twelve patches accounted for
(ten fingerprints, two documented exemptions):

```
ok      0011 walkthrough brand reached nls.messages.js
ok      0012 callback route reached server-main.js
exit=0
```

**Fails** on the tree packaged before 0012, naming the patch and stopping the script:

```
FAIL    0012 callback route reached server-main.js  out/server-main.js does not contain '==="/callback"'

  This server tree is missing at least one patch this checkout applies.
  …
EXIT = 1
```

The failing run was the guard block copied verbatim out of the script and executed under the same
`set -euo pipefail`, so what was tested is the code that ships, not a paraphrase of it. The line
after the guard was never reached.

## Behaviour change worth knowing

This will start failing builds that were previously passing — specifically, any checkout with a
cached server tarball older than its `patches/`. That is the point, and the message tells you what
to do about it. `patches/fingerprints.txt` and the checker itself come from #94; this only adds the
second caller.