### PR TITLE
test: close two gaps a mutation sweep found in the setup and registry tests

### DIFF
--- a/android/app/src/test/kotlin/com/vscodroid/setup/ElfHeaderTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/ElfHeaderTest.kt
@@ -59,6 +59,18 @@ class ElfHeaderTest {
     }
 
     @Test
+    fun `rejects ELF preceded by the wrong first byte`() {
+        // The one check nothing else here reaches. Every other rejection above
+        // is already decided by byte 1 not being 'E', so deleting the 0x7F
+        // comparison left the whole suite green -- measured, not assumed. This
+        // is the case that distinguishes a real object from anything whose
+        // second, third and fourth bytes happen to spell ELF.
+        assertFalse(isElfHeader(bytes(0x00, 0x45, 0x4C, 0x46)))
+        assertFalse(isElfHeader(bytes(0x7E, 0x45, 0x4C, 0x46)))
+        assertFalse(isElfHeader(" ELF".toByteArray()))
+    }
+
+    @Test
     fun `reads the same verdict from a real file as from its bytes`(@TempDir dir: File) {
         val binary = File(dir, "compile").apply { writeBytes(elf + ByteArray(64)) }
         val header = binary.inputStream().use { it.readNBytes(4) }

--- a/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainRegistryTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainRegistryTest.kt
@@ -28,10 +28,16 @@ class ToolchainRegistryTest {
         @Test
         fun `all toolchains have valid fields`() {
             for (tc in ToolchainRegistry.available) {
-                assertNotNull(tc.packName, "packName must not be null")
-                assertNotNull(tc.displayName, "displayName must not be null")
-                assertNotNull(tc.shortLabel, "shortLabel must not be null")
-                assertNotNull(tc.description, "description must not be null")
+                // Not assertNotNull: these four are non-nullable String, so an
+                // assertion that they are not null cannot fail and never could.
+                // It read as validation while checking nothing -- with every
+                // displayName and description set to "" the whole suite stayed
+                // green, measured. Blank is the failure that can actually reach
+                // a user, as an unnamed card in the toolchain picker.
+                assertTrue(tc.packName.isNotBlank(), "packName is blank")
+                assertTrue(tc.displayName.isNotBlank(), "displayName is blank: ${tc.packName}")
+                assertTrue(tc.shortLabel.isNotBlank(), "shortLabel is blank: ${tc.packName}")
+                assertTrue(tc.description.isNotBlank(), "description is blank: ${tc.packName}")
                 assert(tc.estimatedSize > 0) { "estimatedSize must be positive: ${tc.packName}" }
                 assert(tc.packName.startsWith("toolchain_")) { "packName must start with 'toolchain_': ${tc.packName}" }
             }


### PR DESCRIPTION
Ten test files, checked by breaking the code each claims to guard and asking whether it noticed.

## Result

| File | Mutation applied | Verdict |
|---|---|---|
| WriteAtomicallyTest | write straight to dest; ignore rename failure | caught (2, then 4) |
| SupersededPythonTest | always return empty | caught (3) |
| SupersededExtensionsTest | always return empty | caught (3) |
| StorageManagerTest | swap the MB and KB units | caught (6) |
| EnvironmentSafTest | shorten the hash from 6 bytes to 3 | caught (3) |
| EnvironmentTest | drop `.vscodroid` from the user-data path | caught (1) |
| ToolchainLibsTest | ignore `baseShipped` entirely | caught (1) |
| SettingsPathsTest | stop rewriting `git.path` | caught (5) |
| **ElfHeaderTest** | **remove the `0x7F` magic comparison** | **missed** |
| **ToolchainRegistryTest** | **blank every `displayName` / `description`** | **missed** |

## ElfHeaderTest — the magic byte was never exercised

Every rejection the file already had is decided one byte later. A shell script, a zip, a Mach-O
and a JSON manifest all fail on byte 1 not being `'E'`, so nothing ever supplied a header whose
second, third and fourth bytes spell `ELF` behind a wrong first byte.

That is exactly the case the file's own docstring says it exists for:

> Claiming something is an ELF that is not hands the execute bit to a data file, which is a
> permission granted for no reason and can never be taken back by this pass, since it only ever adds.

Added: `\0ELF`, `\x7EELF`, and `" ELF"`.

## ToolchainRegistryTest — four assertions that could not fail

```kotlin
assertNotNull(tc.packName, "packName must not be null")     // val packName: String
assertNotNull(tc.displayName, "displayName must not be null") // val displayName: String
assertNotNull(tc.shortLabel, "shortLabel must not be null")   // val shortLabel: String
assertNotNull(tc.description, "description must not be null") // val description: String
```

All four are non-nullable. The assertions read as validation while checking nothing. Measured:
with every `displayName` and `description` set to `""`, the suite stayed green — which is what an
unnamed card in the toolchain picker would look like on the way to a user.

Now `isNotBlank()`. `shortLabel` turned out to be covered incidentally by the tests naming each
toolchain, and `downloadUrl` is genuinely nullable, so its `assertNotNull` stays.

## Both fixes verified by re-running the mutation that exposed them

```
before   isElfHeader: remove 0x7F check      MISSED   1 file,  0 failures
after    isElfHeader: remove 0x7F check      CAUGHT   rejects ELF preceded by the wrong first byte
before   blank every displayName             MISSED   3 files, 0 failures
after    blank every displayName             CAUGHT   all toolchains have valid fields
```

## Method note — one verdict was wrong before it was right

A mutation that lands on a **comment** changes nothing and reports the same "no test failed" as a
genuinely fake test. One of mine hit a comment in `FirstRunSetup.kt` and would have condemned
`SettingsPathsTest`, which in fact catches everything thrown at it. The harness now rejects a
mutation whose diff touches only comment lines.

The other half of the discriminator: a run that fails **before reaching the tests** writes no
result files. A non-zero exit with zero result files means the mutation was broken, not that the
test is sound — reading the exit code alone cannot tell those apart, and calling the second one
"the test caught it" is how a sweep certifies tests that never ran.

Suite and lint pass: exit 0, 48 result files written by that run, 0 failures.