### PR TITLE
ci: drop an input setup-android has never accepted

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,10 +37,15 @@ jobs:
           java-version: "17"
           distribution: "temurin"
 
+      # No api-level here, and that is deliberate rather than an omission.
+      # android-actions/setup-android has never declared one: its inputs are
+      # cmdline-tools-version, accept-android-sdk-licenses,
+      # log-accepted-android-sdk-licenses and packages. Passing api-level: 36
+      # produced "Unexpected input(s) 'api-level'" on every run and set nothing,
+      # for as long as it was there. The platform this build needs is fetched by
+      # Gradle from compileSdk, which is why removing it changes no behaviour.
       - name: Set up Android SDK
         uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
-        with:
-          api-level: 36
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0

--- a/.github/workflows/r8.yml
+++ b/.github/workflows/r8.yml
@@ -74,10 +74,15 @@ jobs:
           java-version: "17"
           distribution: "temurin"
 
+      # No api-level here, and that is deliberate rather than an omission.
+      # android-actions/setup-android has never declared one: its inputs are
+      # cmdline-tools-version, accept-android-sdk-licenses,
+      # log-accepted-android-sdk-licenses and packages. Passing api-level: 36
+      # produced "Unexpected input(s) 'api-level'" on every run and set nothing,
+      # for as long as it was there. The platform this build needs is fetched by
+      # Gradle from compileSdk, which is why removing it changes no behaviour.
       - name: Set up Android SDK
         uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
-        with:
-          api-level: 36
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0


### PR DESCRIPTION
`lint.yml` and `r8.yml` both passed `api-level: 36` to `android-actions/setup-android`. That action declares four inputs and `api-level` is not among them, in v4 or in the v3 that preceded it. Every run printed:

```
##[warning]Unexpected input(s) 'api-level', valid inputs are ['cmdline-tools-version',
'accept-android-sdk-licenses', 'log-accepted-android-sdk-licenses', 'packages']
```

and set nothing. Actions warns on an undeclared input rather than failing, so two workflows stated an SDK level while neither selected one, and CI stayed green throughout.

No behaviour changes: the platform these builds need is fetched by Gradle from `compileSdk`, which is what has been happening all along. A comment replaces the line so the absence reads as a decision rather than an omission someone should correct.

Found while checking whether the action bump had removed an input we depend on. It had not, and the check is worth recording because it is the one that would have caught a removal: comparing every `with:` key against the inputs each action declares at its pinned commit. All twelve bumped actions accept every input this repository passes; this line was already dead before the bump.