### PR TITLE
fix(app): stop advertising a file-open capability that was never implemented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- VSCodroid no longer offers itself in the Android "Open with" list for source files. It advertised about twenty file types and never opened any of them: picking it brought up the editor on the default folder with no file and no message. Folders still open through "Open Folder from Device"
 - Builds now check that the downloaded server tree actually carries every patch this repository applies, instead of only checking that at build time. A tree built before a patch landed has the same filename, the same version and a digest that verifies, so nothing here could previously tell it apart -- and an app could ship a server missing a fix that the repository already contained
 - The build now refuses a server tree that is missing any of the Android adaptations, instead of checking only the ones someone remembered to list. A patch added without its check used to produce a clean-looking build that quietly shipped without it
 - npm upgraded 10.8.2 → 11.16.0, the version the bundled Node runtime actually ships with. The app had been packaging npm taken from an older Node release it no longer runs, left behind when the runtime was replaced

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -49,16 +49,6 @@
             android:windowSoftInputMode="adjustResize"
             android:theme="@style/Theme.VSCodroid">
 
-            <!-- Open code files from file managers and other apps -->
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <data android:mimeType="text/*" />
-                <data android:mimeType="application/json" />
-            </intent-filter>
-
             <!-- Extension callback relay: vscodroid://callback?data=... -->
             <!-- Bridges localStorage gap between Chrome (callback.html) and WebView -->
             <intent-filter>
@@ -69,63 +59,21 @@
                 <data android:scheme="vscodroid" android:host="callback" />
             </intent-filter>
 
