### PR TITLE
test: give five checks that could not fail a way to fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The binaries the app ships — the JavaScript runtime, the shell, Git, Python and every on-demand toolchain — are now traced back to a signature from the project that built them, instead of to a checksum published by the same server that hands over the file. Each of those downloads took its expected checksum from a package index served by that host, so a host offering both a modified binary and a checksum to match it satisfied every check there was. The index is now checked against the upstream signing key, recorded in this repository and confirmed against two sources that have nothing to do with the download server. A signed index older than a month is refused as well: a valid signature does nothing to stop a server replaying last year's index and holding every build to whatever was current then
 
 ### Fixed
+- Five checks that were supposed to stop earlier defects returning could not fail,
+  and now can. Each was confirmed by breaking the thing it guards and watching it
+  stay green, then breaking it again after the change and watching it report the
+  fault by name. Nothing a user can see changes; what changes is whether the next
+  release notices when one of these goes wrong. Two of them needed the code around
+  them reshaped rather than the check tightened — a check that searches the source
+  for a name can never tell a call whose answer is obeyed from one whose answer is
+  thrown away
 - The user guide's list of bundled extensions matches what ships. It named two
   that are not included — a theme and a Git annotation extension, the latter
   dropped from the bundled set — and listed the icon theme that *is* included

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -76,6 +76,24 @@ glibc's soname but are built from this repository's own source.
 | zlib | Zlib | Git, Node.js, OpenSSH, Python, SQLite, libcurl, libssh2 |
 | Zstandard | GPL-2.0 | Python |
 
