### PR TITLE
docs: warn that Clear Data deletes every project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -274,6 +274,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Documentation**
 
+- The white-screen fix no longer sends readers to Clear Data without saying it deletes every project, and now lists how to rescue unsaved work first.
 - The user guide's list of bundled extensions matches what ships. It named two that are not included and listed an included one under "extensions to install".
 - The on-device toolchain checklist can be followed. Its five rows pointed at a Settings screen that does not exist, and expected `go build` to succeed.
 - Fourteen disagreements between the bridge API documentation and the bridge, including an SSH argument documented as a key type when it is the comment, and seven methods missing entirely.

--- a/android/app/src/main/kotlin/com/vscodroid/util/Environment.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/util/Environment.kt
@@ -121,8 +121,22 @@ object Environment {
         "${context.filesDir}/server/server.js"
 
     fun getProjectsDir(context: Context): String {
-        // App-external storage: no permissions needed, visible in file managers
+        // App-external storage, which needs no permission.
         // Path: /storage/emulated/0/Android/data/<pkg>/files/projects
+        //
+        // "visible in file managers" is what this comment claimed until
+        // 2026-08-16, and it is not something to rely on. Android 11 closed
+        // Android/data to other apps and to the system Files app, and minSdk
+        // here is 33, so no supported device has the unrestricted access the
+        // claim assumed. Some routes remain (MTP over USB, a few OEM managers),
+        // which is how the projects folder gets deleted from outside at all;
+        // see the CHANGELOG entry about surviving exactly that.
+        //
+        // The consequence that matters is the one for Clear Data: it wipes this
+        // directory, and a user cannot count on being able to copy anything out
+        // first. docs/USER_GUIDE.md carries the warning and the rescue steps
+        // where it recommends clearing. Work that has to stay reachable from
+        // outside the app belongs in a folder opened through the SAF picker.
         val externalDir = context.getExternalFilesDir(null)
         return if (externalDir != null) {
             File(externalDir, "projects").absolutePath

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -562,7 +562,25 @@ If the app shows a white screen after opening:
 
 1. Wait 10-15 seconds -- the Node.js server may still be starting.
 2. If it persists, force-close the app and reopen it.
-3. If the issue continues, clear app data (Settings > Apps > VSCodroid > Clear Data) and relaunch. This triggers a fresh extraction.
+3. If the issue continues, clearing app data forces a fresh extraction. **Read the
+   warning below before you do it.**
+
+> **Clearing app data deletes every project in `~/projects/`.**
+>
+> Android's Clear Data removes the app's external files directory as well as its
+> internal storage, and `~/projects/` lives in the first of those. Nothing is
+> backed up, and on Android 11 and later that directory is not reachable from
+> most file managers, so the files cannot be recovered afterwards.
+
+Rescue anything unsaved first:
+
+- Push to a remote, if the project is a git repository.
+- Or run **VSCodroid: Open Folder from Device** from the Command Palette
+  (**Ctrl+Shift+P**), choose a folder outside the app such as Documents, and copy
+  your work there. A folder opened that way lives outside the app's storage, so
+  Clear Data does not touch it.
+
+Then clear app data from Settings > Apps > VSCodroid > Clear Data and relaunch.
 
 ### Terminal Commands Not Found
 


### PR DESCRIPTION
The white-screen troubleshooting step told readers to clear app data and described the consequence as "a fresh extraction". The default workspace is `getExternalFilesDir(null)/projects` (`Environment.getProjectsDir`), and Android's Clear Data removes the external files directory along with internal storage. Following the documented fix destroys every project the user has.

There is no recovery path afterwards: nothing backs that directory up, and since Android 11 it is closed to the system Files app and to other apps, so a user cannot count on copying anything out first.

The step now carries the warning and two rescue routes that work: push to a remote, or move the work into a folder opened through **VSCodroid: Open Folder from Device**, which lives outside app storage and is untouched by Clear Data.

Also corrects the comment on `getProjectsDir`, which claimed the directory is visible in file managers. That has not been reliably true since Android 11 and `minSdk` here is 33. It is corrected rather than deleted, because some routes do remain (MTP, a few OEM managers) and the changelog records a user reaching it from outside.

A sweep of the tree found no other place recommending Clear Data as troubleshooting. The two remaining mentions are in the privacy policy, where removing data is what the reader wants, and in the development guide as `adb shell pm clear`.