### PR TITLE
ci: keep major action bumps out of the routine update branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,12 +19,32 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    # Grouped so twelve actions do not arrive as twelve pull requests, each
-    # re-running the full matrix. A single branch is one review and one CI pass.
+    # Two groups, split by update type, because they are different decisions
+    # wearing the same shape.
+    #
+    # Measured on the first run of this config: every one of the twelve actions
+    # was several majors behind, and a single group proposed checkout v4 to v7,
+    # download-artifact v4 to v8 and action-gh-release v2 to v3 in one pull
+    # request titled "bump the actions group with 12 updates". That reads as
+    # routine and is twelve breaking-risk changes, in the workflows that hold the
+    # signing keystore. upload-artifact and download-artifact in particular have
+    # broken across majors before.
+    #
+    # Splitting them keeps the routine branch routine, which is what restores the
+    # freshness a floating tag used to give, and leaves majors visible rather
+    # than either hidden by an ignore rule or smuggled in beside patches.
     groups:
-      actions:
+      actions-patch:
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - major
     commit-message:
       prefix: ci
     labels:


### PR DESCRIPTION
The first run of the actions update config proposed twelve major bumps in a single branch: `checkout` v4 to v7, `download-artifact` v4 to v8, `upload-artifact` v4 to v7, `action-gh-release` v2 to v3, and eight more. The pull request title reads `bump the actions group with 12 updates`, which looks routine and is twelve breaking-risk changes in the workflows that hold the signing keystore. `upload-artifact` and `download-artifact` have broken across majors before.

Pinning to commit SHAs removed the freshness a floating major tag was quietly providing. Restoring it should mean patches and minors inside the major a workflow already runs, not an upgrade across majors.

Two groups split by update type do that. The routine branch stays routine and can be reviewed as one. Majors still appear, as their own branch and their own decision, rather than being suppressed by an ignore rule or riding along beside patch updates.

Supersedes the currently open grouped bump, which was generated under the single-group config.