### PR TITLE
fix: five defects a review of the last batch turned up

### DIFF
--- a/android/app/src/main/kotlin/com/vscodroid/service/NodeService.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/service/NodeService.kt
@@ -591,13 +591,22 @@ class NodeService : Service() {
         endFailureEpisode()
         startupNotice = null
         Logger.i(tag, "Server is ready on port ${processManager.port}")
+        // Unconditional, and that is the fix for what the guarded version got
+        // wrong. [degradableNotificationText] derives the line from
+        // [ProcessManager.isAdopted] every time the card is built, so re-posting
+        // is always right and never needs to know which way the state moved.
+        // Guarding on isAdopted() only covered becoming adopted: when an adopted
+        // server stops answering the watch clears the flag and a normal respawn
+        // follows, and nothing re-posted, so a healthy session kept telling the
+        // user its network was gone.
+        //
         // Deliberately not [reportStartupNotice], which is the path that reads
         // "the server is not serving": MainActivity toasts one of those and
         // returns WITHOUT loading the editor. An adopted server is serving, and
         // the user should get their editor. What is wrong is narrower than the
         // startup path can express, so it goes on the card instead, where it
         // lasts as long as the condition does rather than for a toast.
-        if (processManager.isAdopted()) refreshNotification()
+        refreshNotification()
         onServerReady?.invoke(processManager.port)
     }
 
@@ -874,6 +883,19 @@ class NodeService : Service() {
     }
 
     /**
+     * The running card's line, derived rather than remembered.
+     *
+     * Adoption is discovered after the first `startForeground`, so the card is
+     * built once before the answer exists and again after. Holding the answer in
+     * a field would mean [refreshNotification] rebuilding with defaults and
+     * quietly reverting it, which is the shape of bug that outlives whoever
+     * wrote it. Asking [ProcessManager] each time cannot drift.
+     */
+    private fun degradableNotificationText(): String =
+        if (processManager.isAdopted()) getString(R.string.notification_text_adopted)
+        else getString(R.string.notification_text)
+
+    /**
      * Builds the notification shown while the server is running, and — with
      * [serverRunning] cleared and its own wording — the one left behind after it
      * has stopped for good.
@@ -905,18 +927,6 @@ class NodeService : Service() {
      * relay and nothing else. With no Stop on the card there was no way back at
      * all short of force-stopping the app.
      */
