### PR TITLE
docs(api): describe the bridge security model that exists

### DIFF
--- a/docs/05-API_SPEC.md
+++ b/docs/05-API_SPEC.md
@@ -30,13 +30,23 @@ webView.addJavascriptInterface(AndroidBridge(this), "AndroidBridge")
 
 ### 2.2 Bridge Security Model
 
-Bridge exposure is restricted with a capability-token model plus origin checks:
+Bridge exposure is controlled by a per-session capability token. That is the whole
+mechanism -- there is no origin-based control, and there cannot be one on this transport:
+`@JavascriptInterface` does not carry the caller's origin, so a bridge method has nothing to
+compare.
 
-1. **Trusted origin only**: bridge calls are processed only when top-level URL is `http://127.0.0.1:<port>/...` (or `http://localhost:<port>/...`).
-2. **Per-session token**: Kotlin generates a random token at server start and injects it only into trusted workbench context.
-3. **Sensitive method gating**: clipboard read, external URL open, storage permission, file/folder picker, and device info require valid token.
-4. **Scheme allowlist**: `openExternalUrl()` allows `https://` and `mailto:` only; blocks `javascript:`, `file:`, `intent:`, and custom schemes.
-5. **Deny by default**: calls from extension webviews (`vscode-webview://`), iframes, or unknown origins are rejected and logged.
+1. **Per-session token**: `SecurityManager` generates 32 random bytes at construction
+   (`SecurityManager.kt:51-55`). `MainActivity.injectBridgeToken()` writes it to
+   `window.__vscodroid.authToken` after the page loads (`MainActivity.kt:564-569`).
+2. **Every method, not a chosen subset**: all 28 `@JavascriptInterface` methods take the
+   token as their first parameter and validate it before doing anything, returning the
+   method's empty value on refusal. `BridgeTokenUniformityTest` enumerates them by
+   reflection and fails the build if one is added without the check, and a second test
+   asserts a refused call touches nothing -- so the rule holds for the class, not for a
+   list that was correct when it was written.
+3. **Scheme allowlist**: `openExternalUrl()` accepts `https://`, `mailto:`, and `http://`
+   to `localhost` or `127.0.0.1` (the last for dev-server preview). Everything else is
+   refused and logged, including unparseable URLs (`SecurityManager.kt:21-49`).
 
 ### 2.3 Kotlin → JavaScript Methods
 


### PR DESCRIPTION
From re-reading #139/#144/#148. Documentation only.

## What

`docs/05-API_SPEC.md` §2.2 listed five controls for the bridge. Measured against the code,
two describe enforcement that is not implemented anywhere, and one is stale.

**The two.** Both claimed bridge calls are accepted only from a trusted top-level URL and
refused otherwise. Grepping the whole Kotlin tree for any such enforcement returns nothing —
with a positive control confirming the search can find what *is* there, since a checker that
cannot say "yes" proves nothing by saying "no".

The reason is structural rather than an omission: `@JavascriptInterface` does not carry the
caller's origin, so a bridge method has nothing to compare against. No amount of code inside
that method could add one.

**The stale one** named five methods as requiring the token. All 28 do.

## Why this is worth a PR rather than a shrug

A specification that promises a control nobody implemented is worse than one that omits it,
because it becomes a premise. The next person adds a bridge method, reads that the surface is
already gated by origin, and leaves out the check that actually does the gating.

## What replaces it

What the code does, with a citation per claim so the next reader can check rather than trust:

- where the token comes from (`SecurityManager.kt:51-55`, `MainActivity.kt:564-569`);
- that every one of the 28 methods validates it and returns its empty value on refusal;
- that two reflection tests fail the build if a method is added without the check, or acts
  despite a refusal;
- the actual scheme allowlist — `https:`, `mailto:`, and `http:` to `localhost`/`127.0.0.1`
  for dev-server preview, which the old text omitted, plus the refusal of unparseable URLs.

Written in the present tense throughout. A specification states what holds; `git log` already
carries how it got there.

## Verification

Every claim in the new text was checked against the code before writing it:

```
ByteArray(32) in SecurityManager        1
__vscodroid.authToken in MainActivity   1
@JavascriptInterface in AndroidBridge  28
security.validateToken in AndroidBridge 28
@Test in BridgeTokenUniformityTest      2
```

No code touched, so no test outcome can change.
