### PR TITLE
fix(test): hold the port in the readiness test instead of freeing it

### DIFF
--- a/android/app/src/test/kotlin/com/vscodroid/service/ProcessManagerTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/service/ProcessManagerTest.kt
@@ -778,14 +778,31 @@ class ServerReadinessTest {
         // The cold-start window itself: a port is allocated and the process is
         // spawning, but nothing is bound to it yet. This is the state the
         // Activity used to navigate into.
-        val server = StubServer(200)
-        manager.portField = server.port
-        server.stop()
+        //
+        // The port is held rather than freed, for the reason already written out
+        // in `a probe against a server that is not serving leaves the answer
+        // alone`. Stopping the stub first would make this assert that nothing
+        // else on the machine is listening on that port, which is not this
+        // test's to guarantee: on a shared runner something else takes the freed
+        // port between the stop and the probe, the probe gets its 200, and the
+        // assertion fails for a reason that has nothing to do with readiness.
+        // Measured on CI 2026-08-16, one failure out of 909 tests.
+        //
+        // It still tests what it says it does. The probe cannot tell a refused
+        // connection from one that is accepted and dropped; both are "not
+        // serving" in the only sense it can observe, and only the second cannot
+        // be taken by someone else.
+        val server = StubServer(null)
+        try {
+            manager.portField = server.port
 
-        val ready = runBlocking { manager.waitForReady(timeoutMs = 400, pollIntervalMs = 25) }
+            val ready = runBlocking { manager.waitForReady(timeoutMs = 400, pollIntervalMs = 25) }
 
-        assertFalse(ready)
-        assertFalse(manager.isReady())
+            assertFalse(ready)
+            assertFalse(manager.isReady())
+        } finally {
+            server.stop()
+        }
     }
 
     @Test


### PR DESCRIPTION
`ServerReadinessTest > nothing listening is not ready` builds a stub server, takes its port, then stops it before probing. That makes the assertion depend on nothing else on the machine binding that port in the interval, which the test cannot guarantee. On a shared runner something else takes it, the probe gets a 200, and the test fails for a reason unrelated to readiness.

Observed as one failure out of 909 on a pull request whose only change was two lines of `.gitignore`.

The file already contains the fix and its rationale, in `a probe against a server that is not serving leaves the answer alone`: `StubServer(null)` holds the port and accepts without replying. This was the single site the earlier change did not reach. A sweep of every `StubServer` construction in the file found no others.

The test still asserts what it claims: the probe cannot distinguish a refused connection from one accepted and dropped, so both read as not serving, and only the second cannot be taken by someone else.

Verified locally: `testDebugUnitTest --tests ServerReadinessTest` executes the task and reports 10 test cases with the target among them, passing.