### PR TITLE
test: reach the two branches these tests were named for

### DIFF
--- a/android/app/src/test/kotlin/com/vscodroid/setup/SettingsPathsTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/SettingsPathsTest.kt
@@ -292,6 +292,27 @@ class SettingsPathsTest {
         }
 
         @Test
+        fun `re-points the shape production actually writes`() {
+            // Every other case here uses the legacy filesDir shape, so the
+            // /data/app/ alternative in CLAUDE_WRAPPER was matched by nothing.
+            // Measured: deleting that alternative left all nine of these green,
+            // while no real install would ever have its wrapper re-pointed.
+            //
+            // Production writes this shape and only this shape --
+            // Environment.getMuslLoaderPath() returns
+            // "${nativeLibraryDir}/libldmusl.so" -- and nativeLibraryDir moves on
+            // every reinstall, which is the entire reason the value is rewritten.
+            val stale = settings(shell, git, args = "[]",
+                claudeWrapper = "$oldDir/libldmusl.so")
+            val result = requireNotNull(refreshManagedPaths(stale, shell, git, wrapper)) {
+                "a wrapper under the old nativeLibraryDir must be re-pointed"
+            }
+
+            assertTrue(result.contains(""""claudeCode.claudeProcessWrapper": "$wrapper""""))
+            assertTrue(!result.contains(oldDir), "stale nativeLibraryDir survived:\n$result")
+        }
+
+        @Test
         fun `re-points a wrapper the user has stale`() {
             val stale = settings(shell, git, args = "[]",
                 claudeWrapper = "/data/user/0/com.vscodroid/files/usr/bin/node-old")

--- a/android/app/src/test/kotlin/com/vscodroid/setup/SupersededExtensionsTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/SupersededExtensionsTest.kt
@@ -75,6 +75,31 @@ class SupersededExtensionsTest {
     }
 
     @Test
+    fun `a non-numeric component is not treated as zero`() {
+        // The case above never reaches the numeric guard. Its three names are
+        // dropped earlier, by the `current[id] ?: return@filter false` lookup:
+        // "extensions.json" and the un-versioned directory do not split into an
+        // id the bundled set knows, and "ms-python.python-2026.4.0-rc1" splits
+        // on its LAST dash, so its id is "ms-python.python-2026.4.0" -- also
+        // unknown. Measured: making a non-numeric component parse as 0 instead
+        // of refusing left that test green.
+        //
+        // This one uses an id the bundled set does know AND a version with no
+        // dash in it, so split() keeps the id intact and the version really is
+        // compared. Both matter: split cuts at the LAST dash, so "5.35.0-rc1"
+        // would leave the id as "PKief.material-icon-theme-5.35.0", which the
+        // bundled set does not contain -- dropped before the guard again.
+        //
+        // Scored with "x" as 0, 5.35.x looks older than the bundled 5.37.0 and
+        // gets deleteRecursively()d, taking a directory the app did not ship.
+        val present = bundled + "PKief.material-icon-theme-5.35.x"
+        assertTrue(
+            supersededExtensionDirs(present, bundled).isEmpty(),
+            "a version with a non-numeric component must be left alone, not scored as 0",
+        )
+    }
+
+    @Test
     fun `treats a missing trailing component as zero`() {
         val present = bundled + "ms-python.python-2026.4"
         assertTrue(supersededExtensionDirs(present, bundled).isEmpty())


### PR DESCRIPTION
Part of #121 — section B, minus the `ElfHeader` item already closed by #124.

Each claim was re-measured before being acted on. **All three held.** An earlier version of this
PR said one did not; that is corrected below, and the correction is the most useful thing here.

## The numeric guard was unreachable from its own test

`leaves alone anything whose version is not numeric` supplies three names, and all three are
dropped by `current[id] ?: return@filter false` before `parts()` runs:

| Input | Why it never reaches the guard |
|---|---|
| `extensions.json` | does not split into an id |
| `PKief.material-icon-theme` | no version component |
| `ms-python.python-2026.4.0-rc1` | `split` cuts at the **last** dash, so the id is `ms-python.python-2026.4.0` — not in the bundled set |

**Measured**: making a non-numeric component parse as `0` instead of refusing left that test green.

The new case uses an id the bundled set knows **and** a version with no dash, so the comparison
actually runs. Scored with `x` as 0, `5.35.x` looks older than the bundled `5.37.0` and is
`deleteRecursively()`d — taking a directory the app never shipped.

## Every wrapper test used the shape production never writes

`CLAUDE_WRAPPER` accepts a wrapper under `nativeLibraryDir` (`/data/app/…`) or a legacy `filesDir`
path. All nine `ClaudeWrapper` cases used the legacy one.

**Measured**: deleting the `/data/app/` alternative left all nine green. Production writes only the
first — `Environment.getMuslLoaderPath()` returns `"${nativeLibraryDir}/libldmusl.so"`, and
`nativeLibraryDir` moves on every reinstall, which is the entire reason the value is rewritten.

## The `[^{}]` fence — and a correction

Every document these tests build gives bash a `path` and `args` of its own, so the lazy span
stops before the fence can matter. Widening it to `[\s\S]` left all 24 cases green.

**An earlier version of this PR reported the opposite, and the reason matters more than the
result.** The replacement written into the source was `[\\s\\S]` — inside a Kotlin raw string that
is a character class of backslash, `s` and `S`, which matches almost nothing. The regex stopped
matching, seven tests failed, and the run reported exactly like a genuine catch.

A mutation that **compiles, runs, and fails tests for a different reason than intended** is
indistinguishable from a caught one by any of the guards used today — not by the exit code, not by
the result-file count, not by the skip count. Only reading the mutated line tells them apart. This
was caught by a contradicting measurement from another reading, not by the harness.

Covering it needs a **fixture, not a stricter assertion**: two profiles where bash lacks the thing
being searched for, so the span has to keep looking and the fence is the only thing stopping it.

```
fence 1 (path regex) widened   ->  never rewrites a sibling profile's path as if it were bash   FAILED
fence 2 (args regex) widened   ->  never clears a sibling profile's args as if they were bash's FAILED
```

This is issue #3 from the other side of the key: that one rewrote a path into a directory; this
would rewrite the wrong profile's path.

## Verification

Every new test confirmed to catch the mutation that exposed its gap. Suite and lint: exit 0,
**382 tests, 0 failures, 0 skipped** — the last column checked because a fully-skipped run reports
zero failures too.