### PR TITLE
test: make four assertions in the keyboard and mirror tests able to fail

### DIFF
--- a/android/app/src/test/kotlin/com/vscodroid/keyboard/KeyMappingTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/keyboard/KeyMappingTest.kt
@@ -111,6 +111,39 @@ class KeyMappingTest {
         }
 
         @Test
+        fun `a shifted symbol shares its physical key with the unshifted one`() {
+            // The test above cannot see a wrong code or keyCode -- it asserts they
+            // are non-empty and positive, which every wrong value also is. Only
+            // Tab, Escape, Enter and Space have theirs pinned, so the other 26
+            // entries rest on this.
+            //
+            // These six are one key each on a US layout, which is why KeyInjector
+            // sends the same code and keyCode for both and lets requiresShift pick
+            // the character. Giving '{' the pair belonging to '(' -- Digit9, 57 --
+            // makes the extra key row type '(' when the user presses '{', and every
+            // test in this file stays green.
+            val pairs = listOf(
+                "{" to "[", "}" to "]", ":" to ";", "\"" to "'", "|" to "\\", "~" to "`"
+            )
+            for ((shifted, plain) in pairs) {
+                val s = KeyMapping.getKeyDef(shifted)
+                val p = KeyMapping.getKeyDef(plain)
+                assertNotNull(s, "KeyDef for '$shifted' should exist")
+                assertNotNull(p, "KeyDef for '$plain' should exist")
+                assertEquals(
+                    p!!.code, s!!.code,
+                    "'$shifted' and '$plain' are the same physical key, so code must match"
+                )
+                assertEquals(
+                    p.keyCode, s.keyCode,
+                    "'$shifted' and '$plain' are the same physical key, so keyCode must match"
+                )
+                assertTrue(s.requiresShift, "'$shifted' is the shifted half of the pair")
+                assertFalse(p.requiresShift, "'$plain' is the unshifted half of the pair")
+            }
+        }
+
+        @Test
         fun `Tab has correct keyCode 9`() {
             assertEquals(9, KeyMapping.getKeyDef("Tab")!!.keyCode)
         }

--- a/android/app/src/test/kotlin/com/vscodroid/keyboard/KeyPageConfigTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/keyboard/KeyPageConfigTest.kt
@@ -2,6 +2,7 @@ package com.vscodroid.keyboard
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
@@ -74,9 +75,15 @@ class KeyPageConfigTest {
         fun `curly brace button has bracket alternates`() {
             val braces = page.items.filterIsInstance<KeyItem.Button>().find { it.value == "{" }
             assertNotNull(braces, "Page 1 should have curly brace button")
-            assertTrue(braces!!.alternates.isNotEmpty(), "Curly brace should have alternate keys")
-            val altValues = braces.alternates.map { it.value }
-            assertTrue(altValues.contains("["), "Alternates should include '['")
+            // Pinned rather than searched. Asserting only that '[' is somewhere in
+            // the list left the second alternate unguarded: replacing '<' with a
+            // duplicate '[' removes the '<' long-press option and passes both the
+            // isNotEmpty and the contains check.
+            assertEquals(
+                listOf("[" to "[", "<" to "<"),
+                braces!!.alternates.map { it.label to it.value },
+                "Curly brace long-press offers the bracket then the angle bracket"
+            )
         }
     }
 
@@ -135,12 +142,24 @@ class KeyPageConfigTest {
         }
 
         @Test
