### PR TITLE
fix(webview): enforce the documented minimum WebView version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- VSCodroid warns when the installed Android System WebView is older than Chrome 105, the version it is tested against. It warns and continues rather than refusing to start, and a version it cannot read is not treated as an old one.
 - **Serve on Network**: lists the ports your dev servers are listening on, shows the address other devices can reach them at, and copies it. Loopback-only servers are called out.
 - You can preview your own dev server at the device's network address from inside the editor, not only at `localhost`.
 - `Simple Browser: Show` opens any loopback address in a tab beside your code. It shipped all along and was documented nowhere.

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -27,6 +27,7 @@ import androidx.activity.SystemBarStyle
 import androidx.activity.enableEdgeToEdge
 import com.vscodroid.util.CrashReporter
 import com.vscodroid.util.StorageManager
+import com.vscodroid.util.WebViewVersion
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
@@ -205,6 +206,7 @@ class MainActivity : AppCompatActivity() {
         startAndBindService()
         checkPreviousCrash()
         checkStorageHealth()
+        checkWebViewVersion()
         // Reading it here, and not only in onNewIntent, is what makes a sign-in
         // survive the app being killed while the browser had the screen. See
         // receiveCallbackIntent.
@@ -1452,6 +1454,42 @@ class MainActivity : AppCompatActivity() {
             Toast.LENGTH_LONG
         ).show()
         Logger.w(tag, "Storage low: $available available")
+    }
+
+    /**
+     * Warns when the installed WebView is older than the version this project
+     * is tested against.
+     *
+     * `minSdk` is 33, which ships Chrome 105 or newer, so a stock device passes
+     * and sees nothing. What this catches are the cases a user cannot diagnose:
+     * a System WebView disabled or downgraded by hand or by an OEM image, a
+     * device where WebView updates are blocked so the component ages while the
+     * OS does not, and emulators or custom ROMs carrying an older WebView than
+     * their API level implies. On those the workbench loads against something it
+     * was never tested on, and the failure is missing CSS or a blank editor
+     * rather than a clean refusal. `onReceivedError` only logs, so nothing else
+     * would reach the user.
+     *
+     * It warns and continues rather than refusing to start. The floor is a
+     * tested one, not a hard incompatibility, and an editor that degrades is
+     * worth more than one that will not open. A version that cannot be read is
+     * not treated as an old one; see [WebViewVersion.majorVersionOf].
+     */
+    private fun checkWebViewVersion() {
+        val pkg = WebView.getCurrentWebViewPackage()
+        val version = pkg?.versionName
+        if (!WebViewVersion.isBelowMinimum(version)) {
+            Logger.i(tag, "WebView: ${pkg?.packageName ?: "unknown"} ${version ?: "unknown version"}")
+            return
+        }
+        Toast.makeText(
+            this,
+            "Android System WebView is version $version. VSCodroid is tested against " +
+                "${WebViewVersion.MINIMUM_CHROME_MAJOR} and newer, so parts of the editor " +
+                "may not work. Update it from the Play Store.",
+            Toast.LENGTH_LONG
+        ).show()
+        Logger.w(tag, "WebView $version is below the tested minimum ${WebViewVersion.MINIMUM_CHROME_MAJOR}")
     }
 
 