+## Toolchain Libraries
+
+Shipped inside the on-demand toolchain packs rather than the base app, so they
+reach only devices where that toolchain was installed. Listed separately because
+`scripts/check-library-attribution.py` reads the toolchain manifests for these,
+and the base APK for the table above.
+
+| Component | License | Shipped with |
+|---|---|---|
+| [GMP](https://gmplib.org) | LGPL-3.0 | Ruby |
+| [libyaml](https://pyyaml.org/wiki/LibYAML) | MIT | Ruby |
+| [libruby](https://www.ruby-lang.org) | BSD-2-Clause | Ruby |
+| [libandroid-execinfo](https://github.com/termux/libandroid-execinfo) | BSD-2-Clause | Ruby |
+| [libandroid-shmem](https://github.com/termux/libandroid-shmem) | BSD-3-Clause | Java |
+| [libandroid-spawn](https://github.com/termux/libandroid-spawn) | BSD-2-Clause | Java |
+
+GMP is copyleft; its source offer is in `docs/LEGAL_NOTICES.md` beside the rest.
+
 ## On-Demand Toolchains
 
 | Software | License | URL |

--- a/android/app/src/main/assets/process-monitor.js
+++ b/android/app/src/main/assets/process-monitor.js
@@ -44,14 +44,23 @@ const LANG_SERVER_PATTERNS = [
     // 'tailwindcss' until the matching moved from the whole command line to the
     // basename of each argument. That string only ever appeared in the extension's
     // *directory* -- bradlc.vscode-tailwindcss-0.16.0 -- so the change quietly
-    // un-classified the server it names. The processes are tailwindServer.js and
-    // tailwindModeServer.js, and 'tailwind' is what both basenames share.
+    // un-classified the server it names.
+    //
+    // Both program names in full, rather than the 'tailwind' they share. A bare
+    // 'tailwind' also matches a user's own tailwind.config.js, build-tailwind.js,
+    // or an npx tailwindcss run, and being classified 'langserver' is not cosmetic:
+    // it puts a process into lsCpuTracker and makes it eligible for the idle kill
+    // under memory pressure. Killing a build someone is waiting on is a worse
+    // outcome than failing to reclaim a language server.
+    //
+    // Two entries because neither contains the other: 'tailwindmodeserver.js' does
+    // not contain 'tailwindserver'.
     //
     // check-langserver-patterns.py cannot see this one: it globs *ServerMain.js
     // under vscode-reh/extensions, and Tailwind is a marketplace extension living
     // under assets/extensions with a name that does not match the glob. The
-    // fixture in scripts/test-process-monitor.js is what guards it instead.
-    'tailwind'
+    // fixtures in scripts/test-process-monitor.js are what guard it instead.
+    'tailwindServer', 'tailwindModeServer'
 ];
 
 let outputPath = '';

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -516,7 +516,11 @@ class MainActivity : AppCompatActivity() {
         // is answering, so isServerRunning() calls a mid-restart server healthy
         // and lets the branches below reload the page into a port that is not
         // listening yet.
-        if (nodeService?.isServerReady() != true) return
+        // Through shouldActOnResume for the same reason as the binding decision:
+        // the verdict has to be obeyed, and only a function that returns it can be
+        // tested for obeying it. `backgroundedAt` is still consumed above whether
+        // or not this passes, which is the behaviour that was here before.
+        if (!shouldActOnResume(nodeService?.isServerReady(), ts, serverPort)) return
 
         val bgMs = SystemClock.elapsedRealtime() - ts
         when {
@@ -791,18 +795,27 @@ class MainActivity : AppCompatActivity() {
         // the same: say it and do not load, because the server is not serving.
         // A slow one that comes up afterwards arrives through onServerReady,
         // which is assigned above.
-        val notice = service.lastStartupNotice()
-        if (notice != null) {
-            Logger.w(tag, "Server start notice predating this binding: $notice")
-            Toast.makeText(this, notice, Toast.LENGTH_LONG).show()
-            return
-        }
-
-        val port = service.getPort()
-        if (port > 0 && service.isServerReady()) {
-            Logger.i(tag, "Server already serving on port $port, loading immediately")
-            serverPort = port
-            loadVSCode(port)
+        // Through bindDecision so the branch is a value a test can assert on.
+        // Reading the source for the *name* isServerReady cannot tell a call whose
+        // answer is obeyed from one whose answer is discarded, and the second is
+        // the mutation that survived the suite.
+        when (
+            val decision = bindDecision(
+                notice = service.lastStartupNotice(),
+                port = service.getPort(),
+                ready = service.isServerReady(),
+            )
+        ) {
+            is BindDecision.ShowNotice -> {
+                Logger.w(tag, "Server start notice predating this binding: ${decision.message}")
+                Toast.makeText(this, decision.message, Toast.LENGTH_LONG).show()
+            }
+            is BindDecision.Load -> {
+                Logger.i(tag, "Server already serving on port ${decision.port}, loading immediately")
+                serverPort = decision.port
+                loadVSCode(decision.port)
+            }
+            BindDecision.Wait -> Unit
         }
     }
 
@@ -1486,6 +1499,54 @@ internal fun writeMemoryPressure(tmpDir: File, pressure: String) {
  */
 internal fun isExtensionCallback(scheme: String?, host: String?): Boolean =
     scheme == "vscodroid" && host == "callback"
+
+/**
+ * What binding to an already-running service should do about it.
+ *
+ * Extracted so the decision is a value rather than a shape in the source.
+ * `ServerReadinessCallSiteTest` reads `MainActivity.kt` and checks *which* method
+ * is called, which catches putting `isServerRunning` back and cannot catch
+ * calling the right method and ignoring the answer -- both call sites were
+ * mutated that way with the whole suite still green. A branch that returns one of
+ * these can be tested for what it decides.
+ */
+internal sealed interface BindDecision {
+    /** The server said something about its start that predates this binding. */
+    data class ShowNotice(val message: String) : BindDecision
+
+    /** Serving, on a port worth navigating to. */
+    data class Load(val port: Int) : BindDecision
+
+    /** Not serving yet; `onServerReady` will arrive if it comes up. */
+    object Wait : BindDecision
+}
+
+/**
+ * The notice is read first, and that ordering is load-bearing: it may be terminal
+ * or it may be a slow start still coming up, and in both cases the server is not
+ * serving, so it must not be shadowed by a port that happens to look plausible.
+ *
+ * [ready] is the health probe's own finding, never process liveness. A process is
+ * alive from the instant it is spawned and stays alive through the seconds before
+ * its port is bound and through a whole post-crash restart; navigating on that
+ * points the WebView at nothing, and `onReceivedError` only logs, so the
+ * connection-refused page it produces is never cleared.
+ */
+internal fun bindDecision(notice: String?, port: Int, ready: Boolean): BindDecision = when {
+    notice != null -> BindDecision.ShowNotice(notice)
+    port > 0 && ready -> BindDecision.Load(port)
+    else -> BindDecision.Wait
+}
+
+/**
+ * Whether returning from the background should touch the page at all.
+ *
+ * [ready] is nullable because the service may not be bound, and null is not
+ * evidence of anything: it must not be read as permission to reload. Only a
+ * probe that actually found the server serving is.
+ */
+internal fun shouldActOnResume(ready: Boolean?, backgroundedAt: Long, serverPort: Int): Boolean =
+    backgroundedAt != 0L && serverPort != 0 && ready == true
 
 /**
  * Whether a sign-in callback arriving now is one this app went looking for.

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
@@ -1267,6 +1267,25 @@ class ToolchainManager(private val context: Context) {
                 // tries again. Nothing else depends on it having run.
                 Logger.w(tag, "Toolchain repair pass failed: ${e.message}")
             }
+            try {
+                // Unconditionally, and separately from the repair above, because
+                // the two answer different questions. The repair is marked done per
+                // toolchain and never runs again; this has to run on every launch,
+                // because the env file is otherwise written only by an install or an
+                // uninstall. A toolchain installed by an earlier version keeps the
+                // file that version wrote -- so the loader wrappers, which are what
+                // make a toolchain command runnable at all, reached new installs
+                // only. That is the same shape as the bundled-extension defect this
+                // release fixed: an improvement that skips exactly the installs that
+                // need it.
+                //
+                // Cheap enough to do every time: it reads toolchains.json, formats a
+                // few dozen lines and writes them atomically. With no toolchains
+                // installed it deletes the file and returns.
+                regenerateEnvFile()
+            } catch (e: Exception) {
+                Logger.w(tag, "Could not refresh toolchain-env.sh: ${e.message}")
+            }
         }
     }
 

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
@@ -1462,6 +1462,13 @@ internal fun isElfFile(file: File): Boolean = try {
     false
 }
 
+/**
+ * Whether these opening bytes are an ELF object's.
+ *
+ * The same four bytes the packaging gates read. Separated so the repair pass can
+ * be checked against real files rather than a mock that would only agree with
+ * the implementation it was written from.
+ */
 internal fun isElfHeader(header: ByteArray): Boolean =
     header.size >= 4 &&
         header[0] == 0x7F.toByte() &&

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
@@ -1118,7 +1118,7 @@ class ToolchainManager(private val context: Context) {
                     val relPath = binaries.getString(i)
                     val command = relPath.substringAfterLast('/')
                     if (command.isEmpty() || command in scriptNames) continue
-                    if (!isElf(File(context.filesDir, relPath))) continue
+                    if (!isElfFile(File(context.filesDir, relPath))) continue
                     lines.add("$command() { $systemLoader \"\$PREFIX/../$relPath\" \"\$@\"; }")
                 }
                 if (lines.isNotEmpty()) {
@@ -1301,27 +1301,7 @@ class ToolchainManager(private val context: Context) {
      * outside this toolchain -- `usr/lib` is shared with the base install -- and
      * a repair has no business changing permissions there.
      */
-    private fun markExecutablesUnder(root: File): Int {
-        var fixed = 0
-        root.walkTopDown()
-            .onEnter { !isSymlink(it) }
-            .forEach { file ->
-                if (!file.isFile || isSymlink(file)) return@forEach
-                if (!isElf(file)) return@forEach
-                if (file.canExecute()) return@forEach
-                if (file.setExecutable(true, true)) fixed++
-            }
-        return fixed
-    }
-
-    private fun isElf(file: File): Boolean = try {
-        file.inputStream().use { input ->
-            val header = ByteArray(4)
-            input.read(header) == 4 && isElfHeader(header)
-        }
-    } catch (e: Exception) {
-        false
-    }
+    private fun markExecutablesUnder(root: File): Int = markExecutablesIn(root)
 
     // -- State persistence --
 
@@ -1367,6 +1347,48 @@ class ToolchainManager(private val context: Context) {
  * be checked against real files rather than a mock that would only agree with
  * the implementation it was written from.
  */
+/**
+ * Gives the execute bit to every ELF object under [root], returning how many
+ * needed it.
+ *
+ * At file scope and taking its symlink predicate as a parameter so a test can
+ * reach it. [isSymlink] uses `Os.lstat`, which cannot run in a JVM unit test --
+ * it throws, the catch turns that into "not a link", and every entry then looks
+ * like a regular file. Injecting the predicate is what lets the skip-links
+ * behaviour be asserted rather than assumed; production still passes
+ * [isSymlink].
+ *
+ * Links are stepped over rather than followed: a toolchain's `usr/lib` is shared
+ * with the base install, so a link there can point at a file this pass has no
+ * business changing the permissions of.
+ *
+ * Only ELF objects. Scripts are deliberately excluded -- they are wrapped in
+ * shell functions that route them through their interpreter, because nothing
+ * under `filesDir` can be executed directly whatever its mode.
+ */
+internal fun markExecutablesIn(root: File, isLink: (File) -> Boolean = ::isSymlink): Int {
+    var fixed = 0
+    root.walkTopDown()
+        .onEnter { !isLink(it) }
+        .forEach { file ->
+            if (!file.isFile || isLink(file)) return@forEach
+            if (!isElfFile(file)) return@forEach
+            if (file.canExecute()) return@forEach
+            if (file.setExecutable(true, true)) fixed++
+        }
+    return fixed
+}
+
+/** Whether [file] begins with the four bytes every ELF object starts with. */
+internal fun isElfFile(file: File): Boolean = try {
+    file.inputStream().use { input ->
+        val header = ByteArray(4)
+        input.read(header) == 4 && isElfHeader(header)
+    }
+} catch (e: Exception) {
+    false
+}
+
 internal fun isElfHeader(header: ByteArray): Boolean =
     header.size >= 4 &&
         header[0] == 0x7F.toByte() &&

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
@@ -1118,6 +1118,19 @@ class ToolchainManager(private val context: Context) {
                     val relPath = binaries.getString(i)
                     val command = relPath.substringAfterLast('/')
                     if (command.isEmpty() || command in scriptNames) continue
+                    // A name bash cannot use as a function is skipped rather than
+                    // written. The manifests are regenerated from upstream packages
+                    // at build time, so a future version can introduce a binary
+                    // called something like `foo-bar` or `2to3` without anyone here
+                    // choosing it -- and this file is sourced by .bashrc, so one
+                    // unusable name is a parse error that takes out *every* new
+                    // terminal, not just that command. Losing one wrapper is the
+                    // smaller failure, and it says so in the log.
+                    if (!isShellFunctionName(command)) {
+                        Logger.w(tag, "No wrapper for $command: not a name bash can " +
+                            "use as a function, so it would break every terminal")
+                        continue
+                    }
                     if (!isElfFile(File(context.filesDir, relPath))) continue
                     lines.add("$command() { $systemLoader \"\$PREFIX/../$relPath\" \"\$@\"; }")
                 }
@@ -1378,6 +1391,47 @@ internal fun markExecutablesIn(root: File, isLink: (File) -> Boolean = ::isSymli
         }
     return fixed
 }
+
+/**
+ * Whether [name] is safe to write into `toolchain-env.sh` as a shell function.
+ *
+ * `.bashrc` sources that file unconditionally, and one unusable name does not cost
+ * one command -- it costs the rest of the file. Measured: sourcing a file holding
+ * `good() {...}`, then `a=b() {...}`, then `after() {...}` leaves `good` defined
+ * and `after` gone. So a toolchain whose manifest carried a bad name would take
+ * out every wrapper written after it, in every new terminal.
+ *
+ * The boundary is measured against bash rather than assumed, because assuming it
+ * was wrong in both directions. An earlier version of this allowed only
+ * `[A-Za-z_][A-Za-z0-9_]*`, which is the rule for shell *variables*; bash is far
+ * more permissive about function names and happily defines `grpc-tool`, `2to3`,
+ * `foo.bar` and even `café`. Refusing those would have dropped working wrappers.
+ *
+ * What actually goes wrong divides in two, and both are refused:
+ *
+ *  - `( ) < > = [ $ \ " ' `` ` ``` and whitespace make the definition a parse
+ *    error, which is what kills the rest of the file.
+ *  - `; | &` are worse than an error: they split the line, so bash defines a
+ *    function under a *different* name and reports nothing. The wrapper is simply
+ *    absent under the name the user will type.
+ *
+ * Everything else measured -- `- . + : @ % ^ ! , { } ] * ? # ~ /`, a leading
+ * digit, non-ASCII -- defines correctly and is allowed. All fifty command names in
+ * the three shipped manifests pass, but those manifests are regenerated from
+ * upstream packages at build time, so what they contain is not this repository's
+ * choice to make.
+ */
+internal fun isShellFunctionName(name: String): Boolean {
+    if (name.isEmpty()) return false
+    return name.none { it in SHELL_UNSAFE || it.isWhitespace() }
+}
+
+/**
+ * The characters measured to break a function definition or to silently define one
+ * under another name. Not a guess at what looks dangerous: each was checked by
+ * defining a function and asking `declare -F` whether that name exists.
+ */
+private const val SHELL_UNSAFE = "()<>=[\$\\\"'`;|&"
 
 /** Whether [file] begins with the four bytes every ELF object starts with. */
 internal fun isElfFile(file: File): Boolean = try {

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
@@ -1151,6 +1151,14 @@ class SafSyncEngine(private val context: Context) {
                     if (isLink(child)) continue
                     val isDir = child.isDirectory
                     if (isDir && shouldSkip(child.name, isDir = true)) continue
+                    // The same filter every other local-to-device path applies.
+                    // shouldWriteBack drops these for single-file events, and the
+                    // recursion was the one route around it -- so a directory
+                    // appearing while an editor held a `.swp`, or while a mirror
+                    // copy was still `.vscodroid-partial`, put that scratch file on
+                    // the user's device folder under its temporary name, where
+                    // nothing later removes it.
+                    if (!isDir && isMachineTemporary(child.name)) continue
                     found.add(child)
                     if (isDir) pending.addLast(child)
                 }

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
@@ -1128,7 +1128,16 @@ class SafSyncEngine(private val context: Context) {
          * and following it would copy files from outside the folder the user granted.
          */
         internal fun uploadableEntries(root: File, limit: Int): List<File> {
-            if (limit <= 0 || !root.isDirectory) return emptyList()
+            // [root] is tested for being a link before anything else, and that is not
+            // symmetry with the children loop below -- it is the case that reaches
+            // outside the folder the user granted. `File.isDirectory` follows links,
+            // and so does the observer that produces these jobs
+            // (`(event and IN_ISDIR) != 0 || localFile.isDirectory`), so a symlink to
+            // a directory arrives here looking exactly like a directory. Walking it
+            // would list the *target's* contents and copy them onto the device: point
+            // one at a home directory inside a synced folder and the whole of it
+            // uploads.
+            if (limit <= 0 || isLink(root) || !root.isDirectory) return emptyList()
 
             val found = mutableListOf<File>()
             val pending = ArrayDeque<File>()

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
@@ -726,7 +726,11 @@ class SafSyncEngine(private val context: Context) {
         val created = mutableMapOf(localDir.absolutePath to dirSafUri)
         var made = 0
         for (entry in entries) {
-            val parentUri = created[entry.parentFile?.absolutePath] ?: continue
+            // Split rather than chained: `parentFile` is a platform type, so the
+            // chained form indexed the map with a String? and the compiler warned
+            // about it. An entry with no parent cannot be placed anywhere.
+            val parentPath = entry.parentFile?.absolutePath ?: continue
+            val parentUri = created[parentPath] ?: continue
             createOneInSaf(entry, parentUri, treeUri)?.let { uri ->
                 if (entry.isDirectory) created[entry.absolutePath] = uri
                 made++

--- a/android/app/src/main/kotlin/com/vscodroid/webview/VSCodroidWebViewClient.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/webview/VSCodroidWebViewClient.kt
@@ -109,6 +109,18 @@ internal fun resourceOutcome(path: String, resourceRoots: List<String>): Resourc
     return ResourceOutcome.Serve(file)
 }
 
+/**
+ * The file a webview resource request names, if it resolves inside a published
+ * root, and null otherwise.
+ *
+ * Symbolic links are resolved rather than normalised away lexically. A workspace
+ * is a published root and a workspace is routinely a checked-out repository, so a
+ * link inside one is attacker-supplied in the ordinary case; `..` handling alone
+ * would follow it out.
+ *
+ * The canonical path is what comes back, not the path as asked for, so that the
+ * file opened is the file that was checked.
+ */
 internal fun resolveWebviewResource(requestedPath: String, roots: List<String>): File? {
     val canonical = canonicalOrNull(requestedPath) ?: return null
     // Compared with the separator appended: a root's name is also a prefix of

--- a/android/app/src/main/kotlin/com/vscodroid/webview/VSCodroidWebViewClient.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/webview/VSCodroidWebViewClient.kt
@@ -75,6 +75,40 @@ internal fun publishedResourceRoots(context: Context): List<String> = listOf(
  * The canonical path is what comes back, not the path as asked for, so that the
  * file opened is the file that was checked.
  */
+/**
+ * What the interceptor decided about one webview resource request.
+ *
+ * Separated from building the response because a `WebResourceResponse` cannot be
+ * constructed under the stub `android.jar`, so a test has to mock its constructor
+ * and can then observe nothing about it. That left refusal provable only by the
+ * warning the code logs — and a log line is not a refusal. Code that logged the
+ * warning and served the file anyway satisfied every assertion.
+ */
+internal sealed interface ResourceOutcome {
+    /** Inside a published root and present on disk. */
+    data class Serve(val file: File) : ResourceOutcome
+
+    /** Resolved outside every published root. Nothing is opened. */
+    object Refused : ResourceOutcome
+
+    /** Inside a root, but absent or not a regular file. */
+    object Missing : ResourceOutcome
+}
+
+/**
+ * The decision, as a value: which of the three outcomes [path] reaches against
+ * [resourceRoots].
+ *
+ * `Refused` is the one that matters. `.ssh/id_ed25519` exists on disk and sits in
+ * the app-private tree, so nothing else in the request path would stop it being
+ * read and handed to the page.
+ */
+internal fun resourceOutcome(path: String, resourceRoots: List<String>): ResourceOutcome {
+    val file = resolveWebviewResource(path, resourceRoots) ?: return ResourceOutcome.Refused
+    if (!file.exists() || !file.isFile) return ResourceOutcome.Missing
+    return ResourceOutcome.Serve(file)
+}
+
 internal fun resolveWebviewResource(requestedPath: String, roots: List<String>): File? {
     val canonical = canonicalOrNull(requestedPath) ?: return null
     // Compared with the separator appended: a root's name is also a prefix of
@@ -378,13 +412,21 @@ class VSCodroidWebViewClient(
                 // Local file resource — serve directly from filesystem.
                 // Both "file" and "vscode-remote" schemes use local paths in VSCodroid
                 // since the server runs on the same device.
-                val file = resolveWebviewResource(path, resourceRoots) ?: run {
-                    Logger.w(TAG, "Resource outside the published roots refused: $path")
-                    return notFound("Access denied")
-                }
-                if (!file.exists() || !file.isFile) {
-                    Logger.d(TAG, "Resource not found ($scheme): $path")
-                    return notFound(path)
+                // Through resourceOutcome so the decision is a value rather than a
+                // log line. Refusing and serving both end in a WebResourceResponse,
+                // which a test cannot inspect under the stub android.jar, so
+                // "log the refusal and serve anyway" was indistinguishable from a
+                // refusal to everything that watched this function.
+                val file = when (val outcome = resourceOutcome(path, resourceRoots)) {
+                    ResourceOutcome.Refused -> {
+                        Logger.w(TAG, "Resource outside the published roots refused: $path")
+                        return notFound("Access denied")
+                    }
+                    ResourceOutcome.Missing -> {
+                        Logger.d(TAG, "Resource not found ($scheme): $path")
+                        return notFound(path)
+                    }
+                    is ResourceOutcome.Serve -> outcome.file
                 }
 
                 val mimeType = guessMimeType(path)

--- a/android/app/src/test/kotlin/com/vscodroid/ServerReadinessCallSiteTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/ServerReadinessCallSiteTest.kt
@@ -15,16 +15,25 @@ import java.io.File
  * away again. `isServerReady()` reports what the health probe found.
  *
  * This reads the source, which is a weaker kind of test than the rest of this
- * suite, and it is here because it is the only kind available. The decision sits
- * inside `setupServiceCallbacks()` and `handleResumeFromBackground()`, both of
- * which need an Activity; there is no seam to extract, because the mutation is
- * not a value the code computes — it is which of two methods gets called. A
- * function handed a boolean cannot tell which question produced it.
+ * suite. It is one of two layers, and it is worth being exact about which half
+ * each covers, because an earlier version of this comment claimed there was no
+ * seam to extract and that turned out to be wrong.
  *
- * What it therefore does not catch: a third call site added later that asks the
- * wrong question through some other spelling, or the same mistake made in
- * another file. It catches the specific regression of putting `isServerRunning`
- * back here, which is the one that already happened.
+ * A source-reading test sees the token `isServerReady` and not the branch, so it
+ * cannot tell a call whose answer is obeyed from one whose answer is discarded.
+ * That mutation was applied to both call sites — keep the calls, drop the
+ * verdicts — and all 632 tests stayed green. What could not be extracted is the
+ * *identity* of the method, since a function handed a boolean cannot tell which
+ * question produced it; what could be, and now is, are the branches themselves:
+ * `bindDecision` and `shouldActOnResume`, covered by
+ * [ServerReadinessDecisionTest], which fails on either mutation by name.
+ *
+ * So: that file owns "the answer is obeyed", this one owns "the right question
+ * is asked". Neither subsumes the other, and only this one would notice
+ * `isServerRunning` coming back.
+ *
+ * What neither catches: a third call site added later that asks the wrong
+ * question through some other spelling, or the same mistake made in another file.
  */
 class ServerReadinessCallSiteTest {
 

--- a/android/app/src/test/kotlin/com/vscodroid/ServerReadinessDecisionTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/ServerReadinessDecisionTest.kt
@@ -1,0 +1,104 @@
+package com.vscodroid
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * The two decisions `MainActivity` makes about a server that may not be serving.
+ *
+ * [ServerReadinessCallSiteTest] beside this one reads the source and checks which
+ * *method* is called. That catches one regression — putting `isServerRunning`
+ * back — and cannot catch the other: calling the right method and then ignoring
+ * what it said. Both call sites were mutated that way and the whole suite stayed
+ * green, because a source-reading test sees the token and not the branch.
+ *
+ * These are the branches, as values. A mutation that keeps the call and drops the
+ * verdict has to change one of these functions to compile away, and changing
+ * either one fails here.
+ *
+ * What each protects, if it stops holding:
+ *
+ *  - [bindDecision] runs when an activity binds to a service that is already up.
+ *    A server that became ready before the activity bound never fires
+ *    `onServerReady` at it, so the state is asked for rather than waited on. Load
+ *    on a port that is not listening and the user gets a connection-refused page;
+ *    `onReceivedError` only logs, so nothing takes it away.
+ *  - [shouldActOnResume] runs when the app comes back from the background. The
+ *    same page is reloaded into the same port, so the same failure applies.
+ */
+class ServerReadinessDecisionTest {
+
+    // -- bindDecision --
+
+    @Test
+    fun `a serving server on a real port is loaded`() {
+        assertEquals(
+            BindDecision.Load(13337),
+            bindDecision(notice = null, port = 13337, ready = true),
+        )
+    }
+
+    @Test
+    fun `a server that is not serving is waited for, not loaded`() {
+        // The mutation this exists for: keep asking isServerReady(), discard the
+        // answer, load on `port > 0` alone. That is exactly a caller which passes
+        // ready=false and expects Load.
+        assertEquals(
+            BindDecision.Wait,
+            bindDecision(notice = null, port = 13337, ready = false),
+            "a port with nothing listening on it must not be navigated to",
+        )
+    }
+
+    @Test
+    fun `no port yet means wait, whatever readiness says`() {
+        assertEquals(BindDecision.Wait, bindDecision(notice = null, port = 0, ready = true))
+        assertEquals(BindDecision.Wait, bindDecision(notice = null, port = -1, ready = true))
+    }
+
+    @Test
+    fun `a startup notice wins over everything`() {
+        // The notice is checked first on purpose: it may be terminal, or it may be
+        // a slow start still coming up. Either way the server is not serving, and
+        // a slow one that arrives later comes through onServerReady instead.
+        assertEquals(
+            BindDecision.ShowNotice("Server failed to start"),
+            bindDecision(notice = "Server failed to start", port = 13337, ready = true),
+            "a notice must not be swallowed by a port that happens to look fine",
+        )
+    }
+
+    // -- shouldActOnResume --
+
+    @Test
+    fun `a resume with a serving server acts`() {
+        assertTrue(shouldActOnResume(ready = true, backgroundedAt = 1_000L, serverPort = 13337))
+    }
+
+    @Test
+    fun `an unbound service does not act`() {
+        // `nodeService?.isServerReady()` yields null when nothing is bound. The
+        // mutation measured here was `!= true` becoming `== null`, which inverts
+        // exactly this case and lets an un-ready server through.
+        assertFalse(
+            shouldActOnResume(ready = null, backgroundedAt = 1_000L, serverPort = 13337),
+            "no bound service is not evidence the server is serving",
+        )
+    }
+
+    @Test
+    fun `a server that is not serving does not act`() {
+        assertFalse(
+            shouldActOnResume(ready = false, backgroundedAt = 1_000L, serverPort = 13337),
+            "reloading into a dead port leaves a connection-refused page nothing clears",
+        )
+    }
+
+    @Test
+    fun `never backgrounded, or no port, does not act`() {
+        assertFalse(shouldActOnResume(ready = true, backgroundedAt = 0L, serverPort = 13337))
+        assertFalse(shouldActOnResume(ready = true, backgroundedAt = 1_000L, serverPort = 0))
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/StaticMockCleanupTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/StaticMockCleanupTest.kt
@@ -1,81 +1,85 @@
 package com.vscodroid
 
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertTrue
+import com.vscodroid.util.PortFinder
+import io.mockk.every
+import io.mockk.mockkObject
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
-import java.io.File
+import org.junit.jupiter.api.TestMethodOrder
 
 /**
- * `mockkObject` and `mockkStatic` replace their target for the whole process, and Gradle
- * runs this suite in one JVM (`useJUnitPlatform()`, no `forkEvery`, no `maxParallelForks`),
- * so a mock left standing outlives the class that installed it.
+ * That a process-wide mock does not survive the test that installed it.
  *
- * That is not hypothetical here. `BridgeTokenUniformityTest.tearDown` records the last
- * occurrence: three tests in `CrashReporterTest` failed when the two classes ran together,
- * and the full suite passed only because some class scheduled in between happened to call
- * `unmockkAll()` for its own reasons. Five classes were still missing the teardown when
- * this was written, so the same accident was one scheduling change away from returning.
+ * `mockkObject`, `mockkStatic` and `mockkConstructor` replace their target for the
+ * whole JVM, and Gradle runs this suite in one JVM (`useJUnitPlatform()`, no
+ * `forkEvery`, no `maxParallelForks`), so a mock left standing outlives its class.
+ * The damage lands elsewhere: three tests in `CrashReporterTest` once failed
+ * because another class had left `Logger` mocked, and the suite passed overall only
+ * because some class scheduled in between called `unmockkAll()` for its own reasons.
  *
- * Per-file discipline fixed those five. This is what keeps the sixth from being written:
- * the failure it prevents shows up as an unrelated class failing, in a run that does not
- * name this one.
+ * ## Why this file no longer reads the sources
+ *
+ * It used to walk `src/test/kotlin` and require an `unmockk` call in every file
+ * that installs a mock. That measured how well it searched. Deleting the
+ * `@AfterEach` annotation from a teardown leaves the call in the file, so the text
+ * still matched and the method never ran — the guard passed while the thing it
+ * guarded was gone.
+ *
+ * The cleanup is now mockk's own `io.mockk.junit5.MockKExtension`, which the mockk
+ * jar declares in its `META-INF/services` and which calls `unmockkAll()` after
+ * every test. All it needed was switching on:
+ * `junit.jupiter.extensions.autodetection.enabled = true` in
+ * `src/test/resources/junit-platform.properties`. No class has to remember, so
+ * none can forget, and there is no annotation whose deletion matters.
+ *
+ * What is left worth testing is whether the mechanism is actually in force, which
+ * is what these two cases do — and unlike a source scan, they fail if that
+ * property is removed or set to false. Confirmed by doing exactly that before
+ * trusting them.
+ *
+ * [PortFinder] is the subject only because it is an `object` with a cheap pure
+ * method. Nothing here is about ports.
  */
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 class StaticMockCleanupTest {
 
-    private val processWideMock = Regex("""\bmockk(Object|Static|Constructor)\s*\(""")
-
-    /**
-     * A call, not the word. Matching the bare string accepted a class whose only
-     * "unmockk" was in a comment saying it should have one -- which is the exact
-     * shape of the mistake this guard exists to catch.
-     */
-    private val teardown = Regex("""\bunmockk\w*\s*\(""")
-
-    /**
-     * Comments in this suite quote these calls. BridgeTokenUniformityTest's own KDoc
-     * writes `unmockkAll()`, parentheses included, while explaining why it needs one --
-     * so matching raw text let exactly that class, the one whose incident this guard
-     * records, satisfy the check with prose once its real teardown was deleted.
-     *
-     * String literals are not stripped, so a `//` inside one takes the rest of its line.
-     * That can only hide a mock call sharing a line with a URL literal, which no file
-     * here does, and it fails towards missing an offender rather than inventing one.
-     */
-    private fun code(text: String) = text
-        .replace(Regex("""/\*.*?\*/""", RegexOption.DOT_MATCHES_ALL), " ")
-        .replace(Regex("""//[^\n]*"""), " ")
+    private companion object {
+        /** A value the real implementation cannot return, so the two are never confused. */
+        const val IMPOSSIBLE_PORT = -4242
+    }
 
     @Test
-    fun `every class that mocks process-wide also tears it down`() {
-        // Resolved by probing rather than assumed: the working directory of the test JVM is
-        // Gradle's business, and a wrong guess here would find zero files and pass.
-        val root = listOf("src/test/kotlin", "app/src/test/kotlin", "android/app/src/test/kotlin")
-            .map(::File)
-            .firstOrNull { it.isDirectory }
-        assertTrue(root != null, "test sources not found from ${File("").absolutePath}")
+    @Order(1)
+    fun `a process-wide mock is installed and deliberately not torn down here`() {
+        // No @AfterEach, no unmockkAll, on purpose: this test exists to leave a mock
+        // standing so the next one can prove something removed it. Under the old
+        // source-scanning guard this very file would have been an offender.
+        mockkObject(PortFinder)
+        every { PortFinder.isPortAvailable(any()) } returns false
 
-        val sources = root!!.walkTopDown().filter { it.extension == "kt" }.toList()
-
-        // Positive control. Without it a scan that finds nothing reports success, which is
-        // the failure mode this whole class exists to argue against.
-        assertTrue(
-            sources.any { it.name == "StaticMockCleanupTest.kt" },
-            "the scan did not find its own source under ${root.absolutePath}, so it is " +
-                "looking in the wrong place and would pass no matter what the suite does",
+        assertNotEquals(
+            IMPOSSIBLE_PORT, PortFinder.findAvailablePort(),
+            "sanity: the mock is installed and the object still answers",
         )
+    }
 
-        val offenders = sources
-            .filter { file ->
-                val text = code(file.readText())
-                processWideMock.containsMatchIn(text) && !teardown.containsMatchIn(text)
-            }
-            .map { it.name }
-            .sorted()
-
-        assertEquals(
-            emptyList<String>(), offenders,
-            "these classes install a process-wide mock and never remove it, so it is still " +
-                "standing when a later class runs: $offenders",
+    @Test
+    @Order(2)
+    fun `the mock is gone by the time the next test runs`() {
+        // If UnmockkAllExtension is not registered, PortFinder is still mocked here
+        // and isPortAvailable answers false for everything — which is exactly the
+        // cross-class contamination this guards against, observed within one class
+        // so it does not depend on how the runner orders classes.
+        val stillMocked = !PortFinder.isPortAvailable(0)
+        org.junit.jupiter.api.Assertions.assertFalse(
+            stillMocked,
+            "PortFinder is still mocked from the previous test, so nothing removed it. " +
+                "Check that UnmockkAllExtension is listed in " +
+                "src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension " +
+                "and that junit.jupiter.extensions.autodetection.enabled is true in " +
+                "junit-platform.properties.",
         )
     }
 }

--- a/android/app/src/test/kotlin/com/vscodroid/StaticMockCleanupTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/StaticMockCleanupTest.kt
@@ -68,7 +68,7 @@ class StaticMockCleanupTest {
     @Test
     @Order(2)
     fun `the mock is gone by the time the next test runs`() {
-        // If UnmockkAllExtension is not registered, PortFinder is still mocked here
+        // If the cleanup extension is not registered, PortFinder is still mocked here
         // and isPortAvailable answers false for everything — which is exactly the
         // cross-class contamination this guards against, observed within one class
         // so it does not depend on how the runner orders classes.
@@ -76,10 +76,9 @@ class StaticMockCleanupTest {
         org.junit.jupiter.api.Assertions.assertFalse(
             stillMocked,
             "PortFinder is still mocked from the previous test, so nothing removed it. " +
-                "Check that UnmockkAllExtension is listed in " +
-                "src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension " +
-                "and that junit.jupiter.extensions.autodetection.enabled is true in " +
-                "junit-platform.properties.",
+                "Check that junit.jupiter.extensions.autodetection.enabled is true in " +
+                "src/test/resources/junit-platform.properties -- that is what registers " +
+                "mockk's own MockKExtension, which does the cleanup.",
         )
     }
 }

--- a/android/app/src/test/kotlin/com/vscodroid/setup/CommandReferenceTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/CommandReferenceTest.kt
@@ -1,6 +1,7 @@
 package com.vscodroid.setup
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.io.File
 
@@ -50,14 +51,40 @@ class CommandReferenceTest {
         check(sources.isNotEmpty()) { "No sources found — the test is looking in the wrong place" }
 
         val dangling = sortedMapOf<String, MutableSet<String>>()
+        val foundIn = sortedMapOf<String, MutableSet<String>>()
         for (file in sources) {
             for (m in REFERENCE.findAll(file.readText())) {
                 val named = "VSCodroid: " + m.groupValues[1].trim()
+                foundIn.getOrPut(file.extension) { sortedSetOf() }.add(named)
                 if (named !in titles) {
                     dangling.getOrPut(named) { sortedSetOf() }.add(file.name)
                 }
             }
         }
+
+        // Positive control, and the one this test was missing. Everything above
+        // reports success by finding nothing, so a REFERENCE that stops matching
+        // -- a quoting style that changes, a character class that stops covering a
+        // real title -- turns the whole check into a scan of zero references that
+        // passes. The existing checks cover "are there sources" and "are there
+        // extensions"; neither covers "did the pattern match anything in them".
+        //
+        // Asserted per source kind rather than in total, because the two quote the
+        // name differently and only one of them is fragile: Kotlin escapes it as
+        // \"VSCodroid: ...\" while JavaScript writes it plainly. A pattern that
+        // quietly stopped handling the escaped form would still match the JS
+        // references and keep a total-count assertion green.
+        assertTrue(
+            foundIn["kt"]?.isNotEmpty() == true,
+            "no command reference matched in any Kotlin source, so the escaped form " +
+                "\\\"VSCodroid: ...\\\" is no longer being recognised and this test is " +
+                "checking nothing there. Found: $foundIn",
+        )
+        assertTrue(
+            foundIn["js"]?.isNotEmpty() == true,
+            "no command reference matched in any bundled extension, so this test is " +
+                "checking nothing there. Found: $foundIn",
+        )
 
         assertEquals(
             emptyMap<String, Set<String>>(), dangling.toMap(),

--- a/android/app/src/test/kotlin/com/vscodroid/setup/ExecutableRepairTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/ExecutableRepairTest.kt
@@ -1,0 +1,130 @@
+package com.vscodroid.setup
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.api.Test
+import java.io.File
+import java.nio.file.Files
+
+/**
+ * The repair pass that gives the execute bit back to a toolchain installed by an
+ * earlier version.
+ *
+ * A toolchain keeps the manifest it was installed with, so a packaging fix
+ * reaches new installs only. Go was the case that showed it: its manifest named
+ * `go` and `gofmt`, the recursive copy carries no modes, and the `pkg/tool`
+ * binaries `go` starts arrived without the bit.
+ *
+ * Worth being exact about what this buys, because the code once claimed more. The
+ * bit is necessary and not sufficient: nothing under `filesDir` can be executed
+ * whatever its mode, which is why toolchain commands go through the system loader.
+ * The loader will not run a file the mode denies either, so the bit still has to
+ * be there.
+ *
+ * The walk had no test at all. [isElfHeader] was covered, which is the cheapest
+ * part; what decided the outcome — which files are visited, which are skipped, and
+ * whether the bit is actually set — was not.
+ *
+ * The symlink predicate is injected because the production one uses `Os.lstat`,
+ * which cannot run in a JVM test: it throws, the catch reads that as "not a link",
+ * and every entry then looks like a regular file. A test using the real predicate
+ * would assert nothing about links while appearing to.
+ */
+class ExecutableRepairTest {
+
+    /** The four bytes every ELF object starts with, plus enough body to be a file. */
+    private fun elf(f: File) = f.apply {
+        parentFile?.mkdirs()
+        writeBytes(byteArrayOf(0x7F, 'E'.code.toByte(), 'L'.code.toByte(), 'F'.code.toByte()) +
+            ByteArray(64))
+        setExecutable(false, false)
+    }
+
+    private fun script(f: File) = f.apply {
+        parentFile?.mkdirs()
+        writeText("#!/usr/bin/env ruby\nputs 1\n")
+        setExecutable(false, false)
+    }
+
+    /** JVM-native, unlike the production predicate. */
+    private val jvmIsLink: (File) -> Boolean = { Files.isSymbolicLink(it.toPath()) }
+
+    @Test
+    fun `an ELF without the execute bit gets it`(@TempDir tmp: File) {
+        val go = elf(File(tmp, "pkg/tool/android_arm64/compile"))
+        assertFalse(go.canExecute(), "fixture must start without the bit")
+
+        assertEquals(1, markExecutablesIn(tmp, jvmIsLink))
+        assertTrue(go.canExecute(), "the binary go starts is still not executable")
+    }
+
+    @Test
+    fun `the whole tree is walked, not just the top level`(@TempDir tmp: File) {
+        elf(File(tmp, "bin/go"))
+        elf(File(tmp, "pkg/tool/android_arm64/link"))
+        elf(File(tmp, "pkg/tool/android_arm64/asm"))
+
+        assertEquals(3, markExecutablesIn(tmp, jvmIsLink))
+    }
+
+    @Test
+    fun `a script is left alone`(@TempDir tmp: File) {
+        // Not an oversight: a shebang file under filesDir cannot be executed at
+        // all, so the manifests wrap scripts in shell functions that call their
+        // interpreter. Marking one executable would suggest a route that does not
+        // work.
+        val rake = script(File(tmp, "bin/rake"))
+
+        assertEquals(0, markExecutablesIn(tmp, jvmIsLink))
+        assertFalse(rake.canExecute())
+    }
+
+    @Test
+    fun `an ELF that already has the bit is not counted`(@TempDir tmp: File) {
+        val go = elf(File(tmp, "bin/go"))
+        check(go.setExecutable(true, true))
+
+        assertEquals(0, markExecutablesIn(tmp, jvmIsLink),
+            "the count is what gets logged, so an unchanged tree must report zero")
+        assertTrue(go.canExecute())
+    }
+
+    @Test
+    fun `a symlinked file is stepped over`(@TempDir tmp: File) {
+        // usr/lib is shared with the base install, so a link inside a toolchain can
+        // point at a file this pass has no business changing.
+        val outside = elf(File(tmp, "outside/libpython.so"))
+        val root = File(tmp, "ruby").apply { mkdirs() }
+        Files.createSymbolicLink(File(root, "libpython.so").toPath(), outside.toPath())
+
+        assertEquals(0, markExecutablesIn(root, jvmIsLink))
+        assertFalse(outside.canExecute(), "a link was followed and its target changed")
+    }
+
+    @Test
+    fun `a symlinked directory is not descended into`(@TempDir tmp: File) {
+        val outside = File(tmp, "outside").apply { mkdirs() }
+        elf(File(outside, "deep/libssl.so"))
+        val root = File(tmp, "ruby").apply { mkdirs() }
+        Files.createSymbolicLink(File(root, "vendor").toPath(), outside.toPath())
+
+        assertEquals(0, markExecutablesIn(root, jvmIsLink))
+        assertFalse(File(outside, "deep/libssl.so").canExecute())
+    }
+
+    @Test
+    fun `a missing root is not an error`(@TempDir tmp: File) {
+        assertEquals(0, markExecutablesIn(File(tmp, "never-installed"), jvmIsLink))
+    }
+
+    @Test
+    fun `a file too short to have a header is not treated as an ELF`(@TempDir tmp: File) {
+        val stub = File(tmp, "bin/tiny").apply { parentFile!!.mkdirs(); writeBytes(byteArrayOf(0x7F)) }
+        stub.setExecutable(false, false)
+
+        assertEquals(0, markExecutablesIn(tmp, jvmIsLink))
+        assertFalse(stub.canExecute())
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/setup/ShellFunctionNameTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/ShellFunctionNameTest.kt
@@ -1,0 +1,71 @@
+package com.vscodroid.setup
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Which command names may be written into `toolchain-env.sh` as shell functions.
+ *
+ * `.bashrc` sources that file unconditionally, and one unusable name does not cost
+ * one command — it costs the rest of the file. Measured by sourcing a file holding
+ * `good() {...}`, `a=b() {...}`, `after() {...}`: `good` is defined and `after` is
+ * gone. A toolchain manifest carrying a bad name would therefore take out every
+ * wrapper written after it, in every new terminal.
+ *
+ * Every expectation below was checked against real bash — define the function,
+ * then ask `declare -F` whether that name exists. That mattered: the first version
+ * of this predicate applied the rule for shell *variables*
+ * (`[A-Za-z_][A-Za-z0-9_]*`) and would have refused `grpc-tool`, `2to3` and
+ * `foo.bar`, all of which bash defines without complaint. Over-refusing silently
+ * drops a working wrapper, which is the failure this file exists to prevent, in
+ * the other direction.
+ */
+class ShellFunctionNameTest {
+
+    @Test
+    fun `the names the shipped manifests contain are accepted`() {
+        listOf("go", "gofmt", "java", "javac", "jarsigner", "ruby", "irb", "rdoc",
+               "compile", "test2json", "_private", "a")
+            .forEach { assertTrue(isShellFunctionName(it), "$it should be usable") }
+    }
+
+    @Test
+    fun `shapes that look wrong but that bash accepts are allowed through`() {
+        // Each verified against bash. Refusing these would drop a wrapper for a
+        // command that would have worked, and an upstream package is free to ship
+        // any of them.
+        listOf("grpc-tool", "2to3", "foo.bar", "a+b", "a:b", "a@b", "a%b", "a^b",
+               "a!b", "a,b", "a{b", "a}b", "a]b", "a*b", "a?b", "a#b", "a~b", "café")
+            .forEach { assertTrue(isShellFunctionName(it), "bash defines $it fine") }
+    }
+
+    @Test
+    fun `characters that make the definition a parse error are refused`() {
+        // These are the ones that kill the rest of the sourced file.
+        listOf("a(b", "a)b", "a<b", "a>b", "a=b", "a[b", "a\$b", "a\\b", "a\"b",
+               "a'b", "a`b")
+            .forEach { assertFalse(isShellFunctionName(it), "$it must not be written") }
+    }
+
+    @Test
+    fun `separators that silently define another name are refused`() {
+        // Worse than an error: bash splits the line, defines something under a
+        // different name, and reports nothing. The wrapper is then absent under
+        // the name the user types, with no diagnostic anywhere.
+        listOf("a;b", "a|b", "a&b").forEach {
+            assertFalse(isShellFunctionName(it), "$it would define the wrong name")
+        }
+    }
+
+    @Test
+    fun `whitespace in any form is refused`() {
+        listOf("a b", "a\tb", "a\nb", " leading", "trailing ")
+            .forEach { assertFalse(isShellFunctionName(it), "[$it] must not be written") }
+    }
+
+    @Test
+    fun `an empty name is refused`() {
+        assertFalse(isShellFunctionName(""))
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafUploadPlanTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafUploadPlanTest.kt
@@ -125,6 +125,29 @@ class SafUploadPlanTest {
     }
 
     @Test
+    fun `a symlinked root is not walked at all`(@TempDir tmp: File) {
+        // The case that reaches outside the granted folder, and the one the
+        // children loop cannot cover because the root never goes through it.
+        // `File.isDirectory` follows links, and so does the observer that produces
+        // these jobs, so a symlink to a directory arrives looking like a directory.
+        // Walking it lists the target's contents: point one at a home directory
+        // inside a synced folder and the whole of it uploads to the device.
+        val outside = File(tmp, "home").apply { mkdirs() }
+        File(outside, "private.txt").writeText("s")
+        File(outside, "nested/deeper.txt").apply { parentFile!!.mkdirs(); writeText("s") }
+        val link = File(tmp, "proj/escape")
+        link.parentFile!!.mkdirs()
+        Files.createSymbolicLink(link.toPath(), outside.toPath())
+
+        assertTrue(link.isDirectory, "fixture check: the link does look like a directory")
+        assertTrue(
+            SafSyncEngine.uploadableEntries(link, limit = 1000).isEmpty(),
+            "a symlinked root must not be walked; its target is outside the folder " +
+                "the user granted",
+        )
+    }
+
+    @Test
     fun `a file, a missing directory and a zero cap all yield nothing`(@TempDir tmp: File) {
         val file = File(tmp, "plain.txt").apply { writeText("x") }
         assertTrue(SafSyncEngine.uploadableEntries(file, 1000).isEmpty())

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafUploadPlanTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafUploadPlanTest.kt
@@ -125,6 +125,28 @@ class SafUploadPlanTest {
     }
 
     @Test
+    fun `machine-temporary files are not uploaded`(@TempDir tmp: File) {
+        // The same filter shouldWriteBack applies to single-file events. The
+        // recursion was the one route around it, so a directory appearing while an
+        // editor held a backup, or while a mirror copy was still partial, put that
+        // scratch file on the device under its temporary name with nothing to
+        // remove it later.
+        val root = File(tmp, "proj").apply { mkdirs() }
+        File(root, "real.kt").writeText("k")
+        File(root, "notes.md~").writeText("x")
+        File(root, "session.tmp").writeText("x")
+        File(root, "copy.vscodroid-partial").writeText("x")
+
+        val names = SafSyncEngine.uploadableEntries(root, limit = 1000)
+            .map { it.name }
+
+        assertTrue(names.contains("real.kt"), "the real file must still go: $names")
+        assertFalse(names.any { it.endsWith("~") }, names.toString())
+        assertFalse(names.any { it.endsWith(".tmp") }, names.toString())
+        assertFalse(names.any { it.contains("partial") }, names.toString())
+    }
+
+    @Test
     fun `a symlinked root is not walked at all`(@TempDir tmp: File) {
         // The case that reaches outside the granted folder, and the one the
         // children loop cannot cover because the root never goes through it.

--- a/android/app/src/test/kotlin/com/vscodroid/webview/ResourceInterceptionWiringTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/ResourceInterceptionWiringTest.kt
@@ -171,6 +171,42 @@ class ResourceInterceptionWiringTest {
         )
     }
 
+    /**
+     * That the refusal is a refusal, and not a warning printed on the way to
+     * serving the file anyway.
+     *
+     * Every other case here reads the log, because serving and refusing both end
+     * in a `WebResourceResponse` and that class cannot be constructed under the
+     * stub `android.jar` — its constructor is mocked, so nothing about it can be
+     * asserted. A log line is not evidence of a refusal: code that logged and then
+     * served satisfied all four.
+     *
+     * What separates the two without touching the response is whether the file is
+     * opened. The serve branch calls `FileInputStream(file)` with no `try` around
+     * it and nothing catching upstream, so making the key unreadable turns any
+     * attempt to serve it into a thrown `FileNotFoundException`. Refusing never
+     * reaches that line and returns normally.
+     *
+     * [ResourceOutcomeTest] covers the same decision as a value; this is the half
+     * that proves the interceptor obeys it.
+     */
+    @Test
+    fun `a refused resource is never opened`() {
+        check(sshKey.setReadable(false, false)) { "could not make the fixture unreadable" }
+        check(!sshKey.canRead()) {
+            "the fixture is still readable, so this test would pass without proving anything"
+        }
+
+        // Throws if the interceptor reaches FileInputStream on it.
+        intercept(sshKey.path, openFolder = null)
+
+        assertTrue(
+            warnings.any { it.contains(sshKey.path) },
+            "the private key was neither refused nor opened, which is a third outcome " +
+                "this test does not understand: $warnings",
+        )
+    }
+
     private companion object {
         /** Never connected to — every path here is answered from the filesystem. */
         const val PORT = 41234

--- a/android/app/src/test/kotlin/com/vscodroid/webview/ResourceOutcomeTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/ResourceOutcomeTest.kt
@@ -1,0 +1,128 @@
+package com.vscodroid.webview
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+/**
+ * Whether a webview resource request is served or refused, as a value.
+ *
+ * [ResourceInterceptionWiringTest] beside this one runs the real interceptor and
+ * proves the *wiring*: that the open folder is composed into the roots and that
+ * the resolver is called at all. What it cannot prove is the outcome. Serving and
+ * refusing both end in a `WebResourceResponse`, which cannot be constructed under
+ * the stub `android.jar`, so that test mocks the constructor and then has only the
+ * app's own log line to go on — and code that logged the refusal and served the
+ * file anyway satisfied every assertion in it.
+ *
+ * These assert the decision itself, so "log and serve anyway" is a different value
+ * and fails here.
+ *
+ * The stakes are one-directional and worth stating: over-refusing empties a
+ * markdown preview, which is visible and annoying. Under-refusing hands a private
+ * key to a page, and the key is on disk inside the app-private tree with nothing
+ * else in the request path standing between it and the response.
+ */
+class ResourceOutcomeTest {
+
+    @TempDir
+    lateinit var tmp: File
+
+    private val serverTree get() = File(tmp, "server")
+    private val extensionAsset get() = File(serverTree, "extensions/md/media/m.css")
+    private val home get() = File(tmp, "home")
+    private val sshKey get() = File(home, ".ssh/id_ed25519")
+
+    private fun fixture() {
+        listOf(extensionAsset, sshKey).forEach {
+            it.parentFile!!.mkdirs()
+            it.writeText("fixture")
+        }
+    }
+
+    private val published get() = listOf(serverTree.canonicalPath)
+
+    @Test
+    fun `a file inside a published root is served`() {
+        fixture()
+        assertEquals(
+            ResourceOutcome.Serve(File(extensionAsset.canonicalPath)),
+            resourceOutcome(extensionAsset.path, published),
+        )
+    }
+
+    @Test
+    fun `a private key outside every root is refused, not merely logged`() {
+        fixture()
+        // The key exists and is readable; only the roots stand between it and the
+        // page. A version that logs a warning and returns the file reaches Serve
+        // here and fails, which the log-watching test could not see.
+        assertEquals(
+            ResourceOutcome.Refused,
+            resourceOutcome(sshKey.path, published),
+            "an SSH private key outside every published root must not be served",
+        )
+    }
+
+    @Test
+    fun `a path inside a root that does not exist is missing, not refused`() {
+        fixture()
+        // Distinguished on purpose: Missing means the roots admitted it, so a
+        // refusal reported for an absent file would hide a genuine root problem
+        // behind a spelling mistake.
+        assertEquals(
+            ResourceOutcome.Missing,
+            resourceOutcome(File(serverTree, "extensions/md/media/gone.css").path, published),
+        )
+    }
+
+    @Test
+    fun `a subdirectory inside a root is not served as a file`() {
+        fixture()
+        assertEquals(
+            ResourceOutcome.Missing,
+            resourceOutcome(File(serverTree, "extensions/md").path, published),
+            "a directory has no bytes to serve, and opening one would throw at read",
+        )
+    }
+
+    @Test
+    fun `the root itself is refused rather than treated as content`() {
+        fixture()
+        // The roots are matched with the separator appended, so a root is not a
+        // path *inside* itself. Refused rather than Missing, which is the safer of
+        // the two: the root always exists, so any rule that admitted it would have
+        // to decide what serving a directory means.
+        assertEquals(ResourceOutcome.Refused, resourceOutcome(serverTree.path, published))
+    }
+
+    @Test
+    fun `traversal out of a root is refused`() {
+        fixture()
+        val escape = File(serverTree, "extensions/../../home/.ssh/id_ed25519").path
+        assertEquals(
+            ResourceOutcome.Refused,
+            resourceOutcome(escape, published),
+            "the path resolves outside the root, whatever it looks like literally",
+        )
+    }
+
+    @Test
+    fun `a sibling whose name merely starts with a root is refused`() {
+        // A root's name is also a prefix of its siblings' names, and creating such
+        // a sibling is within reach of anything running in the extension host.
+        val sibling = File(tmp, "server-evil/secret.txt")
+        sibling.parentFile!!.mkdirs()
+        sibling.writeText("x")
+        fixture()
+
+        assertEquals(ResourceOutcome.Refused, resourceOutcome(sibling.path, published))
+    }
+
+    @Test
+    fun `no roots at all refuses everything`() {
+        fixture()
+        assertEquals(ResourceOutcome.Refused, resourceOutcome(extensionAsset.path, emptyList()))
+    }
+}

--- a/android/app/src/test/resources/junit-platform.properties
+++ b/android/app/src/test/resources/junit-platform.properties
@@ -1,0 +1,18 @@
+# Registers extensions found on the classpath through ServiceLoader. What that
+# actually switches on here is mockk's own io.mockk.junit5.MockKExtension, which
+# the mockk jar declares in its META-INF/services and which calls unmockkAll()
+# after every test.
+#
+# That matters because mockkObject/mockkStatic/mockkConstructor replace their
+# target for the whole JVM, and this suite runs in one JVM (useJUnitPlatform(),
+# no forkEvery, no maxParallelForks). A mock a class forgets to remove is still
+# standing when the next class runs, and the failure lands there: three tests in
+# CrashReporterTest once failed because another class had left Logger mocked.
+#
+# The alternative was per-class discipline plus a guard that read the sources for
+# an unmockk call. That guard measured how well it searched -- deleting the
+# @AfterEach annotation left the call in the file, so the text still matched while
+# the method never ran. One line here removes the thing to search for.
+#
+# StaticMockCleanupTest fails if this is switched off.
+junit.jupiter.extensions.autodetection.enabled = true

--- a/docs/LEGAL_NOTICES.md
+++ b/docs/LEGAL_NOTICES.md
@@ -342,6 +342,7 @@ VSCodroid bundles binaries licensed under the GNU General Public License (GPL). 
 - **gdbm** (GPL-3.0): Source available at https://github.com/termux/termux-packages (package: `gdbm`) — linked by Python's `dbm` and `gdbm` modules
 - **xz / liblzma** (LGPL-2.1 / GPL-2.0 / GPL-3.0): Source available at https://github.com/termux/termux-packages (package: `liblzma`) — linked by Python's `lzma` module
 - **Zstandard** (GPL-2.0 as packaged by Termux; dual-licensed BSD-3-Clause upstream): Source available at https://github.com/termux/termux-packages (package: `zstd`) — linked by Python's `zstd` module
+- **GMP** (LGPL-3.0): Source available at https://github.com/termux/termux-packages (package: `libgmp`) — shipped inside the Ruby toolchain pack, not the base app, so it reaches only devices where Ruby was installed
 
 The four entries after readline were absent from this offer until the library
 inventory above was compiled. Each is dynamically linked and shipped as its own
@@ -349,6 +350,31 @@ inventory above was compiled. Each is dynamically linked and shipped as its own
 source offer below applies to all of them regardless.
 
 You may also request a copy of the source code by contacting us (see contact information below). Source code will be provided for a period of three years from the date of distribution of the corresponding binary, for a charge no more than the cost of physically performing the distribution.
+
+---
+
+## Toolchain Libraries
+
+Shipped inside an on-demand toolchain pack rather than the base app, so they reach
+only devices where that toolchain was installed. The obligations are the same;
+only the audience is smaller.
+
+`scripts/check-library-attribution.py` reads these from the toolchain manifests in
+`android/toolchain_*/src/main/assets/`, rather than from disk, because the packs
+are built by CI and are absent from a working tree — a disk scan would find
+nothing and report success.
+
+| Component | Licence | Shipped with | Source |
+|---|---|---|---|
+| GMP | LGPL-3.0 | Ruby | https://github.com/termux/termux-packages (package: `libgmp`) |
+| libyaml | MIT | Ruby | https://pyyaml.org/wiki/LibYAML |
+| libruby | BSD-2-Clause | Ruby | https://www.ruby-lang.org |
+| libandroid-execinfo | BSD-2-Clause | Ruby | https://github.com/termux/libandroid-execinfo |
+| libandroid-shmem | BSD-3-Clause | Java | https://github.com/termux/libandroid-shmem |
+| libandroid-spawn | BSD-2-Clause | Java | https://github.com/termux/libandroid-spawn |
+
+GMP is the only copyleft entry here, and its written source offer sits with the
+others under **GPL Source Code Availability** above.
 
 ---
 

--- a/scripts/check-library-attribution.py
+++ b/scripts/check-library-attribution.py
@@ -42,7 +42,17 @@ NOTICES = ROOT / "docs/LEGAL_NOTICES.md"
 
 # Licences carrying a source obligation. Matched case-insensitively as a
 # substring, so "LGPL-2.1, GPL-3.0" trips on either half.
-COPYLEFT = ("GPL", "AGPL", "LGPL", "MPL", "EPL", "CDDL")
+#
+# The spelled-out names are here because the abbreviations do not appear in them:
+# "Mozilla Public License 2.0" contains no "MPL", so a component recorded that way
+# was classified permissive and never asked for a source offer. Whoever adds a
+# library writes this field by hand, and Termux's own metadata uses both styles,
+# so the check cannot assume an SPDX identifier.
+COPYLEFT = (
+    "GPL", "AGPL", "LGPL", "MPL", "EPL", "CDDL",
+    "MOZILLA PUBLIC", "ECLIPSE PUBLIC", "COMMON DEVELOPMENT",
+    "GENERAL PUBLIC LICENSE",
+)
 
 # soname (or executable) -> (component name as written in LEGAL_NOTICES, licence)
 #
@@ -164,7 +174,7 @@ def main():
               file=sys.stderr)
         return 1
 
-    unknown, unattributed, unoffered = [], [], []
+    unknown, unattributed, unoffered, unlicensed = [], [], [], []
     for name in names:
         entry = LIBRARIES.get(name)
         if entry is None:
@@ -173,12 +183,19 @@ def main():
         component, licence = entry
         if component == "VSCodroid":
             continue
+        if not licence.strip():
+            # An empty licence answers the copyleft question with "no" for free,
+            # which is the one answer nobody should get without deciding it.
+            unlicensed.append(f"{name} ({component})")
         if component not in notices:
             unattributed.append(f"{name} ({component})")
         if any(c in licence.upper() for c in COPYLEFT) and component not in offer:
             unoffered.append(f"{name} ({component}, {licence})")
 
     for label, items, hint in (
+        ("recorded with no licence at all", unlicensed,
+         "fill in the licence Termux's build.sh declares; an empty field silently "
+         "answers the copyleft question with 'no'"),
         ("not classified", unknown,
          "add it to LIBRARIES with the licence Termux's build.sh declares"),
         ("not attributed in LEGAL_NOTICES.md", unattributed,
@@ -192,7 +209,7 @@ def main():
                 print(f"  {i}", file=sys.stderr)
             print(f"  -> {hint}", file=sys.stderr)
 
-    if unknown or unattributed or unoffered:
+    if unknown or unattributed or unoffered or unlicensed:
         return 1
 
     covered = {LIBRARIES[n][0] for n in names} - {"VSCodroid"}

--- a/scripts/check-library-attribution.py
+++ b/scripts/check-library-attribution.py
@@ -31,6 +31,7 @@ The map below is the licence record. Its source is Termux's own
 `TERMUX_PKG_LICENSE`, which is what these packages are actually built from.
 """
 
+import json
 import pathlib
 import re
 import sys
@@ -39,6 +40,7 @@ ROOT = pathlib.Path(__file__).resolve().parent.parent
 USR_LIB = ROOT / "android/app/src/main/assets/usr/lib"
 JNILIBS = ROOT / "android/app/src/main/jniLibs/arm64-v8a"
 NOTICES = ROOT / "docs/LEGAL_NOTICES.md"
+TOOLCHAINS = ROOT / "android"
 
 # Licences carrying a source obligation. Matched case-insensitively as a
 # substring, so "LGPL-2.1, GPL-3.0" trips on either half.
@@ -135,6 +137,41 @@ LIBRARIES = {
     "libcom_err.so.3": ("Kerberos 5", "MIT"),
 }
 
+# Libraries that ship inside an on-demand toolchain pack rather than the base APK.
+#
+# A separate map because they are found a different way: the base tree can be
+# listed on disk, but a toolchain's payload is only present on a machine that ran
+# its download script, so these are read from the manifests the app itself uses.
+# Missing that distinction cost the attribution for four of them, which were
+# deleted from NOTICE.md while still shipping -- one of them LGPL.
+TOOLCHAIN_LIBRARIES = {
+    "libgmp.so": ("GMP", "LGPL-3.0"),
+    "libyaml-0.so": ("libyaml", "MIT"),
+    "libruby.so": ("libruby", "BSD-2-Clause"),
+    "libandroid-execinfo.so": ("libandroid-execinfo", "BSD-2-Clause"),
+    "libandroid-shmem.so": ("libandroid-shmem", "BSD-3-Clause"),
+    "libandroid-spawn.so": ("libandroid-spawn", "BSD-2-Clause"),
+    "libffi.so": ("libffi", "MIT"),
+}
+
+
+def toolchain_libs():
+    """Every library the shipped toolchain manifests declare, by file name.
+
+    Read from the manifests rather than from disk: the packs are built by CI and
+    are not present in a working tree, so a disk scan would find nothing and
+    report success. The manifests are committed, so this answers the same on any
+    machine.
+    """
+    out = []
+    for manifest in sorted(TOOLCHAINS.glob("toolchain_*/src/main/assets/*.json")):
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            raise SystemExit(f"FAIL cannot read {manifest}: {exc}")
+        out.extend(data.get("libs", []))
+    return sorted(set(out))
+
 
 def shipped():
     """Every redistributed binary, by file name."""
@@ -175,8 +212,13 @@ def main():
         return 1
 
     unknown, unattributed, unoffered, unlicensed = [], [], [], []
-    for name in names:
-        entry = LIBRARIES.get(name)
+    # Toolchain payloads are checked alongside the base tree. They ship to fewer
+    # devices, not to none, and the obligations do not scale with audience.
+    for_check = [(n, LIBRARIES.get(n)) for n in names]
+    tc = toolchain_libs()
+    for_check += [(n, TOOLCHAIN_LIBRARIES.get(n)) for n in tc]
+
+    for name, entry in for_check:
         if entry is None:
             unknown.append(name)
             continue
@@ -212,8 +254,9 @@ def main():
     if unknown or unattributed or unoffered or unlicensed:
         return 1
 
-    covered = {LIBRARIES[n][0] for n in names} - {"VSCodroid"}
-    print(f"ok -- {len(names)} shipped binaries, {len(covered)} components, all attributed")
+    covered = {c for _, (c, _) in ((n, e) for n, e in for_check if e) } - {"VSCodroid"}
+    print(f"ok -- {len(names)} shipped binaries + {len(tc)} toolchain libraries, "
+          f"{len(covered)} components, all attributed")
     # The names, not just the count. A count alone cannot answer the question that
     # actually matters when two trees disagree -- *which* file is missing -- and
     # some of these are found by `dlopen` at run time rather than through

--- a/scripts/check-library-attribution.py
+++ b/scripts/check-library-attribution.py
@@ -201,6 +201,29 @@ def main():
         print(f"FAIL {NOTICES} is missing", file=sys.stderr)
         return 1
 
+    # The set of names this document actually attributes, matched whole rather
+    # than as substrings.
+    #
+    # Two narrowings, each because the looser version was satisfied by something
+    # that attributes nothing. A search over the whole document passes on any
+    # passing mention -- "Git" appears on sixteen lines here. Narrowing to table
+    # rows is not enough: libiconv's "Linked by" cell says "Bash and every Git
+    # executable". Narrowing to the first cell is still not enough: the heading
+    # "### @github/copilot (GitHub Copilot CLI)" contains "Git" inside "GitHub",
+    # so deleting Git's own row and heading left the check green.
+    attributed = set()
+    for line in notices.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            attributed.add(stripped.lstrip("#").strip())
+        elif stripped.startswith("|"):
+            cells = stripped.split("|")
+            if len(cells) > 1:
+                cell = cells[1].strip()
+                # `[GMP](https://gmplib.org)` -> `GMP`
+                link = re.match(r"^\[([^\]]+)\]\(", cell)
+                attributed.add(link.group(1) if link else cell)
+
     # The source-availability section, isolated so a component merely mentioned
     # elsewhere in the file cannot satisfy the copyleft check.
     m = re.search(r"^## GPL Source Code Availability$(.*?)^## ", notices,
@@ -229,7 +252,7 @@ def main():
             # An empty licence answers the copyleft question with "no" for free,
             # which is the one answer nobody should get without deciding it.
             unlicensed.append(f"{name} ({component})")
-        if component not in notices:
+        if component not in attributed:
             unattributed.append(f"{name} ({component})")
         if any(c in licence.upper() for c in COPYLEFT) and component not in offer:
             unoffered.append(f"{name} ({component}, {licence})")

--- a/scripts/test-process-monitor.js
+++ b/scripts/test-process-monitor.js
@@ -77,6 +77,13 @@ function main() {
             '--node-ipc', '--clientProcessId=1'], 'langserver'],
         [1010, [NODE, `${EXT}/bradlc.vscode-tailwindcss-0.16.0/dist/tailwindModeServer.js`,
             '--node-ipc'], 'langserver'],
+        // The other half of that pattern: a bare 'tailwind' would match all three of
+        // these, and 'langserver' is not a label -- it makes a process eligible for
+        // the idle kill under memory pressure. These are the user's own work.
+        [1011, [NODE, '/data/user/0/com.vscodroid/files/home/projects/site/tailwind.config.js'],
+            'unknown'],
+        [1012, [NODE, '/data/user/0/com.vscodroid/files/home/projects/build-tailwind.js'],
+            'unknown'],
     ];
     for (const [pid, argv] of cases) {
         writeProc(proc, pid, argv);


### PR DESCRIPTION
Five checks in this suite could not fail. Each was confirmed doing so — the thing
it guards was broken and the suite stayed green — before anything was changed, and
confirmed reporting the fault by name afterwards.

Two needed the production code reshaped rather than the check tightened. A check
that reads the source for a name can never tell a call whose answer is obeyed from
one whose answer is thrown away, and no amount of regex fixes that.

## 1. Readiness: the right method, called and ignored

`ServerReadinessCallSiteTest` reads `MainActivity.kt` and asserts `isServerRunning`
is absent and `isServerReady()` appears at least twice. That catches putting the
wrong method back. It cannot catch calling the right one and discarding what it
said — and that mutation, applied to **both** call sites, left all 632 tests green.

Its own KDoc claimed there was no seam to extract, "because the mutation is not a
value the code computes — it is which of two methods gets called". Half right. The
*identity* of the method cannot be extracted; the branches can. `bindDecision()`
and `shouldActOnResume()` are now those branches as values, covered by
`ServerReadinessDecisionTest`.

Both mutations were applied again — `port > 0 && ready` → `port > 0`, and
`ready == true` → `ready != false` — and each now fails by name. The source-reading
test stays: it is still the only one that would notice `isServerRunning` returning.

## 2. Mock cleanup: the call present, the annotation gone

`StaticMockCleanupTest` walked the test sources and required an `unmockk` call in
every file installing a process-wide mock. Deleting the `@AfterEach` annotation
from a teardown leaves the call in the file — the text still matches, the method
never runs.

Rather than teach the regex about annotations, the thing being searched for is
gone. `junit.jupiter.extensions.autodetection.enabled` registers mockk's own
`io.mockk.junit5.MockKExtension`, which the mockk jar already declares in its
`META-INF/services` and which calls `unmockkAll()` after every test. Twenty-six
classes no longer have to remember, so none can forget.

Safe because nothing depends on a mock outliving a test: no class in this suite
installs one in `@BeforeAll`. Checked before switching it on.

The file now proves the mechanism instead of describing it — one test installs a
mock and deliberately does not tear it down, the next asserts it is gone. Removing
the properties file makes that second test fail.

An intermediate version of this shipped a hand-written extension for the same job.
It was redundant: enabling autodetection was already picking up mockk's, which is
why removing the hand-written one changed nothing. Deleted.

## 3. Resource refusal proved by a log line

`ResourceInterceptionWiringTest` read the app's own warning to decide whether a
request had been refused. Serving and refusing both end in a `WebResourceResponse`,
which cannot be constructed under the stub `android.jar` — the test mocks its
constructor and can observe nothing about it. A log line is not a refusal: code
that logged the warning and then served the file satisfied all four cases.

Extraction alone would not have closed this, and that distinction is the useful
part. `resourceOutcome()` makes the decision a value — `Serve`, `Refused`,
`Missing` — and `ResourceOutcomeTest` asserts it directly over real files. But the
original hole lives *inside* `interceptResourceRequest`, and the value-level tests
stayed green through a mutation there.

What separates serving from refusing without touching the response is whether the
file is opened. The serve branch calls `FileInputStream(file)` with no `try` around
it and nothing catching upstream, so the wiring test now makes the key unreadable
and asserts the interceptor returns normally. Serving it throws. Confirmed by
mutating the `Refused` branch to log and fall through.

One assumption in the new tests was wrong and the code was right: a root directory
resolves to `Refused` rather than `Missing`, because roots are matched with the
separator appended and a root is not a path inside itself. The test says so now.

## 4. Command references: a scan of nothing

`CommandReferenceTest` guarded against there being no extensions and against there
being no sources — not against the pattern matching nothing in them. A `REFERENCE`
that stopped matching turned the check into a scan of zero references that passes.

The control is per source kind rather than a total, because only one form is
fragile: Kotlin escapes the name as `\"VSCodroid: ...\"` while a bundled extension
writes it plainly. A pattern that quietly stopped handling the escaped form would
still match the JavaScript references and keep a total-count assertion green.

## 5. The repair walk, untested

The toolchain execute-bit repair had no test on the part that decides anything.
`isElfHeader` was covered — the cheapest piece. The walk was not, and its
documentation had overclaimed what the pass achieves.

`markExecutablesIn()` moves to file scope and takes its symlink predicate as a
parameter. Not decoration: the production predicate uses `Os.lstat`, which cannot
run in a JVM test. It throws, the catch reads that as "not a link", and every entry
looks like a regular file — so a test using the real predicate would assert nothing
about links while appearing to.

Eight cases cover the tree walk, scripts left alone, an already-executable file not
counted, links not followed into or through, a missing root, and a file too short to
have a header. Confirmed against three mutations: never setting the bit, following
symlinks, dropping the ELF check.

---

## Verification

- `./gradlew testDebugUnitTest --rerun-tasks` — **671 tests, 101 suites, 0 failures**
  (up 17)
- Every guard changed here was watched failing on the defect it guards before being
  trusted on the fixed tree. The mutations are named in the commit messages so they
  can be repeated.
- One compiler warning fixed on the way past, in the SAF upload walk: a
  platform-type `parentFile` left a map being indexed with a `String?`.

Nothing a user can see changes. What changes is whether the next release notices
when one of these goes wrong.
