### PR TITLE
test: assert the derived values reach the code that runs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ Thank you for your interest in contributing to VSCodroid. This guide covers ever
 - [Project Structure](#project-structure)
 - [Download Scripts](#download-scripts)
 - [Building](#building)
+- [The on-device test suite](#the-on-device-test-suite)
 - [Testing on Device](#testing-on-device)
 - [How to Add a New Bundled Tool](#how-to-add-a-new-bundled-tool)
 - [How to Add a New Patch](#how-to-add-a-new-patch)
@@ -248,7 +249,7 @@ Each script downloads pre-built binaries and places them in the correct location
 - `fetch-vscode-oss.sh` needs the `gh` CLI authenticated, or `VSCODE_OSS_URL` pointing at a tarball.
 - The Node.js binary (`libnode.so`) is Termux's `nodejs-lts` package, installed by `download-node.sh`. It is not cross-compiled here and not checked in. An earlier hand-cross-compiled build was abandoned for segfaulting inside several CLI tools; `toolchains/build-node.sh` is what remains of it and is not part of any build.
 
-## Testing on a device
+## The on-device test suite
 
 `scripts/device-test.sh` installs the APK and checks that what shipped actually
 runs: the server answers, every bundled tool starts, and Python imports the ten
@@ -279,6 +280,34 @@ This suite once demanded Node `v20.x` for two releases after the runtime moved t
 versions it checks are now read from the build rather than written down, and
 `--self-check` runs in CI to confirm those readings still resolve — but neither
 replaces running it on a device.
+
+### Test the wire, not only the predicate
+
+Pulling a decision into a pure function makes it easy to test and easy to leave
+disconnected. Two of these shipped: `heapCeilingMb` and the port-reuse branch in
+`PortFinder` were both well covered, and both could be cut out of the code that
+runs with every one of their tests still green. The tests named the right
+behaviour and never checked that anything used it.
+
+Two habits catch it, and they are cheap:
+
+**Assert at the far end of the wire.** Something downstream can usually already
+observe the value. `ProcessManagerTest` spawns `/bin/echo` and merges stderr
+into stdout, so the process prints its own arguments and `onServerOutput`
+receives them -- the command line was observable before anyone tried to assert
+on it. Look for the seam that exists before adding one.
+
+**Pick a fixture value the broken path cannot also produce.** This is what let
+both of them through. A 4 GB device derives a 512 MB ceiling, which is exactly
+the literal that the regression restores, so the obvious fixture agrees with the
+bug; 3 GB derives 384 and the test bites. `findAvailablePort()` scans upward
+from a fixed default, so the first remembered port and a fresh scan return the
+same number, and a test comparing two calls to each other moves with the bug
+instead of catching it -- holding the first port forces the paths apart.
+
+Confirm it rather than assuming: delete the line under test, run the suite, and
+check that something red points at the deletion. A test that stays green has not
+been proven wrong, only proven silent.
 
 ## Building
 

--- a/android/app/src/test/kotlin/com/vscodroid/service/ProcessManagerTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/service/ProcessManagerTest.kt
@@ -1,5 +1,6 @@
 package com.vscodroid.service
 
+import android.app.ActivityManager
 import android.content.Context
 import com.vscodroid.util.Environment
 import com.vscodroid.util.Logger
@@ -42,6 +43,7 @@ class ProcessManagerTest {
     lateinit var tempDir: File
 
     private lateinit var manager: ProcessManager
+    private lateinit var contextMock: Context
 
     @BeforeEach
     fun setUp() {
@@ -60,11 +62,11 @@ class ProcessManagerTest {
         every { Environment.getUserDataDir(any()) } returns "data"
         every { Environment.getLogsDir(any()) } returns "logs"
 
-        val context = mockk<Context>(relaxed = true)
-        every { context.cacheDir } returns tempDir
-        every { context.filesDir } returns tempDir
+        contextMock = mockk<Context>(relaxed = true)
+        every { contextMock.cacheDir } returns tempDir
+        every { contextMock.filesDir } returns tempDir
 
-        manager = ProcessManager(context)
+        manager = ProcessManager(contextMock)
     }
 
     @AfterEach
@@ -167,6 +169,50 @@ class ProcessManagerTest {
         // The unbounded overload would hang the caller forever, which is the
         // shape this replaced elsewhere in the app.
         verify(exactly = 0) { process.waitFor() }
+    }
+
+    @Test
+    fun `the derived heap ceiling reaches the command line`() {
+        // The wire, not the predicate. HeapCeilingTest pins how the number is
+        // computed and says nothing about whether it is used: replacing
+        // "--max-old-space-size=$heapMb" with a literal 512 left all of those
+        // green, because heapMb stayed referenced by the log line beside it and
+        // the file still compiled.
+        //
+        // The command line is already observable. startServer spawns /bin/echo
+        // in this fixture and redirects stderr into stdout, so the process
+        // prints its own arguments and onServerOutput receives them. Nothing had
+        // to be added to production code to see them -- the seam was already
+        // there, unused.
+        //
+        // 3 GB is chosen so the expected ceiling is 384, which no literal in the
+        // production path happens to equal. Asserting against 512 would have
+        // passed against the very mutation this exists to catch.
+        val am = mockk<ActivityManager>(relaxed = true) {
+            every { isLowRamDevice } returns false
+            every { getMemoryInfo(any()) } answers {
+                firstArg<ActivityManager.MemoryInfo>().totalMem = 3L * 1024 * 1024 * 1024
+            }
+        }
+        every { contextMock.getSystemService(ActivityManager::class.java) } returns am
+
+        val expected = heapCeilingMb(3L * 1024, isLowRam = false)
+        assertNotEquals(
+            HEAP_CEILING_DEFAULT_MB, expected,
+            "the fixture must not pick the value a regression would also produce"
+        )
+
+        val output = StringBuilder()
+        val printed = CountDownLatch(1)
+        manager.onServerOutput = { line -> output.append(line).append('\n'); printed.countDown() }
+
+        assertTrue(manager.startServer(), "the fixture server must start")
+        assertTrue(printed.await(5, TimeUnit.SECONDS), "the spawned process never printed its arguments")
+
+        assertTrue(
+            output.contains("--max-old-space-size=$expected"),
+            "the derived ceiling must reach the command line; got: $output"
+        )
     }
 
     // -- Connection token --

--- a/android/app/src/test/kotlin/com/vscodroid/service/ProcessManagerTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/service/ProcessManagerTest.kt
@@ -206,7 +206,11 @@ class ProcessManagerTest {
         val printed = CountDownLatch(1)
         manager.onServerOutput = { line -> output.append(line).append('\n'); printed.countDown() }
 
-        assertTrue(manager.startServer(), "the fixture server must start")
+        // Through the helper, not startServer() directly: the output latch fires
+        // when echo prints, which is before it exits, so waiting on that alone
+        // would leave the watchdog thread running into the next test class and
+        // logging through a Logger mock that unmockkAll() has already torn down.
+        assertTrue(startAndAwaitWatchdog(), "the fixture server must start")
         assertTrue(printed.await(5, TimeUnit.SECONDS), "the spawned process never printed its arguments")
 
         assertTrue(

--- a/android/app/src/test/kotlin/com/vscodroid/util/PortFinderTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/util/PortFinderTest.kt
@@ -138,6 +138,35 @@ class PortFinderTest {
         }
 
         @Test
+        fun `does not drift back to a lower port once it has moved`() {
+            // `returns the same port on the next cold start` cannot see whether
+            // the port was remembered. findAvailablePort() scans upward from a
+            // fixed default, so while that default is free -- the ordinary case --
+            // a fresh scan returns the same number the remembered branch would
+            // have. Both calls move together, and the assertion holds with the
+            // branch deleted.
+            //
+            // Holding the first port forces the two paths apart: the remembered
+            // port is now the higher one, and only a scan would go back down to
+            // the lower one. Drifting back is not harmless -- it is a second
+            // origin change, and it discards whatever the workbench stored under
+            // the port we had just moved to.
+            val first = PortFinder.getOrAllocatePort(context)
+
+            val moved = ServerSocket(first).use {
+                PortFinder.getOrAllocatePort(context).also { moved ->
+                    assertNotEquals(first, moved, "a held port cannot be reused")
+                }
+            }
+
+            assertEquals(
+                moved, PortFinder.getOrAllocatePort(context),
+                "once $first was free again the remembered $moved must still win; " +
+                    "returning $first would empty the storage keyed to $moved",
+            )
+        }
+
+        @Test
         fun `moves off a remembered port that something else has taken`() {
             val first = PortFinder.getOrAllocatePort(context)
 


### PR DESCRIPTION
Closes #105. Addresses the first two call sites catalogued in #118.

## What was wrong

`heapCeilingMb` and `PortFinder`'s port-reuse branch were both well covered, and
both could be deleted with every one of their tests still green. The tests pinned
how each value is computed; nothing checked that anything used it.

| Mutation | Predicate tests | This branch |
|---|---|---|
| `"--max-old-space-size=$heapMb"` → `"...=512"` | 5/5 green | red |
| delete `if (remembered != 0 && isPortAvailable(remembered))` | 5/5 green | red |

## Why both slipped through the same crack

The fixture value coincided with what the broken path also produces.

A 4 GB device derives a 512 MB ceiling — exactly the literal a regression
restores, so the obvious fixture agrees with the bug. `findAvailablePort()` scans
upward from a fixed default, so a remembered port and a fresh scan return the same
number while that default is free, and `assertEquals(first, second)` moves with
the bug instead of catching it.

## What the tests do instead

**Assert at the far end of the wire.** `ProcessManagerTest` already spawns
`/bin/echo`, merges stderr into stdout, and forwards every line to
`onServerOutput` — the process prints its own arguments, so the command line was
observable before anything asserted on it. No production code was added to see it.

**Pick a value the broken path cannot produce.** The heap test reports 3 GB, so
the expected ceiling is 384. The port test holds the first port until the
allocator has moved past it, putting the remembered value above what a scan
returns; drifting back down is a second origin change and discards the storage
keyed to the port then in use.

Both were confirmed by deleting the line under test and watching the suite go red,
and by checking the existing tests stayed green while it did.

## Also here

`CONTRIBUTING.md` records the two habits under "Test the wire, not only the
predicate", since eleven further call sites of this shape are open in #118. The
heading I added in an earlier change was one word from an existing one; it is now
distinct and listed in the contents.

Full suite: 52 classes, 372 tests, 0 failures.