### PR TITLE
docs: stop documenting a callback that nothing invokes

### DIFF
--- a/android/app/src/main/kotlin/com/vscodroid/service/ProcessManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/service/ProcessManager.kt
@@ -84,7 +84,16 @@ class ProcessManager(private val context: Context) {
     /** Invoked on the watchdog thread when the server process exits unexpectedly. */
     var onServerCrashed: ((exitCode: Int) -> Unit)? = null
 
-    /** Invoked on the watchdog thread before an automatic restart attempt. */
+    /**
+     * Declared for symmetry with [onServerCrashed], and invoked by nothing.
+     *
+     * Its sibling is assigned in `NodeService.setupServiceCallbacks()` and fires from the
+     * watchdog; this one has no assignment and no call site anywhere in the tree. The
+     * previous wording said it was "invoked on the watchdog thread before an automatic
+     * restart attempt", which reads as a documented contract a caller could rely on.
+     * Whether to wire it up or drop it is a question about behaviour, not about this
+     * comment.
+     */
     var onServerRestarting: (() -> Unit)? = null
 
     /** Invoked on the output-reader thread for every line of server stdout/stderr. */


### PR DESCRIPTION
Comment only, found while checking the documentation against the code.

## What

`ProcessManager.onServerRestarting` carries:

```kotlin
/** Invoked on the watchdog thread before an automatic restart attempt. */
var onServerRestarting: (() -> Unit)? = null
```

Nothing invokes it. `grep -rn "onServerRestarting"` across the tree returns **one** hit — its
own declaration. Its sibling `onServerCrashed` is assigned in
`NodeService.setupServiceCallbacks()` (`NodeService.kt:156`) and does fire from the watchdog,
which is what makes the asymmetry easy to miss.

## Why it is worth changing

The old wording reads as a documented contract. Someone adding a "restarting…" indicator
would assign this callback and wait for something that never arrives; the symptom would look
like a UI bug, several layers from the cause.

The comment now says it is declared for symmetry and invoked by nothing, and names the
wired-up sibling so the difference is visible from the declaration itself.

## Left open deliberately

Whether to connect it or drop it is a question about behaviour, not about a comment, so it is
stated rather than decided here.

## Verification

Full suite green: 430 tests, 0 failures. Comment only — no code path touched.