-    /**
-     * The running card's line, derived rather than remembered.
-     *
-     * Adoption is discovered after the first `startForeground`, so the card is
-     * built once before the answer exists and again after. Holding the answer in
-     * a field would mean [refreshNotification] rebuilding with defaults and
-     * quietly reverting it, which is the shape of bug that outlives whoever
-     * wrote it. Asking [ProcessManager] each time cannot drift.
-     */
-    private fun degradableNotificationText(): String =
-        if (processManager.isAdopted()) getString(R.string.notification_text_adopted)
-        else getString(R.string.notification_text)
 
     private fun createNotification(
         title: String = getString(R.string.notification_title),

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
@@ -696,7 +696,7 @@ class ToolchainManager(private val context: Context) {
                 // Once, before either request, so the manifest and the payload
                 // name the same release however long the transfer takes. Falls
                 // back to the unpinned URL, which is what shipped before this.
-                val pinnedUrl = pinLatest(url)
+                val pinnedUrl = pinLatest(url, download)
 
                 // Resolved before the payload, not after. A release that cannot
                 // vouch for this ZIP should cost a few hundred bytes and a clear
@@ -914,13 +914,30 @@ class ToolchainManager(private val context: Context) {
      * and involves no asset, which is why it is asked rather than the asset URL:
      * that one redirects twice and ends at a signed CDN address carrying no tag.
      *
-     * **Falls back to the unpinned URL on any failure, deliberately.** A wrong
-     * pin would 404 every toolchain for everyone, while the unpinned URL is what
-     * shipped before this existed. So the floor here is the old behaviour and
-     * the ceiling is a closed window, and nothing in between can be worse than
-     * where it started.
+     * **Falls back to the unpinned URL when the resolution fails, deliberately.**
+     * A wrong pin would 404 every toolchain for everyone, while the unpinned URL
+     * is what shipped before this existed.
+     *
+     * That floor covers a failure to resolve and nothing more, which is narrower
+     * than this once claimed. Once a pin IS returned, both requests use it and
+     * neither falls back: a 404 on the pinned release becomes
+     * [MissingFromRelease], which [retrying] rethrows on the first attempt, and
+     * the install is refused. So a release published inside the one request
+     * between the HEAD and the manifest fetch pins to the older one and fails
+     * where the unpinned path would have taken both files from the newer.
+     *
+     * That window is one request wide against a transfer measured in minutes,
+     * it fails closed, and retrying succeeds, so it is the price of closing the
+     * wide window rather than a defect in the trade. It is written down because
+     * the sentence it replaces asserted the price could not exist, and the next
+     * reader would have believed it.
      */
-    private fun pinLatest(zipUrl: String): String {
+    private fun pinLatest(zipUrl: String, download: HttpDownload): String {
+        // Before the request, for the reason the check above this call records: a
+        // pack cancelled while queued must not spend one, and this one carries a
+        // 30 s connect and a 30 s read timeout that nothing else here would
+        // interrupt.
+        if (download.cancelled) return zipUrl
         val latestUrl = latestReleaseUrlFor(zipUrl) ?: return zipUrl
         val pinned = try {
             val conn = URL(latestUrl).openConnection() as HttpURLConnection

--- a/android/app/src/test/kotlin/com/vscodroid/service/ProcessManagerTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/service/ProcessManagerTest.kt
@@ -1183,7 +1183,11 @@ class AdoptionTest {
         val crashed = CountDownLatch(1)
         manager.onServerCrashed = { crashed.countDown() }
 
-        stub?.stop()
+        // Stops answering without releasing the port, for the reason
+        // StubServer.status documents. Freeing it here was the same dependency
+        // `nothing listening is not ready` was fixed for, and it was missed
+        // because the sweep matched `x.stop()` and this site reads `stub?.stop()`.
+        stub?.status = null
 
         assertTrue(
             crashed.await(30, TimeUnit.SECONDS),
@@ -1427,7 +1431,17 @@ class AdoptionTest {
  * It records the request line so a test can assert *which* route was asked for,
  * which is half of what the probe's contract says.
  */
-private class StubServer(status: Int?) {
+private class StubServer(initialStatus: Int?) {
+
+    /**
+     * What this answers with, or null for a port it holds without serving on.
+     *
+     * Mutable so a test can stop a server answering WITHOUT freeing its port.
+     * Freeing it and then requiring that nothing answers there asserts something
+     * about the whole machine, which a shared runner does not honour.
+     */
+    @Volatile
+    var status: Int? = initialStatus
 
     private val socket = ServerSocket(0, 0, InetAddress.getByName("127.0.0.1"))
     private val requestLine = AtomicReference<String?>(null)


### PR DESCRIPTION
Five defects a review of the last batch turned up, all in code from the last few changes.

**The adopted-session card never went back to the truth.** `announceReady` re-posted it only when `isAdopted()` was true, which covers becoming adopted and not the other direction: when an adopted server stops answering, `ProcessManager.kt:1026-1029` clears the flag and a normal respawn follows, and nothing re-posted. A healthy session went on telling the user its network was gone. The re-post is unconditional now, which is also simpler: the line is derived from `isAdopted()` every time the card is built, so it never needs to know which way the state moved.

**`createNotification`'s KDoc had come loose from `createNotification`.** The new `degradableNotificationText` was inserted between them, so a block recording a measured API 36 result about the notification's Stop action ended up documenting a two-line string helper. The helper moves above it.

**`pinLatest`'s KDoc claimed a floor the code does not hold.** Falling back covers a failure to *resolve*. Once a pin is returned, both requests use it and neither falls back: a 404 becomes `MissingFromRelease`, which `retrying` rethrows on the first attempt. So a release published inside the one request between the HEAD and the manifest fetch pins to the older one and is refused where the unpinned path would have succeeded. That window is one request wide against a transfer measured in minutes and it fails closed, so it is the price of closing the wide window. It is written down now instead of denied.

**`pinLatest` ran before any cancellation check**, adding up to sixty uncancellable seconds per pack to a queue serialised on one thread. It reads the flag first now, which is the property the check above its call site exists to hold.

**The freed-port fix missed a second site in the same file.** The sweep matched a plain method call and the site uses a safe call, so it was hidden. Its exposure was wider than the one that was fixed: a thirty-second await rather than a four-hundred-millisecond poll. `StubServer`'s status is mutable now, so that test stops the server answering without releasing its port.

That last change needed a second fix to work at all, and the test is what caught it: making the property alone left the serving thread reading the constructor parameter, which shadows it and is captured immutable, so flipping the property did nothing and the test went red. Renaming the parameter is what makes the flip reach the thread.

The corrected sweep, matching safe calls too, now reports only the two `@AfterEach` teardowns, which are correct.

919 tests pass, lint is green.
