### PR TITLE
docs: correct two KDoc claims that name the wrong thing

### DIFF
--- a/android/app/src/main/kotlin/com/vscodroid/service/NodeService.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/service/NodeService.kt
@@ -22,7 +22,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 /**
- * Foreground Service that owns the Node.js code-server process.
+ * Foreground Service that owns the Node.js server process.
  *
  * Responsibilities:
  * - Promoting itself to a foreground service with a persistent notification

--- a/android/app/src/main/kotlin/com/vscodroid/service/ProcessManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/service/ProcessManager.kt
@@ -18,8 +18,8 @@ import kotlin.concurrent.thread
  * Manages the Node.js server process lifecycle.
  *
  * Responsibilities:
- * - Starting and stopping the Node.js code-server process
- * - Health-checking the server via /healthz endpoint
+ * - Starting and stopping the Node.js server process
+ * - Health-checking the server -- see [isServerHealthy] for which endpoint and why
  * - Monitoring process liveness via a watchdog thread
  * - Streaming stdout/stderr output for diagnostics
  *
@@ -92,7 +92,7 @@ class ProcessManager(private val context: Context) {
     // -- Lifecycle --
 
     /**
-     * Starts the Node.js code-server process.
+     * Starts the Node.js server process.
      *
      * Resolves the port on the first call and keeps it for the lifetime of this
      * instance, builds the command line from [Environment] paths, spawns the


### PR DESCRIPTION
Comments only, and the mirror case of the usual one:
where the document was right and the code's own comments were wrong.

## `/healthz`

`ProcessManager`'s class KDoc says health checking happens "via /healthz endpoint". There has
never been a `/healthz` here — VS Code Server does not serve one — and the probe uses
`/version`, accepting only `200` (`ProcessManager.kt:212-226`).

That `/healthz` is wrong has been recorded for some
time. The file that implements it still said `/healthz`.

**Rather than swap one endpoint name for another,** the summary now points at
`[isServerHealthy]`. Naming an endpoint in a one-line summary is what let this rot: the
endpoint moved from `/` to `/version` for a stated reason, and a summary that repeats the name
has no way to learn that. The KDoc on `isServerHealthy` already carries the reasoning — `/`
began answering 403 once the server required a connection token, so a probe accepting anything
under 500 reported a healthy start for a server that would serve nothing but Forbidden.

A summary that points at the decision cannot go stale when the decision changes.

## "code-server"

Three comments call the child process "the Node.js code-server process":

- `ProcessManager.kt:21` (class KDoc)
- `ProcessManager.kt:95` (`startServer`)
- `NodeService.kt:25` (class KDoc)

code-server is a different project, evaluated and rejected for this app. What actually starts
is `filesDir/server/server.js` (`Environment.getServerScript`), the bootstrap for the Code -
OSS server tree. Someone reading these and going to look for code-server's configuration,
CLI flags, or docs would find nothing that matches what runs.

## Verification

Full suite green: 430 tests, 0 failures. A grep for `healthz|code-server` across
`app/src/main/kotlin` now returns nothing, with a positive control confirming the pattern can
still match.

## Noticed and deliberately not touched

`ProcessManager.kt:87` declares `onServerRestarting`, which is never assigned and never
invoked anywhere in the tree — while its sibling `onServerCrashed` is wired up at
`NodeService.kt:156`. Whether that callback should be removed or connected is a question about
behaviour, not about a comment, so it does not belong in this PR.

