### PR TITLE
fix(toolchain): resolve latest once so a download cannot straddle a release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Toolchains**
 
+- A sideloaded toolchain install resolves `latest` once and takes both the digest and the payload from that release, so a release published mid-download no longer refuses the install.
 - Installed toolchains can be run. Android refuses to execute any file in an app's data directory, so terminal commands are handed to the system loader. **The redirect is shell functions, so its reach is the shell's reach**: `make`, `bash -c`, scripts and extension-spawned processes still hit the binary directly and are refused. **Go cannot compile** even in the terminal, because `go build` starts its own compiler directly.
 - You can add and remove languages after first run. Touch and hold the app icon and choose **Manage toolchains**. The picker is shown once and previously had no other way in.
 - **`go build` would have failed with a permission error in the next release.** The Go manifest named only `go` and `gofmt`, leaving the compiler, linker and assembler unrunnable. The manifest is now built from the toolchain itself.

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
@@ -693,14 +693,19 @@ class ToolchainManager(private val context: Context) {
                     return@execute
                 }
 
+                // Once, before either request, so the manifest and the payload
+                // name the same release however long the transfer takes. Falls
+                // back to the unpinned URL, which is what shipped before this.
+                val pinnedUrl = pinLatest(url)
+
                 // Resolved before the payload, not after. A release that cannot
                 // vouch for this ZIP should cost a few hundred bytes and a clear
                 // refusal, rather than 179 MB and then a refusal.
-                val expectedDigest = publishedDigestFor(url, download)
+                val expectedDigest = publishedDigestFor(pinnedUrl, download)
 
                 // Download
                 retrying(packName, download) {
-                    downloadFile(packName, url, zipFile, estimatedSize, download)
+                    downloadFile(packName, pinnedUrl, zipFile, estimatedSize, download)
                 }
 
                 if (download.cancelled) {
@@ -893,6 +898,59 @@ class ToolchainManager(private val context: Context) {
                 String(buffer, 0, total)
             }
         }
+
+    /**
+     * [zipUrl] with `latest` resolved to the release it names right now, or
+     * [zipUrl] unchanged when it cannot be resolved.
+     *
+     * The manifest and the payload are two requests minutes apart, and both used
+     * to go through `latest` independently, so a release published between them
+     * handed back bytes to check against a digest read from the release before
+     * it. Resolving once and building both URLs from the answer is what closes
+     * that; [manifestUrlFor] derives the manifest beside the ZIP, so pinning the
+     * ZIP pins the manifest for free.
+     *
+     * One HEAD, one hop, no body. `releases/latest` answers `releases/tag/<tag>`
+     * and involves no asset, which is why it is asked rather than the asset URL:
+     * that one redirects twice and ends at a signed CDN address carrying no tag.
+     *
+     * **Falls back to the unpinned URL on any failure, deliberately.** A wrong
+     * pin would 404 every toolchain for everyone, while the unpinned URL is what
+     * shipped before this existed. So the floor here is the old behaviour and
+     * the ceiling is a closed window, and nothing in between can be worse than
+     * where it started.
+     */
+    private fun pinLatest(zipUrl: String): String {
+        val latestUrl = latestReleaseUrlFor(zipUrl) ?: return zipUrl
+        val pinned = try {
+            val conn = URL(latestUrl).openConnection() as HttpURLConnection
+            try {
+                conn.connectTimeout = HTTP_TIMEOUT_MS
+                conn.readTimeout = HTTP_TIMEOUT_MS
+                conn.instanceFollowRedirects = false
+                conn.requestMethod = "HEAD"
+                conn.setRequestProperty("User-Agent", "VSCodroid")
+                val code = conn.responseCode
+                val location = if (code in 300..399) conn.getHeaderField("Location") else null
+                location?.let { releaseTagFromLocation(it) }?.let { pinnedAssetUrl(zipUrl, it) }
+            } finally {
+                conn.disconnect()
+            }
+        } catch (e: IOException) {
+            Logger.w(tag, "Could not resolve the latest release: ${e.message}")
+            null
+        }
+        if (pinned == null) {
+            Logger.w(
+                tag,
+                "Falling back to the unpinned release URL; the digest and the payload " +
+                    "may come from different releases if one is published mid-download",
+            )
+            return zipUrl
+        }
+        Logger.i(tag, "Pinned this install to ${pinned.substringBeforeLast('/')}")
+        return pinned
+    }
 
     /**
      * The digest the release publishes for [zipName], or a refusal.
@@ -1567,15 +1625,77 @@ private const val MANIFEST_NAME = "toolchains.sha256"
  * beyond that is diagnostic: in the log it is indistinguishable from the
  * tampering this check exists to catch.
  *
- * Closing it properly means resolving `latest` to a concrete release once and
- * building both URLs from that, so the pair cannot straddle a publish. That is
- * deliberately not done here: it depends on the shape of GitHub's redirect
- * chain for release assets, which nothing in this repository has measured, and
- * a wrong guess about it breaks every install rather than a rare one. Measure
- * it against a real release first.
+ * That window is closed before this is called, by [pinnedAssetUrl] and the
+ * resolution in front of it: the ZIP URL handed here already names a concrete
+ * release, so deriving the manifest beside it inherits the same one. The
+ * paragraphs above describe what happens when that resolution fails and the
+ * unpinned URL is used as a fallback, which is the old behaviour and the floor
+ * this can never drop below.
  */
 internal fun manifestUrlFor(zipUrl: String): String =
     zipUrl.substringBeforeLast('/') + "/" + MANIFEST_NAME
