### PR TITLE
test: pin the watchdog's use of the signal name

### DIFF
--- a/android/app/src/test/kotlin/com/vscodroid/service/ProcessManagerTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/service/ProcessManagerTest.kt
@@ -310,6 +310,42 @@ class ProcessManagerTest {
         )
     }
 
+    @Test
+    fun `the watchdog names the signal that killed the server`() {
+        // SignalNameTest pins the translation and nothing checked that the
+        // watchdog performs it. Replacing the call with the bare number leaves
+        // every one of those green: they call signalName directly, and the log
+        // line is the only place the result was ever used.
+        //
+        // What is lost is only the diagnostic -- onServerCrashed still fires, so
+        // the restart still happens -- which is why it could rot unnoticed. The
+        // log is what someone reads to understand why the server died, and
+        // "signal 11" makes them look it up while "SIGSEGV" tells them.
+        //
+        // 139, not 137: the branch above this one claims 137 for the
+        // out-of-memory message, so a fixture using it never reaches the code
+        // under test at all. 139 is 128 + SIGSEGV, and "SIGSEGV" is a string the
+        // broken path cannot produce.
+        manager.serverProcessField = mockk<Process>(relaxed = true) {
+            every { waitFor() } returns 139
+            every { isAlive } returns false
+        }
+
+        val named = CountDownLatch(1)
+        every { Logger.w(any(), match<String> { it.contains("SIGSEGV") }, any()) } answers {
+            named.countDown()
+        }
+
+        ProcessManager::class.java.getDeclaredMethod("startWatchdog")
+            .apply { isAccessible = true }
+            .invoke(manager)
+
+        assertTrue(
+            named.await(5, TimeUnit.SECONDS),
+            "the watchdog must name the signal, not print its number"
+        )
+    }
+
     // -- Connection token --
 
     @Test


### PR DESCRIPTION
One more call site from #118. Follows #125, #133, #137.

| Mutation | Existing suite | This branch |
|---|---|---|
| `signalName(exitCode - 128)` → `${exitCode - 128}` | green (417 tests) | `the watchdog names the signal that killed the server` |

Reproduced before writing anything, since claims in this issue have not all held:
the mutation survives the whole suite, and `SignalNameTest` stays green through it
— those three tests call `signalName` directly, and the log line was the only
place its result was ever used.

## What breaks quietly

Only the diagnostic. `onServerCrashed` still fires, so the automatic restart still
happens; the log is the sole casualty. That is exactly why it could rot with
nothing to notice — and the log in question is what someone reads to find out why
the server died. `signal 11` sends them to look it up; `SIGSEGV` tells them.

## The fixture is 139, and that is the whole trick

The first attempt used 137, on the reasoning that it is the code the watchdog
already had a branch for. That is precisely why it is wrong:

```kotlin
exitCode == 137        -> Logger.w(tag, "Server killed (OOM or phantom limit)")
exitCode in 129..192   -> Logger.w(tag, "Server killed by ${signalName(exitCode - 128)}")
```

137 is claimed by the branch above, so the test never reached the code it was
written for. It failed with a timed-out latch, which reads like a mocking problem
and sent me to check `Logger` overloads before reading the branch order.

139 is `128 + SIGSEGV`, and `SIGSEGV` is a string the broken path cannot produce.
The watchdog is driven through a `Process` whose `waitFor()` returns the code, so
the real branch runs rather than a copy of it.

Lint and unit tests green: 61 classes, 418 tests, 0 failures.

