### PR TITLE
docs(test): measure the macOS runner, and close the open question

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -283,12 +283,20 @@ jobs:
       # Compiles the instrumented tests without running them, which is the only
       # thing CI can do for them and is better than the nothing that was here.
       #
-      # They cannot be RUN on any runner GitHub offers, and that is measured
-      # rather than assumed: the app is arm64-v8a only, so the emulator has to
-      # be arm64 too; ubuntu-latest has /dev/kvm but only accelerates x86_64,
-      # and ubuntu-24.04-arm reports no /dev/kvm and no virtualisation flag at
-      # all. An arm64 image there would be pure software emulation, for a 340 MB
-      # APK that boots a Node server.
+      # They cannot be RUN on any runner GitHub offers, and all three families
+      # have now been measured rather than assumed. The app is arm64-v8a only,
+      # so the emulator has to be arm64 too; ubuntu-latest has /dev/kvm but only
+      # accelerates x86_64, and ubuntu-24.04-arm reports no /dev/kvm and no
+      # virtualisation flag at all.
+      #
+      # macos-15 was the open question until 2026-08-16, because Apple silicon
+      # should mean HVF. It is itself a virtual machine, reporting
+      # "Apple M1 (Virtual)" with kern.hv_support absent, so nested
+      # virtualisation is not exposed and qemu fails with HV_UNSUPPORTED before
+      # the emulator reaches adb. Measured on API 34 and 36 alike.
+      #
+      # So an arm64 image would be pure software emulation everywhere, for a
+      # 340 MB APK that boots a Node server.
       #
       # What this does catch is the second way they were rotting: nothing
       # compiled them either, so they could drift out of the app's API and stay

--- a/android/app/src/androidTest/README.md
+++ b/android/app/src/androidTest/README.md
@@ -4,10 +4,12 @@
 project has measured can.**
 
 That is a measured conclusion, not an omission, and it is written here because a
-populated `androidTest/` directory otherwise reads as coverage. The wording is
-deliberately narrower than "nothing can": what was measured is two Linux runner
-families, which is not every runner GitHub offers. See *The route nobody has
-measured* below.
+populated `androidTest/` directory otherwise reads as coverage.
+
+The wording was once narrower than "nothing can", because only two Linux runner
+families had been measured and that is not every runner GitHub offers. The third
+has since been measured too, and it fails for the same underlying reason. See
+*The route that has now been measured* below.
 
 Because nothing schedules them, the cadence is a person's. `CONTRIBUTING.md`
 names the moments; the one that belongs to this directory is **after touching
@@ -29,28 +31,47 @@ So an arm64 image would run under pure software emulation, for a 340 MB APK
 that boots a Node server. This is the same wall `scripts/device-test.sh`
 documents for the same reason.
 
-## The route nobody has measured
+## The route that has now been measured
 
 GitHub's `macos-14` / `macos-15` runners are Apple silicon, so an arm64 system
-image there would run under HVF rather than software emulation. **Nobody has
-tried it here**, and this section exists to price it honestly rather than to
-recommend it, because "nothing can" was overstating a measurement of two Linux
-runners.
+image there would in principle run under HVF rather than software emulation.
+This section used to say nobody had tried it. Somebody has, on 2026-08-16, and
+the answer is no.
 
-What such a job would have to solve first, one item of which is checkable
-without a runner and is true today:
+| Runner | Architecture | Hardware acceleration |
+|---|---|---|
+| `macos-15` | arm64, reported as `Apple M1 (Virtual)` | `kern.hv_support` absent; `HVF error: HV_UNSUPPORTED` |
 
-- the assets cache key in `build.yml` is `assets-${{ hashFiles(...) }}` with no
-  `runner.os` in it, so a macOS job would restore a tree built on Linux and save
-  its own forward under the same key — verified by reading the workflow;
-- the 874 MB asset tree would have to build on macOS, where `sed -i` is not the
-  GNU one (`scripts/download-*.sh` already use `python3` for in-place edits for
-  exactly this reason);
-- installing a 340 MB APK over the emulator's adb, then two `SplashActivityTest`
-  cases that wait on first-run extraction.
+The runner is itself a virtual machine, and nested virtualisation is not exposed
+to it, so QEMU cannot initialise HVF at all:
 
-None of that says it will not work. It says the cost is a day, not an
-afternoon, and that nobody should quote this section as evidence either way.
+```
+qemu-system-aarch64-headless: failed to initialize HVF: Invalid argument
+```
+
+The emulator never reaches adb, and the job ends in `Timeout waiting for
+emulator to boot`. Measured on API 34 and API 36, identically, from a job that
+built and installed nothing so that a dead route cost nothing to find.
+
+So it is the same wall as `ubuntu-24.04-arm`, under a different name: no
+accessible hardware virtualisation for an arm64 guest. All three runner families
+GitHub offers have now been measured, and the sentence at the top of this file no
+longer rests on a gap.
+
+What that leaves, none of it tried here:
+
+- self-hosted hardware, where the virtualisation is real;
+- a physical device attached to a runner;
+- nothing else. Software emulation of a 340 MB APK that boots a Node server was
+  never a serious option, and it is the only thing these runners can offer.
+
+One item from the old estimate is worth keeping, because it stays true and is
+cheap: `build.yml`'s asset cache key is `assets-${{ hashFiles(...) }}` with no
+`runner.os` in it, so any future non-Linux job would restore a tree built on
+Linux and save its own forward under the same key. Verified by reading the
+workflow. Another item from that estimate was wrong and is worth recording as
+wrong: it assumed such a job would have to build the 874 MB asset tree on macOS,
+when the APKs can be built on Linux and only installed on the other runner.
 
 ## What CI does instead
 


### PR DESCRIPTION
`android/app/src/androidTest/README.md` carried a section named *The route nobody has measured*. GitHub's Apple silicon runners should mean HVF, nobody here had tried an arm64 AVD on one, and the section priced the attempt at a day while telling readers not to quote it as evidence either way. It was right to refuse to conclude, and the only thing that could settle it was running one.

Measured 2026-08-16 on `macos-15`, API 34 and API 36 alike:

```
cpu       : Apple M1 (Virtual)
hvf       : absent
HVF error: HV_UNSUPPORTED
qemu-system-aarch64-headless: failed to initialize HVF: Invalid argument
```

The runner is itself a virtual machine and nested virtualisation is not exposed to it, so QEMU cannot initialise HVF at all. The emulator never reaches adb and the job ends in `Timeout waiting for emulator to boot`. That is the same wall as `ubuntu-24.04-arm`, under a different name: no accessible hardware virtualisation for an arm64 guest.

The measuring job built and installed nothing, so a dead route cost nothing to find. It is not kept in the tree; what survives is the result.

Two corrections to the old estimate ride along:

- the asset cache key really does lack `runner.os`, so that is recorded, and deliberately **not** fixed: with no non-Linux job able to exist, fixing it would be work for a trap nothing can spring
- the estimate assumed such a job would have to build the 874 MB asset tree on macOS. That was wrong. The APKs build on Linux and only the install needs the other runner, which would have removed the most expensive line from that estimate had the route survived

All three runner families GitHub offers have now been measured, so the claim at the top of that file no longer rests on a gap, and `build.yml`'s comment says three where it said two.

What this leaves for the instrumented tests: self-hosted hardware or a physical device on a runner. Neither is tried here, and neither is proposed by this change.