### PR TITLE
docs: correct claims this cycle introduced that do not hold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -277,7 +277,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **Documentation**
 
 - The white-screen fix no longer sends readers to Clear Data without saying it deletes every project, and now lists how to rescue unsaved work first.
-- The Go toolchain card and the user guide now say Go cannot compile on device. The guide demonstrated `go run`, and the limit was stated only in this changelog.
+- The Go toolchain card and the user guide now say Go cannot compile on device. The guide demonstrated `go run`, while the limit was stated only here and in the device checklist.
 - The user guide's list of bundled extensions matches what ships. It named two that are not included and listed an included one under "extensions to install".
 - The on-device toolchain checklist can be followed. Its five rows pointed at a Settings screen that does not exist, and expected `go build` to succeed.
 - Fourteen disagreements between the bridge API documentation and the bridge, including an SSH argument documented as a key type when it is the comment, and seven methods missing entirely.

--- a/android/app/src/androidTest/README.md
+++ b/android/app/src/androidTest/README.md
@@ -54,9 +54,10 @@ emulator to boot`. Measured on API 34 and API 36, identically, from a job that
 built and installed nothing so that a dead route cost nothing to find.
 
 So it is the same wall as `ubuntu-24.04-arm`, under a different name: no
-accessible hardware virtualisation for an arm64 guest. All three runner families
-GitHub offers have now been measured, and the sentence at the top of this file no
-longer rests on a gap.
+accessible hardware virtualisation for an arm64 guest. Three runner images have now been
+measured, one per family GitHub offers, and the sentence at the top of this file
+no longer rests on a gap. It is images rather than every image: nothing here has
+tried macos-14, and there is no reason to expect it to differ.
 
 What that leaves, none of it tried here:
 

--- a/android/app/src/main/kotlin/com/vscodroid/SplashActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/SplashActivity.kt
@@ -97,7 +97,8 @@ class SplashActivity : AppCompatActivity() {
         repair("the native library paths in settings.json") { setup.updateSettingsNativeLibPaths() }
         // Beside the other idempotent repairs, for the same reason they are
         // here: it can disappear between launches. This one because it is
-        // visible in a file manager, not because the app moved it.
+        // reachable from outside the app by some routes, and wiped by Clear
+        // Data, not because the app moved it.
         repair("the projects directory") { setup.ensureProjectsDir() }
         // A toolchain keeps the manifest it was installed with, so a
         // packaging fix never reaches an install that already exists. This

--- a/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
@@ -322,9 +322,11 @@ class FirstRunSetup(
      * Recreates the projects directory if it has gone.
      *
      * Alone among the directories above, this one lives in app-external storage
-     * -- /storage/emulated/0/Android/data/<pkg>/files/projects -- which shows up
-     * in every file manager and is exactly the kind of path a cleaner app
-     * removes. The rest are under filesDir, where nothing outside the app can
+     * -- /storage/emulated/0/Android/data/<pkg>/files/projects -- which some routes
+     * outside the app can still reach (MTP over USB, a few OEM managers) and
+     * which Clear Data wipes outright. Android 11 closed Android/data to the
+     * system Files app and to other apps, so this is narrower than the "shows up
+     * in every file manager" it used to say, and still enough to lose it. The rest are under filesDir, where nothing outside the app can
      * reach them, so they only ever need creating. This one needs repairing.
      *
      * Creating it once per version was not enough. isFirstRun() gates on

--- a/docs/09-DEVELOPMENT_GUIDE.md
+++ b/docs/09-DEVELOPMENT_GUIDE.md
@@ -252,7 +252,7 @@ applied to the downloaded server. There are no `.diff` files anywhere in the bui
 
 ```bash
 # View logs
-adb logcat -s VSCodroid
+adb logcat -s VSCodroid.MainActivity VSCodroid.NodeService VSCodroid.ProcessManager VSCodroid.ToolchainManager
 
 # View all app logs
 adb logcat --pid=$(adb shell pidof com.vscodroid)

--- a/docs/DEVICE_TEST_CHECKLIST.md
+++ b/docs/DEVICE_TEST_CHECKLIST.md
@@ -94,7 +94,7 @@
 | BG-4 | Server process killed | `adb shell kill <node PID>` | Server auto-restarts, notification shows | | |
 | BG-5 | Foreground notification | Check notification shade while app runs | "VSCodroid running" notification visible | | |
 | BG-6 | Return after screen off | Lock screen, wait 2min, unlock | App resumes without crash | | |
-| BG-7 | Adopted session says its network is gone | Kill the **bootstrap** `server.js` only (`adb shell ps -A \| grep server.js`, kill the parent, leave the child holding the port), then relaunch the app | Editor loads against the surviving server, and the foreground notification reads "No network for extensions, git or npm". Confirm the claim: the marketplace and `npm view express` both fail in that session, and both work again after a full restart | | |
+| BG-7 | Adopted session says its network is gone | `adb shell ps -A \| grep libnode` shows two processes; **`kill -9` the parent** (the lower PID, the one the other lists as its PPID), then relaunch the app. It must be SIGKILL: the bootstrap handles SIGTERM and kills its child on the way out, so a plain `kill` leaves nothing to adopt. `ps` shows `libnode` rather than `server.js` because that is argv[0] | Editor loads against the surviving server, and the foreground notification reads "No network for extensions, git or npm". Confirm the claim: the marketplace and `npm view express` both fail in that session, and both work again after a full restart | | |
 
 BG-7 is the one case where the editor being healthy is the problem. An adopted
 server outlived the bootstrap that forked it, and the DNS proxy died with that
