### PR TITLE
test(bridge): unmock the singletons the guard replaces

### DIFF
--- a/android/app/src/test/kotlin/com/vscodroid/bridge/BridgeTokenUniformityTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/bridge/BridgeTokenUniformityTest.kt
@@ -14,7 +14,9 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.unmockkAll
 import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -103,6 +105,25 @@ class BridgeTokenUniformityTest {
             onBackPressed = { false },
             onMinimize = { },
         )
+    }
+
+    /**
+     * mockkObject replaces a singleton process-wide, and Gradle runs the whole suite in one
+     * JVM (no forkEvery, no maxParallelForks), so a mock left standing here is still standing
+     * when a later class runs. CrashReporter is stubbed above to return null and to do
+     * nothing, which is exactly what CrashReporterTest asserts against real behaviour.
+     *
+     * Without this, `--tests "*BridgeTokenUniformityTest*" --tests "*CrashReporterTest*"`
+     * fails three tests. The full suite passed only because some class scheduled in between
+     * calls unmockkAll() for its own reasons -- a dependency on another test's cleanup that
+     * nothing states and nothing enforces.
+     *
+     * unmockkAll() rather than naming the two objects: it is what the other five classes in
+     * this suite use, and it keeps covering this class if a mockkStatic is added later.
+     */
+    @AfterEach
+    fun tearDown() {
+        unmockkAll()
     }
 
     /** A value of the right type for each parameter; the call only has to reach the check. */


### PR DESCRIPTION
## What

`BridgeTokenUniformityTest` calls `mockkObject(Logger)` and `mockkObject(CrashReporter)` in
`@BeforeEach` and never unmocks them. `mockkObject` replaces a singleton **process-wide**,
and this suite runs in one JVM — `app/build.gradle.kts:148-150` is
`useJUnitPlatform()` with no `forkEvery` and no `maxParallelForks` — so both mocks are
still standing when every later class runs.

`CrashReporter` is stubbed to return `null` from `getLastCrash()` and to do nothing in
`clearCrashLogs()`. `CrashReporterTest` asserts those exact methods against real behaviour.

## The leak is not theoretical

```
./gradlew testDebugUnitTest \
  --tests "*BridgeTokenUniformityTest*" --tests "*CrashReporterTest*"

CrashReporterTest$ClearCrashLogsTest::clearCrashLogs removes all crash log files
    expected: <0> but was: <3>                  (clear removed nothing)
CrashReporterTest$CrashLogLifecycleTest::getLastCrash returns most recent crash log
    expected: <Newer crash> but was: <null>     (read returned the stub)
CrashReporterTest$CrashLogLifecycleTest::getLastCrash returns content after writing
    expected: <true> but was: <false>           (same)
```

Three failures, and neither class is wrong on its own.

## Why the full suite is green today

Not because of anything either class does. Measured from the JUnit XML `timestamp`
attributes: `BridgeTokenUniformityTest` runs **5th**, `CrashReporterTest` runs **51st** —
the leak is in scope for it — and something scheduled in between calls `unmockkAll()` for
its own reasons. Five classes in this suite do (`MemoryPressureTest`,
`TerminalShellPathTest`, `ProjectsDirTest`, `SafWalkTreeSkipTest`, `ProcessManagerTest`).

So the suite depends on another test's cleanup, which nothing states and nothing enforces.
Remove any one of those `unmockkAll()` calls, add a class that shifts the discovery order,
or simply run a subset while iterating on crash handling — three tests go red with nothing
nearby having changed, and the cause is eleven classes away.

## Change

One `@AfterEach` calling `unmockkAll()`, plus a comment recording why.

`unmockkAll()` rather than naming the two objects: it is the pattern the other five classes
already use, and it keeps covering this class if a `mockkStatic` is added here later.

## Verification

- The two-class run: **3 red → 0 red** (11 tests, 0 failures).
- Full suite: **430 tests, 0 failures**.
- The teardown does not weaken the guard: re-running the discard-the-answer mutation on
  `getLastCrash` still fails the guard, so the property #148 added is intact.

Production code untouched.