+
+/**
+ * The release-level `latest` URL an asset URL resolves through, or null when
+ * the URL is not of that shape.
+ *
+ * `https://host/o/r/releases/latest/download/x.zip` gives
+ * `https://host/o/r/releases/latest`.
+ *
+ * Deliberately the RELEASE redirect and not the asset one. Measured 2026-08-16:
+ * `releases/latest/download/<asset>` redirects to
+ * `releases/download/<tag>/<asset>` and then again to a signed CDN URL that
+ * carries no tag, so reading the end of that chain answers nothing and reading
+ * its middle means depending on how many hops there are. `releases/latest`
+ * redirects once, to `releases/tag/<tag>`, and involves no asset at all.
+ */
+internal fun latestReleaseUrlFor(assetUrl: String): String? {
+    val i = assetUrl.indexOf(LATEST_DOWNLOAD)
+    return if (i < 0) null else assetUrl.substring(0, i) + "/releases/latest"
+}
+
+/**
+ * The tag named by a `releases/latest` redirect, or null.
+ *
+ * `https://host/o/r/releases/tag/v1.2.3` gives `v1.2.3`.
+ *
+ * A tag that is not plainly a tag is refused rather than pasted into a URL.
+ * Everything downstream falls back to the unpinned URL on null, so refusing
+ * costs the old behaviour; accepting something with a slash or a space in it
+ * would build a URL that 404s for every toolchain.
+ */
+internal fun releaseTagFromLocation(location: String): String? {
+    val i = location.indexOf(RELEASES_TAG)
+    if (i < 0) return null
+    val tag = location.substring(i + RELEASES_TAG.length)
+        .substringBefore('?')
+        .substringBefore('#')
+        .trim('/')
+    return if (tag.isNotEmpty() && TAG_CHARS.matches(tag)) tag else null
+}
+
+/**
+ * [assetUrl] with `latest` replaced by a concrete [tag], or null.
+ *
+ * `.../releases/latest/download/x.zip` and `v1.2.3` give
+ * `.../releases/download/v1.2.3/x.zip`.
+ *
+ * Refuses an asset name containing a slash, because that would mean the URL was
+ * not the flat `releases/latest/download/<name>` this is written for and the
+ * result would name something else entirely.
+ */
+internal fun pinnedAssetUrl(assetUrl: String, tag: String): String? {
+    val i = assetUrl.indexOf(LATEST_DOWNLOAD)
+    if (i < 0) return null
+    val asset = assetUrl.substring(i + LATEST_DOWNLOAD.length)
+    if (asset.isEmpty() || asset.contains('/')) return null
+    if (!TAG_CHARS.matches(tag)) return null
+    return assetUrl.substring(0, i) + "/releases/download/" + tag + "/" + asset
+}
+
+private const val LATEST_DOWNLOAD = "/releases/latest/download/"
+private const val RELEASES_TAG = "/releases/tag/"
+private val TAG_CHARS = Regex("""[A-Za-z0-9._-]+""")
 
 /**
  * The digest a `sha256sum` manifest publishes for [fileName], or null when it

--- a/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainDigestTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainDigestTest.kt
@@ -216,3 +216,118 @@ class ToolchainDigestTest {
         assertEquals(1, manifests.size, "registered toolchains disagree about the manifest: $manifests")
     }
 }
+
+/**
+ * Resolving `latest` to one concrete release, so the manifest and the payload
+ * cannot come from two.
+ *
+ * The risk here runs one way, and it is the opposite of the digest reader's. A
+ * resolver that answers null too often costs the old behaviour, which is a rare
+ * race that fails closed and succeeds on retry. One that answers a plausible but
+ * wrong URL 404s every toolchain for everyone, so each function below refuses
+ * anything it does not fully recognise rather than pasting it into a URL.
+ *
+ * The redirect shape these are written against was measured on 2026-08-16:
+ * `releases/latest` answers `302` to `releases/tag/<tag>` in one hop, while
+ * `releases/latest/download/<asset>` takes two and ends at a signed CDN address
+ * that carries no tag at all.
+ */
+class LatestReleasePinningTest {
+
+    private val zip = "https://github.com/rmyndharis/VSCodroid/releases/latest/download/toolchain_go.zip"
+
+    @Test
+    fun `the release URL is derived from an asset URL`() {
+        assertEquals(
+            "https://github.com/rmyndharis/VSCodroid/releases/latest",
+            latestReleaseUrlFor(zip),
+        )
+    }
+
+    @Test
+    fun `a URL that does not go through latest resolves to nothing`() {
+        // Already pinned, so there is nothing to resolve and the caller keeps
+        // what it has.
+        assertNull(
+            latestReleaseUrlFor(
+                "https://github.com/rmyndharis/VSCodroid/releases/download/v1.0.0/toolchain_go.zip"
+            )
+        )
+    }
+
+    @Test
+    fun `the tag is read out of the redirect GitHub actually sends`() {
+        assertEquals(
+            "v1.0.0",
+            releaseTagFromLocation("https://github.com/rmyndharis/VSCodroid/releases/tag/v1.0.0"),
+        )
+        // The server release tag is not v-prefixed, and is the one this has to
+        // keep out of the app channel rather than mis-parse.
+        assertEquals(
+            "server-1.133.0",
+            releaseTagFromLocation("https://github.com/rmyndharis/VSCodroid/releases/tag/server-1.133.0"),
+        )
+    }
+
+    @Test
+    fun `a redirect that names no usable tag is refused`() {
+        // Kills a parser that takes whatever follows the marker. Each of these
+        // would build a URL that 404s, and the fallback is strictly better.
+        assertNull(releaseTagFromLocation("https://github.com/o/r/releases"))
+        assertNull(releaseTagFromLocation("https://github.com/o/r/releases/tag/"))
+        assertNull(releaseTagFromLocation("https://github.com/o/r/releases/tag/a b"))
+        assertNull(releaseTagFromLocation("https://github.com/o/r/releases/tag/../../evil"))
+    }
+
+    @Test
+    fun `pinning replaces latest with the tag and keeps the asset`() {
+        assertEquals(
+            "https://github.com/rmyndharis/VSCodroid/releases/download/v1.0.0/toolchain_go.zip",
+            pinnedAssetUrl(zip, "v1.0.0"),
+        )
+    }
+
+    @Test
+    fun `pinning refuses what it does not recognise`() {
+        assertNull(pinnedAssetUrl("https://example.test/some/other/path.zip", "v1.0.0"))
+        assertNull(pinnedAssetUrl(zip, "not a tag"))
+        // An asset that is itself a path was never the shape this is for, and
+        // pasting it would name something else entirely.
+        assertNull(
+            pinnedAssetUrl(
+                "https://github.com/o/r/releases/latest/download/nested/x.zip",
+                "v1.0.0",
+            )
+        )
+    }
+
+    @Test
+    fun `pinning the ZIP pins the manifest beside it`() {
+        // The invariant the whole change rests on. Only the ZIP URL is resolved;
+        // the manifest is derived from it afterwards, so if this ever stopped
+        // holding the two requests would silently address different releases
+        // again and nothing else would notice.
+        val pinned = pinnedAssetUrl(zip, "v1.1.0")!!
+
+        assertEquals(
+            "https://github.com/rmyndharis/VSCodroid/releases/download/v1.1.0/toolchains.sha256",
+            manifestUrlFor(pinned),
+        )
+    }
+
+    @Test
+    fun `every registered toolchain can be pinned to one release`() {
+        // The registry-wide version of the test above: one resolution has to
+        // serve all three, or a single install could pin while another does not.
+        val pinned = ToolchainRegistry.available
+            .mapNotNull { it.downloadUrl }
+            .map { pinnedAssetUrl(it, "v1.1.0") }
+
+        assertEquals(emptyList<String?>(), pinned.filter { it == null }, "a registered toolchain could not be pinned")
+        assertEquals(
+            1,
+            pinned.filterNotNull().map { manifestUrlFor(it) }.toSet().size,
+            "pinned toolchains disagree about the manifest",
+        )
+    }
+}

