### PR TITLE
fix(service): reap the editor server left behind when its bootstrap is killed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A server that is merely slow is no longer treated as failed. At two minutes the app says the start is taking longer than usual and keeps waiting.
 - The app no longer hangs forever when something else holds its port. A start that cannot bind is detected, reported, and the processes behind it shut down.
 - The editor no longer adopts a server that is not answering. The app asks the port whether anything responds before reusing what its record names.
+- Stopping the app now ends an adopted server instead of leaving it running. A bootstrap killed by the system leaves its editor server behind, and that survivor used to hold its memory and one of the 32 process slots Android allows until the app was force-stopped.
+- A server of ours that holds the port without answering is ended before a new one starts, rather than being spawned over into a launch that cannot bind.
 - An emergency port taken from the ephemeral range is no longer remembered, which used to move the workbench to a new address and empty its stored state.
 - **Everything you set was forgotten on every cold start**, because the port changed each launch and the browser keys storage to the address. The port is now kept between launches.
 - Stopping the server and starting again no longer leaves the new start unable to finish, and stopping the editor can no longer restart it.

--- a/android/app/src/main/kotlin/com/vscodroid/service/ProcessManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/service/ProcessManager.kt
@@ -132,6 +132,13 @@ class ProcessManager(private val context: Context) {
      */
     private var procDir = File("/proc")
 
+    /**
+     * How [reapRecordedEditorServer] signals a process. A `var` for the same reason
+     * [procDir] is one: the suite runs on a JVM where `android.os.Process` is a stub, so a
+     * test calling through to it could only ever assert that nothing happened.
+     */
+    internal var killRecordedProcess: (Int) -> Unit = { android.os.Process.killProcess(it) }
+
     // Cached on the first successful read and never invalidated, which is correct
     // rather than merely convenient: the server generates the token only when the
     // file is absent and otherwise reuses what is there, so the value survives its
@@ -289,6 +296,21 @@ class ProcessManager(private val context: Context) {
             startAdoptionWatch()
             return true
         }
+        // An editor server of ours that is alive, holds the port, and answers nothing is
+        // the one shape worth ending before spawning over it. Adoption already declined it
+        // just above, and leaving it there guarantees the spawn below hits EADDRINUSE:
+        // that child does not exit, so the run ends in CANNOT_BIND with two processes
+        // where the user wanted one, and the survivor outlives every retry.
+        //
+        // The judgement is `/version` not answering within a second, which a server still
+        // starting up could fail. Ending it is still the better error: the alternative is
+        // not "wait for it to come up" but a failed launch, because nothing here can bind
+        // the port while it is held. A server killed a second early is restarted by the
+        // line below; one left alone is not.
+        if (!portIsFree && portHeldByOurEditorServer()) {
+            reapRecordedEditorServer("holding port $_port without serving")
+        }
+
         // Reaching here means the port was free, or was held by something that is
         // not ours. Nothing refuses to start in either case, and that is a
         // decision rather than an omission: a refusal was tried and removed. What
@@ -603,6 +625,76 @@ class ProcessManager(private val context: Context) {
     }
 
     /**
+     * Ends the editor server the note names, when it is still one of ours.
+     *
+     * The gap this closes: `assets/server.js` forwards SIGTERM to the editor server it
+     * forked, but a SIGKILLed bootstrap forwards nothing and `fork()` sets no PDEATHSIG,
+     * so the child outlives its parent. [stopServer] cannot end that one, because it holds
+     * a `Process` handle only for a child it spawned itself. The survivor then keeps its
+     * heap for the life of the app and counts against the 32-process limit
+     * `assets/process-monitor.js` exists to stay under.
+     *
+     * Killing by a recorded pid has an obvious hazard: pids are recycled, so the process
+     * at that number may no longer be the one the note described. Three things bound it,
+     * and the first is doing most of the work:
+     *
+     *  - **The kernel refuses across uids.** `kill(2)` needs a matching uid, and every
+     *    other app on the device runs as a different one, so a pid recycled outside this
+     *    app cannot be killed here at all: the call fails rather than hitting a stranger.
+     *    What remains reachable is this app's own processes, which is a much smaller set.
+     *  - **The cmdline is re-read immediately before the signal**, so a pid recycled into
+     *    one of our terminals or a language server does not match [EDITOR_ENTRY_POINT] and
+     *    is left alone. The window between that read and the signal is what cannot be
+     *    closed from userspace; it is microseconds wide and needs a recycle landing inside
+     *    it onto another editor server of ours.
+     *  - **The note is consumed either way**, so a pid this declines to kill is not
+     *    reconsidered on the next call.
+     *
+     * @return whether a process was signalled. False covers no note, a note for another
+     *   port, a pid already gone, and a pid that is no longer an editor server.
+     */
+    internal fun reapRecordedEditorServer(reason: String): Boolean {
+        val note = File(Environment.getServerDir(context), EDITOR_PID_FILE)
+        val recorded = try {
+            if (!note.isFile) return false
+            JSONObject(note.readText())
+        } catch (e: Exception) {
+            Logger.w(tag, "Could not read the editor server note: ${e.message}")
+            return false
+        }
+        val pid = recorded.optInt("pid", 0)
+        val port = recorded.optInt("port", 0)
+        if (pid <= 0 || port != _port) return false
+
+        // Deliberately the last thing before the signal. Re-reading here rather than
+        // trusting the check adoption already made is the whole mitigation: that one may
+        // be minutes old, and this one is the only thing standing between a recycled pid
+        // and a process of ours that has nothing to do with the editor.
+        val cmdline = try {
+            File(File(procDir, pid.toString()), "cmdline").takeIf { it.isFile }?.readText()
+        } catch (e: Exception) {
+            null
+        }
+        note.delete()
+        if (cmdline == null) {
+            Logger.i(tag, "Editor server $pid is already gone; nothing to reap ($reason)")
+            return false
+        }
+        if (!cmdline.contains(EDITOR_ENTRY_POINT)) {
+            Logger.w(tag, "Pid $pid is no longer an editor server; leaving it alone ($reason)")
+            return false
+        }
+        return try {
+            killRecordedProcess(pid)
+            Logger.i(tag, "Ended the editor server $pid still holding port $_port ($reason)")
+            true
+        } catch (e: Exception) {
+            Logger.w(tag, "Could not end the editor server $pid: ${e.message}")
+            false
+        }
+    }
+
+    /**
      * Whether the port is answering right now.
      *
      * The second half of the adoption test, and it is not a restatement of the
@@ -695,19 +787,25 @@ class ProcessManager(private val context: Context) {
         isShuttingDown = true
         _isReady = false
         if (adopted) {
-            // Said plainly rather than passed over. This class did not spawn the
-            // server on the port and holds no handle to it, so there is nothing
-            // here that can end it — and the honest version of that is a log line
-            // saying so, not a silent return that leaves the caller believing the
-            // stop succeeded. Before adoption existed this case still arrived, and
-            // it was worse: `serverProcess` referenced a process that never served
-            // anything, so the stop destroyed the wrong one and reported success.
-            Logger.w(
-                tag,
-                "The server on port $_port was adopted, not started here, so stopping " +
-                    "this service cannot end it. It keeps running until the system " +
-                    "reclaims it.",
-            )
+            // No `Process` handle exists for a server this class did not spawn, which is
+            // why this used to be a log line saying the stop could not end it. The note
+            // the bootstrap wrote is the way in: it names the pid, and killing by pid is
+            // what [reapRecordedEditorServer] bounds. Leaving it running cost an idle Node
+            // process for the life of the app, holding its heap and one of the 32 slots
+            // the phantom-process limit allows.
+            //
+            // Still reported when it cannot be ended, because that outcome has not gone
+            // away: a note that has been consumed, a pid already recycled, or a kill the
+            // kernel refuses all land here, and a silent return would leave the caller
+            // believing the stop succeeded.
+            if (!reapRecordedEditorServer("service stopping")) {
+                Logger.w(
+                    tag,
+                    "The server on port $_port was adopted, not started here, and could " +
+                        "not be ended from its recorded pid. It keeps running until the " +
+                        "system reclaims it.",
+                )
+            }
             adopted = false
         }
         Logger.i(tag, "Stopping server...")

--- a/android/app/src/test/kotlin/com/vscodroid/service/ProcessManagerTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/service/ProcessManagerTest.kt
@@ -1218,24 +1218,111 @@ class AdoptionTest {
     }
 
     @Test
-    fun `stopping says plainly that an adopted server cannot be stopped`() {
-        // Not cosmetic. Before adoption this case still arrived, and it was worse:
-        // serverProcess referenced a process that never served anything, so the
-        // stop destroyed the wrong one and reported success while the real server
-        // kept running.
-        val warnings = mutableListOf<String>()
-        every { Logger.w(any(), any()) } answers { warnings += secondArg<String>() }
+    fun `stopping ends the adopted server rather than leaving it running`() {
+        // This used to be "say plainly that it cannot be stopped", which was honest and
+        // still cost an idle Node process for the life of the app, holding its heap and
+        // one of the 32 slots the phantom-process limit allows. No Process handle exists
+        // for a server this instance did not spawn; the note names its pid, which is the
+        // way in.
+        val killed = mutableListOf<Int>()
+        manager.killRecordedProcess = { killed += it }
         val holder = serving(200)
         recordEditorServer(pid = 4242, port = holder.port)
         assertTrue(manager.startServer())
 
         manager.stopServer()
 
-        assertFalse(manager.isAdopted(), "the stop must at least end our relationship with it")
-        assertTrue(
-            warnings.any { it.contains("adopted") },
-            "a stop that cannot stop anything must say so: $warnings",
+        assertEquals(listOf(4242), killed, "the stop must end the process the note names")
+        assertFalse(manager.isAdopted(), "the stop must also end our relationship with it")
+    }
+
+    /**
+     * The direction that costs someone else something. A pid is recycled the moment its
+     * process exits, and the kernel refuses a kill across uids, so what stays reachable is
+     * this app's own processes: a terminal the user is typing in, a language server.
+     * Nothing but the cmdline separates those from the server this means to end.
+     */
+    @Test
+    fun `a recycled pid that is no longer an editor server is left alone`() {
+        val killed = mutableListOf<Int>()
+        manager.killRecordedProcess = { killed += it }
+        val holder = serving(200)
+        recordEditorServer(pid = 4242, port = holder.port)
+        assertTrue(manager.startServer())
+        // Recycled between adoption and the stop, into something of ours that is not it.
+        File(tempDir, "proc/4242/cmdline").writeText("/lib/libbash.so -i ")
+
+        manager.stopServer()
+
+        assertTrue(killed.isEmpty(), "a pid that is not an editor server must not be signalled")
+    }
+
+    @Test
+    fun `a pid that has already gone is not signalled`() {
+        val killed = mutableListOf<Int>()
+        manager.killRecordedProcess = { killed += it }
+        val holder = serving(200)
+        recordEditorServer(pid = 4242, port = holder.port)
+        assertTrue(manager.startServer())
+        File(tempDir, "proc/4242/cmdline").delete()
+
+        manager.stopServer()
+
+        assertTrue(killed.isEmpty(), "nothing to signal once the process is gone")
+    }
+
+    @Test
+    fun `the note is consumed even when nothing is killed`() {
+        // Otherwise a pid this declines to kill is reconsidered on every later call, and
+        // the note goes on vouching for a process that is not there.
+        manager.killRecordedProcess = { }
+        val holder = serving(200)
+        recordEditorServer(pid = 4242, port = holder.port)
+        assertTrue(manager.startServer())
+        File(tempDir, "proc/4242/cmdline").writeText("/lib/libbash.so -i ")
+
+        manager.stopServer()
+
+        assertFalse(
+            File(tempDir, "server/editor-server.pid").exists(),
+            "the note must not survive the attempt",
         )
+    }
+
+    /**
+     * The other call site. A server of ours that holds the port and answers nothing is
+     * refused adoption just above, and leaving it there guarantees the spawn hits
+     * EADDRINUSE: that child does not exit, so the launch ends with two processes where
+     * the user wanted one and the survivor outlives every retry.
+     */
+    @Test
+    fun `a server of ours holding the port without serving is ended before spawning`() {
+        val killed = mutableListOf<Int>()
+        manager.killRecordedProcess = { killed += it }
+        val holder = holdingPortSilently()
+        recordEditorServer(pid = 7311, port = holder.port)
+
+        manager.startServer()
+
+        assertEquals(
+            listOf(7311),
+            killed,
+            "a recorded server that answers nothing must be ended, not spawned over",
+        )
+    }
+
+    @Test
+    fun `a healthy adopted server is not killed on the way in`() {
+        // The reap belongs to the stop and to the unresponsive case. Adoption itself must
+        // leave the server serving the user exactly where it is.
+        val killed = mutableListOf<Int>()
+        manager.killRecordedProcess = { killed += it }
+        val holder = serving(200)
+        recordEditorServer(pid = 4242, port = holder.port)
+
+        assertTrue(manager.startServer())
+
+        assertTrue(killed.isEmpty(), "adopting a working server must not end it")
     }
 }
 


