### PR TITLE
fix(setup): credit the bundled part of usr/ in the update storage check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **Setup and storage**
 
 - First run asks for as much free space as unpacking needs, measured from what the app carries. The old figure was 500 MB against a tree now over 800 MB, so devices in between failed partway with "Setup failed".
-- Updating no longer asks for room the install already occupies. What is unpacked is credited, so an update asks roughly 334 MB instead of 874 MB.
+- Updating no longer asks for room the install already occupies. What is unpacked is credited, so an update asks about 177 MB instead of 874 MB.
+- That credit now covers `usr/` and the extensions directory too, not just the server tree. Both are shared with installed toolchains and gallery extensions, which are subtracted, so a device with 177 MB free is no longer refused an update that needed 334 MB only on paper.
 - A setup interrupted partway can be retried. The retry now counts what is already on disk rather than demanding the full amount again.
 - A first run that cannot unpack the editor stops and offers to retry instead of reporting success, which previously left an app that opened but could never start its server.
 - An installation left broken by an interrupted setup repairs itself on the next launch. Files partly written but still plausible are left untouched.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -79,6 +79,30 @@ android {
             "LARGEST_ASSET_BYTES",
             "${fileTree("src/main/assets").files.maxOfOrNull { it.length() } ?: 0L}L"
         )