--- a/android/app/src/main/kotlin/com/vscodroid/util/WebViewVersion.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/util/WebViewVersion.kt
@@ -1,0 +1,45 @@
+package com.vscodroid.util
+
+/**
+ * The WebView version this project states as its floor, and the parsing that
+ * decides whether an installed one is below it.
+ *
+ * Kept out of the Activity that shows the warning so the decision can be tested
+ * without a device. The framework call naming the installed package is the only
+ * part that needs one, and it is a single line at the call site.
+ *
+ * The floor is stated in three places a reader can reach (`README.md`, and
+ * NFR-COMPAT-04 in `docs/02-SRS.md`) and for a year was enforced in none, which
+ * is what [MINIMUM_CHROME_MAJOR] and the test pinning it to those documents
+ * exist to prevent recurring.
+ */
+object WebViewVersion {
+
+    /**
+     * Chrome 105, the version `minSdk` 33 ships with.
+     *
+     * Raising this means raising it in the documents too; `WebViewVersionTest`
+     * reads them and fails when the three disagree.
+     */
+    const val MINIMUM_CHROME_MAJOR = 105
+
+    /**
+     * The Chrome major version in a WebView package's `versionName`, or null
+     * when there is no version or it is not shaped like one.
+     *
+     * Null is deliberately not "too old". An unreadable version means the
+     * question went unanswered, and treating that as a failure would accuse
+     * every device whose WebView reports something unexpected. The check this
+     * feeds can be wrong in two directions, and a false accusation is the
+     * costlier one: it sends someone to update a component that is already
+     * current.
+     */
+    fun majorVersionOf(versionName: String?): Int? =
+        versionName?.trim()?.substringBefore('.')?.toIntOrNull()?.takeIf { it > 0 }
+
+    /** True only when a version was read *and* it is below the floor. */
+    fun isBelowMinimum(versionName: String?): Boolean {
+        val major = majorVersionOf(versionName) ?: return false
+        return major < MINIMUM_CHROME_MAJOR
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/util/WebViewVersionTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/util/WebViewVersionTest.kt
@@ -1,0 +1,128 @@
+package com.vscodroid.util
+
+import java.io.File
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * The WebView floor, checked in both directions and pinned to the documents
+ * that state it.
+ *
+ * The defect this covers was not a wrong comparison, it was the absence of one:
+ * the project stated Chrome 105 in the README and as NFR-COMPAT-04 while no code
+ * read the installed version at all. A test that only exercised the comparison
+ * would therefore miss what actually went wrong, which is the documents and the
+ * constant drifting apart. [minimumMatchesTheDocumentsThatStateIt] is the half
+ * that catches that.
+ */
+class WebViewVersionTest {
+
+    // ---- parsing -----------------------------------------------------------
+
+    @Test
+    fun `a full Chrome version yields its major`() {
+        assertEquals(105, WebViewVersion.majorVersionOf("105.0.5195.79"))
+        assertEquals(131, WebViewVersion.majorVersionOf("131.0.6778.200"))
+    }
+
+    @Test
+    fun `a bare major is read as one`() {
+        assertEquals(105, WebViewVersion.majorVersionOf("105"))
+    }
+
+    @Test
+    fun `surrounding whitespace does not defeat parsing`() {
+        assertEquals(120, WebViewVersion.majorVersionOf("  120.0.6099.230 "))
+    }
+
+    /**
+     * Every shape meaning "not answered" has to come back null rather than zero
+     * or a default, because [WebViewVersion.isBelowMinimum] turns null into "do
+     * not warn" and any number into a verdict.
+     */
+    @Test
+    fun `an unreadable version is null rather than a number`() {
+        assertNull(WebViewVersion.majorVersionOf(null), "no package installed")
+        assertNull(WebViewVersion.majorVersionOf(""), "empty string")
+        assertNull(WebViewVersion.majorVersionOf("   "), "whitespace only")
+        assertNull(WebViewVersion.majorVersionOf("dev-build"), "not a number")
+        assertNull(WebViewVersion.majorVersionOf(".105"), "leading dot")
+        assertNull(WebViewVersion.majorVersionOf("0.0.0.0"), "zero is not a Chrome version")
+    }
+
+    // ---- the verdict, in both directions -----------------------------------
+
+    @Test
+    fun `a version below the floor is reported`() {
+        assertTrue(WebViewVersion.isBelowMinimum("104.0.5112.97"))
+        assertTrue(WebViewVersion.isBelowMinimum("88.0.4324.181"))
+    }
+
+    @Test
+    fun `the floor itself passes`() {
+        assertFalse(
+            WebViewVersion.isBelowMinimum("105.0.5195.79"),
+            "105 is the minimum, not the first rejected version",
+        )
+    }
+
+    @Test
+    fun `a version above the floor passes`() {
+        assertFalse(WebViewVersion.isBelowMinimum("131.0.6778.200"))
+    }
+
+    /**
+     * The direction that costs a user something they cannot act on: being told
+     * to update a WebView that may well be current, because its version string
+     * was not one we could read.
+     */
+    @Test
+    fun `an unreadable version does not accuse the device`() {
+        assertFalse(WebViewVersion.isBelowMinimum(null), "no WebView package")
+        assertFalse(WebViewVersion.isBelowMinimum(""), "empty version")
+        assertFalse(WebViewVersion.isBelowMinimum("dev-build"), "unparseable version")
+    }
+
+    // ---- the constant against the documents that state it ------------------
+
+    /**
+     * Reads the floor out of the two documents that state it to a reader and
+     * fails when either disagrees with the constant.
+     *
+     * Every file is required to exist and to contain a figure. A test that
+     * silently passed when it could not find the claim would restore exactly the
+     * condition being fixed: a stated requirement with nothing holding it.
+     *
+     * Two other documents name a Chrome version and are deliberately left out.
+     * `docs/07-TESTING_STRATEGY.md` lists 105, 120 and 131 as a matrix of
+     * versions to test against, so its numbers are not a claim about the floor
+     * and matching them here would fail on a non-subject hit.
+     * `docs/08-RISK_MATRIX.md` is a historical document whose T04 row names
+     * `MainActivity.checkWebViewVersion`, so a reader there already has a path
+     * back to the code.
+     */
+    @Test
+    fun minimumMatchesTheDocumentsThatStateIt() {
+        val claim = Regex("""Chrome (\d+)\+?""")
+        val stated = listOf("../../README.md", "../../docs/02-SRS.md", "../../docs/05-API_SPEC.md")
+        for (path in stated) {
+            val file = File(path)
+            assertTrue(file.isFile, "$path is missing; this test cannot check what it claims")
+            val found = claim.findAll(file.readText()).map { it.groupValues[1].toInt() }.toSet()
+            assertTrue(
+                found.isNotEmpty(),
+                "$path states no Chrome version, so the requirement it is supposed to carry " +
+                    "has quietly disappeared",
+            )
+            assertEquals(
+                setOf(WebViewVersion.MINIMUM_CHROME_MAJOR),
+                found,
+                "$path states Chrome $found while WebViewVersion.MINIMUM_CHROME_MAJOR is " +
+                    "${WebViewVersion.MINIMUM_CHROME_MAJOR}; move both together",
+            )
+        }
+    }
+}

--- a/docs/05-API_SPEC.md
+++ b/docs/05-API_SPEC.md
@@ -860,12 +860,17 @@ Exit codes:
 > `error_setup_failed`, `status_server_slow_start` — plus log lines. Errors are not
 > classified by code, so nothing can be filed, matched or triaged by one.
 >
-> Two rows are worth naming because they describe detection that does not exist rather
-> than merely a missing label: **E102 WEBVIEW_TOO_OLD** implies a WebView version check,
-> and there is none — no `WebViewCompat`, no `getCurrentWebViewPackage`, no comparison
-> against Chrome 105 — so an out-of-date WebView is not detected at all. **E101
-> WEBVIEW_CRASH** is detected (`onRenderProcessGone` rebuilds the view) but is never
-> reported to the user in any form.
+> One row is worth naming because it describes detection that does not exist rather than
+> merely a missing label: **E101 WEBVIEW_CRASH** is detected (`onRenderProcessGone`
+> rebuilds the view) but is never reported to the user in any form.
+>
+> **E102 WEBVIEW_TOO_OLD** was in the same position until 2026-08-16, when the check it
+> implies was added: `MainActivity.checkWebViewVersion` reads
+> `WebView.getCurrentWebViewPackage()` and compares it against
+> `WebViewVersion.MINIMUM_CHROME_MAJOR`. There is still no code named `E102` and no log
+> line carrying it, so the row remains a design record like the rest; what changed is
+> that the condition behind it is now detected, and reported as a toast rather than a
+> code. A version the app cannot parse is not treated as an old one.
 >
 > Kept as a design record. Do not write code that expects to receive these, and do not
 > cite a code in a bug report — no log line will contain one.

--- a/docs/08-RISK_MATRIX.md
+++ b/docs/08-RISK_MATRIX.md
@@ -206,7 +206,7 @@ These plans cover risks that did not yet have dedicated sections above.
 
 | Risk | Mitigation Plan | Contingency |
 |------|------------------|-------------|
-| T04 — WebView fragmentation | Enforce runtime minimum WebView check (Chrome 105+), maintain compatibility matrix in CI/device lab, gate release on WebView smoke tests | Show blocking upgrade dialog for outdated WebView; limit supported devices |
+| T04 (WebView fragmentation) | **Done:** a runtime check reads the installed WebView at launch and warns when it is below Chrome 105 (`MainActivity.checkWebViewVersion`). **Not done:** no compatibility matrix in CI or a device lab, and no release gate on WebView smoke tests | Deliberately a warning, not a blocking dialog: the floor is a tested one rather than a hard incompatibility, and an editor that degrades beats one that will not open |
 | T05 — Memory pressure/OOM | Keep V8 heap cap (`--max-old-space-size=512`), lazy-load extensions/LSP, add memory watchdog and pressure-based cleanup | Auto-disable heavy extensions and reduce concurrent LSP to 1 |
 | T06 — node-pty failure | Build node-pty in CI for each Node.js bump, run PTY integration tests on physical device, keep pinned known-good node-pty version | Fallback terminal mode with reduced features until PTY patch is fixed |
 | T07 — 16KB page alignment | Enforce linker flags in all native build scripts, validate with `readelf` checks in CI | Block release for API 36 target until all binaries pass alignment checks |


### PR DESCRIPTION
Closes #176.

The README lists Chrome 105 under requirements and `docs/02-SRS.md` carries it
as NFR-COMPAT-04 at priority P0. Nothing read the installed WebView version.
Grepping the Kotlin sources for `WebViewCompat`, `getCurrentWebViewPackage` or
any version comparison returned nothing; the only trace that a check was ever
intended was an unused string resource, since removed.

## Why it is worth having

`minSdk` is 33, which ships Chrome 105 or newer, so a stock device was never at
risk. The cases this covers are the ones a user cannot diagnose on their own:

- System WebView disabled or downgraded, by hand or by an OEM image
- A device where WebView updates are blocked, so the component ages while the
  OS does not
- Emulators and custom ROMs carrying an older WebView than their API level
  implies

On those the workbench loads against something it was never tested on, and the
result is missing CSS or a blank editor rather than a clean refusal.
`onReceivedError` only logs, so nothing else reaches the user.

## Approach

`MainActivity.checkWebViewVersion` warns and continues. The stated floor is a
tested one rather than a hard incompatibility, and an editor that degrades is
worth more than one that will not open.

A version the app cannot parse is **not** treated as an old one. This check can
be wrong in two directions, and the false accusation is the costlier: it sends
someone to update a component that may already be current. `null`, an empty
string, and anything not shaped like a version all mean "not answered".

The parsing lives in `util/WebViewVersion` so the decision is testable without
a device; the framework call naming the installed package is a single line at
the call site.

## Tests

`WebViewVersionTest` covers both directions, including the floor itself and
each shape of unreadable version. One case reads the floor back out of the
three non-historical documents that state it and fails when any of them
disagrees with the constant, so the documents and the code cannot drift apart
again, which is the actual defect here rather than a wrong comparison.

Confirmed by mutation: moving the constant to 110, and treating an unreadable
version as old, each turn the suite red; reverting restores it.

`docs/05-API_SPEC.md` and `docs/08-RISK_MATRIX.md` are updated, since both
described this detection as absent.