### PR DESCRIPTION
Closes #185.

`assets/server.js` forwards SIGTERM to the editor server it forked, but a
bootstrap killed by the OOM killer or the phantom-process limit forwards
nothing, and `fork()` sets no PDEATHSIG. The child outlives its parent still
holding the port.

`stopServer()` holds a `Process` handle only for a child it spawned itself, so
for that survivor it could say the stop was unable to end it and nothing more.
The cost was one idle Node process for the life of the app, holding its heap
and one of the 32 slots the phantom-process limit allows, reclaimed only when
Android killed it or the user force-stopped the app.

## Approach

The note the bootstrap writes names the pid, which is the way in. Two call
sites use it:

- **the stop**, which now ends what it adopted
- **the launch**, where a recorded server holding the port and answering
  nothing is ended before spawning

The second matters as much as the first. Leaving that server in place
guaranteed the spawn hit `EADDRINUSE`, and that child does not exit, so the
launch finished with two processes where the user wanted one and the survivor
outlived every retry.

## Bounding the pid hazard

Killing by a recorded pid risks hitting a recycled one. Three things bound it,
and the first does most of the work:

1. **The kernel refuses across uids.** `kill(2)` needs a matching uid, so a pid
   recycled outside this app cannot be signalled from here at all. What stays
   reachable is this app's own processes, a much smaller set.
