### PR TITLE
docs: name the worktree trap that fails only once the app runs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -263,6 +263,37 @@ checkouts differed.
 
 ## The on-device test suite
 
+**Before testing an APK built in a worktree, copy the artifact trees into it.**
+
+```bash
+MAIN=/path/to/the/main/checkout
+for d in jniLibs assets/vscode-reh assets/usr; do
+    cp -R "$MAIN/android/app/src/main/$d" android/app/src/main/$d
+done
+```
+
+`jniLibs/`, `assets/vscode-reh` and `assets/usr` are gitignored build output that
+the download scripts fill in. A fresh worktree has none of them, and nothing
+fails: the build is green, the APK is written, `adb install` succeeds, the splash
+screen appears. Then the screen goes white and stays white, because the APK
+contains **zero** native libraries and the server cannot start:
+
+```
+Cannot run program ".../lib/arm64/libnode.so": error=2, No such file or directory
+```
+
+`error=2` is the string to search for, because nothing else points here. A white
+screen after a successful setup reads as a WebView or server problem, and every
+visible clue leads away from an APK that is structurally complete and empty of
+content. The same hole has also produced an APK carrying no server files at all,
+noticed only because its size looked wrong rather than because anything
+reported it.
+
+A worktree has one other missing-file trap, and the contrast is the point: without
+`local.properties` the build dies in well under a second, loudly and at the right
+place. This one costs more precisely because it passes every gate first.
+
+
 `scripts/device-test.sh` installs the APK and checks that what shipped actually
 runs: the server answers, every bundled tool starts, and Python imports the ten
 modules that need a bundled library behind them.


### PR DESCRIPTION
Found while testing #161 on a device. Not a defect in the app — a hole in how the
repository is set up for testing, and one that costs time because every visible
clue points elsewhere.

## What happens

A fresh git worktree has no `jniLibs/`, `assets/vscode-reh` or `assets/usr` —
all three are gitignored build output the download scripts fill in. Nothing about
their absence fails:

- `./gradlew assembleDebug` → **green**
- APK written → **0 native libraries in it** (341 MB is the *main checkout* build; the size of the broken one was never recorded)
- `adb install` → **Success**
- splash screen → **appears**, first-run setup completes in 73 s
- then the screen goes white and stays white

```
Cannot run program ".../lib/arm64/libnode.so": error=2, No such file or directory
```

## Why it is worth a section rather than a line

The symptom points away from the cause. A white screen *after a successful setup*
reads as a WebView or server problem — and the server is exactly what is missing,
but nothing says so until you read the log. Three minutes went into watching the
screen first.

`error=2` is written into the note deliberately: it is the only string in the
failure that leads back to this page.

The same hole has produced the sibling case of an APK with no server files,
noticed only because its size looked wrong. Structurally complete, empty of
content, and no gate sees either.

Contrast with the other worktree trap: without `local.properties` the build dies
in well under a second, loudly and in the right place. This one costs more
*because* it passes every gate first.

## Checked before writing

- the copy recipe was **run against a real fresh worktree**: it fills `jniLibs`
  with the eleven entries the build needs, and introduces **zero** untracked
  files, so following it cannot pollute a PR
- all three trees confirmed gitignored with `git check-ignore`
- a cross-reference to a `local.properties` section "below" was **cut**: the only
  occurrence of that string in the file was the sentence pointing at it
- the sibling APK's size was **cut**: that measurement is not mine

Documentation only. No behaviour change, so no changelog entry.

