### PR TITLE
fix(toolchain): say that Go cannot compile, where the user decides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -275,6 +275,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **Documentation**
 
 - The white-screen fix no longer sends readers to Clear Data without saying it deletes every project, and now lists how to rescue unsaved work first.
+- The Go toolchain card and the user guide now say Go cannot compile on device. The guide demonstrated `go run`, and the limit was stated only in this changelog.
 - The user guide's list of bundled extensions matches what ships. It named two that are not included and listed an included one under "extensions to install".
 - The on-device toolchain checklist can be followed. Its five rows pointed at a Settings screen that does not exist, and expected `go build` to succeed.
 - Fourteen disagreements between the bridge API documentation and the bridge, including an SSH argument documented as a key type when it is the comment, and seven methods missing entirely.

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainRegistry.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainRegistry.kt
@@ -25,7 +25,18 @@ object ToolchainRegistry {
             packName = "toolchain_go",
             displayName = "Go",
             shortLabel = "Go",
-            description = "Go programming language (CGO_ENABLED=0)",
+            // The second sentence is not padding, and removing it would put the
+            // picker back to selling 179 MB for something the user cannot use as
+            // advertised. Android refuses to execute a file under the app's data
+            // directory, so binaries are reached through a bash function that
+            // hands them to the system loader. A function reaches only as far as
+            // the shell: `go build` and `go run` start the compiler, assembler
+            // and linker themselves, those forks hit the binaries directly, and
+            // they are refused. The card renders this text verbatim
+            // (ToolchainPickerAdapter), so it is the only place a user is told
+            // before choosing.
+            description = "Go programming language (CGO_ENABLED=0). Runs on device, " +
+                "but cannot compile: go build and go run are refused by Android.",
             estimatedSize = 179_000_000,
             downloadUrl = "https://github.com/rmyndharis/VSCodroid/releases/latest/download/toolchain_go.zip",
         ),

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -427,12 +427,12 @@ it.
 New terminals automatically pick up toolchain PATH changes. No app restart is needed.
 
 ```bash
-# Go
+# Go: the toolchain installs and runs, but it cannot compile on Android.
+# `go build` and `go run` are refused. See Known Limitations below.
 go version
+go env GOROOT
 mkdir hello && cd hello
 go mod init hello
-# edit main.go
-go run main.go
 
 # Ruby
 ruby -v
@@ -512,6 +512,29 @@ The status bar shows a phantom process count. This tells you how many background
 ### Native npm Packages
 
 Packages that require C/C++ compilation (node-gyp) fail on VSCodroid because there is no C compiler on the device. This affects packages like `better-sqlite3`, `bcrypt`, `sharp`, `canvas`, and `node-sass`. Pure JavaScript or WASM alternatives exist for most of them (see the [Web Development](#package-compatibility) section).
+
+### Toolchains Run Only From the Terminal, and Go Cannot Compile
+
+Android refuses to execute any file inside an app's data directory, which is
+where installed toolchains live. VSCodroid works around this by defining a shell
+function for each toolchain binary that hands the file to the system loader, so
+typing `go`, `ruby` or `javac` in a terminal works.
+
+A shell function reaches only as far as the shell. Anything that launches a
+binary itself gets the file rather than the function, and is refused:
+
+- `make`, `bash -c "..."` and shell scripts
+- processes started by an extension, including language servers
+- a compiler that starts its own sub-tools
+
+That last case is why **Go cannot compile on VSCodroid**. `go build` and `go run`
+start the compiler, assembler and linker as separate programs, and those starts
+do not go through the shell function. `go version`, `go env` and `go mod` work;
+building does not.
+
+Ruby and Java are reached the same way and hit the same wall whenever something
+other than your terminal starts them, an extension or a Makefile for example.
+Typing `ruby` or `javac` yourself goes through the shell function and works.
 
 ### Android Phantom Process Limit
 


### PR DESCRIPTION
The Go card offers 179 MB as "Go programming language (CGO_ENABLED=0)", and the user guide's toolchain section demonstrated `go run main.go`. Neither works.

Android refuses to execute a file under the app's data directory, so toolchain binaries are reached through a bash function that hands them to the system loader. A shell function reaches only as far as the shell, and `go build` and `go run` start the compiler, assembler and linker as separate programs; those starts get the binary rather than the function and are refused.

The limit was already stated accurately, in `CHANGELOG.md`, which is the one place a user choosing a toolchain will not look. This puts it where the decision is made:

- `ToolchainRegistry` Go description, which `ToolchainPickerAdapter` renders verbatim on the picker card
- the guide's Go example, which now shows commands that work
- a Known Limitations entry explaining the mechanism and its wider reach: `make`, shell scripts and extension-spawned processes hit the same wall, and Ruby and Java do too whenever something other than the terminal starts them

No behaviour changes. A sweep of docs, resources, bundled extensions and the device harness found no other place promising Go compilation; `DEVICE_TEST_CHECKLIST.md` already expects `go build` to fail.

Verified: `compileDebugKotlin` and `testDebugUnitTest` executed, 909 tests across 141 classes, zero failures.