@@ -147,7 +147,7 @@ the device.
 | TC-4 | Ruby and Java run | `ruby -e 'puts 1+1'`; write and run a `Hello.java` with `java Hello.java` | Both print their output | | |
 | TC-5 | Go runs but does not compile | `go version`, then `go build` on any package | `go version` prints; `go build` **is expected to fail** with a permission error. Anything else is the surprise worth reporting | | |
 | TC-6 | Toolchain uninstall | Manage toolchains > uninstall one | Files removed, command no longer found in a new terminal | | |
-| TC-7 | A sideloaded install pins one release | Install any toolchain on a build that is NOT from Play, with `adb logcat -s ToolchainManager` running | One line reading `Pinned this install to .../releases/download/<tag>`, naming a concrete tag rather than `latest`, and the install completes. A `Falling back to the unpinned release URL` line instead is not a failure, but record it: it means the resolve did not work on this network | | |
+| TC-7 | A sideloaded install pins one release | Install any toolchain on a build that is NOT from Play, with `adb logcat -s VSCodroid.ToolchainManager` running (Logger prefixes every tag, so the bare name matches nothing) | One line reading `Pinned this install to .../releases/download/<tag>`, naming a concrete tag rather than `latest`, and the install completes. A `Falling back to the unpinned release URL` line instead is not a failure, but record it: it means the resolve did not work on this network | | |
 
 TC-5 is written as an expected failure on purpose. `go` starts its compiler and
 linker as separate programs from the app's own storage, and Android refuses to

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -595,13 +595,32 @@ If the app shows a white screen after opening:
 > backed up, and on Android 11 and later that directory is not reachable from
 > most file managers, so the files cannot be recovered afterwards.
 
-Rescue anything unsaved first:
+Rescue anything unsaved first. Which route is open to you depends on whether the
+editor still works, and on a white screen it does not:
 
-- Push to a remote, if the project is a git repository.
+**If the editor will not open**, the only routes are from a computer, because
+every in-app route needs the editor. With USB debugging on:
+
+```
+adb pull /storage/emulated/0/Android/data/com.vscodroid/files/projects
+```
+
+Some devices also expose that path over MTP when plugged in, so a file manager on
+the computer can copy it. Both work while the app is unusable, which is the
+situation this section is about.
+
+**If the editor does open** and you are clearing data for some other reason, two
+in-app routes exist:
+
+- Push to a remote, if the project is a git repository. This is the only route
+  that preserves history.
 - Or run **VSCodroid: Open Folder from Device** from the Command Palette
   (**Ctrl+Shift+P**), choose a folder outside the app such as Documents, and copy
   your work there. A folder opened that way lives outside the app's storage, so
-  Clear Data does not touch it.
+  Clear Data does not touch it. **It does not carry `.git` or `.env`**, along
+  with `node_modules`, `.gradle`, `.idea`, `venv` and `__pycache__`: the
+  device-folder sync skips those directories, so this rescues your files but not
+  your repository history and not your local configuration.
 
 Then clear app data from Settings > Apps > VSCodroid > Clear Data and relaunch.
 


### PR DESCRIPTION
Six corrections, all to text added in the last few changes, all found by reading the code the text describes.

**The Clear Data rescue advice was unusable in the situation it was written for.** Both routes it offered need a working editor, and the section they sit in is reached only when the editor shows a white screen. It now leads with `adb pull` and MTP, which work while the app does not, and keeps the in-app routes for the case where the editor still opens.

**That advice was also wrong about what it rescues.** `SafSyncEngine.SKIP_DIRECTORIES` excludes `.git` and `.env` along with `node_modules`, `.gradle`, `.idea`, `venv` and `__pycache__`, so copying a project into a device folder saves the files and not the history or the local configuration. It was offered as the alternative for exactly the git-repository case. The list in the guide is checked against the code rather than retyped.

**BG-7 could not be performed.** It said to kill the bootstrap and leave the child, but `server.js:289-291` installs a SIGTERM handler that kills its child on the way out, so a plain `kill` leaves nothing to adopt and the row reports a false failure. It needs SIGKILL. It also said to find the process with `grep server.js`, while `ps` prints argv[0], which is `libnode`; `scripts/device-launch.sh:62` already greps that.

**TC-7 could not observe anything.** `Logger` emits `VSCodroid.<tag>` (`Logger.kt:7,20`) and the row filtered logcat on the bare tag, which matches nothing. The row passed identically whether the pin engaged, fell back, or was absent from the build, which is the one state it was added to rule out. `docs/09-DEVELOPMENT_GUIDE.md` had the same defect and is corrected too.

**Two comments still asserted the retracted claim** that the projects directory shows up in every file manager, after it was corrected where it was first written. The directory can still be lost, so the conclusion stands and only the reason is narrowed.

**Two overstatements.** The changelog said the Go compile limit was stated only there, while `DEVICE_TEST_CHECKLIST.md` already carried TC-5 for it. The instrumented-test README said all three runner families were measured, when it is three images, one per family.

917 unit tests pass, lint is green, and `device-test.sh --self-check` passes.