### PR TITLE
docs: document the in-editor dev server preview that already ships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The Java toolchain is now checked the same way, completing the set — every downloadable toolchain is examined before it is packaged
 
 ### Added
+- Previewing a dev server no longer means leaving the editor: `Simple Browser: Show` opens any loopback address in a tab beside your code, with back, forward and reload. It shipped all along and was documented nowhere, so nobody knew to type it
 - **Serve on Network**: a command that answers "what address do I give my friend?" — it lists the ports your dev servers are listening on, shows the address other devices can reach them at, and copies it. Servers listening only on this device are called out as such, with the flag needed to change that
 - You can now preview your own dev server at the device's network address from inside the editor, not only at `localhost` — the same thing a laptop does when you check how a page looks from another machine on the same Wi-Fi
 - **GitHub Copilot Chat now works on device**: the bundled extension's platform packages are aliased under the name Android resolves, its SDK entry ships again, and `@vscode/sqlite3` is rebuilt for Bionic so model selection completes end to end

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ If you are **ready to learn**, you should be able to **start today**.
 - **Mobile-Optimized** — Extra Key Row (Ctrl, Alt, Tab, Esc, arrows), touch-friendly UI, clipboard bridge.
 - **SSH Out of the Box** — Bundled OpenSSH client and `ssh-keygen`, preconfigured with sane defaults (ed25519, keepalive, `accept-new`).
 - **Language Picker** — Select your languages; Go/Ruby/Java install on demand — via Play Asset Delivery on Play installs, or direct download on sideloaded installs.
-- **Dev Server Preview** — Open localhost URLs in your device's browser for web app testing.
+- **Dev Server Preview** — Preview a running dev server in an editor tab beside your code, or hand it to the device's browser.
 
 ## 📸 Screenshots
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -315,22 +315,35 @@ npm install express
 
 ### Dev Server Preview
 
-When running a local dev server (Vite, Next.js, Express, Flask, etc.), you can preview it in your device's browser:
+When running a local dev server (Vite, Next.js, Express, Flask, etc.), you can preview it
+**inside the editor**, in a tab beside your code:
 
 1. Start the dev server in the terminal:
    ```bash
    npm run dev
    # Output: Local: http://localhost:5173/
    ```
-2. Open the Command Palette (**Ctrl+Shift+P**) and run `Terminal: Open Last URL Link`
-3. The page opens in your device's browser
+2. Open the Command Palette (**Ctrl+Shift+P**) and run `Simple Browser: Show`
+3. Enter the URL, for example `http://127.0.0.1:5173/`
+
+The page opens in an editor tab with back, forward and reload buttons, and an icon to
+hand the page to your device's browser if you would rather see it full screen. Edit,
+save, tap reload — without leaving the app.
+
+Any loopback port works, whatever port your dev server picked.
+
+#### Opening in the device's browser instead
+
+If you would rather use the device browser, the terminal route still works:
+
+1. Open the Command Palette and run `Terminal: Open Last URL Link`
+2. The page opens in your device's browser
 
 The terminal underlines the URL, but tapping it does nothing: VS Code only follows a
 terminal link on Ctrl+click, and a touch tap carries no Ctrl. The command above exists
 for exactly this case. `Terminal: Open Detected Link...` lets you pick from every link
 currently on screen instead of just the last one.
 
-Any `http://localhost:PORT` address works, whatever port your dev server picked.
 
 ### npm and npx
 


### PR DESCRIPTION
## Summary

The bundled `simple-browser` extension contributes **Simple Browser: Show**, which opens a URL in an editor tab beside the code. It has shipped all along and was mentioned in no README, guide or changelog — so nobody knew to type it. The guide's dev-server section sent people to the device's browser instead: correct, but the worse of the two answers, and the only one written down.

## Confirmed on a device before advertising it

The issue named three plausible failure modes, and **each would have made this documentation wrong**. All three were tested on `emulator-5554`:

| Hypothesis | Observed |
| --- | --- |
| Handed to the system browser by `isLocalhost()`'s port check | **Not observed.** `topResumedActivity` stayed on `MainActivity` through the whole flow |
| Blocked by the webview CSP (`frame-src 'self'`) | **Not observed.** That policy governs the webview *host's* own frames; Simple Browser runs inside one and sets `frame-src *` on the document creating the nested frame |
| Extension does not load — `dist/browser/extension.js` is absent | **It is absent** — and so is the browser bundle of **19 of the 20** bundled extensions that declare one. That makes it the shape of the `vscode-reh-web` target, not a fault here. Its Node entry point ships and is what loads |

**What was actually observed:** the command appears in the palette, prompts for a URL, opens a tab with back/forward/reload and an open-externally button, and renders a live page served on `127.0.0.1:3000` — a port other than the editor server's, which is the case that matters for a dev server.

## One correction worth recording

An earlier probe injected an iframe into the **workbench page** and reported success from JavaScript — `onload` fired — while the screen showed `ERR_BLOCKED_BY_CSP`. That measured the wrong document: the workbench is served with `frame-src 'self' https://*.vscode-cdn.net data:`, which is not the policy Simple Browser runs under.

Looking at the screen is what caught it. The JavaScript said "load"; the screen said "blocked".

## Changes

- `docs/USER_GUIDE.md` — Simple Browser becomes the primary dev-server preview route; the device-browser handoff stays as a labelled alternative rather than being deleted.
- `README.md` — the feature line now says what it does.
- `CHANGELOG.md` — recorded under Added.

Fixes #93