### PR TITLE
fix(ci): keep Gradle caching on the open-source implementation

### DIFF
--- a/.github/workflows/build-vscode-oss.yml
+++ b/.github/workflows/build-vscode-oss.yml
@@ -33,9 +33,9 @@ jobs:
 
     steps:
       # Write permission is real here and cannot be dropped: this job publishes
-      # its own release. What it does not need is a push token sitting in
-      # .git/config while it clones the VS Code source and runs a full npm
-      # install against it. The release is created through the API.
+      # its own release. What it does not need is a persisted push token while
+      # it clones the VS Code source and runs a full npm install against it.
+      # The release is created through the API.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,23 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          # Pinned to the open-source implementation, not left to the default.
+          #
+          # gradle/actions v6 added cache-provider and defaults it to 'enhanced',
+          # which the action's own description calls "the full-featured commercial
+          # caching service (gradle-actions-caching)"; 'basic' is "a simple
+          # open-source caching implementation based on GitHub Actions cache".
+          # v4 declared no such input, so the version bump moved every Gradle job
+          # here onto the commercial one without anything in this repository
+          # saying so, including the job that holds the signing keystore.
+          #
+          # This project drops dependencies over their licences (Berkeley DB went
+          # for being AGPL) and publishes a source offer covering 39 components.
+          # Taking on a commercial service silently is not a decision a dependency
+          # bump gets to make here. Naming the value also means a later default
+          # change cannot move it again.
+          cache-provider: basic
 
       # Cache downloaded tarballs/debs
       #
@@ -264,6 +281,23 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          # Pinned to the open-source implementation, not left to the default.
+          #
+          # gradle/actions v6 added cache-provider and defaults it to 'enhanced',
+          # which the action's own description calls "the full-featured commercial
+          # caching service (gradle-actions-caching)"; 'basic' is "a simple
+          # open-source caching implementation based on GitHub Actions cache".
+          # v4 declared no such input, so the version bump moved every Gradle job
+          # here onto the commercial one without anything in this repository
+          # saying so, including the job that holds the signing keystore.
+          #
+          # This project drops dependencies over their licences (Berkeley DB went
+          # for being AGPL) and publishes a source offer covering 39 components.
+          # Taking on a commercial service silently is not a decision a dependency
+          # bump gets to make here. Naming the value also means a later default
+          # change cannot move it again.
+          cache-provider: basic
 
       # Unit tests only need compiled Kotlin, not the full assets.
       # Create minimal directory structure so Gradle does not fail.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,6 +49,23 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          # Pinned to the open-source implementation, not left to the default.
+          #
+          # gradle/actions v6 added cache-provider and defaults it to 'enhanced',
+          # which the action's own description calls "the full-featured commercial
+          # caching service (gradle-actions-caching)"; 'basic' is "a simple
+          # open-source caching implementation based on GitHub Actions cache".
+          # v4 declared no such input, so the version bump moved every Gradle job
+          # here onto the commercial one without anything in this repository
+          # saying so, including the job that holds the signing keystore.
+          #
+          # This project drops dependencies over their licences (Berkeley DB went
+          # for being AGPL) and publishes a source offer covering 39 components.
+          # Taking on a commercial service silently is not a decision a dependency
+          # bump gets to make here. Naming the value also means a later default
+          # change cannot move it again.
+          cache-provider: basic
 
       # For the JavaScript self-checks below. Pinned rather than left to
       # whatever the runner image happens to carry, so the version they run

--- a/.github/workflows/r8.yml
+++ b/.github/workflows/r8.yml
@@ -86,6 +86,23 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          # Pinned to the open-source implementation, not left to the default.
+          #
+          # gradle/actions v6 added cache-provider and defaults it to 'enhanced',
+          # which the action's own description calls "the full-featured commercial
+          # caching service (gradle-actions-caching)"; 'basic' is "a simple
+          # open-source caching implementation based on GitHub Actions cache".
+          # v4 declared no such input, so the version bump moved every Gradle job
+          # here onto the commercial one without anything in this repository
+          # saying so, including the job that holds the signing keystore.
+          #
+          # This project drops dependencies over their licences (Berkeley DB went
+          # for being AGPL) and publishes a source offer covering 39 components.
+          # Taking on a commercial service silently is not a decision a dependency
+          # bump gets to make here. Naming the value also means a later default
+          # change cannot move it again.
+          cache-provider: basic
 
       # The shrinker needs compiled classes and processed resources, not the
       # 874 MB asset tree. Measured with --dry-run, which computes the graph

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,8 +56,10 @@ jobs:
           # This job runs Gradle plugins, npm postinstalls and several download
           # scripts, and it holds the signing secrets. It never pushes: the one
           # step that reaches GitHub asks the API with GH_TOKEN scoped to itself,
-          # and the git commands here only read local history. A token left in
-          # .git/config would be reachable by all of that for ninety minutes.
+          # and the git commands here only read local history. A persisted token
+          # would be readable by all of that for ninety minutes. Where checkout
+          # stores it is deliberately not named here: it has moved between major
+          # versions, and this setting is right whatever the location is.
           persist-credentials: false
 
       # A tag whose versionName does not match the one in build.gradle.kts is the
@@ -132,6 +134,23 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          # Pinned to the open-source implementation, not left to the default.
+          #
+          # gradle/actions v6 added cache-provider and defaults it to 'enhanced',
+          # which the action's own description calls "the full-featured commercial
+          # caching service (gradle-actions-caching)"; 'basic' is "a simple
+          # open-source caching implementation based on GitHub Actions cache".
+          # v4 declared no such input, so the version bump moved every Gradle job
+          # here onto the commercial one without anything in this repository
+          # saying so, including the job that holds the signing keystore.
+          #
+          # This project drops dependencies over their licences (Berkeley DB went
+          # for being AGPL) and publishes a source offer covering 39 components.
+          # Taking on a commercial service silently is not a decision a dependency
+          # bump gets to make here. Naming the value also means a later default
+          # change cannot move it again.
+          cache-provider: basic
 
       # The gates the pull request path runs, applied to the bits actually being
       # published. They were reachable on no other trigger: lint.yml fires on
@@ -588,8 +607,8 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Nothing here pushes, and the release is created through the API with
-          # its own token. Leaving the checkout token in .git/config would make
-          # it readable by anything this job runs.
+          # its own token. A persisted checkout token would be readable by
+          # anything this job runs, wherever checkout chooses to keep it.
           persist-credentials: false
 
       - name: Download build artifacts


### PR DESCRIPTION
`gradle/actions` v6 added a `cache-provider` input and defaults it to `enhanced`. From the action's own description:

> `'enhanced'` (default) uses the full-featured **commercial** caching service (gradle-actions-caching). `'basic'` uses a simple **open-source** caching implementation based on GitHub Actions cache.

The v4 this repository came from declared no such input. So the version bump moved all five Gradle jobs onto the commercial service, including the one that holds the signing keystore, with nothing in the repository recording the choice.

This project drops dependencies over their licences and publishes a source offer covering 39 components. Taking on a commercial service is not a decision a dependency bump gets to make silently. All five call sites now name `basic` explicitly, which also means a later default change cannot move them again.

**Worth recording how this was missed.** The twelve-action bump was checked by comparing every `with:` key against the inputs each action declares at its pinned commit, and all twelve passed. That check can only see input *names*. A new input with a new default is invisible to it, and that is exactly what this was.

Three `checkout` comments are corrected in the same change. They justified `persist-credentials: false` by saying a token would otherwise sit in `.git/config`, and where checkout keeps credentials has moved between major versions. The setting is right whatever the location is, so the comments no longer name one.