--- a/docs/DEVICE_TEST_CHECKLIST.md
+++ b/docs/DEVICE_TEST_CHECKLIST.md
@@ -147,6 +147,7 @@ the device.
 | TC-4 | Ruby and Java run | `ruby -e 'puts 1+1'`; write and run a `Hello.java` with `java Hello.java` | Both print their output | | |
 | TC-5 | Go runs but does not compile | `go version`, then `go build` on any package | `go version` prints; `go build` **is expected to fail** with a permission error. Anything else is the surprise worth reporting | | |
 | TC-6 | Toolchain uninstall | Manage toolchains > uninstall one | Files removed, command no longer found in a new terminal | | |
+| TC-7 | A sideloaded install pins one release | Install any toolchain on a build that is NOT from Play, with `adb logcat -s ToolchainManager` running | One line reading `Pinned this install to .../releases/download/<tag>`, naming a concrete tag rather than `latest`, and the install completes. A `Falling back to the unpinned release URL` line instead is not a failure, but record it: it means the resolve did not work on this network | | |
 
 TC-5 is written as an expected failure on purpose. `go` starts its compiler and
 linker as separate programs from the app's own storage, and Android refuses to


### PR DESCRIPTION
Part of #195.

A sideloaded install reads the digest manifest, then transfers the payload, with up to two backed-off retries behind it: minutes for Go at 179 MB on a phone connection. Both requests went through `releases/latest` independently, so a release published anywhere in that span handed back bytes to check against a digest read from the release before it. It fails closed, so it costs a refused install rather than a bad one, but in the log it is indistinguishable from the tampering the check exists to catch.

