### PR TITLE
fix(service): say when an adopted session cannot reach the network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Server lifecycle**
 
+- A session that adopted a surviving server now says on its notification that extensions, git and npm cannot reach the network, and that restarting fixes it. It failed silently.
 - Reopening the app while the server is still coming up no longer lands on a connection-refused page. Readiness now comes from the health check rather than from whether a process exists.
 - A start that fails while no window is open is reported to the next window that opens, instead of leaving a loading screen that never changes.
 - A server that is merely slow is no longer treated as failed. At two minutes the app says the start is taking longer than usual and keeps waiting.

--- a/android/app/src/main/kotlin/com/vscodroid/service/NodeService.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/service/NodeService.kt
@@ -591,6 +591,13 @@ class NodeService : Service() {
         endFailureEpisode()
         startupNotice = null
         Logger.i(tag, "Server is ready on port ${processManager.port}")
+        // Deliberately not [reportStartupNotice], which is the path that reads
+        // "the server is not serving": MainActivity toasts one of those and
+        // returns WITHOUT loading the editor. An adopted server is serving, and
+        // the user should get their editor. What is wrong is narrower than the
+        // startup path can express, so it goes on the card instead, where it
+        // lasts as long as the condition does rather than for a toast.
+        if (processManager.isAdopted()) refreshNotification()
         onServerReady?.invoke(processManager.port)
     }
 
@@ -898,9 +905,22 @@ class NodeService : Service() {
      * relay and nothing else. With no Stop on the card there was no way back at
      * all short of force-stopping the app.
      */
+    /**
+     * The running card's line, derived rather than remembered.
+     *
+     * Adoption is discovered after the first `startForeground`, so the card is
+     * built once before the answer exists and again after. Holding the answer in
+     * a field would mean [refreshNotification] rebuilding with defaults and
+     * quietly reverting it, which is the shape of bug that outlives whoever
+     * wrote it. Asking [ProcessManager] each time cannot drift.
+     */
+    private fun degradableNotificationText(): String =
+        if (processManager.isAdopted()) getString(R.string.notification_text_adopted)
+        else getString(R.string.notification_text)
+
     private fun createNotification(
         title: String = getString(R.string.notification_title),
-        text: String = getString(R.string.notification_text),
+        text: String = degradableNotificationText(),
         serverRunning: Boolean = true,
     ): Notification {
         val openIntent = Intent(this, MainActivity::class.java).apply {

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -5,6 +5,14 @@
     <string name="notification_channel_description">Keeps the local development server running</string>
     <string name="notification_title">VSCodroid is running</string>
     <string name="notification_text">Local development server active</string>
+    <!-- Replaces the line above when the server was adopted rather than started.
+         An adopted server outlived the bootstrap that forked it, and the DNS
+         proxy died with that bootstrap while the survivor kept the dead address
+         in its environment. Everything honouring HTTPS_PROXY then fails for the
+         rest of the session: the extension marketplace, the agent host, and git,
+         npm and curl in every terminal, which inherit it. The editor looks
+         healthy throughout, so this card is the only thing a user can see. -->
+    <string name="notification_text_adopted">No network for extensions, git or npm. Restart the app to fix it.</string>
     <string name="action_stop">Stop Server</string>
 
     <!-- Shown once the automatic restart budget is spent. Replaces the two

--- a/docs/DEVICE_TEST_CHECKLIST.md
+++ b/docs/DEVICE_TEST_CHECKLIST.md
@@ -94,6 +94,13 @@
 | BG-4 | Server process killed | `adb shell kill <node PID>` | Server auto-restarts, notification shows | | |
 | BG-5 | Foreground notification | Check notification shade while app runs | "VSCodroid running" notification visible | | |
 | BG-6 | Return after screen off | Lock screen, wait 2min, unlock | App resumes without crash | | |
+| BG-7 | Adopted session says its network is gone | Kill the **bootstrap** `server.js` only (`adb shell ps -A \| grep server.js`, kill the parent, leave the child holding the port), then relaunch the app | Editor loads against the surviving server, and the foreground notification reads "No network for extensions, git or npm". Confirm the claim: the marketplace and `npm view express` both fail in that session, and both work again after a full restart | | |
+
+BG-7 is the one case where the editor being healthy is the problem. An adopted
+server outlived the bootstrap that forked it, and the DNS proxy died with that
+bootstrap while the survivor kept the dead address in its environment. Nothing in
+the editor looks wrong; only the card says so. If the card reads "Local
+development server active" here, the degradation is silent again.
 
 ## 8. Low Memory & Stress
 


### PR DESCRIPTION
An adopted server is one that outlived the bootstrap that forked it. `assets/dns-proxy.js` runs inside that bootstrap and hands the child its address once, at fork time, so the survivor keeps a dead address that nothing in a running process can change.

Everything honouring `HTTPS_PROXY` then fails for the rest of the session: the extension marketplace, the agent host, and git, npm and curl in every terminal, which inherit that environment. The workbench looks perfectly healthy throughout, and the only statement of what is wrong was a `Logger.w` in `ProcessManager`, which reaches logcat and nobody else. Restarting the app is the cure, and there was no way for a user to learn that.

It now reaches the foreground notification, which lasts as long as the condition does and names the cure.

**Deliberately not routed through `reportStartupNotice`**, which is the mechanism the problem's shape suggests. `MainActivity` turns one of those into `BindDecision.ShowNotice`, toasts it and returns *without loading the editor*, because that path means the server is not serving. An adopted server is serving; the user should get their editor. Using it here would have traded a silent degradation for a blank screen.

The text is derived from `ProcessManager.isAdopted()` each time the card is built rather than held in a field. Adoption is discovered after the first `startForeground`, so the card is built twice, and `refreshNotification()` rebuilds with defaults: a remembered flag would be reverted by it, silently.

**This does not fix the degradation.** Closing it needs a proxy whose lifetime is not the bootstrap's, which `ProcessManager` already notes is out of reach from there.

Verified locally: `compileDebugKotlin`, `testDebugUnitTest` (909 tests, zero failures) and `lintDebug` all green, and `device-test.sh --self-check` passes. The behaviour itself is only observable on a device, so it gets checklist row BG-7 rather than a JVM test that would assert the branch and not the effect.