2. **The cmdline is re-read immediately before the signal**, not trusted from
   the check adoption made, which may be minutes old. A pid recycled into a
   terminal or a language server does not match and is left alone.
3. **The note is consumed either way**, so a pid this declines to kill is not
   reconsidered on the next call.

The window between the final cmdline read and the signal cannot be closed from
userspace. It is microseconds wide and needs a recycle landing inside it onto
another editor server of ours.

## A judgement worth stating

The launch-side case judges on `/version` failing within a second, which a
server still starting up could fail. Ending it is still the better error: the
alternative is not waiting for it but a failed launch, because nothing can bind
the port while it is held. A server killed a second early is restarted
immediately; one left alone is not.

## Tests

Six cases in `AdoptionTest` cover the stop, the launch-side reap, a recycled
pid that is no longer an editor server, a pid already gone, the note being
consumed when nothing is killed, and a healthy adopted server not being touched
on the way in. The case asserting the old behaviour is rewritten rather than
removed.

Confirmed by mutation that skipping the cmdline recheck and removing the reap
each turn the suite red.

On an API 36 emulator, SIGKILL on the bootstrap does leave the child running and
reparented to init, as described. Driving it the rest of the way from adb was
not possible: killing the app process to trigger adoption also takes the child
with it, so the adoption path itself is covered by the unit tests rather than on
device.