`manifestUrlFor`'s own documentation named this fix and declined it, because it depends on the shape of GitHub's redirect chain for release assets and nothing here had measured it, and a wrong guess breaks every install rather than a rare one.

Measured 2026-08-16:

| URL | Hops | Ends at |
|---|---|---|
| `releases/latest` | 1 | `releases/tag/<tag>` |
| `releases/latest/download/<asset>` | 2 | signed CDN address, no tag in it |

So the release redirect is the one asked, once, before either request, and both URLs are built from the answer. The manifest is derived beside the ZIP, so pinning the ZIP pins the manifest for free.

**Falls back to the unpinned URL on any failure, deliberately.** A wrong pin would 404 every toolchain for everyone, while the unpinned URL is what shipped before this existed. The floor is the old behaviour and the ceiling is a closed window; nothing in between is worse than where it started. Each parsing step refuses what it does not fully recognise rather than pasting it into a URL: a tag with a space, an empty tag, a traversal attempt, an asset that is itself a path.

Verified: 917 unit tests pass, eight of them new. They cover the parsing, the refusals, and the invariant the whole change rests on, that pinning the ZIP pins the manifest beside it. `lintDebug` is green and `device-test.sh --self-check` still passes.

The end-to-end behaviour is only observable on a device, so it also gets checklist row **TC-7**, which reads the pin out of `logcat` and treats a fallback line as something to record rather than a failure.

**This leaves issue 195 open.** The other half of it is that the release `latest` names today carries no `toolchains.sha256` at all, which publishing 1.1.0 fixes and which was deferred until then.