### PR TITLE
fix(app): correct three claims this session's own changes left behind

### DIFF
--- a/android/app/src/main/kotlin/com/vscodroid/SplashActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/SplashActivity.kt
@@ -425,12 +425,18 @@ class SplashActivity : AppCompatActivity() {
      * Publishes the launcher shortcut that opens [ToolchainActivity].
      *
      * The screen had no way in. It is not exported, it has no launcher entry,
-     * and its only caller is a BroadcastChannel command that nothing can send:
-     * every bundled extension of ours declares `main` without `browser`, so they
-     * run on the Node host, where BroadcastChannel is the one from
-     * node:worker_threads and shares nothing but a name with the DOM channel the
-     * relay opens in the WebView page. So the picker's one appearance decided
-     * the toolchains permanently.
+     * and its only caller is the `openToolchainSettings` command on the
+     * BroadcastChannel relay -- which no bundled extension sends. So the
+     * picker's one appearance decided the toolchains permanently.
+     *
+     * That last sentence used to explain itself by saying every bundled
+     * extension of ours ran on the Node host, where `BroadcastChannel` is the
+     * one from `node:worker_threads` and shares nothing but a name with the DOM
+     * channel the relay opens. That stopped being true: `saf-bridge` now
+     * declares `browser` and reaches the relay, and contributes six commands
+     * through it. `openToolchainSettings` is still not one of them, so the
+     * conclusion holds and the reason for it does not -- which is why the reason
+     * is written as history rather than as a standing fact.
      *
      * A launcher shortcut is deliberately the entry point that does not depend on
      * the WebView, because reaching this screen matters most when the editor

--- a/android/app/src/test/kotlin/com/vscodroid/keyboard/KeyMappingTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/keyboard/KeyMappingTest.kt
@@ -122,8 +122,14 @@ class KeyMappingTest {
             // the character. Giving '{' the pair belonging to '(' -- Digit9, 57 --
             // makes the extra key row type '(' when the user presses '{', and every
             // test in this file stays green.
+            // Every pair in the table where both halves are present, not the six
+            // that were visible in the first forty lines of it. The original list
+            // stopped at '<' because that is where the read stopped, which left
+            // five pairs asserting nothing -- including '?' and '_', both of
+            // which the extra key row sends.
             val pairs = listOf(
-                "{" to "[", "}" to "]", ":" to ";", "\"" to "'", "|" to "\\", "~" to "`"
+                "{" to "[", "}" to "]", ":" to ";", "\"" to "'", "|" to "\\", "~" to "`",
+                "<" to ",", ">" to ".", "_" to "-", "+" to "=", "?" to "/"
             )
             for ((shifted, plain) in pairs) {
                 val s = KeyMapping.getKeyDef(shifted)

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -25,7 +25,7 @@ A practical guide to using VSCodroid -- the full VS Code IDE running natively on
 
 1. **Install** -- Download from the [Play Store](#) or [GitHub Releases](https://github.com/rmyndharis/VSCodroid/releases). The core download is approximately 150-200 MB.
 2. **Binary extraction** -- On first launch, VSCodroid extracts bundled tools (Node.js, Python, Git, Bash, and others) to internal storage. This takes 5-10 seconds and only happens once.
-3. **Language Picker** -- A prompt asks "What do you code in?" with options for Go, Ruby, and Java. This is the only time you are asked, so pick everything you expect to need ([#92](https://github.com/rmyndharis/VSCodroid/issues/92)). Whatever you select downloads there on the setup screen, one at a time; a download that fails is skipped and the rest continue. Skip goes straight to the editor.
+3. **Language Picker** -- A prompt asks "What do you code in?" with options for Go, Ruby, and Java. This is the only time you are *asked*, but not your only chance to choose: touch and hold the app icon and pick **Manage toolchains** to add or remove them later. Whatever you select downloads there on the setup screen, one at a time; a download that fails is skipped and the rest continue. Skip goes straight to the editor.
 4. **Ready** -- The VS Code editor loads with terminal, file explorer, and all bundled tools available immediately.
 
 ### Default File Locations
@@ -605,8 +605,9 @@ du -sh ~/projects/*
 du -sh ~/.vscodroid/extensions/*
 ```
 
-Removing an installed toolchain is not reachable from the editor yet
-([#92](https://github.com/rmyndharis/VSCodroid/issues/92)).
+To remove an installed toolchain, touch and hold the app icon and choose
+**Manage toolchains**. It is not reachable from inside the editor, deliberately —
+see [Installing After Setup](#installing-after-setup).
 
 ### App Crashes or Restarts Unexpectedly
 


### PR DESCRIPTION
Checking the three changes that landed from this session (#116, #135, #136) against
current main found three places where they claim more than they deliver. All three were
introduced by those changes.

## 1. A comment that stopped being true after it landed

`publishToolchainShortcut`'s KDoc justified "nothing can reach this screen" by stating that
every bundled extension declares `main` without `browser`, so they all run on the Node host
where `BroadcastChannel` is the `node:worker_threads` one and shares nothing but a name with
the DOM channel the relay opens.

That is no longer true. `saf-bridge` declares `browser` now, reaches the relay, and
contributes six commands through it. `openToolchainSettings` is still not one of them — so
the conclusion holds and the reason for it does not.

Rewritten so the reason reads as history rather than as a standing fact, which is the shape
that stops it going stale again. This repository keeps a table of comments that were wrong
and misled someone; this one would have earned a row.

## 2. An assertion that guarded six of eleven cases

`a shifted symbol shares its physical key with the unshifted one` listed six shift/unshift
pairs. `KeyMapping` has **eleven**.

The six are exactly the pairs visible in the first forty lines of the table — which is where
the read that produced the list stopped. `<`/`,`, `>`/`.`, `_`/`-`, `+`/`=` and `?`/`/` were
never in view, so those five entries' `code` and `keyCode` were asserted by nothing. Four of
the five are on the extra key row.

Measured rather than assumed: giving `?` the `code` and `keyCode` belonging to `*` leaves the
six-pair version green and fails the eleven-pair version, by exactly one test.

## 3. Two more places in a document that was only half updated

`docs/USER_GUIDE.md` was edited in #116 where the issue pointed. Two other passages in the
same file still said the picker is the only chance to choose, and that removing a toolchain
is unreachable — both citing an issue that is now closed.

## What was checked and found correct

Stated so the silence above means something:

- **All seven `launchMain()` call sites**, including the two inside `lifecycleScope`
  coroutines and the Cancel button during downloads. Every one is reached only after
  `runSetup()` has succeeded, so the shortcut cannot exist before the setup it needs.
- **The double-`launchMain` race** — Cancel firing as the last download completes — is
  pre-existing and unaffected: `pushDynamicShortcut` with the same id updates in place, and
  `MainActivity` is `singleTask`.
- **Manifest assumptions**: `ToolchainActivity` is still `exported="false"` with
  `parentActivityName`, `SplashActivity` still `noHistory="true"`. The reorder in #135 is
  safe against an `Error` escaping the `catch`, because `noHistory` removes the splash even
  if `finish()` never runs.
- **`contentDescription != label`** still holds for all 23 buttons, and the pinned `{`
  alternates still match.
- **No translated `strings.xml`**, so the corrected `picker_subtitle` has no stale
  counterpart in another locale.
- **R8 and resource shrinking**: `ToolchainActivity` is kept by the manifest,
  `ShortcutManagerCompat` / `IconCompat` are direct calls rather than reflective, and the new
  drawable is referenced through `R.drawable.` so the shrinker traces it. Release-only, and
  nothing here needs a keep rule.
- **Both CHANGELOG entries** are present and accurate, including the measured figures.

## One finding left alone deliberately

`MainActivity.kt:954` shows a Toast when storage is critically low: *"Storage low (N
available). Clear caches in Settings."* There is no Settings screen, and `clearCaches` has no
sender on the relay — so the advice cannot be followed, at the moment it matters most.

That is pre-existing rather than caused by these changes, and it is the same class as the
picker subtitle that #97 covered. It is reported separately rather than folded in here, since
it needs its own decision about where that action should live.

No CHANGELOG entry: nothing about the app changes. The behaviour these three describe already
shipped and already has its entry.
