### PR TITLE
test: stop the profile regexes from reaching into a sibling profile

### DIFF
--- a/android/app/src/test/kotlin/com/vscodroid/setup/SettingsPathsTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/SettingsPathsTest.kt
@@ -152,6 +152,104 @@ class SettingsPathsTest {
         }
     }
 
+    /**
+     * Two profiles under `profiles.linux`, which every other document here
+     * lacks.
+     *
+     * The prefix of the profile regexes is fenced with `[^{}]` so a lazy span
+     * cannot cross out of the bash object into a sibling. Nothing tested that:
+     * with one profile there is no brace to cross, so widening the fence to
+     * `[\s\S]` left all 24 cases green -- measured, after an earlier attempt
+     * that reported the opposite because the replacement it wrote was
+     * `[\\s\\S]`, a class of backslash-s-S that matches almost nothing and
+     * broke the regex instead of widening it.
+     *
+     * This is issue #3 from the other side of the key: that one rewrote a path
+     * into a directory, this one would rewrite the wrong profile's path.
+     */
+    @Nested
+    inner class SiblingProfiles {
+
+        // bash carries no path of its own, so the lazy span has to keep looking
+        // -- and the only thing left to find is the NEXT profile's. The fence is
+        // the only thing stopping it.
+        private fun bashWithoutPath(zshPath: String) = """
+            {
+                "claudeCode.claudeProcessWrapper": "$wrapper",
+                "extensions.verifySignature": false,
+                "terminal.integrated.profiles.linux": {
+                    "bash": {
+                        "icon": "terminal-bash"
+                    },
+                    "zsh": {
+                        "path": "$zshPath",
+                        "args": ["-i"]
+                    }
+                },
+                "git.path": "$git",
+                "terminal.integrated.shellIntegration.enabled": false
+            }
+        """.trimIndent()
+
+        @Test
+        fun `never rewrites a sibling profile's path as if it were bash`() {
+            val zsh = "$oldDir/libzsh.so"
+            val before = bashWithoutPath(zsh)
+
+            // Widening the prefix fence from [^{}] to anything that can cross a
+            // brace makes this match zsh's path and rewrite it to the bash
+            // binary. Every other document here gives bash a path of its own, so
+            // the lazy span stops before the fence ever matters -- measured: with
+            // one profile, widening the fence left all 24 cases green.
+            val result = refreshManagedPaths(before, shell, git, wrapper)
+
+            if (result != null) {
+                assertTrue(
+                    result.contains(""""path": "$zsh""""),
+                    "the zsh profile's path was rewritten:\n$result",
+                )
+                assertTrue(
+                    !result.contains(""""zsh": {\n        "path": "$shell""""),
+                    "bash's binary was written into the zsh profile:\n$result",
+                )
+            }
+        }
+
+        // bash has a stale path but no args, so the path rewrite fires -- which
+        // is what makes the result observable at all -- while the args span has
+        // nothing of bash's to find and must not go looking in the sibling.
+        private fun bashWithoutArgs(zshPath: String) = """
+            {
+                "claudeCode.claudeProcessWrapper": "$wrapper",
+                "extensions.verifySignature": false,
+                "terminal.integrated.profiles.linux": {
+                    "bash": {
+                        "path": "$oldDir/libbash.so",
+                        "icon": "terminal-bash"
+                    },
+                    "zsh": {
+                        "path": "$zshPath",
+                        "args": ["-i"]
+                    }
+                },
+                "git.path": "$git",
+                "terminal.integrated.shellIntegration.enabled": false
+            }
+        """.trimIndent()
+
+        @Test
+        fun `never clears a sibling profile's args as if they were bash's`() {
+            val result = requireNotNull(
+                refreshManagedPaths(bashWithoutArgs("$oldDir/libzsh.so"), shell, git, wrapper)
+            ) { "the stale bash path still needed repairing" }
+
+            assertTrue(
+                result.contains(""""args": ["-i"]"""),
+                "the zsh profile's args were cleared:\n$result",
+            )
+        }
+    }
+
     @Nested
     inner class LeavesAlone {
 


### PR DESCRIPTION
The last item of #121's section B. It was measured while #134 was open and missed that merge, so
it arrives on its own; everything else from that section is already in.

## What was uncovered

Both profile regexes fence their prefix with `[^{}]` so a lazy span cannot cross out of the `bash`
object into a sibling. Every document these tests build gives bash a `path` and `args` of its own,
so the span stops before the fence can matter.

**Measured**: widening it to `[\s\S]` left all 24 cases green.

## The first fixture did not work either

A document with two profiles is not enough — the regex is lazy and stops at bash's own `"path"`
before the fence is ever reached. What discriminates is a document where **bash lacks the thing
being searched for**, so the span has to keep looking:

| Fixture | bash has | What the widened fence then matches |
|---|---|---|
| `bashWithoutPath` | no `path` | the **zsh** profile's path, rewritten to the bash binary |
| `bashWithoutArgs` | `path`, no `args` | the **zsh** profile's args, cleared |

The second also needs bash to carry a stale path, or nothing is rewritten at all and
`refreshManagedPaths` returns null with nothing to assert against.

## Verified

```
fence 1 (path) widened  ->  never rewrites a sibling profile's path as if it were bash    FAILED
    became: …"bash"\s*:\s*\{[\s\S]*?"path"\s*:\s*)"/data/app/[^"]*["]…
fence 2 (args) widened  ->  never clears a sibling profile's args as if they were bash's  FAILED
    became: …"bash"\s*:\s*\{[\s\S]*?"args"\s*:\s*)\["-i"\]…
```

The mutated line is printed alongside the verdict deliberately. An earlier measurement of this
same fence reported the opposite because the replacement written into the source was `[\\s\\S]` —
inside a Kotlin raw string, a character class of backslash, `s` and `S`, which broke the regex
instead of widening it. A mutation that compiles, runs and fails tests **for the wrong reason**
reports exactly like a caught one; only reading the changed line separates them.

This is issue #3 from the other side of the key: that one rewrote a path into a directory, this
rewrites the wrong profile's.

Suite and lint: exit 0, **420 tests, 0 failures, 0 skipped**.