### PR TITLE
fix(saf): pair a rename that moves a folder to a different parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,7 +145,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renaming a folder inside a device folder no longer empties it. Android reports a rename as an unrelated delete and create, and the delete used to remove the subtree.
 - A folder that appears is copied across with its contents, which also covers creating a folder that already has files in it. Symbolic links are not followed, since a synced folder is routinely a checked-out repository, and very large moves stop at a bound and say so.
 - Renaming a folder no longer leaves a second copy behind. The two halves are joined where possible and the device folder is moved, carrying everything under it.
-- Where the halves cannot be joined, a move to a different parent or a provider without rename support, the old copy still stays, because losing it would cost files that exist nowhere else.
+- Moving a folder into a different folder is carried across too, not just renaming one in place. Dragging `src/util` into `src/legacy/` used to leave the old copy on the device, reappearing beside the new one every time the folder was reopened.
+- Where the halves still cannot be joined, a provider that supports neither move nor rename, a folder moved out of the workspace, or the second half of a two-step swap such as `mv dist dist.old; mv dist.new dist`, the old copy stays, because losing it would cost files that exist nowhere else.
 - **Edits you had not saved back to a device folder are kept.** The guard compared size before timestamps, and almost every edit changes length, so almost every unsaved edit was overwritten.
 - Reopening a folder no longer discards edits made since it was opened. Files are replaced only when the device copy differs in size, carries no timestamp, or is newer.
 - Saving a file inside a subfolder of a device folder reaches the device. The mirror was watched at its top level only.

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
@@ -824,6 +824,32 @@ class SafSyncEngine(private val context: Context) {
     }
 
     /**
+     * Moves an existing device document into a different parent, in place.
+     *
+     * The counterpart to [renameInSaf] for the half of the problem a rename cannot
+     * express. It carries the subtree for the same reason: the provider relocates the
+     * document itself, so the `.git` and `node_modules` the mirror never held travel with
+     * it. Without this, dragging `src/util` into `src/legacy/` left the old copy standing
+     * on the device, and reopening the folder copied it back down beside the new one.
+     *
+     * `moveDocument` is a different call from `renameDocument` behind a different flag
+     * (`FLAG_SUPPORTS_MOVE` rather than `FLAG_SUPPORTS_RENAME`), so a provider may offer
+     * one and not the other. A null return puts the caller back on the pre-existing
+     * fallback: build the new name from the mirror and leave the old copy alone.
+     *
+     * @return the document's URI in its new parent, or null when the provider would not
+     *   move it.
+     */
+    private fun moveInSaf(safDocUri: Uri, sourceParentUri: Uri, targetParentUri: Uri): Uri? = try {
+        DocumentsContract.moveDocument(
+            context.contentResolver, safDocUri, sourceParentUri, targetParentUri
+        )
+    } catch (e: Exception) {
+        Logger.w(tag, "Could not move a document between directories: ${e.message}")
+        null
+    }
+
+    /**
      * Deletes a document from the SAF tree.
      */
     private fun deleteFromSaf(safDocUri: Uri) {
@@ -885,8 +911,27 @@ class SafSyncEngine(private val context: Context) {
                 // reported them. Those stay mirror-only. They were mirror-only before the
                 // rename too — this does not lose them, it just stops incidentally
                 // rescuing them.
+                //
+                // A move to a different directory is a second call and has to come first:
+                // `moveDocument` returns the document's URI in its new home, and renaming
+                // before moving would rename in the old one and then move a URI this code
+                // no longer holds. Where the parents match, `safSourceParentUri` is null
+                // and nothing here changes.
                 val localFile = File(job.localPath)
-                val renamed = job.safDocUri != null && renameInSaf(job.safDocUri, localFile.name)
+                val moved = if (job.safDocUri != null && job.safSourceParentUri != null &&
+                    job.safParentUri != null
+                ) {
+                    moveInSaf(job.safDocUri, job.safSourceParentUri, job.safParentUri)
+                } else {
+                    job.safDocUri
+                }
+                // Renaming is skipped when the name did not change, which is the common
+                // shape of a move: dragging `src/util` into `src/legacy/` keeps the name.
+                // Decided from the two paths rather than from the moved document's URI,
+                // because a document ID is not required to be a path and reading a name
+                // out of one is only right on the providers where it happens to be.
+                val nameUnchanged = job.previousName == localFile.name
+                val renamed = moved != null && (nameUnchanged || renameInSaf(moved, localFile.name))
                 if (!renamed && localFile.exists() &&
                     job.safParentUri != null && job.safTreeUri != null
                 ) {
@@ -1021,6 +1066,15 @@ class SafSyncEngine(private val context: Context) {
         val renamedFromUri = renamedFrom?.let { resolveDocumentUri(safTreeUri, it) }
         if (renamedFrom != null && renamedFromUri != null) forgetCachedSubtree(renamedFrom)
 
+        // Only for a pair that crosses directories, and resolved from where the document
+        // actually is rather than from the destination: `moveDocument` refuses a source
+        // parent the document is not in. Resolving it unconditionally would ask the
+        // provider on every ordinary rename for a value nothing would read.
+        val sourceParentUri =
+            if (renamedFrom != null && renamedFromUri != null &&
+                parentPathOf(renamedFrom) != parentPathOf(relativePath)
+            ) resolveDocumentUri(safTreeUri, parentPathOf(renamedFrom)) else null
+
         writeBackQueue.offer(
             SyncJob(
                 type = if (renamedFromUri != null) SyncType.RENAME else type,
@@ -1028,7 +1082,9 @@ class SafSyncEngine(private val context: Context) {
                 safDocUri = renamedFromUri ?: safDocUri,
                 safParentUri = safParentUri,
                 safTreeUri = safTreeUri,
-                timestamp = now
+                timestamp = now,
+                safSourceParentUri = sourceParentUri,
+                previousName = renamedFrom?.let { File(it).name }
             )
         )
     }
@@ -1162,11 +1218,18 @@ class SafSyncEngine(private val context: Context) {
          * - **Exactly one candidate.** Two directories in flight at once cannot be told
          *   apart by arrival order alone once their events interleave, and pairing the
          *   wrong two would put each subtree under the other's name.
-         * - **Same parent.** A move between directories is not a rename;
-         *   `renameDocument` cannot express one, and it is `moveDocument` — a different
-         *   call, with its own provider flag — that would. Such a move falls back to the
-         *   old behaviour rather than being half-performed.
          * - **Recent.** See [RENAME_PAIR_WINDOW_MS].
+         *
+         * A third rule required the two halves to share a parent, and it was dropped once
+         * the write-back learned `moveDocument`. It was never about pairing being less
+         * certain across parents; it was that `renameDocument` cannot express a move, so a
+         * pair the engine could not act on was better left unclaimed. Dragging `src/util`
+         * into `src/legacy/` is an ordinary thing to do and used to leave the old copy on
+         * the device, reappearing beside the new one on every reopen. Removing the rule
+         * does widen the mis-pair window: an unrelated arrival anywhere in the mirror can
+         * now be joined to a departure, where before it had to arrive in the same
+         * directory. The two surviving rules are what bound it, and the cost of being
+         * wrong is unchanged, because nothing is deleted either way.
          *
          * Declining costs exactly what the code did before there was any pairing: the
          * device keeps the copy under the old name.
@@ -1175,16 +1238,13 @@ class SafSyncEngine(private val context: Context) {
             vanished: List<VanishedDirectory>,
             newRelativePath: String,
             now: Long
-        ): String? {
-            val candidate = vanished
-                .filter { now - it.atMillis <= RENAME_PAIR_WINDOW_MS }
-                .singleOrNull() ?: return null
-            if (parentPathOf(candidate.relativePath) != parentPathOf(newRelativePath)) return null
-            return candidate.relativePath
-        }
+        ): String? = vanished
+            .filter { now - it.atMillis <= RENAME_PAIR_WINDOW_MS }
+            .singleOrNull()
+            ?.relativePath
 
         /** The directory part of a mirror-relative path; empty for a top-level entry. */
-        private fun parentPathOf(relativePath: String): String =
+        internal fun parentPathOf(relativePath: String): String =
             File(relativePath).parent ?: ""
 
         /**
@@ -1493,7 +1553,21 @@ internal data class SyncJob(
     val safDocUri: Uri?,
     val safParentUri: Uri?,
     val safTreeUri: Uri?,
-    val timestamp: Long
+    val timestamp: Long,
+    /**
+     * For a RENAME, the parent the document sits under *now*, which is what
+     * `moveDocument` needs alongside the destination and is not recoverable from
+     * the other fields: [safDocUri] names the document and [safParentUri] names
+     * where it is going. Null on every other job type, and on a rename that
+     * stays inside one directory.
+     */
+    val safSourceParentUri: Uri? = null,
+    /**
+     * For a RENAME, the name the document currently carries on the device, so
+     * the write-back can tell a move that keeps its name from one that does not
+     * without reading a name out of a document ID. Null on every other type.
+     */
+    val previousName: String? = null
 )
 
 internal enum class SyncType {

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafDirectoryRenameTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafDirectoryRenameTest.kt
@@ -69,6 +69,7 @@ class SafDirectoryRenameTest {
         every { DocumentsContract.deleteDocument(any(), any()) } returns true
         every { DocumentsContract.renameDocument(any(), any(), any()) } returns mockk(relaxed = true)
         every { DocumentsContract.createDocument(any(), any(), any(), any()) } returns mockk(relaxed = true)
+        every { DocumentsContract.moveDocument(any(), any(), any(), any()) } returns mockk(relaxed = true)
 
         resolver = mockk(relaxed = true)
         val context = mockk<Context>(relaxed = true)
@@ -103,6 +104,53 @@ class SafDirectoryRenameTest {
         }
     }
 
+    /**
+     * A device folder with real structure, for the cases that turn on *where* a name is.
+     *
+     * [deviceFolderHolding] answers the same child list under every parent, which is fine
+     * while a case only cares whether a name exists somewhere. It is not fine for a move:
+     * claiming the pair requires the destination path to resolve to nothing, and a flat
+     * answer makes `lib/util` resolve the moment both `lib` and `util` exist anywhere. A
+     * case written against the flat mock therefore passes with no move attempted at all.
+     *
+     * [tree] maps a parent's document id to the names directly under it, with `root` as
+     * the tree's own document id.
+     */
+    private fun deviceTree(tree: Map<String, List<String>>) {
+        every { DocumentsContract.buildChildDocumentsUriUsingTree(any(), any()) } answers {
+            val parent = secondArg<String>()
+            mockk<Uri>(relaxed = true).also { every { it.toString() } returns "children:$parent" }
+        }
+        // A document URI has to carry which document it is, and getDocumentId has to
+        // agree with it. The flat setUp answers "root" for every URI, which made the
+        // create-fallback case look at the wrong parent: it asked whether `lib` already
+        // held `util`, was answered from `root`, found the old copy still standing there
+        // and skipped the create it was supposed to perform.
+        every { DocumentsContract.buildDocumentUriUsingTree(any(), any()) } answers {
+            val docId = secondArg<String>()
+            mockk<Uri>(relaxed = true).also { every { it.toString() } returns "doc-uri:$docId" }
+        }
+        every { DocumentsContract.getDocumentId(any()) } answers {
+            firstArg<Uri>().toString().removePrefix("doc-uri:")
+        }
+        every { resolver.query(any(), any(), any(), any(), any()) } answers {
+            val parent = firstArg<Uri>().toString().removePrefix("children:")
+            val names = tree[parent] ?: emptyList()
+            val cursor = mockk<Cursor>(relaxed = true)
+            var row = -1
+            every { cursor.moveToNext() } answers { ++row < names.size }
+            every {
+                cursor.getColumnIndexOrThrow(DocumentsContract.Document.COLUMN_DOCUMENT_ID)
+            } returns 0
+            every {
+                cursor.getColumnIndexOrThrow(DocumentsContract.Document.COLUMN_DISPLAY_NAME)
+            } returns 1
+            every { cursor.getString(0) } answers { "doc:${names[row]}" }
+            every { cursor.getString(1) } answers { names[row] }
+            cursor
+        }
+    }
+
     /** Delivers one event, without letting the write-back queue run. */
     private fun observe(event: Int, entry: String) {
         engine.handleMirrorEvent(event, File(mirror, entry), mirror, treeUri)
@@ -131,6 +179,80 @@ class SafDirectoryRenameTest {
         // the second copy left standing under the old name.
         verify(exactly = 0) { DocumentsContract.deleteDocument(any(), any()) }
         verify(exactly = 0) { DocumentsContract.createDocument(any(), any(), any(), any()) }
+    }
+
+    /**
+     * The case the same-parent rule used to refuse. Dragging `util` into `lib/` is a move,
+     * not a rename, and leaving it unclaimed meant the old copy stayed on the device and
+     * came back down beside the new one on the next reopen.
+     *
+     * The name is unchanged here, so no rename should follow the move: asking a provider
+     * to rename a document to the name it already has is a request that can be answered
+     * with `util (1)`.
+     */
+    @Test
+    fun `a directory dragged into another folder is moved on the device`() {
+        deviceTree(mapOf("root" to listOf("util", "lib"), "doc:lib" to emptyList()))
+        File(mirror, "lib").mkdirs()
+
+        observe(FileObserver.MOVED_FROM or isDirFlag, "util")
+        deliver(FileObserver.MOVED_TO or isDirFlag, "lib/util")
+
+        verify(exactly = 1) { DocumentsContract.moveDocument(any(), any(), any(), any()) }
+        verify(exactly = 0) { DocumentsContract.renameDocument(any(), any(), any()) }
+        verify(exactly = 0) { DocumentsContract.deleteDocument(any(), any()) }
+        verify(exactly = 0) { DocumentsContract.createDocument(any(), any(), any(), any()) }
+    }
+
+    /** `mv util lib/helpers`: the move relocates it, the rename gives it the new name. */
+    @Test
+    fun `a move that also renames does both, in that order`() {
+        deviceTree(mapOf("root" to listOf("util", "lib"), "doc:lib" to emptyList()))
+        File(mirror, "lib").mkdirs()
+
+        observe(FileObserver.MOVED_FROM or isDirFlag, "util")
+        deliver(FileObserver.MOVED_TO or isDirFlag, "lib/helpers")
+
+        verify(exactly = 1) { DocumentsContract.moveDocument(any(), any(), any(), any()) }
+        verify(exactly = 1) { DocumentsContract.renameDocument(any(), any(), "helpers") }
+        verify(exactly = 0) { DocumentsContract.deleteDocument(any(), any()) }
+    }
+
+    /**
+     * `moveDocument` sits behind `FLAG_SUPPORTS_MOVE`, which a provider may withhold while
+     * still offering rename. The fallback has to be what the code did before there was a
+     * move at all: build the new name from the mirror and leave the old copy alone, rather
+     * than deleting a subtree the mirror cannot fully replace.
+     */
+    @Test
+    fun `a provider that will not move still gets the new name`() {
+        deviceTree(mapOf("root" to listOf("util", "lib"), "doc:lib" to emptyList()))
+        File(mirror, "lib").mkdirs()
+        every { DocumentsContract.moveDocument(any(), any(), any(), any()) } returns null
+
+        observe(FileObserver.MOVED_FROM or isDirFlag, "util")
+        observe(FileObserver.MOVED_TO or isDirFlag, "lib/util")
+        File(mirror, "lib/util").mkdirs()
+        drain()
+
+        verify(exactly = 1) { DocumentsContract.createDocument(any(), any(), any(), "util") }
+        verify(exactly = 0) { DocumentsContract.deleteDocument(any(), any()) }
+    }
+
+    /**
+     * A rename staying inside one directory must not start reaching for `moveDocument`.
+     * It is a second provider call behind a second flag, and a provider offering rename
+     * but not move would go from working to falling back.
+     */
+    @Test
+    fun `a rename within one directory does not call move`() {
+        deviceFolderHolding("util")
+
+        observe(FileObserver.MOVED_FROM or isDirFlag, "util")
+        deliver(FileObserver.MOVED_TO or isDirFlag, "helpers")
+
+        verify(exactly = 1) { DocumentsContract.renameDocument(any(), any(), "helpers") }
+        verify(exactly = 0) { DocumentsContract.moveDocument(any(), any(), any(), any()) }
     }
 
     @Test

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafRenamePairingTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafRenamePairingTest.kt
@@ -8,10 +8,14 @@ import org.junit.jupiter.api.Test
  * Which vanished directory a newly arrived one is allowed to claim.
  *
  * inotify pairs the two halves of a rename with a cookie and `FileObserver` does not
- * expose it, so `renameSourceFor` is a heuristic: arrival time and parent are all that is
- * left. What it decides is which device document gets renamed, so the interesting cases
- * are the ones where it has to refuse — a wrong pair puts one directory's subtree under
- * another's name on the user's device.
+ * expose it, so `renameSourceFor` is a heuristic: arrival time and how many are in flight
+ * are all that is left. What it decides is which device document gets renamed, so the
+ * interesting cases are the ones where it has to refuse. A wrong pair puts one directory's
+ * subtree under another's name on the user's device.
+ *
+ * A third rule once required both halves to share a parent. It went when the write-back
+ * learned `moveDocument`, and its absence is itself pinned below: the two remaining rules
+ * now carry a wider set of arrivals than they used to.
  *
  * The rule is pinned here rather than through the engine because the two refusals that
  * matter most cannot be driven from an event: expiry needs a clock the engine reads for
@@ -66,12 +70,38 @@ class SafRenamePairingTest {
     }
 
     @Test
-    fun `a directory that arrives in another parent is not a rename`() {
-        // `renameDocument` cannot express a move between parents -- that is
-        // `moveDocument`, a different call behind a different provider flag -- so this
-        // falls back to the old behaviour rather than being half-performed.
-        assertNull(sourceFor("lib/util", vanished("util", ago = 5)))
-        assertNull(sourceFor("util", vanished("lib/util", ago = 5)))
+    fun `a directory that arrives in another parent is still a rename`() {
+        // This used to be refused, because `renameDocument` cannot express a move between
+        // parents and a pair the engine could not act on was better left unclaimed. The
+        // write-back now reaches for `moveDocument` when the parents differ, so the pair
+        // is claimable in both directions: down into a subdirectory and back out of one.
+        assertEquals("util", sourceFor("lib/util", vanished("util", ago = 5)))
+        assertEquals("lib/util", sourceFor("util", vanished("lib/util", ago = 5)))
+    }
+
+    @Test
+    fun `a move that also changes the name pairs`() {
+        // `mv src/util src/legacy/helpers`: both halves change, which is the case needing
+        // a move followed by a rename rather than either alone.
+        assertEquals("src/util", sourceFor("src/legacy/helpers", vanished("src/util", ago = 5)))
+    }
+
+    /**
+     * The parent no longer gates pairing, so the two surviving rules are the only thing
+     * bounding a mis-pair. Pinned here because widening the pairing widened what they have
+     * to carry: before, an unrelated arrival had to land in the same directory to be
+     * joined to a departure; now it can land anywhere in the mirror.
+     */
+    @Test
+    fun `dropping the parent rule did not weaken the other two`() {
+        assertNull(
+            sourceFor("lib/b", vanished("a", ago = 10), vanished("c", ago = 5)),
+            "two live candidates stay ambiguous across parents",
+        )
+        assertNull(
+            sourceFor("lib/helpers", vanished("util", ago = window + 1)),
+            "an expired candidate stays expired across parents",
+        )
     }
 
     @Test


### PR DESCRIPTION
Closes #186.

Android does not expose inotify's cookie, so a rename inside a mirrored folder
arrives as an unrelated `MOVED_FROM` and `MOVED_TO`. `renameSourceFor` joins
them by circumstance, and one of its rules required both halves to share a
parent.

That rule was not about the pairing being less certain across directories. It
was that `renameDocument` cannot express a move, so a pair the engine could not
act on was better left unclaimed. The cost fell on an ordinary action: dragging
`src/util` into `src/legacy/` left the old copy standing on the device, and
reopening the folder copied it back down, so the old name reappeared beside the
new one and one more copy accumulated per move.

## What changed

The write-back reaches for `DocumentsContract.moveDocument` when the parents
differ, and the pairing rule is gone.

Move runs before rename. `moveDocument` returns the document's URI in its new
parent, so renaming first would rename in the old one and then move a URI the
code no longer holds. A move that keeps its name skips the rename entirely,
decided from the two mirror paths rather than by reading a name out of a
document ID, which is only a path on some providers.

`moveDocument` sits behind `FLAG_SUPPORTS_MOVE`, which a provider may withhold
while still offering rename. A null return falls back to what the code did
before: build the new name from the mirror and leave the old copy alone, rather
than deleting a subtree the mirror cannot fully replace.

## Trade-off

Dropping the parent rule widens the mis-pair window. An unrelated arrival can
now be joined to a departure anywhere in the mirror, where before it had to
arrive in the same directory. The two surviving rules, exactly one live
candidate and a one-second window, are what bound it, and they now have a test
of their own asserting they still hold across parents.

The cost of being wrong is unchanged: nothing is deleted either way, and
reopening the folder brings a misplaced subtree back where it can be seen.

## Not covered

Two-step swaps such as `mv dist dist.old; mv dist.new dist` are still refused.
The first rename is queued when the second pair arrives and the device still
answers for the old name, so the existing-name guard declines it.

## Tests

Three write-back cases cover a move that keeps its name, a move that also
renames, and a provider that refuses to move. A fourth asserts that a rename
staying inside one directory does not start calling `moveDocument`, since that
is a second provider call behind a second flag.

Those needed a device-folder mock with real structure. The existing flat mock
answers the same child list under every parent, which makes a destination path
resolve as soon as its segments exist anywhere, so a case written against it
passes with no move attempted at all.

Confirmed by mutation that restoring the parent rule and removing the
`moveDocument` call each turn the suite red.
