### PR TITLE
refactor(service): drop the two server-state wrappers nothing calls

### DIFF
--- a/android/app/src/main/kotlin/com/vscodroid/service/NodeService.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/service/NodeService.kt
@@ -136,18 +136,19 @@ class NodeService : Service() {
      */
     fun getConnectionToken(): String? = processManager.connectionToken
 
-    /** Performs a synchronous health check against the running server. */
-    fun isServerHealthy(): Boolean = processManager.isServerHealthy()
-
-    /** Returns `true` if the Node.js process is alive. */
-    fun isServerRunning(): Boolean = processManager.isRunning()
-
     /**
      * Whether the server has answered a health check and has not stopped since.
      *
-     * This is the question a caller almost always means when it reaches for
-     * [isServerRunning], and [ProcessManager.isReady] explains the difference and
-     * why it matters. Costs no I/O, so it is safe on the main thread.
+     * The only server-state question this class answers, and the narrowness is
+     * deliberate. Two other wrappers stood here — one returning `Process.isAlive`
+     * and one forwarding the blocking health probe — and both are gone: see
+     * [ProcessManager.isReady] for what separates a process that exists from a
+     * server that serves, and why asking the first while meaning the second put a
+     * connection-refused page in front of users.
+     *
+     * Costs no I/O, so it is safe on the main thread. That is the property the
+     * removed pair could not offer, and the reason a caller should not have to
+     * choose between three names to find it.
      */
     fun isServerReady(): Boolean = processManager.isReady()
 


### PR DESCRIPTION
> **This is a follow-up you may decline.** It is separable from the readiness fix and outside the items assigned this round, so it arrives as an offer rather than as part of the work. Nothing depends on it.

## Why these two, specifically

**`NodeService.isServerRunning()` is not merely unused — it is the wrong question.** It is public, has zero callers, sits one word away from `isServerReady()`, and #169 exists because somebody reached for it. It forwards `Process.isAlive`, which is true from the instant the process is spawned and stays true for the whole of a restart after a crash, so a caller that trusts it navigates the WebView at a port with nothing listening. Leaving it available leaves the same reach open to the next person, under a name that still reads correct.

**`NodeService.isServerHealthy()` goes for a sharper reason than being idle.** It wraps a blocking HTTP call, so its first main-thread caller gets `NetworkOnMainThreadException` — the precise constraint that shaped the readiness defect. A public method that punishes its first correct-looking use is worse company than one that is simply unused.

`ProcessManager` keeps both `isRunning()` and `isServerHealthy()`, and the latter is still called by `waitForReady()`. Reviving either wrapper is one line if a device test ever wants one.

## The deletion is checkable, not asserted

Zero calls to either method across **87 Kotlin files** under `android/app/src`. Every remaining mention in the tree is a comment, a KDoc reference, or a test's own string literal:

| File | What remains |
|---|---|
| `MainActivity.kt` | two comments explaining why the readiness question replaced the liveness one |
| `ServerReadinessCallSiteTest.kt` | the guard's own documentation and the string it greps for |
| `ProcessManagerTest.kt` | a comment naming `ProcessManager.isServerHealthy()`, which stays |
| `ProcessManager.kt` | the live method and its own KDoc |

## Base

Stacked on `fix/b1-server-readiness` rather than cut from `main`, and deliberately: `main` still has two callers of `isServerRunning()`, so this deletion merged ahead of #169 would not compile. GitHub will retarget the base to `main` once #169 lands.

## No changelog entry

Nothing a user can observe changes. The changelog records what a user gained or lost rather than which functions moved, so an entry here would be the second kind. Stated rather than omitted, so the absence reads as a decision.

## Gates

Run sequentially, each exit code captured before any pipe.

- `testDebugUnitTest`: 590 tests, 0 failures, 0 errors, 0 skipped — unchanged, as a pure deletion of uncalled methods should be
- `lint`: 0 errors, enforcing
- `assembleDebugAndroidTest`: green