+
+        // The two subtrees extraction writes into ground it does not own alone.
+        // `usr/` also holds installed toolchains and anything `npm install -g`
+        // leaves; the extensions directory also holds whatever the user took
+        // from the gallery. So neither directory's size on disk answers "how
+        // much of what we are about to write is already there", and the gate
+        // used to charge both in full on every update: about 334 MB asked of a
+        // device that needed roughly 180.
+        //
+        // Measured from the same tree as the two figures above so they cannot
+        // drift apart, and used by FirstRunSetup.sharedTreeCredit as the ceiling
+        // on what an existing directory may be credited for. A build with no
+        // real asset tree gets zero, which credits nothing and is the safe
+        // direction.
+        buildConfigField(
+            "long",
+            "BUNDLED_USR_BYTES",
+            "${fileTree("src/main/assets/usr").files.sumOf { it.length() }}L"
+        )
+        buildConfigField(
+            "long",
+            "BUNDLED_EXTENSION_BYTES",
+            "${fileTree("src/main/assets/extensions").files.sumOf { it.length() }}L"
+        )
     }
 
     buildTypes {

--- a/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
@@ -57,6 +57,47 @@ class FirstRunSetup(
         runSetupLocked()
     }
 
+    /**
+     * How much of `usr/` belongs to installed toolchains rather than to the APK.
+     *
+     * Read from `ToolchainRegistry` rather than by measuring the directories a
+     * toolchain occupies, and the imprecision is the point. The registry's
+     * figures are the ones shown to a user before a download and run a little
+     * over what lands on disk (Go is listed at 179 MB against about 163 MB
+     * unpacked), so this over-states what is foreign, which under-states the
+     * credit. That is the direction [sharedTreeCredit] needs to be wrong in.
+     *
+     * Null when the record cannot be read, which [sharedTreeCredit] turns into
+     * no credit at all. Answering zero there would have been the opposite of
+     * safe: zero means "nothing in `usr/` is foreign", so an unreadable record
+     * would have credited the directory in full, which is exactly the direction
+     * that lets the gate pass a device it should refuse. A record that is simply
+     * absent is different and does answer zero, because the file is written by
+     * the first install and its absence means none has run.
+     *
+     * Reads `toolchains.json` directly rather than through `ToolchainManager`,
+     * whose constructor builds an `AssetPackManagerFactory` and therefore cannot
+     * be instantiated in a JVM unit test. Routing the gate through it took four
+     * existing storage tests down with `NoClassDefFoundError` before this was a
+     * plain file read.
+     */
+    private fun installedToolchainBytes(): Long? = try {
+        val record = File(context.filesDir, "home/.vscodroid/toolchains.json")
+        if (!record.exists()) {
+            // Written by the first install; absent means none has run.
+            0L
+        } else {
+            val state = JSONArray(record.readText())
+            (0 until state.length()).sumOf { i ->
+                val name = state.optJSONObject(i)?.optString("name").orEmpty()
+                ToolchainRegistry.find(name)?.estimatedSize ?: 0L
+            }
+        }
+    } catch (e: Exception) {
+        Logger.w(tag, "Could not read installed toolchains; crediting none of usr/: ${e.message}")
+        null
+    }
+
     private suspend fun runSetupLocked(): SetupResult = withContext(Dispatchers.IO) {
         val previousVersionCode = getPreviousVersionCode()
         val currentVersionCode = getCurrentVersionCode()
@@ -111,7 +152,19 @@ class FirstRunSetup(
             // with a Retry button that measures the same thing for ever and a
             // MainActivity that never runs, so nothing the app offers can free a byte.
             val available = context.filesDir.usableSpace
-            val installed = installedExtractionBytes(File(context.filesDir, "server"))
+            val installed = installedExtractionBytes(File(context.filesDir, "server")) +
+                sharedTreeCredit(
+                    installedBytes = installedExtractionBytes(File(context.filesDir, "usr")),
+                    bundledBytes = BuildConfig.BUNDLED_USR_BYTES,
+                    foreignBytes = installedToolchainBytes(),
+                ) +
+                sharedTreeCredit(
+                    installedBytes = installedExtractionBytes(
+                        File(context.filesDir, "home/.vscodroid/extensions")
+                    ),
+                    bundledBytes = BuildConfig.BUNDLED_EXTENSION_BYTES,
+                    foreignBytes = 0,
+                )
             val required = requiredExtractionBytes(assetBytes, largestAssetBytes, installed)
             if (available < required) {
                 lastRefusedBytes = required
@@ -2037,6 +2090,47 @@ claude() {
             val missing = (assetBytes - installedBytes).coerceAtLeast(0)
             val rewriteHeadroom = if (installedBytes > 0) largestAssetBytes else 0L
             return missing + rewriteHeadroom + EXTRACTION_SLACK_BYTES
+        }
+
+        /**
+         * How much of a directory extraction shares with something else may be
+         * credited as already unpacked.
+         *
+         * `server/` can be measured and believed, because nothing but extraction
+         * writes there. `usr/` and the extensions directory cannot: toolchains
+         * install into the first, `npm install -g` lands there too, and the
+         * second fills with whatever the user takes from the gallery. Their size
+         * on disk is therefore not an answer to "how much of what we are about
+         * to write is already here", and charging them in full instead was
+         * asking an updater for about 334 MB where roughly 180 would do.
+         *
+         * Two clamps, both pointing the same way:
+         *
+         *  - subtract [foreignBytes], what is known to belong to something else.
+         *    An over-estimate here credits less, which is the safe direction.
+         *  - cap at [bundledBytes]. Extraction writes exactly the bundled tree,
+         *    so nothing beyond it can be a byte we are about to write over, and
+         *    without this cap a directory swollen by toolchains would credit the
+         *    install for space that overwriting never gives back.
+         *
+         * A null [foreignBytes] means the share could not be determined and
+         * yields no credit. It is not the same as zero: zero asserts the
+         * directory is ours alone, which is the assumption that would credit a
+         * toolchain-filled `usr/` in full.
+         *
+         * Getting it wrong upward is the failure worth avoiding: the gate passes,
+         * extraction runs out of disk partway, and the user is told "Setup
+         * failed" with no figure, on every retry, because the toolchains stay
+         * where they are. Getting it wrong downward costs one round of freeing
+         * space that was not strictly needed.
+         */
+        internal fun sharedTreeCredit(
+            installedBytes: Long,
+            bundledBytes: Long,
+            foreignBytes: Long?,
+        ): Long {
+            if (foreignBytes == null) return 0
+            return minOf(bundledBytes, (installedBytes - foreignBytes).coerceAtLeast(0))
         }
 
         /**

--- a/android/app/src/test/kotlin/com/vscodroid/setup/SharedTreeCreditTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/SharedTreeCreditTest.kt
@@ -1,0 +1,169 @@
+package com.vscodroid.setup
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * What the storage gate may credit for a directory it does not own alone.
+ *
+ * `server/` can be measured and believed; nothing but extraction writes there.
+ * `usr/` and the extensions directory cannot, because toolchains, `npm install
+ * -g` and gallery installs all land in them. Charging both in full on every
+ * update is what asked an updater for about 334 MB where roughly 180 would do.
+ *
+ * Every case here is chosen for the direction it can be wrong in. Crediting too
+ * little costs a user one round of freeing space they did not need to free.
+ * Crediting too much is the failure that matters: the gate passes, extraction
+ * runs out of disk partway, and the user is told "Setup failed" with no figure,
+ * on every retry, because the toolchains stay exactly where they are.
+ */
+class SharedTreeCreditTest {
+
+    private val mb = 1_048_576L
+
+    /** Stands in for `BUNDLED_USR_BYTES`; the real one is zero on a CI runner. */
+    private val bundled = 110 * mb
+
+    @Test
+    fun `a directory holding exactly the bundled tree is credited in full`() {
+        assertEquals(
+            bundled,
+            FirstRunSetup.sharedTreeCredit(
+                installedBytes = bundled,
+                bundledBytes = bundled,
+                foreignBytes = 0,
+            ),
+        )
+    }
+
+    @Test
+    fun `a partially unpacked directory is credited for what it holds`() {
+        assertEquals(
+            40 * mb,
+            FirstRunSetup.sharedTreeCredit(
+                installedBytes = 40 * mb,
+                bundledBytes = bundled,
+                foreignBytes = 0,
+            ),
+        )
+    }
+
+    /**
+     * The case the whole function exists for: `usr/` swollen by Java and Go is
+     * still only worth the bundled part, because overwriting the bundled part is
+     * all extraction does.
+     */
+    @Test
+    fun `toolchains in the directory do not inflate the credit`() {
+        val java = 146 * mb
+        val go = 179 * mb
+        assertEquals(
+            bundled,
+            FirstRunSetup.sharedTreeCredit(
+                installedBytes = bundled + java + go,
+                bundledBytes = bundled,
+                foreignBytes = java + go,
+            ),
+        )
+    }
+
+    /**
+     * Without the cap this would credit 325 MB of toolchain as though extraction
+     * were about to write over it, which is the direction that lets a device
+     * through that cannot finish.
+     */
+    @Test
+    fun `the credit never exceeds what the APK actually carries`() {
+        val credit = FirstRunSetup.sharedTreeCredit(
+            installedBytes = 500 * mb,
+            bundledBytes = bundled,
+            foreignBytes = 0,
+        )
+        assertEquals(bundled, credit)
+        assertTrue(credit <= bundled, "a credit above the bundled size is space that does not exist")
+    }
+
+    @Test
+    fun `a foreign share larger than the directory yields no credit rather than a negative one`() {
+        assertEquals(
+            0L,
+            FirstRunSetup.sharedTreeCredit(
+                installedBytes = 50 * mb,
+                bundledBytes = bundled,
+                foreignBytes = 400 * mb,
+            ),
+        )
+    }
+
+    /**
+     * Null and zero must not be interchangeable, and the same inputs are used
+     * for both so the difference cannot come from anywhere else.
+     *
+     * Zero asserts the directory is ours alone. Null says we could not tell, and
+     * the honest answer to that is to credit nothing: an unreadable
+     * `toolchains.json` would otherwise credit a `usr/` full of toolchains in
+     * full, which is the exact shape of the bug being avoided.
+     */
+    @Test
+    fun `an unknown foreign share credits nothing, unlike a foreign share of zero`() {
+        val installed = bundled + 300 * mb
+        val unknown = FirstRunSetup.sharedTreeCredit(installed, bundled, foreignBytes = null)
+        val none = FirstRunSetup.sharedTreeCredit(installed, bundled, foreignBytes = 0)
+
+        assertEquals(0L, unknown, "an undetermined share must credit nothing")
+        assertEquals(bundled, none, "a share known to be zero credits the bundled tree")
+        assertTrue(
+            unknown < none,
+            "null is being treated as zero, so a directory we cannot account for is " +
+                "credited as if we owned all of it",
+        )
+    }
+
+    @Test
+    fun `a build with no asset tree credits nothing`() {
+        assertEquals(
+            0L,
+            FirstRunSetup.sharedTreeCredit(
+                installedBytes = 300 * mb,
+                bundledBytes = 0,
+                foreignBytes = 0,
+            ),
+            "with nothing bundled there is nothing extraction will write over",
+        )
+    }
+
+    /**
+     * Ties the credit back to the demand, which is the number a user reads.
+     *
+     * Not a restatement of [FirstRunSetup.requiredExtractionBytes]: it checks
+     * that crediting the shared trees actually moves the demand down, which is
+     * the user-visible effect, and that it moves down by the credited amount
+     * rather than by some other quantity.
+     */
+    @Test
+    fun `crediting the shared trees lowers what the gate demands`() {
+        // Proportioned like the shipping tree: server, usr and extensions sum to
+        // the asset total, so the credit stays inside what is still missing and
+        // the subtraction is not clamped. Rounding the three to whole MB against
+        // a separately rounded total is what made an earlier version of this
+        // test expect a fall 1 MiB larger than the arithmetic can produce.
+        val server = 654 * mb
+        val usr = 110 * mb
+        val extensions = 47 * mb
+        val assetBytes = server + usr + extensions
+        val largest = 113 * mb
+
+        val before = FirstRunSetup.requiredExtractionBytes(assetBytes, largest, server)
+        val credit = FirstRunSetup.sharedTreeCredit(usr, usr, 0) +
+            FirstRunSetup.sharedTreeCredit(extensions, extensions, 0)
+        val after = FirstRunSetup.requiredExtractionBytes(assetBytes, largest, server + credit)
+
+        assertTrue(after < before, "crediting the shared trees must lower the demand")
+        assertEquals(
+            credit,
+            before - after,
+            "the demand should fall by exactly what was credited, no more",
+        )
+    }
+}


### PR DESCRIPTION
Closes #187.

The update storage check credits what is already unpacked, so an update asks
for the remainder rather than for a second copy of the whole tree. It measured
only `filesDir/server`. The other two trees extraction overwrites, `usr/` and
the extensions directory, were charged in full every time.

Measured against a generated `BuildConfig`:

| | Before | After |
|---|---|---|
| First install | 874 MB | 874 MB |
| Update | 334 MB | 177 MB |

A device with between those two figures free was refused an update it could
have completed.

## Why it was not simply credited

Crediting those directories by their size on disk would be wrong in the
dangerous direction. Toolchains install into `usr/` (Java about 146 MB, Go
about 179 MB), `npm install -g` lands there, and the extensions directory
fills with gallery installs. Those bytes are not ones the next unpack writes
over, and subtracting them lets the gate pass a device that then runs out of
disk partway, reporting "Setup failed" with no figure, on every retry, because
the toolchains stay where they are.

Over-charging costs one round of freeing space that was not strictly needed.
Under-charging costs an install that cannot complete and cannot explain itself.

## Approach

`sharedTreeCredit` clamps twice, both toward under-crediting:

- subtract what is known to belong to something else
- cap at what the APK actually carries, so a directory swollen by toolchains
  cannot be credited beyond the bundled tree

The foreign share comes from `ToolchainRegistry`, whose figures run slightly
over what lands on disk. That over-states what is foreign, which under-states
the credit, which is the direction this needs to be wrong in.

An undetermined foreign share is `null`, not zero, and yields no credit at all.
Zero asserts the directory is ours alone, so an unreadable `toolchains.json`
would otherwise credit a toolchain-filled `usr/` in full.

The record is read as a plain file rather than through `ToolchainManager`,
whose constructor builds an `AssetPackManagerFactory` and cannot be
instantiated in a JVM unit test.

## Tests

`SharedTreeCreditTest` covers each clamp, the boundary where the foreign share
exceeds the directory, and a case asserting that `null` and zero are not
interchangeable on identical inputs. Confirmed by mutation that removing the
cap and treating `null` as zero each turn the suite red.
