### PR TITLE
test(toolchain): cover the library deletion where it acts, not where it decides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -301,7 +301,7 @@ disconnected. Two of these shipped: `heapCeilingMb` and the port-reuse branch in
 runs with every one of their tests still green. The tests named the right
 behaviour and never checked that anything used it.
 
-Two habits catch it, and they are cheap:
+Three habits catch it, and they are cheap:
 
 **Assert at the far end of the wire.** Something downstream can usually already
 observe the value. `ProcessManagerTest` spawns `/bin/echo` and merges stderr
@@ -316,6 +316,18 @@ bug; 3 GB derives 384 and the test bites. `findAvailablePort()` scans upward
 from a fixed default, so the first remembered port and a fresh scan return the
 same number, and a test comparing two calls to each other moves with the bug
 instead of catching it -- holding the first port forces the paths apart.
+
+**Before asserting that something did not change, prove the code that would have
+changed it actually ran.** "Unchanged" is the same result for "correctly guarded"
+and "never reached", and nothing in the run distinguishes them. `settings.json` is
+written through `writeAtomically` so a failed write leaves the user's file intact
+-- but the method returns early when there is nothing to refresh, several lines
+above the write. A test asserting the file survived a failed write passes just as
+happily when the refresh decided there was nothing to do and no write was ever
+attempted. The fix is to make the success case assert the file *did* change, which
+establishes that the write path is reachable with that fixture; only then does the
+failure case mean anything. The same reasoning applies to any `verify(exactly = 0)`
+and to every "still exists", "was not deleted", "was left alone".
 
 When the thing being judged is a guard rather than a test, measure the tree it
 will guard, not the tree that caused it to be written. A rule for the welcome

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -132,6 +132,10 @@ dependencies {
     testImplementation(libs.junit.jupiter.api)
     testRuntimeOnly(libs.junit.jupiter.engine)
     testImplementation(libs.mockk)
+    // The android.jar stub throws "not mocked" from every org.json method, which puts
+    // any code that parses a manifest out of reach of a JVM test. No unit test parsed
+    // JSON before this, so replacing the stub cannot change an existing verdict.
+    testImplementation("org.json:json:20250107")
 
     // Instrumented Testing (JUnit 4, runs on device)
     androidTestImplementation(libs.androidx.test.ext.junit)

--- a/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainUninstallLibsTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainUninstallLibsTest.kt
@@ -1,0 +1,138 @@
+package com.vscodroid.setup
+
+import android.content.Context
+import android.content.res.AssetManager
+import com.google.android.play.core.assetpacks.AssetPackManagerFactory
+import com.vscodroid.util.Logger
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkObject
+import io.mockk.unmockkStatic
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.io.IOException
+
+/**
+ * Tests for the library deletion in `ToolchainManager.uninstallSync` — the call site,
+ * not the decision.
+ *
+ * [toolchainLibsSafeToRemove] is covered by [ToolchainLibsTest] in both directions:
+ * a null listing removes nothing, an empty listing removes everything named. Both stayed
+ * green while the call site could be changed from passing `null` to passing `emptySet()`
+ * when the base listing cannot be read — which turns "keep everything, we cannot tell"
+ * into "delete everything, the base ships nothing".
+ *
+ * That is the `libffi.so` bug the comment above the call site describes: Ruby's manifest
+ * names it, Python's `_ctypes` links it, and deleting it on a Ruby uninstall broke
+ * `import ctypes` until the next app update, with nothing pointing at the uninstall.
+ *
+ * Both directions are asserted here. A test that only checked the unreadable case would
+ * also pass against a call site that never deletes anything at all.
+ */
+class ToolchainUninstallLibsTest {
+
+    @TempDir
+    lateinit var filesDir: File
+
+    private lateinit var context: Context
+    private lateinit var assets: AssetManager
+    private lateinit var libDir: File
+
+    /** Ships in the base APK too — Python's _ctypes links it. */
+    private val shared = "libffi.so"
+
+    /** Ships only with this toolchain. */
+    private val ownOnly = "libruby.so"
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(Logger)
+        every { Logger.d(any(), any()) } just Runs
+        every { Logger.i(any(), any()) } just Runs
+        every { Logger.w(any(), any(), any()) } just Runs
+        every { Logger.e(any(), any(), any()) } just Runs
+
+        // The constructor reaches Play Core through field initialisation, so it runs
+        // before any method can be called. mockkConstructor does not help — the
+        // constructor body still executes.
+        mockkStatic(AssetPackManagerFactory::class)
+        every { AssetPackManagerFactory.getInstance(any()) } returns mockk(relaxed = true)
+
+        assets = mockk(relaxed = true)
+        context = mockk(relaxed = true)
+        every { context.filesDir } returns filesDir
+        every { context.assets } returns assets
+
+        libDir = File(filesDir, "usr/lib").apply { mkdirs() }
+        File(libDir, shared).writeText("elf")
+        File(libDir, ownOnly).writeText("elf")
+
+        File(filesDir, "home/.vscodroid").mkdirs()
+        File(filesDir, "home/.vscodroid/toolchains.json").writeText(
+            """[{"name":"ruby","libs":["$shared","$ownOnly"]}]"""
+        )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkObject(Logger)
+        unmockkStatic(AssetPackManagerFactory::class)
+    }
+
+    /** `uninstallSync` is private; `uninstall` hands the work to an executor. */
+    private fun uninstallSync(name: String) {
+        val m = ToolchainManager::class.java
+            .getDeclaredMethod("uninstallSync", String::class.java)
+            .apply { isAccessible = true }
+        m.invoke(ToolchainManager(context), name)
+    }
+
+    /**
+     * When the base listing cannot be read the uninstall must delete nothing. A leftover
+     * library is reclaimed by the next install; a deleted base library is not.
+     */
+    @Test
+    fun `an unreadable base listing deletes no libraries`() {
+        every { assets.list("usr/lib") } throws IOException("assets unavailable")
+
+        uninstallSync("ruby")
+
+        assertTrue(File(libDir, shared).exists(), "$shared was deleted despite an unreadable base listing")
+        assertTrue(File(libDir, ownOnly).exists(), "$ownOnly was deleted despite an unreadable base listing")
+    }
+
+    /**
+     * The other direction, and it is what makes the test above mean something: with a
+     * readable listing the uninstall does delete, and keeps only what the base also
+     * ships. Without this, a call site that never deleted anything would pass.
+     */
+    @Test
+    fun `a readable base listing deletes only what the base does not ship`() {
+        every { assets.list("usr/lib") } returns arrayOf(shared)
+
+        uninstallSync("ruby")
+
+        assertTrue(File(libDir, shared).exists(), "$shared is shipped by the base install and must survive")
+        assertFalse(File(libDir, ownOnly).exists(), "$ownOnly belongs only to this toolchain and should be gone")
+    }
+
+    /** `list` returning null is the same "cannot tell" as throwing, and must be treated alike. */
+    @Test
+    fun `a null base listing deletes no libraries`() {
+        every { assets.list("usr/lib") } returns null
+
+        uninstallSync("ruby")
+
+        assertTrue(File(libDir, shared).exists(), "$shared was deleted on a null listing")
+        assertTrue(File(libDir, ownOnly).exists(), "$ownOnly was deleted on a null listing")
+    }
+}


