### PR TITLE
docs(comment): stop describing the terminal profile as unread

### DIFF
--- a/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
@@ -1023,16 +1023,27 @@ claude() {
         val settingsFile = File(Environment.getMachineSettingsPath(context))
         settingsFile.parentFile?.mkdirs()
         if (!settingsFile.exists()) {
-            // The terminal profile is inert today and is written for the day it is
-            // not. VS Code keys these settings `…profiles.linux`, the remote
-            // reports its platform as "android", so the whole block is skipped and
-            // terminals fall back to $SHELL — which is why Environment sets SHELL
-            // to the usr/bin/bash symlink rather than the .so. Verified on device:
-            // even an explicit --init-file placed in these args never reached the
-            // spawned shell. Fixing platform detection at source makes the profile
-            // live again, so it is kept correct: the path names the symlink so the
-            // basename is `bash`, and the args stay empty because VS Code only
+            // The terminal profile is read, and the `linux` suffix is not a guess.
+            // The workbench builds the key from the OS *integer* the remote sends:
+            // `getPlatformKey()` maps 1 to "windows", 2 to "osx" and everything
+            // else to "linux", and the server computes that integer as
+            // `isMacintosh || isIOS ? 2 : isWindows ? 1 : 3`. Linux is the branch
+            // nothing tests for, so Android — neither darwin nor win32 — has always
+            // landed on it. isLinux is not consulted anywhere on this path, so
+            // patches/0001 neither made this work nor is needed for it.
+            //
+            // Both fields below carry weight: the path names the symlink so the
+            // basename is `bash`, which is the key the ptyHost looks up to decide
+            // the injection arguments, and the args stay empty because it only
             // injects shell integration for empty or login args.
+            //
+            // This block was once documented as inert, on the grounds that the
+            // remote "reports its platform as android". No such mechanism exists —
+            // it reports an integer, never a platform string. The device
+            // measurement offered as proof predates the settings-path fix, when
+            // everything written here went to a file the workbench never read, so
+            // no default profile was selected and terminals took the $SHELL
+            // fallback for an unrelated reason.
             settingsFile.writeText("""
                 {
                     "workbench.startupEditor": "none",

--- a/android/app/src/main/kotlin/com/vscodroid/util/Environment.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/util/Environment.kt
@@ -18,13 +18,18 @@ object Environment {
         //
         // SHELL names the usr/bin/bash symlink rather than the .so it points at,
         // and that indirection is what makes shell integration possible at all.
-        // VS Code never reads our terminal profile: profile settings are keyed
-        // `…profiles.linux`, and the remote reports its platform as "android", so
-        // the whole block is skipped and the terminal falls back to $SHELL with no
-        // arguments. It then decides whether to inject its bash integration by
-        // switching on the *basename* of whatever it launched — `libbash.so`
-        // matches nothing, `bash` matches. Verified on device: with the .so named
-        // here, no terminal ever received --init-file.
+        // The ptyHost picks the injection arguments from a table keyed by the
+        // executable's *basename*: `bash` maps to
+        // ["--init-file", "{0}/shellIntegration-bash.sh"], `libbash.so` matches
+        // nothing. The indirection pays twice, because setupToolSymlinks()
+        // re-points the link on every launch, so a reinstall that moves
+        // nativeLibraryDir cannot leave it dangling.
+        //
+        // SHELL is what a terminal falls back to when no profile supplies a
+        // default, so the basename has to be right on that path too — but it is
+        // not the only path. `terminal.integrated.profiles.linux` is read; see
+        // createDefaultSettings() in FirstRunSetup for why `linux` is the suffix
+        // the workbench looks up on Android.
         val shell = if (File("$nativeLibDir/libbash.so").exists())
             getTerminalShellPath(context)
         else


### PR DESCRIPTION
Fixes #91.

## What the comments say

Two places state that VS Code never reads the terminal profile this app writes, and give a mechanism for it — `Environment.kt:21-27` and `FirstRunSetup.kt:1026-1035`:

> VS Code never reads our terminal profile: profile settings are keyed `…profiles.linux`, and the remote reports its platform as "android", so the whole block is skipped

## No such mechanism exists

The remote does not report a platform string. It reports an `OperatingSystem` integer, and the workbench turns that into the settings suffix:

```js
getPlatformKey(){ ... return e ? e.os===1 ? "windows"
                               : e.os===2 ? "osx"
                               : "linux" : ... }
```

The server computes that integer with a single assignment in `out/server-main.js`:

```js
tr = om||wC ? 2 : nm ? 1 : 3        // isMacintosh||isIOS ? 2 : isWindows ? 1 : 3
```

`isLinux` does not appear in that expression. Linux is the branch nothing tests for, so Android — being neither `darwin` nor `win32` — has always landed on it. `terminal.integrated.profiles.linux` has always been the key looked up, and the profile has always been read.

## The issue's explanation is also wrong

Issue #91 reaches the right conclusion by the wrong route: it attributes the change to `patches/0001-platform-treat-android-as-linux.patch`, which widens `_isLinux`. That patch cannot affect this — `isLinux` is not consulted anywhere on this path.

The issue also says the comment "was true when it was written". It was not. The comment landed in `b179d6a` at 10:30 and patch 0001 in `19b9fbb` at 12:54 the same day, so the comment predates the patch by nearly two and a half hours and described a world that never existed.

Patch 0001 is still load-bearing elsewhere: it feeds the `Platform` enum, which without it reports `Web` rather than `Linux` on Android, and the marketplace target selector tests `isLinux` before `isAndroid` — so patch 0009 is inert without it. The rewritten comments say plainly that 0001 is not what makes the profile work, so nobody removes it on the strength of that.

## The device measurement was real; its explanation was not

The comments cite an on-device observation — an explicit `--init-file` in the profile args never reaching the spawned shell. That measurement predates the settings-path fix, when everything written here went to `<user-data-dir>/User/settings.json`, a file the workbench does not read. With settings unread, `defaultProfile.linux` fell back to its schema default of `null`, no default profile was selected, and terminals took the `$SHELL` fallback. That is exactly the reported symptom, and it does not require the platform key to be wrong.

## What the rewrite keeps

The two reasons for naming the symlink rather than the `.so` survive and are stated more precisely: the ptyHost picks injection arguments from a table keyed by the executable's **basename** (`bash` maps to `["--init-file", "{0}/shellIntegration-bash.sh"]`, `libbash.so` matches nothing), and `setupToolSymlinks()` re-points the link on every launch so a reinstall that moves `nativeLibraryDir` cannot leave it dangling.

Each comment now also carries a short note on what the old claim was, so it is not reintroduced.

## Verification

Comment-only, and that is checked rather than asserted:

- Every changed line begins with `//` — zero non-comment lines in the diff.
- Both trees were compiled and the two classes disassembled without debug info: instructions are **identical** (`Environment` 590 lines, `FirstRunSetup` 4224 lines). The class files themselves do differ, purely in line-number metadata — worth stating, because the naive claim that comments cannot change a class file is false.
- 378 unit tests pass; `./gradlew lint` reports nothing on any line this touches.

## Not claimed

That the profile takes effect on a given device today. Static reading says it should, but two runtime gates were not observed: a profile is rejected when its `path` does not resolve, and `createDefaultSettings()` is guarded by `if (!settingsFile.exists())`, so an install carrying settings from an earlier version keeps them. Re-testing means reading `settings.json` on the device rather than assuming the defaults.