### PR TITLE
test: put the memory-pressure decision where a test can reach it

### DIFF
--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -165,10 +165,15 @@ class MainActivity : AppCompatActivity() {
 
     override fun onTrimMemory(level: Int) {
         super.onTrimMemory(level)
-        val pressure = memoryPressureOf(level)
+        // Deciding and recording live together in applyMemoryPressure. Nothing
+        // here branches on the level, because nothing here can be run: this
+        // method cannot be invoked without an Activity, and an Activity cannot
+        // be built in a plain JVM test, so any decision left inside it is a
+        // decision no test can reach. What remains is super, one call, and two
+        // effects that need the Activity anyway.
+        val pressure = applyMemoryPressure(File(cacheDir, "tmp"), level)
         if (pressure == PRESSURE_NONE) return
         Logger.w(tag, "Memory pressure: $pressure (trim level $level)")
-        writeMemoryPressure(pressure)
         webView?.evaluateJavascript(
             "window.__vscodroid?.onLowMemory?.($level)", null
         )
@@ -271,18 +276,6 @@ class MainActivity : AppCompatActivity() {
     }
 
     // -- Internal --
-
-    private fun writeMemoryPressure(pressure: String) {
-        try {
-            val tmpDir = File(cacheDir, "tmp")
-            // A severity, not Android's trim level. The monitor on the other end
-            // has no business knowing Android's numbering, and when it did, it
-            // compared values that are not ordered by severity.
-            File(tmpDir, "vscodroid-memory-pressure").writeText(pressure)
-        } catch (e: Exception) {
-            Logger.d(tag, "Failed to write memory pressure: ${e.message}")
-        }
-    }
 
     /**
      * After resuming from background, checks if the VS Code connection is still
@@ -1017,4 +1010,46 @@ internal fun memoryPressureOf(level: Int): String = when (level) {
     // hint Android has. This is the only line that changes behaviour, and it
     // changes it for exactly the value that was wrong.
     else -> PRESSURE_NONE
+}
+
+/**
+ * Decides what a trim level means and records it for the process monitor.
+ *
+ * Deciding and recording are one unit, and splitting them is what made this
+ * untestable: the decision sat in `onTrimMemory`, which cannot be invoked
+ * without an Activity, while the recording sat in a private method that reached
+ * `this.cacheDir` for the one thing it needed. Neither half could be reached, so
+ * the wire between the pinned predicate and the file the monitor reads was
+ * covered by nothing — and replacing [memoryPressureOf] here with a `>=`
+ * comparison, the exact defect this whole path exists to prevent, left the
+ * entire suite green.
+ *
+ * Takes the directory rather than reaching for one, so the caller supplies what
+ * it already has and a test supplies a temporary one.
+ *
+ * @return the severity, so the caller can log it and notify the workbench —
+ *   both of which need the Activity and neither of which decides anything.
+ */
+internal fun applyMemoryPressure(tmpDir: File, level: Int): String {
+    val pressure = memoryPressureOf(level)
+    if (pressure != PRESSURE_NONE) writeMemoryPressure(tmpDir, pressure)
+    return pressure
+}
+
+/**
+ * Writes the severity where `process-monitor.js` looks for it.
+ *
+ * A severity, not Android's trim level. The monitor on the other end has no
+ * business knowing Android's numbering, and when it did, it compared values
+ * that are not ordered by severity.
+ *
+ * Failure is swallowed: the file is a hint for a monitor, and losing it is
+ * worth less than the memory callback it is reporting on.
+ */
+internal fun writeMemoryPressure(tmpDir: File, pressure: String) {
+    try {
+        File(tmpDir, "vscodroid-memory-pressure").writeText(pressure)
+    } catch (e: Exception) {
+        Logger.d("MainActivity", "Failed to write memory pressure: ${e.message}")
+    }
 }

--- a/android/app/src/test/kotlin/com/vscodroid/MemoryPressureTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/MemoryPressureTest.kt
@@ -7,8 +7,19 @@ import android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL
 import android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW
 import android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_MODERATE
 import android.content.ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import com.vscodroid.util.Logger
+import java.io.File
 
 /**
  * The mapping exists because Android's trim constants are not ordered by
@@ -57,5 +68,79 @@ class MemoryPressureTest {
         // numerically large, which is exactly how this broke.
         assertEquals(PRESSURE_NONE, memoryPressureOf(999))
         assertEquals(PRESSURE_NONE, memoryPressureOf(-1))
+    }
+}
+
+/**
+ * The wire between that mapping and the file the process monitor reads.
+ *
+ * Every test above pins [memoryPressureOf] and none of them touched the code
+ * that calls it. Replacing the call with the `>=` comparison it replaced — the
+ * original defect, restored verbatim — left the whole suite green, because the
+ * decision sat inside `onTrimMemory`, which cannot be invoked without an
+ * Activity, and the recording sat in a private method that reached `cacheDir`
+ * for the one thing it needed.
+ *
+ * What breaks when this rots is the detector itself: the process monitor stops
+ * seeing memory pressure, silently, in an app whose whole design is built
+ * around a 32-process limit and 400-700 MB of RAM. A dead detector is worse
+ * than no detector, because it produces confidence.
+ */
+class MemoryPressureWireTest {
+
+    @TempDir
+    lateinit var tmpDir: File
+
+    private val file get() = File(tmpDir, "vscodroid-memory-pressure")
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(Logger)
+        every { Logger.d(any(), any()) } just Runs
+    }
+
+    @AfterEach
+    fun tearDown() = unmockkAll()
+
+    @Test
+    fun `real pressure reaches the file the monitor reads`() {
+        // First, because the test below asserts that nothing was written and
+        // "nothing was written" is also what a broken fixture produces. This
+        // proves the writing path works here before that one claims it did not
+        // run.
+        assertEquals(PRESSURE_CRITICAL, applyMemoryPressure(tmpDir, TRIM_MEMORY_RUNNING_CRITICAL))
+        assertEquals(
+            PRESSURE_CRITICAL, file.readText(),
+            "the severity has to reach ${file.name}, which is what process-monitor.js opens"
+        )
+    }
+
+    @Test
+    fun `backgrounding writes nothing, whatever its number`() {
+        // TRIM_MEMORY_UI_HIDDEN is 20 and RUNNING_CRITICAL is 15, so a `>=`
+        // comparison calls an ordinary app switch critical. This is the value
+        // that discriminates: any fixture below 15 would pass against the
+        // comparison too.
+        val sentinel = "left alone"
+        file.writeText(sentinel)
+
+        assertEquals(PRESSURE_NONE, applyMemoryPressure(tmpDir, TRIM_MEMORY_UI_HIDDEN))
+        assertEquals(
+            sentinel, file.readText(),
+            "an app switch must not be recorded as pressure; it arrives on every backgrounding"
+        )
+    }
+
+    @Test
+    fun `a failed write is swallowed rather than thrown at the caller`() {
+        // The destination is a directory, so writeText throws. This runs inside
+        // onTrimMemory, a lifecycle callback: letting it escape would turn a
+        // missing hint into a crash on every app switch.
+        assertTrue(file.mkdirs(), "the fixture must actually block the write")
+
+        assertEquals(
+            PRESSURE_CRITICAL, applyMemoryPressure(tmpDir, TRIM_MEMORY_RUNNING_CRITICAL),
+            "the severity is still the answer even when it could not be recorded"
+        )
     }
 }


### PR DESCRIPTION
`MainActivity.kt:173` from #118. Follows #145.

| Mutation | Before | After |
|---|---|---|
| `memoryPressureOf(level)` → `if (level >= TRIM_MEMORY_RUNNING_CRITICAL) …` | survives all 417 tests | `backgrounding writes nothing, whatever its number` |

Killed by exactly one test, with the five `MemoryPressureTest` methods green
through it — they pin the mapping and never touched the code that calls it.

## Why this needed a production change when the last six did not

Nothing inside `onTrimMemory` can be tested. The method needs an Activity, an
Activity cannot be built in a plain JVM test, and mockk cannot intercept a `super`
call — measured:

```
mockk<MainActivity>(relaxed = true) + callOriginal()
  -> RuntimeException: Method onTrimMemory in android.app.Activity not mocked
```

`mockkStatic` does not apply: `android.util.Log` is a static class, this is an
instance method on a superclass.

So extraction cannot make that line reachable. What it can do is **empty the
callback until nothing worth testing is left inside it** — which is the general
form for any lifecycle callback, not just this one.

## What was extracted, and why it is more honest

Deciding and recording are one unit. Splitting them across the Activity boundary
is what made them unreachable: the decision sat in `onTrimMemory`, the recording
in a private method that reached `this.cacheDir` for the single thing it needed.

`applyMemoryPressure(tmpDir, level)` takes what it needs, does both, and returns
the severity. The callback keeps `super`, one call, and two effects that need the
Activity anyway. **No interface, no injection, no layer.**

## What breaks when this rots

The detector itself. `process-monitor.js` stops seeing memory pressure, silently,
in an app whose design is built around a 32-process limit and 400–700 MB of RAM. A
dead detector is worse than no detector, because it produces confidence — and the
comment already on this path records that the wrong comparison has happened here
before.

## The fixture

`TRIM_MEMORY_UI_HIDDEN` is **20** where `RUNNING_CRITICAL` is **15**, so the
comparison calls an ordinary app switch critical. Anything below 15 would pass
against the bug as happily as against the fix.

Two further precautions, both about the negative assertion:

- the file is pre-filled with a sentinel, so "unchanged" is distinguishable from
  "never written at all"
- the case that *does* write runs first, so the fixture is known to be capable of
  writing before another test asserts that it did not

A third test covers the swallowed failure: the destination is made a directory, so
the write throws, and the severity is still returned rather than escaping into a
lifecycle callback.

Lint and unit tests green: 62 classes, 421 tests, 0 failures. No behaviour change,
so no changelog entry.
