### PR TITLE
docs(api): correct the six bridge signatures that gained a token

### DIFF
--- a/docs/05-API_SPEC.md
+++ b/docs/05-API_SPEC.md
@@ -75,11 +75,18 @@ window.__vscodroid.onOAuthError(provider: string, error: string); // OAuth failu
 
 Exposed via `@JavascriptInterface`:
 
+Every method takes the session token and validates it before doing anything; a call
+with a token that does not match is refused and returns the method's empty value
+(`false`, `null`, `""`, `"{}"`, `"[]"`, `0`, or nothing). Read it from
+`window.__vscodroid.authToken`, which MainActivity sets once the bridge is installed.
+`BridgeTokenUniformityTest` enumerates the methods by reflection and fails if one is
+added without the check, so this holds for the class rather than for the list below.
+
 #### Clipboard
 
 ```kotlin
 @JavascriptInterface
-fun copyToClipboard(text: String): Boolean
+fun copyToClipboard(authToken: String, text: String): Boolean
 // Copies text to Android system clipboard
 // Returns: true if successful
 
@@ -89,7 +96,7 @@ fun readFromClipboard(authToken: String): String?
 // Returns: clipboard text or null
 
 @JavascriptInterface
-fun hasClipboardText(): Boolean
+fun hasClipboardText(authToken: String): Boolean
 // Checks if clipboard has text content
 ```
 
@@ -102,13 +109,13 @@ fun openExternalUrl(url: String, authToken: String)
 // Used by: VS Code "Open in Browser" actions
 
 @JavascriptInterface
-fun onBackPressed(): Boolean
+fun onBackPressed(authToken: String): Boolean
 // Called from VS Code when back button override is needed
 // Returns: true if VS Code handled back navigation (closed a panel/dialog)
 //          false if app should handle back (minimize/exit)
 
 @JavascriptInterface
-fun minimizeApp()
+fun minimizeApp(authToken: String)
 // Moves app to background (moveTaskToBack)
 
 @JavascriptInterface
@@ -188,7 +195,7 @@ fun getDeviceInfo(authToken: String): String
 // }
 
 @JavascriptInterface
-fun getThemeMode(): String
+fun getThemeMode(authToken: String): String
 // Returns: "light" or "dark" (follows Android system theme)
 ```
 
@@ -214,7 +221,7 @@ MainActivity handles the deep link intent and forwards parsed values to WebView 
 
 ```kotlin
 @JavascriptInterface
-fun logToNative(level: String, tag: String, message: String)
+fun logToNative(authToken: String, level: String, tag: String, message: String)
 // Sends log from WebView to Android Logcat
 // level: "debug", "info", "warn", "error"
 ```


### PR DESCRIPTION
## What

#139 added an `authToken` first parameter to six `@JavascriptInterface` methods and did not
update `docs/05-API_SPEC.md`, which still documented the old signatures:

| Method | Documented | Actual |
|---|---|---|
| `copyToClipboard` | `(text: String)` | `(authToken, text)` |
| `hasClipboardText` | `()` | `(authToken)` |
| `onBackPressed` | `()` | `(authToken)` |
| `minimizeApp` | `()` | `(authToken)` |
| `getThemeMode` | `()` | `(authToken)` |
| `logToNative` | `(level, tag, message)` | `(authToken, level, tag, message)` |

## Why it matters even though nothing is broken

Nothing calls these six from JavaScript today — verified by grepping the whole tree
including the gitignored `assets/vscode-reh` and `assets/vscode-web` trees, which `git grep`
does not search.

The cost falls on whoever writes the next caller from the spec. A WebView bridge call with
the wrong arity does not raise on the Kotlin side: it finds no matching method and fails in
JavaScript, several layers from the document that caused it.

The repository's own rule is that the code wins and the document gets fixed in the same
change. This is that fix, late.

## Also added

A short note on the rule the surface follows — every method takes the token and validates
it, refusing with the method's empty value — and where callers get the token
(`window.__vscodroid.authToken`). The spec described none of that, while six of the methods
it listed were the exception to it.

## Verification

Both files parsed and their parameter lists compared, rather than read:

```
before: 21 methods documented and present, 6 disagreeing about the token
after:  21 methods documented and present, 0 disagreeing
```

## Left alone deliberately

- `docs/12-IMPLEMENTATION_PLAN.md` carries the same old signatures, but its header marks it
  a historical document describing the plan as of 2026-02-10. Correcting it would falsify a
  record rather than fix a claim.
- The sequence diagram in `docs/03-ARCHITECTURE.md` writes every call without parameters, so
  it asserts no arity.

## Found while reviewing, not fixed here

`docs/05-API_SPEC.md` documents three methods that do not exist in `AndroidBridge`:
`openFilePicker`, `requestStoragePermission`, `startGitHubOAuth`. That predates these
changes and deciding whether they were dropped or never built is a separate question — worth
an issue rather than a silent deletion.
