### PR TITLE
test: pin the last three guards nothing was checking

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -352,6 +352,22 @@ rule could go back to preferring the newer file and lose nothing. If a fixture
 cannot be written that tells two cases apart, that is worth reading as a
 statement about the code rather than about the test.
 
+And some methods cannot be called at all. A lifecycle callback needs an Activity,
+an Activity cannot be built in a plain JVM test, and mockk cannot intercept the
+`super` call inside it -- `onTrimMemory` gives "Method onTrimMemory in
+android.app.Activity not mocked" however it is approached. Extraction cannot make
+a line in there reachable. What it can do is **empty the method until nothing
+worth testing is left inside it**: move the decision out with the data it needs,
+and leave behind only `super`, one call, and the effects that genuinely need the
+platform. `applyMemoryPressure` came out that way, and the comparison bug it
+guards against went from surviving the whole suite to dying against one test.
+
+The boundary matters, because this reads like permission to split anything.
+It applies where a test cannot invoke the method: lifecycle callbacks, platform
+`super` calls. Everywhere else the six call sites before it needed no production
+change at all -- the seam already existed and was idle. Reach for this only after
+looking for that, and say which one you found.
+
 ## Building
 
 ### Debug Build

--- a/android/app/src/test/kotlin/com/vscodroid/keyboard/KeyInjectorShiftTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/keyboard/KeyInjectorShiftTest.kt
@@ -1,0 +1,72 @@
+package com.vscodroid.keyboard
+
+import android.webkit.WebView
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * The wire between [KeyMapping]'s `requiresShift` flag and the event the page
+ * actually receives.
+ *
+ * `KeyMappingTest` checks the flag on all fifteen characters that carry it and
+ * never checked that anything reads it. Dropping `|| keyDef.requiresShift` from
+ * the injector leaves every one of those green, and leaves the extra key row
+ * sending `shiftKey: false` for `{`, `(`, `:` and the rest.
+ *
+ * What that costs is the whole point of those keys. Monaco decides how to handle
+ * a keystroke from the modifiers on the event, not from the character, so a `{`
+ * arriving without Shift is not the same keystroke — auto-closing brackets and
+ * the bindings that watch for shifted punctuation stop matching. The character
+ * still appears, which is why nothing would look broken.
+ *
+ * The injector already takes its WebView through the constructor, so the script
+ * it hands over can be captured without touching production code.
+ */
+class KeyInjectorShiftTest {
+
+    private val script = slot<String>()
+    private val webView = mockk<WebView>(relaxed = true).also {
+        every { it.evaluateJavascript(capture(script), any()) } returns Unit
+    }
+
+    private fun inject(key: String, shiftKey: Boolean = false): String {
+        KeyInjector(webView).injectKey(key, shiftKey = shiftKey)
+        return script.captured
+    }
+
+    @Test
+    fun `a character that needs Shift is sent with Shift held`() {
+        // `{` rather than a letter: a letter is unshifted, so it would pass
+        // whether or not the flag is read, and the fixture would agree with the
+        // bug it exists to catch.
+        assertTrue(
+            inject("{").contains("shiftKey: true"),
+            "{ requires Shift on a physical keyboard; the event has to say so"
+        )
+    }
+
+    @Test
+    fun `a character that does not need Shift is sent without it`() {
+        // The other half. Without this, forcing shiftKey to a constant true
+        // would satisfy the test above.
+        assertFalse(
+            inject("a").contains("shiftKey: true"),
+            "an ordinary character must not arrive as a shifted keystroke"
+        )
+    }
+
+    @Test
+    fun `an explicit Shift is still honoured for an unshifted character`() {
+        // The flag widens the caller's request; it does not replace it. Tapping
+        // Shift on the key row and then a letter has to reach the page as a
+        // shifted letter.
+        assertTrue(
+            inject("a", shiftKey = true).contains("shiftKey: true"),
+            "a Shift the caller asked for cannot be dropped"
+        )
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafWalkTreeSkipTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafWalkTreeSkipTest.kt
@@ -1,0 +1,144 @@
+package com.vscodroid.storage
+
+import android.content.ContentResolver
+import android.content.Context
+import android.database.Cursor
+import android.net.Uri
+import android.provider.DocumentsContract
+import com.vscodroid.util.Logger
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * The wire between [SafSyncEngine.shouldSkip] and the walk that is supposed to
+ * obey it.
+ *
+ * `ShouldSkipTest` covers fourteen directory names across two parameterised
+ * cases and never checked that the walk consults the answer. Dropping the
+ * `if (shouldSkip(name, isDir)) continue` line leaves all of them green — and
+ * mirrors `node_modules` and `.git` into the local copy.
+ *
+ * The cost is not a slow sync. Every mirrored file is also watched and
+ * reconciled, so a single `node_modules` turns a folder the user picked into
+ * tens of thousands of entries in the app's own storage, on a phone. The sync
+ * still finishes, which is why nothing would report it.
+ *
+ * The walk is driven through the ContentResolver the engine already takes with
+ * its Context: a two-row cursor, one skippable directory and one ordinary one,
+ * so the assertion is what came back rather than what the predicate says.
+ */
+class SafWalkTreeSkipTest {
+
+    private lateinit var engine: SafSyncEngine
+    private val treeUri = mockk<Uri>(relaxed = true)
+
+    @BeforeEach
+    fun setUp() {
+        mockkObjectLogger()
+        // The URI builders are static and would reach a real provider.
+        mockkStatic(DocumentsContract::class)
+        every { DocumentsContract.buildChildDocumentsUriUsingTree(any(), any()) } returns treeUri
+        every { DocumentsContract.buildDocumentUriUsingTree(any(), any()) } returns treeUri
+    }
+
+    private fun mockkObjectLogger() {
+        io.mockk.mockkObject(Logger)
+        every { Logger.w(any(), any()) } just Runs
+        every { Logger.w(any(), any(), any()) } just Runs
+        every { Logger.d(any(), any()) } just Runs
+        every { Logger.i(any(), any()) } just Runs
+    }
+
+    @AfterEach
+    fun tearDown() = unmockkAll()
+
+    /**
+     * A cursor over the given (name, isDir) rows, answering only what walkTree
+     * asks of it.
+     */
+    private fun cursorOver(rows: List<Pair<String, Boolean>>): Cursor {
+        var index = -1
+        return mockk<Cursor>(relaxed = true) {
+            every { getColumnIndexOrThrow(DocumentsContract.Document.COLUMN_DOCUMENT_ID) } returns 0
+            every { getColumnIndexOrThrow(DocumentsContract.Document.COLUMN_DISPLAY_NAME) } returns 1
+            every { getColumnIndexOrThrow(DocumentsContract.Document.COLUMN_MIME_TYPE) } returns 2
+            every { getColumnIndexOrThrow(DocumentsContract.Document.COLUMN_SIZE) } returns 3
+            every { getColumnIndex(DocumentsContract.Document.COLUMN_LAST_MODIFIED) } returns -1
+            every { moveToNext() } answers { ++index < rows.size }
+            every { getString(0) } answers { "doc-${rows[index].first}" }
+            every { getString(1) } answers { rows[index].first }
+            every { getString(2) } answers {
+                if (rows[index].second) DocumentsContract.Document.MIME_TYPE_DIR else "text/plain"
+            }
+            every { getLong(3) } returns 0L
+            every { close() } just Runs
+        }
+    }
+
+    /** Runs the real walk over [rows] and returns the relative paths it kept. */
+    private fun walk(rows: List<Pair<String, Boolean>>): List<String> {
+        // `returns` and not `answers`: the cursor is built once, so the recursive
+        // call walkTree makes for a directory row gets the same, already-exhausted
+        // cursor and stops. Switching to `answers` would hand each level a fresh
+        // one and recurse until the stack runs out.
+        val resolver = mockk<ContentResolver> {
+            every { query(any(), any(), any(), any(), any()) } returns cursorOver(rows)
+        }
+        val context = mockk<Context>(relaxed = true) {
+            every { contentResolver } returns resolver
+        }
+        engine = SafSyncEngine(context)
+
+        val result = mutableListOf<DocumentInfo>()
+        SafSyncEngine::class.java
+            .getDeclaredMethod(
+                "walkTree", Uri::class.java, String::class.java,
+                String::class.java, MutableList::class.java
+            )
+            .apply { isAccessible = true }
+            .invoke(engine, treeUri, "root", "", result)
+        return result.map { it.relativePath }
+    }
+
+    @Test
+    fun `an ordinary directory is kept`() {
+        // First, because the test below asserts an absence, and an absence is
+        // also what a walk that returned nothing at all produces. This proves
+        // the fixture can produce a row before that one claims one was dropped.
+        assertEquals(
+            listOf("src"), walk(listOf("src" to true)),
+            "the fixture must be able to yield a row"
+        )
+    }
+
+    @Test
+    fun `a skippable directory never reaches the result`() {
+        // Both rows through one walk, so "src is here and node_modules is not"
+        // comes from the same run: a walk that dropped everything would fail the
+        // first half.
+        val kept = walk(listOf("node_modules" to true, "src" to true))
+
+        assertEquals(listOf("src"), kept, "node_modules must not be mirrored")
+    }
+
+    @Test
+    fun `a file whose name matches a skipped directory is still kept`() {
+        // shouldSkip returns false for anything that is not a directory, and the
+        // walk passes isDir through rather than deciding on the name alone. A
+        // file called .git is a real thing -- a worktree pointer -- and dropping
+        // it would break the repository it points at.
+        assertTrue(
+            walk(listOf(".git" to false)).contains(".git"),
+            "a file is not a directory, whatever it is called"
+        )
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/util/CrashReporterTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/util/CrashReporterTest.kt
@@ -50,15 +50,53 @@ class CrashReporterTest {
     inner class BeforeInitTest {
 
         @Test
-        fun `getLastCrash returns null before init`() {
-            // Reset crashDir to uninitialized state via reflection
-            val field = CrashReporter::class.java.getDeclaredField("crashDir")
-            field.isAccessible = true
-            // CrashReporter uses lateinit, so we need to check its behavior
-            // when crashDir IS initialized but empty vs not initialized
-            val crashDir = initCrashDir()
-            // With initialized but empty dir, should return null
+        fun `an initialised but empty directory yields no crash`() {
+            // Renamed. This was called `getLastCrash returns null before init`
+            // and began by calling initCrashDir(), so it described a state it
+            // never created: deleting the uninitialised guard left it green.
+            // What it does cover is worth keeping, under a name that says so.
+            initCrashDir()
+
             assertNull(CrashReporter.getLastCrash(), "No crash logs should mean null")
+        }
+
+        @Test
+        fun `asking before init answers instead of throwing`() {
+            // The state the old name claimed. crashDir is lateinit, so reading it
+            // unset raises UninitializedPropertyAccessException -- and this is
+            // reached from AndroidBridge.getLastCrash, a @JavascriptInterface
+            // method. An exception there does not land in Logcat as a Kotlin
+            // stack: it crosses into the WebView as a JS-side failure on a call
+            // the workbench made, which is about as far from the cause as a
+            // symptom can travel.
+            //
+            // The window is real. MainActivity calls checkPreviousCrash() during
+            // onCreate, and the bridge is reachable as soon as the page loads.
+            uninitialiseCrashDir()
+
+            assertNull(
+                CrashReporter.getLastCrash(),
+                "the guard must answer, because the caller is across the JS bridge"
+            )
+        }
+
+        @Test
+        fun `every reader survives being asked before init`() {
+            // getLastCrash is the one with a bridge caller, but all four share
+            // the same lateinit field and the same guard, and a fix applied to
+            // one is exactly the kind that gets applied to one.
+            uninitialiseCrashDir()
+
+            assertNull(CrashReporter.getLastCrash())
+            assertFalse(CrashReporter.hasPendingCrash())
+            CrashReporter.clearCrashLogs()
+        }
+
+        /** Puts the singleton back into the state a fresh process starts in. */
+        private fun uninitialiseCrashDir() {
+            CrashReporter::class.java.getDeclaredField("crashDir")
+                .apply { isAccessible = true }
+                .set(CrashReporter, null)
         }
 
         @Test


### PR DESCRIPTION
The last three call sites in #118. Follows #145 and #146.

| Mutation | Before | After |
|---|---|---|
| drop `if (!::crashDir.isInitialized) return null` | survives 421 tests | `asking before init answers instead of throwing` |
| drop `if (shouldSkip(name, isDir)) continue` | survives 421 tests | `a skippable directory never reaches the result` |
| drop `\|\| keyDef.requiresShift` | survives 421 tests | `a character that needs Shift is sent with Shift held` |

All three reproduced against the full suite before anything was written, since
claims in this issue have not all held. Each mutation now dies by its own test,
with the predicate tests green through all three.

## The crash guard had a test that described a state it never created

`getLastCrash returns null before init` began with `initCrashDir()`. Its own
comment records the author noticing the mismatch:

> // CrashReporter uses lateinit, so we need to check its behavior
> // when crashDir IS initialized but empty vs not initialized

So the case in the name was never built, and deleting the guard left it green.
It is now two tests: the empty-directory case it did cover, renamed to say so,
and one that puts the singleton back to genuinely uninitialised.

Why it matters more than an exception usually would: `CrashReporter.getLastCrash`
is reached from `AndroidBridge.getLastCrash`, a `@JavascriptInterface` method.
An `UninitializedPropertyAccessException` there does not land as a Kotlin stack —
it crosses into the WebView as a failure on a call the workbench made. The window
is real: `checkPreviousCrash()` runs during `onCreate`, and the bridge is live as
soon as the page loads.

A third test covers the other three readers of the same field, because a fix
applied to one guard is exactly the kind that gets applied to one.

## The walk that skips node_modules never checked that it does

Fourteen names across two parameterised cases, none of them touching the walk.
Dropping the guard mirrors `node_modules` and `.git` into local storage — where
every file is then watched and reconciled, so one dependency tree becomes tens of
thousands of entries in the app's own storage on a phone. The sync still finishes.

Driven through the `ContentResolver` the engine already takes with its `Context`,
so the assertion is what the walk returned rather than what the predicate says. A
third case covers a *file* named `.git`, which must be kept — `shouldSkip` returns
false for non-directories and the walk passes `isDir` through.

## The shift flag

Covered on all fifteen characters that carry it; nothing checked the injector
reads it. Monaco decides from the modifiers on the event, so `{` without Shift is
a different keystroke — auto-closing brackets and shifted-punctuation bindings
stop matching while the character still appears.

The injector already takes its `WebView` through the constructor, so the script is
captured with no production change.

## Fixtures

`{` rather than a letter, since an unshifted character passes whether or not the
flag is read. The two-row cursor asserted in a single walk, so "src is here and
node_modules is not" cannot be satisfied by a walk that returned nothing. And in
both new files, the case that produces something runs before the case that asserts
nothing was produced.

## CONTRIBUTING

Fourth entry in that section — that a method a test cannot invoke can only be
emptied, not made reachable — **with its boundary stated**: it applies to
lifecycle callbacks and platform `super` calls, and the six call sites before it
needed no production change at all because the seam already existed and was idle.

Lint and unit tests green: 64 classes, 429 tests, 0 failures. No behaviour change.