-        fun `every button has a contentDescription`() {
+        fun `every button has a contentDescription of its own`() {
+            // This asserted the description was non-empty, which it cannot fail to
+            // be: contentDescription defaults to label, and the sibling test above
+            // already forbids an empty label. Every explicit accessibility string
+            // in KeyPageConfig could be deleted and this stayed green.
+            //
+            // What can fail is taking that default. A screen reader then reads the
+            // symbol -- "{}" instead of "Curly braces" -- which is exactly the case
+            // these strings exist for. All 23 buttons name themselves today, so a
+            // description equal to its label means one was dropped.
             for ((pageIndex, page) in KeyPages.defaults.withIndex()) {
                 for (item in page.items) {
                     if (item is KeyItem.Button) {
-                        assertTrue(item.contentDescription.isNotEmpty(),
-                            "Button contentDescription should not be empty (page ${pageIndex + 1}, label: ${item.label})")
+                        assertNotEquals(
+                            item.label, item.contentDescription,
+                            "Button '${item.label}' on page ${pageIndex + 1} fell back to the " +
+                                "default contentDescription; a screen reader would read the symbol"
+                        )
                     }
                 }
             }

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafSyncEngineTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafSyncEngineTest.kt
@@ -307,6 +307,39 @@ class SafSyncEngineTest {
         }
 
         @Test
+        fun `a document with no reported time still refreshes the mirror`() {
+            // The test above asserts the constructor assigned its arguments, which
+            // is a property of Kotlin rather than of this file. It also never
+            // touches lastModified, and that default is the one field anything
+            // depends on: shouldOverwriteMirror keys its unknown-time branch on
+            // exactly 0.
+            //
+            // Change the default to -1 and that branch stops firing. The comparison
+            // falls through to mirrorModified > sourceModified, which is true
+            // against any real mirror time, so the copy is skipped -- a provider
+            // that reports no timestamp gets its first copy and never an update
+            // again, silently.
+            val doc = DocumentInfo(
+                uri = mockk<Uri>(),
+                docId = "primary:MyProject/src/main.kt",
+                relativePath = "src/main.kt",
+                isDirectory = false,
+                size = 2048
+            )
+            assertEquals(0L, doc.lastModified, "an unreported provider time is 0")
+            assertTrue(
+                SafSyncEngine.shouldOverwriteMirror(
+                    mirrorExists = true,
+                    mirrorModified = 1_700_000_000_000L,
+                    mirrorSize = 1024,
+                    sourceModified = doc.lastModified,
+                    sourceSize = doc.size
+                ),
+                "a document with no reported time must be copied, not treated as older"
+            )
+        }
+
+        @Test
         fun `SyncJob stores fields correctly`() {
             val docUri = mockk<Uri>()
             val parentUri = mockk<Uri>()


### PR DESCRIPTION
Part A of #121 — the claims in files owned by this half of the sweep. Part B
(`ElfHeader`, `SupersededExtensions`, `SettingsPaths`) is separate and there is no
overlap.

**Six claims were re-measured against current main before anything was written. Two of
them no longer apply, and are reported below rather than fixed.** #121 is my own issue,
and that does not make it exempt — the same re-measurement found two of four claims in
the other half did not apply either.

## Fixed — four claims that stood

Each mutation was applied alone against a cleared results directory, the verdict read
from the XML that run wrote rather than an exit code, and the diff checked for a
non-comment line so a no-op mutation could not be mistaken for a blind test.

| Mutation | before | after |
|---|---|---|
| `'{'` carries `Digit9`/`57` instead of `BracketLeft`/`219` | MISSED | **CAUGHT** |
| every explicit `contentDescription` deleted | MISSED | **CAUGHT** |
| `'<'` replaced by a duplicate `'['` in the `{` alternates | MISSED | **CAUGHT** |
| `DocumentInfo.lastModified` defaults to `-1` instead of `0` | MISSED | **CAUGHT** |

Each is killed by exactly one failing test, with no existing test going red. 407 tests
executed, zero skipped — the skipped column is checked, because a suite that is entirely
skipped writes result files and reports zero failures.

The reasoning for each assertion is in the commit message. The short version: three of
them pin a property rather than restating data, and the fourth ties a default to the
branch that reads it.

The `DocumentInfo` one is worth calling out because the consequence is larger than the
issue described. With the default at `-1`, `shouldOverwriteMirror`'s unknown-time branch
stops firing and the comparison falls through to `mirrorModified > sourceModified`, which
is true against any real mirror time. A provider that reports no timestamp gets its first
copy and then never an update again — silently, and only for that class of provider.

## Not applicable — two claims that did not survive re-measurement

**`MAX_FILE_SIZE is 50 MB`** — the issue said inverting the size comparison left the
constant assertion green. It no longer does: `InitialSyncWiringTest` now fails on it,
three tests over. Those tests arrived to close the *wiring* gap in #118, and closing it
covered this weak assertion as a side effect. Nothing to do.

**`SIGKILL is the 137 the watchdog already looked for`** — this was filed in the wrong
place. The mutation changes the log line inside `startWatchdog()`, which is a `Context`
and process dependency, so it belongs to the wiring class in #118 rather than to weak
assertions here. And the test itself is honest: `signalName(137 - 128)` pins the
arithmetic the watchdog's `129..192` branch depends on, and `signalName` is genuinely
covered. What is untested is the watchdog's exit-code classification, which cannot be
reached from a JVM test.

Its user-visible cost is also smaller than the issue implied: the mutation makes a killed
server log "exited cleanly" while `onServerCrashed` still fires, so the behaviour is
unchanged and only the diagnostic lies.

## One claim not measured

**`SyncType has all expected values`** had no production mutation proposed, and on
reading it there is none worth making: `processWriteBack`'s `when` is exhaustive, so
removing an entry is a compile error. The test does catch an entry being *added* without
the writer being updated, which is small but not nothing. Left alone.

No CHANGELOG entry — nothing user-facing changes, matching the six test-only changes that
landed today.

Refs #121. Not closing it: Part B is still open.