-            <!-- Open code files by extension (file:// and content:// schemes).
-                 mimeType is required for content:// URIs — use text/* plus specific
-                 code-related types instead of */* to avoid matching photos/music/etc. -->
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
+            <!-- No VIEW filter for file:// or content:// here, and that is deliberate.
+                 Two of them used to advertise this app for about twenty source-file
+                 extensions, and nothing ever opened one: handleIntent() called
+                 window.__vscodroid.onFileOpen, which has had no consumer since the
+                 initial commit. Choosing VSCodroid from "Open with" brought up the
+                 editor on the default folder with no file, no message and nothing in
+                 the log to attach to a bug report.
 
-                <data android:scheme="file" />
-                <data android:scheme="content" />
-                <data android:host="*" />
-
-                <!-- MIME types for code files -->
-                <data android:mimeType="text/*" />
-                <data android:mimeType="application/json" />
-                <data android:mimeType="application/javascript" />
-                <data android:mimeType="application/xml" />
-                <data android:mimeType="application/x-shellscript" />
-                <data android:mimeType="application/octet-stream" />
-
-                <!-- JavaScript / TypeScript -->
-                <data android:pathPattern=".*\\.js" />
-                <data android:pathPattern=".*\\.ts" />
-
-                <!-- Python -->
-                <data android:pathPattern=".*\\.py" />
-
-                <!-- Web -->
-                <data android:pathPattern=".*\\.html" />
-                <data android:pathPattern=".*\\.css" />
-
-                <!-- Data -->
-                <data android:pathPattern=".*\\.json" />
-                <data android:pathPattern=".*\\.xml" />
-                <data android:pathPattern=".*\\.yaml" />
-                <data android:pathPattern=".*\\.yml" />
-
-                <!-- Documentation -->
-                <data android:pathPattern=".*\\.md" />
-                <data android:pathPattern=".*\\.txt" />
-
-                <!-- Systems -->
-                <data android:pathPattern=".*\\.go" />
-                <data android:pathPattern=".*\\.rs" />
-                <data android:pathPattern=".*\\.c" />
-                <data android:pathPattern=".*\\.cpp" />
-                <data android:pathPattern=".*\\.h" />
-
-                <!-- JVM -->
-                <data android:pathPattern=".*\\.java" />
-                <data android:pathPattern=".*\\.kt" />
-
-                <!-- Ruby -->
-                <data android:pathPattern=".*\\.rb" />
-
-                <!-- Shell -->
-                <data android:pathPattern=".*\\.sh" />
-            </intent-filter>
+                 Implementing it is not a matter of wiring the hook up. A content://
+                 URI has no POSIX path, and the server only ever sees POSIX paths, so
+                 the file has to be materialised locally, at which point saving
+                 writes to a copy and the user's edits never reach the file they
+                 opened. Advertising nothing is honest; advertising this and silently
+                 dropping edits would not be. Folders still open through the SAF
+                 picker, which does have the sync engine that makes write-back work. -->
         </activity>
 
         <!-- Toolchain settings: manage on-demand language toolchains -->

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -55,7 +55,6 @@ class MainActivity : AppCompatActivity() {
     private var backgroundedAt = 0L
     private var bridgeInitialized = false
 
-    private var pendingFileUri: Uri? = null
     private lateinit var securityManager: SecurityManager
     private lateinit var safManager: SafStorageManager
 
@@ -121,23 +120,18 @@ class MainActivity : AppCompatActivity() {
         checkPreviousCrash()
         checkStorageHealth()
 
-        // Capture file URI from launch intent for processing after VS Code loads.
-        // onNewIntent() handles intents when the activity is already running,
-        // but onCreate() intents are lost without this.
-        val launchUri = intent?.data
-        if (launchUri != null && launchUri.scheme != "vscodroid") {
-            pendingFileUri = launchUri
-        }
     }
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
+        // The only intent that reaches here with a URI is the OAuth callback relay,
+        // which is the one VIEW filter the manifest still carries. Anything else is
+        // the launcher bringing this singleTask activity to the front, and there is
+        // nothing to do for it.
         val uri = intent.data
         if (uri?.scheme == "vscodroid" && uri.host == "callback") {
             handleExtensionCallback(uri)
-            return
         }
-        handleIntent(intent)
     }
 
     override fun onDestroy() {
@@ -568,11 +562,6 @@ class MainActivity : AppCompatActivity() {
         )
         // Install JS interceptor so ExtraKeyRow Ctrl/Alt modifiers apply to soft keyboard input
         extraKeyRow?.keyInjector?.setupModifierInterceptor()
-        // Process pending file open intent from cold start (must run after VS Code loads)
-        pendingFileUri?.let { uri ->
-            pendingFileUri = null
-            handleIntent(Intent().apply { data = uri })
-        }
         // Inject safe area CSS for round-corner devices
         injectSafeAreaCSS()
         // Set up BroadcastChannel relay so browser extensions can reach AndroidBridge
@@ -1141,14 +1130,6 @@ class MainActivity : AppCompatActivity() {
         Logger.w(tag, "Storage low: $available available")
     }
 
-    private fun handleIntent(intent: Intent) {
-        val uri = intent.data ?: return
-        Logger.i(tag, "Received intent with URI: $uri")
-        val escaped = org.json.JSONObject.quote(uri.toString())
-        webView?.evaluateJavascript(
-            "window.__vscodroid?.onFileOpen?.($escaped)", null
-        )
-    }
 
     companion object {
         /** Run health check if backgrounded longer than this. */


### PR DESCRIPTION
Fixes #80.

## What was wrong

The app registered itself in Android's "Open with" list for about twenty source extensions across
the `file` and `content` schemes, and opened none of them. `handleIntent()` called
`window.__vscodroid.onFileOpen`, and nothing has ever assigned that hook — the call is doubly
optional, so it evaluated to `undefined` with no crash and no log line.

**Never a regression.** `git log -S onFileOpen` shows it arriving in the initial commit and never
touched since: the advertisement and the missing receiver shipped together.

## Why removal rather than implementation

The issue offered both. Tracing the data path decides it.

A `content://` URI has no POSIX path, and this project's server only ever sees POSIX paths — that
is a load-bearing invariant, not an inconvenience. So any implementation has to materialise the
file locally, and then:

```
user opens file from Downloads  ->  copy under filesDir
user edits, Ctrl+S              ->  saved to the copy
the file they opened            ->  unchanged, silently
```

Making that correct means write-back, which means extending `SafSyncEngine` from folders to single
files, plus expiring `content://` permissions and deciding what happens when the original moves.
That is a feature, and a data-path one.

**Silently dropping someone's edits is worse than not appearing in the list.** Folders keep working
through "Open Folder from Device", which does have the sync engine that makes write-back real.

## Also removed

`pendingFileUri` and its replay in `injectBridgeToken`, and `handleIntent` itself — they existed
only to deliver a URI to the missing hook, and with no filter left to produce one they cannot be
reached. `onNewIntent` keeps the OAuth callback branch (the one VIEW filter the manifest still
carries) and does nothing for anything else; a `singleTask` activity brought to the front has
nothing to handle.

A comment stands where the filters were, explaining why there is nothing there — the next person to
notice the gap should find the reasoning, not the gap.

## Measured on device, both directions, with a negative control

API 36 emulator, `cmd package query-activities`, before and after installing this branch:

| Query | Before | After |
|---|---|---|
| `VIEW file:///…/x.md` `text/markdown` | 12 lines naming vscodroid | **0** |
| `VIEW content://x/y` `text/plain` | 12 | **0** |
| `VIEW content://x/y` `application/json` | 12 | **0** |
| `VIEW vscodroid://callback` | 12 | **12** |

The last row is the control: the OAuth relay filter is the one that must survive, and it does.

Unit suite and lint pass — exit 0, 48 result files written by that run, 0 failures. The app
launches, the workbench loads, the editor reports no errors on the installed build.