### PR TITLE
fix(setup): clean up a retired extension once, not on every update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,6 +212,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Extensions and commands**
 
+- An extension retired from the bundle is cleaned up once instead of on every app update, so reinstalling it from the marketplace no longer loses it at the next upgrade.
 - **Open in Browser, Generate SSH Key, Copy SSH Public Key and About now exist.** All four were registered through a loader API the editor does not ship, so every attempt failed silently.
 - **Open in Browser** told you it had worked when it had not. The bridge method returned nothing, so the relay answered success unconditionally.
 - A link opened from inside the editor no longer disappears when the bridge declines it; the click falls through to the WebView's own handling.

--- a/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
@@ -1678,10 +1678,21 @@ claude() {
         // ever would. Ordered before the manifest work below on purpose --
         // reconcileExtensionsManifest drops any entry whose directory is gone,
         // so removing the directory here is also what unlists it.
-        for (name in retiredFetchedExtensionDirs(present)) {
-            if (File(extensionsDir, name).deleteRecursively()) {
-                Logger.i(tag, "Removed a bundled extension this build no longer ships: $name")
+        // Once per id, not once per update. See [retiredIdsToSweep]: this
+        // cannot distinguish a leftover from a deliberate reinstall, so running
+        // it every time takes the extension away from a user who chose it.
+        val sweptAlready = prefs.getStringSet(KEY_RETIRED_SWEPT, emptySet()) ?: emptySet()
+        val owed = retiredIdsToSweep(sweptAlready)
+        if (owed.isNotEmpty()) {
+            for (name in retiredFetchedExtensionDirs(present, owed)) {
+                if (File(extensionsDir, name).deleteRecursively()) {
+                    Logger.i(tag, "Removed a bundled extension this build no longer ships: $name")
+                }
             }
+            // Recorded whether or not anything was found: the debt is discharged
+            // by looking, and a device that never had the directory must not go
+            // on looking for it at every update either.
+            prefs.edit().putStringSet(KEY_RETIRED_SWEPT, HashSet(sweptAlready + owed)).apply()
         }
 
         // The server manages this file for marketplace installs, so it is never
@@ -2164,6 +2175,14 @@ claude() {
          */
         private const val KEY_BUNDLED_IDS = "bundled_extension_ids"
 
+        /**
+         * Retired extension ids whose one-time cleanup has already run.
+         *
+         * A string set rather than a boolean, so retiring a second extension
+         * later sweeps only that one and leaves the rest alone.
+         */
+        private const val KEY_RETIRED_SWEPT = "retired_extension_ids_swept"
+
         // Process-wide: each Splash instance builds its own FirstRunSetup, so an
         // instance field would serialize nothing.
         private val setupMutex = Mutex()
@@ -2414,6 +2433,25 @@ internal fun retiredFetchedExtensionDirs(
 ): List<String> = present.filter { name ->
     retiredIds.any { id -> name == id || name.startsWith("$id-") }
 }
+
+/**
+ * Which retired ids still have a sweep owed to them.
+ *
+ * The sweep exists to clear what an earlier bundle left behind, which is a
+ * one-time debt against a device. It was running on every app update instead,
+ * and it cannot tell a leftover from a deliberate reinstall: both are a
+ * directory named `eamodio.gitlens-<version>`. So a user who liked the
+ * extension, saw it vanish, and installed it again from the marketplace lost it
+ * again on the next update, and every update after that.
+ *
+ * Recording the ids already swept turns it back into what it was meant to be.
+ * A device that has swept before will sweep once more, because nothing recorded
+ * the earlier runs and nothing can reconstruct them; after that it stops.
+ */
+internal fun retiredIdsToSweep(
+    alreadySwept: Set<String>,
+    retiredIds: List<String> = RETIRED_FETCHED_IDS,
+): List<String> = retiredIds.filterNot { it in alreadySwept }
 
 /**
  * The publisher this project ships extensions under.

--- a/android/app/src/test/kotlin/com/vscodroid/setup/BundledExtractionSplitTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/BundledExtractionSplitTest.kt
@@ -256,4 +256,47 @@ class BundledExtractionSplitTest {
         assertEquals(listOf(fetchedPython), bundledDirsToExtract(present = present, bundled = bundled))
         assertEquals(listOf(fetchedIcons), bundledDirsToExtract(present = bundled, bundled = present))
     }
+
+    @Test
+    fun `a retired id is owed a sweep until one has run`() {
+        assertEquals(listOf("eamodio.gitlens"), retiredIdsToSweep(emptySet()))
+        assertTrue(retiredIdsToSweep(setOf("eamodio.gitlens")).isEmpty())
+    }
+
+    @Test
+    fun `retiring a second extension later sweeps only that one`() {
+        // Kills a boolean in place of the set. With one flag, adding an id to
+        // RETIRED_FETCHED_IDS would either sweep nothing on a device that had
+        // already run, or sweep both again on one that had not.
+        assertEquals(
+            listOf("some.newlyretired"),
+            retiredIdsToSweep(
+                alreadySwept = setOf("eamodio.gitlens"),
+                retiredIds = listOf("eamodio.gitlens", "some.newlyretired"),
+            ),
+        )
+    }
+
+    @Test
+    fun `a reinstalled extension survives once the sweep has run`() {
+        // The defect this pair exists for, stated end to end. The sweep cannot
+        // tell a leftover from a deliberate reinstall -- both are the same
+        // directory name -- so the only thing that can protect the second is
+        // not looking a second time.
+        val reinstalled = "eamodio.gitlens-2026.8.1"
+        val present = listOf(reinstalled, "vscodroid.vscodroid-welcome-1.2.1")
+
+        val firstRun = retiredIdsToSweep(emptySet())
+        assertEquals(
+            listOf(reinstalled),
+            retiredFetchedExtensionDirs(present, firstRun),
+            "the leftover must be removed the first time",
+        )
+
+        val laterRun = retiredIdsToSweep(setOf("eamodio.gitlens"))
+        assertTrue(
+            retiredFetchedExtensionDirs(present, laterRun).isEmpty(),
+            "a later update must not take the user's reinstall away",
+        )
+    }
 }

--- a/android/app/src/test/kotlin/com/vscodroid/setup/ExtensionsManifestWriteTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/ExtensionsManifestWriteTest.kt
@@ -53,6 +53,17 @@ import java.lang.reflect.InvocationTargetException
  */
 class ExtensionsManifestWriteTest {
 
+    /**
+     * The key these rules are about, named rather than matched with any().
+     *
+     * any() was an accurate stand-in while this was the only string set the
+     * setup wrote. It stopped being one when a second key arrived, and it failed
+     * in both directions at once: the two negative tests went red for a write
+     * they do not care about, and the control went green on that write alone,
+     * so it would have passed with the bundled ids not recorded at all.
+     */
+    private val BUNDLED_IDS_KEY = "bundled_extension_ids"
+
     @TempDir
     lateinit var filesDir: File
 
@@ -192,7 +203,7 @@ class ExtensionsManifestWriteTest {
         assertThrows(InvocationTargetException::class.java) { extractBundledExtensions() }
 
         verify(exactly = 0) {
-            editor.putStringSet(any(), any())
+            editor.putStringSet(BUNDLED_IDS_KEY, any())
         }
     }
 
@@ -206,7 +217,7 @@ class ExtensionsManifestWriteTest {
         extractBundledExtensions()
 
         assertTrue(manifestFile.isFile, "the manifest was not written; the harness is wrong")
-        verify { editor.putStringSet(any(), any()) }
+        verify { editor.putStringSet(BUNDLED_IDS_KEY, any()) }
     }
 
     /**
@@ -238,7 +249,7 @@ class ExtensionsManifestWriteTest {
 
         assertThrows(InvocationTargetException::class.java) { extractBundledExtensions() }
 
-        verify(exactly = 0) { editor.putStringSet(any(), any()) }
+        verify(exactly = 0) { editor.putStringSet(BUNDLED_IDS_KEY, any()) }
     }
 
     /** The control: the same upgrade, unobstructed, does record. */
@@ -248,7 +259,7 @@ class ExtensionsManifestWriteTest {
 
         extractBundledExtensions()
 
-        verify { editor.putStringSet(any(), any()) }
+        verify { editor.putStringSet(BUNDLED_IDS_KEY, any()) }
     }
 
     /**


### PR DESCRIPTION
An extension this project stopped bundling leaves its directory behind, and a sweep removes it. That sweep runs inside `extractBundledExtensions`, which runs whenever `versionName` changes, so it ran on **every app update**.

It cannot tell a leftover from a deliberate reinstall. Both are a directory named `eamodio.gitlens-<version>`. So a user who liked the extension, saw it disappear when the bundle dropped it, and installed it again from the marketplace lost it again on the next update, and on every update after that, with nothing on screen saying why.

The ids already swept are now recorded, so the cleanup happens once per id and then stops. A string set rather than a flag, so retiring a second extension later sweeps that one and leaves the rest alone. A device that has swept before will sweep once more, because nothing recorded the earlier runs and nothing can reconstruct them; after that it stops. The record is written whether or not a directory was found, because the debt is discharged by looking.

Three tests cover it, and removing the guard turns all three red.

## One existing pair of tests had to be narrowed

`ExtensionsManifestWriteTest` asserted on `putStringSet(any(), any())` as a stand-in for the bundled-ids key. That was accurate while it was the only string set the setup wrote, and a second key broke it **in both directions at once**:

- the two negative tests went red for a write they do not care about
- the control went **green on that write alone**, so it would have passed with the bundled ids not recorded at all

All four assertions now name the key. Neutering `rememberBundledIds` turns both controls red again, which it did not do before this change.

922 tests pass, lint is green.