### PR DESCRIPTION
Closes the second call site listed in #118.

## What was uncovered

`toolchainLibsSafeToRemove` is tested in both directions — a null listing removes nothing, an empty listing removes everything named — and both stayed green while the call site in `uninstallSync` could be changed from passing `null` to passing `emptySet()` when the base asset listing cannot be read.

That flips the meaning from *"keep everything, we cannot tell"* to *"delete everything, the base ships nothing"*. It is the `libffi.so` bug the comment above the call site describes: Ruby's manifest names it, Python's `_ctypes` links it, and deleting it on a Ruby uninstall broke `import ctypes` until the next app update, with nothing pointing at the uninstall that caused it.

## Three mutations, three tests

Each applied on its own, verdict taken from the result XML rather than an exit code:

| mutation | caught by |
|---|---|
| `catch { … null }` → `emptySet()` | an unreadable base listing deletes no libraries |
| `list(…)?.toSet()` → `?: emptySet()` | a null base listing deletes no libraries |
| the deletion loop → `emptyList()` | a readable base listing deletes only what the base does not ship |

**The third direction matters as much as the first.** A test that only checked the unreadable case would pass just as happily against a call site that never deleted anything at all.

## The dependency, and why it is measured rather than argued

Reaching the call site needed one thing the tree did not have. `uninstallSync` parses the toolchain manifest through `readState()` on its **first line**, and every `org.json` method on the unit-test classpath throws `"not mocked"` — `BundledExtensionHostTest` already works around this by matching the manifest with a regex instead of parsing it, and says so at `:42`.

So `testImplementation("org.json:json:20250107")` replaces the stub. It is a **test** dependency; nothing in production changed.

Because that is a shared build file, the case for it is measurement rather than judgement:

- **No unit test imported `org.json` or parsed JSON before this** — `grep` over `src/test` returns nothing. So replacing the stub cannot change an existing verdict; there was no test that was green *because* JSON threw.
- The suite is **418 green on plain main** and **421 green** with the dependency and these three tests, with no test moving in either direction.

Robolectric would also have reached this, and is the wrong tool: what is being asserted here is that the deletion respects an unreadable listing, not how a JSON parser behaves. The platform implementation is in the way, not under test.

## Standing the class up

The constructor reaches Play Core through field initialisation, so it runs before any method can be called. `mockkConstruction` does not help — the constructor body still executes. `mockkStatic(AssetPackManagerFactory::class)` is what stands it up, and `mockkObject(Logger)` covers `android.util.Log`.

## CONTRIBUTING

Gains the habit that made these tests real rather than decorative, with the case that produced it:

> Before asserting that something did not change, prove the code that would have changed it actually ran. "Unchanged" is the same result for "correctly guarded" and "never reached".

That one bit while writing #140 — `updateSettingsNativeLibPaths` returns early when there is nothing to refresh, several lines above the write, so a test asserting the file survived a failed write passes equally when no write was ever attempted.