### PR TITLE
feat(toolchain): say why an install failed, not just that it did

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Toolchains**
 
+- A toolchain install that fails now says why: out of space, no connection, not in this release, or a download that did not match. It said only "Failed".
 - A sideloaded toolchain install resolves `latest` once and takes both the digest and the payload from that release, so a release published mid-download no longer refuses the install.
 - Installed toolchains can be run. Android refuses to execute any file in an app's data directory, so terminal commands are handed to the system loader. **The redirect is shell functions, so its reach is the shell's reach**: `make`, `bash -c`, scripts and extension-spawned processes still hit the binary directly and are refused. **Go cannot compile** even in the terminal, because `go build` starts its own compiler directly.
 - You can add and remove languages after first run. Touch and hold the app icon and choose **Manage toolchains**. The picker is shown once and previously had no other way in.

--- a/android/app/src/main/kotlin/com/vscodroid/SplashActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/SplashActivity.kt
@@ -30,6 +30,7 @@ import com.vscodroid.util.padForSystemBars
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import android.widget.Toast
 
 @SuppressLint("CustomSplashScreen")
 class SplashActivity : AppCompatActivity() {
@@ -319,8 +320,16 @@ class SplashActivity : AppCompatActivity() {
         // Set up toolchain manager
         val manager = ToolchainManager(this)
         toolchainManager = manager
-        manager.onStateChange = { packName, status, percent ->
-            runOnUiThread { handleDownloadState(packName, status, percent) }
+        manager.onStateChange = { packName, status, percent, why ->
+            runOnUiThread {
+                handleDownloadState(packName, status, percent)
+                // The row has space for one word and the reason is a sentence, so
+                // it is said here rather than squeezed in there. Without it the
+                // queue moves on and the only record of WHY is in logcat.
+                if (why != null) {
+                    Toast.makeText(this, getString(why.message), Toast.LENGTH_LONG).show()
+                }
+            }
         }
         manager.registerListener()
 

--- a/android/app/src/main/kotlin/com/vscodroid/ToolchainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/ToolchainActivity.kt
@@ -15,6 +15,7 @@ import com.vscodroid.util.padForSystemBars
 import com.vscodroid.setup.ToolchainPickerAdapter
 import com.vscodroid.setup.ToolchainRegistry
 import com.vscodroid.util.Logger
+import android.widget.Toast
 
 /**
  * Settings screen for managing on-demand toolchains.
@@ -76,9 +77,15 @@ class ToolchainActivity : AppCompatActivity() {
         grid.adapter = adapter
 
         // Listen for download state changes
-        toolchainManager.onStateChange = { packName, status, percent ->
+        toolchainManager.onStateChange = { packName, status, percent, why ->
             runOnUiThread {
                 adapter.updateState(packName, status, percent)
+                // Same reasoning as the first-run screen: the card carries a
+                // status, not an explanation, and the explanation is the part
+                // that tells the user whether to free space or move to wifi.
+                if (why != null) {
+                    Toast.makeText(this, getString(why.message), Toast.LENGTH_LONG).show()
+                }
                 if (status == AssetPackStatus.REQUIRES_USER_CONFIRMATION) {
                     try {
                         toolchainManager.showConfirmationDialog(this)

--- a/android/app/src/main/kotlin/com/vscodroid/bridge/AndroidBridge.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/bridge/AndroidBridge.kt
@@ -434,7 +434,7 @@ class AndroidBridge(
      */
     private val toolchainManager: ToolchainManager by lazy {
         ToolchainManager(context).apply {
-            onStateChange = { packName, status, _ -> onToolchainState(packName, status) }
+            onStateChange = { packName, status, _, _ -> onToolchainState(packName, status) }
         }
     }
 

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
@@ -3,6 +3,8 @@ package com.vscodroid.setup
 import android.app.Activity
 import android.content.Context
 import android.os.StatFs
+import androidx.annotation.StringRes
+import com.vscodroid.R
 import android.system.Os
 import com.google.android.play.core.assetpacks.AssetPackManagerFactory
 import com.google.android.play.core.assetpacks.AssetPackState
@@ -52,7 +54,36 @@ class ToolchainManager(private val context: Context) {
     }
 
     /** Callback for progress/state updates: (packName, status, percentDone) */
-    var onStateChange: ((String, Int, Int) -> Unit)? = null
+    /**
+     * Progress and outcome for one pack.
+     *
+     * The fourth argument is why it failed, and it is null for every status that
+     * is not a failure. It exists because "Failed" on its own is the same word
+     * for a full disk, a dropped connection and a release that never published
+     * the file, and the user is the one person who can act on the difference:
+     * free space, move to wifi, or wait for a release. The reason was in logcat
+     * and nowhere else.
+     *
+     * Reached through [fail] and [report] rather than invoked directly, so a new
+     * failure site cannot forget to say why: [fail] has no overload without one.
+     */
+    var onStateChange: ((String, Int, Int, ToolchainFailure?) -> Unit)? = null
+
+    /** Progress or success. Never a failure: those go through [fail]. */
+    private fun report(packName: String, status: Int, percent: Int) {
+        onStateChange?.invoke(packName, status, percent, null)
+    }
+
+    /**
+     * A failure, and why.
+     *
+     * There is no overload without a reason, which is the point: every one of
+     * the twelve failure sites had to name one, and a thirteenth cannot be added
+     * without doing the same.
+     */
+    private fun fail(packName: String, why: ToolchainFailure) {
+        onStateChange?.invoke(packName, AssetPackStatus.FAILED, 0, why)
+    }
 
     // -- HTTP fallback state --
 
@@ -259,7 +290,7 @@ class ToolchainManager(private val context: Context) {
         val info = ToolchainRegistry.find(packName)
         if (info == null) {
             Logger.e(tag, "Unknown toolchain: $packName")
-            onStateChange?.invoke(packName, AssetPackStatus.FAILED, 0)
+            fail(packName, ToolchainFailure.INTERNAL)
             return
         }
         Logger.i(tag, "Requesting install of ${info.displayName} (${info.packName})")
@@ -268,7 +299,7 @@ class ToolchainManager(private val context: Context) {
             val url = info.downloadUrl
             if (url == null) {
                 Logger.e(tag, "No downloadUrl for ${info.packName} — Play Store required")
-                onStateChange?.invoke(info.packName, AssetPackStatus.FAILED, 0)
+                fail(info.packName, ToolchainFailure.PLAY_REQUIRED)
                 return
             }
             downloadViaHttp(info.packName, url, info.estimatedSize)
@@ -444,7 +475,7 @@ class ToolchainManager(private val context: Context) {
         regenerateEnvFileLocked()
 
         Logger.i(tag, "Uninstalled toolchain: $name")
-        onStateChange?.invoke("toolchain_$name", AssetPackStatus.NOT_INSTALLED, 0)
+        report("toolchain_$name", AssetPackStatus.NOT_INSTALLED, 0)
     }
 
     // -- Asset pack state handling --
@@ -462,7 +493,7 @@ class ToolchainManager(private val context: Context) {
         // after copyFromAssetPack() finishes extraction (line in copyFromAssetPack).
         // Firing it twice would cause downloadNext() to be called twice, skipping packs.
         if (status != AssetPackStatus.COMPLETED) {
-            onStateChange?.invoke(packName, status, percent)
+            report(packName, status, percent)
         }
 
         when (status) {
@@ -478,11 +509,11 @@ class ToolchainManager(private val context: Context) {
                             Logger.i(tag, "Removed asset pack $packName (freed duplicate storage)")
                         } else {
                             Logger.e(tag, "No assetsPath for completed pack $packName")
-                            onStateChange?.invoke(packName, AssetPackStatus.FAILED, 0)
+                            fail(packName, ToolchainFailure.INTERNAL)
                         }
                     } catch (e: Exception) {
                         Logger.e(tag, "Failed to process completed pack $packName", e)
-                        onStateChange?.invoke(packName, AssetPackStatus.FAILED, 0)
+                        fail(packName, ToolchainFailure.INTERNAL)
                     }
                 }
             }
@@ -512,7 +543,7 @@ class ToolchainManager(private val context: Context) {
         val manifestFile = File(assetsDir, "$packName.json")
         if (!manifestFile.exists()) {
             Logger.e(tag, "No $packName.json in asset pack $packName")
-            onStateChange?.invoke(packName, AssetPackStatus.FAILED, 0)
+            fail(packName, ToolchainFailure.CORRUPT)
             return
         }
 
@@ -520,7 +551,7 @@ class ToolchainManager(private val context: Context) {
         val name = manifest.optString("name", "")
         if (name.isEmpty()) {
             Logger.e(tag, "Invalid manifest.json in $packName: missing 'name'")
-            onStateChange?.invoke(packName, AssetPackStatus.FAILED, 0)
+            fail(packName, ToolchainFailure.CORRUPT)
             return
         }
         Logger.i(tag, "Installing toolchain: $name (from $packName)")
@@ -622,14 +653,14 @@ class ToolchainManager(private val context: Context) {
             // first-run queue moves on, and the card reads "Install" again after
             // the next launch with nothing said.
             if (!writeState(state)) {
-                onStateChange?.invoke(packName, AssetPackStatus.FAILED, 0)
+                fail(packName, ToolchainFailure.STORAGE)
                 return
             }
             regenerateEnvFileLocked()
         }
 
         Logger.i(tag, "Toolchain $name installed successfully")
-        onStateChange?.invoke(packName, AssetPackStatus.COMPLETED, 100)
+        report(packName, AssetPackStatus.COMPLETED, 100)
     }
 
     // -- HTTP fallback (sideloaded installs) --
@@ -662,7 +693,7 @@ class ToolchainManager(private val context: Context) {
         // would discard it just as reliably as the shared flag did.
         val download = HttpDownload()
         httpDownloads[packName] = download
-        onStateChange?.invoke(packName, AssetPackStatus.PENDING, 0)
+        report(packName, AssetPackStatus.PENDING, 0)
 
         ioExecutor.execute {
             val tempDir = File(context.cacheDir, "toolchain-download")
@@ -677,7 +708,7 @@ class ToolchainManager(private val context: Context) {
                 if (availableBytes < requiredBytes) {
                     Logger.e(tag, "Not enough disk space: ${availableBytes / 1_000_000} MB available, " +
                             "${requiredBytes / 1_000_000} MB required")
-                    onStateChange?.invoke(packName, AssetPackStatus.FAILED, 0)
+                    fail(packName, ToolchainFailure.STORAGE)
                     return@execute
                 }
 
@@ -725,13 +756,13 @@ class ToolchainManager(private val context: Context) {
                         "Digest mismatch for $packName: the release publishes $expectedDigest, " +
                             "the download hashes to $actualDigest. Not installing it.",
                     )
-                    onStateChange?.invoke(packName, AssetPackStatus.FAILED, 0)
+                    fail(packName, ToolchainFailure.DIGEST)
                     return@execute
                 }
                 Logger.i(tag, "$packName matches the digest the release publishes")
 
                 // Extract — report as TRANSFERRING (file copy phase)
-                onStateChange?.invoke(packName, AssetPackStatus.TRANSFERRING, 90)
+                report(packName, AssetPackStatus.TRANSFERRING, 90)
                 extractDir.deleteRecursively()
                 extractDir.mkdirs()
                 extractZip(zipFile, extractDir)
@@ -739,19 +770,25 @@ class ToolchainManager(private val context: Context) {
                 // Install from extracted directory (same path as Play Asset Delivery)
                 installFromDirectory(packName, extractDir)
 
+            } catch (e: MissingFromRelease) {
+                // Ahead of the IOException it extends, because they are not the
+                // same event to a user: this one will not succeed on a better
+                // connection, and only a release changes it.
+                Logger.e(tag, "Not published in the release: $packName", e)
+                fail(packName, ToolchainFailure.NOT_PUBLISHED)
             } catch (e: IOException) {
                 if (download.cancelled) {
                     Logger.i(tag, "HTTP download cancelled for $packName")
                 } else {
                     Logger.e(tag, "HTTP download failed for $packName", e)
-                    onStateChange?.invoke(packName, AssetPackStatus.FAILED, 0)
+                    fail(packName, ToolchainFailure.NETWORK)
                 }
             } catch (e: SecurityException) {
                 Logger.e(tag, "Zip security violation for $packName", e)
-                onStateChange?.invoke(packName, AssetPackStatus.FAILED, 0)
+                fail(packName, ToolchainFailure.CORRUPT)
             } catch (e: Exception) {
                 Logger.e(tag, "Unexpected error downloading $packName", e)
-                onStateChange?.invoke(packName, AssetPackStatus.FAILED, 0)
+                fail(packName, ToolchainFailure.INTERNAL)
             } finally {
                 // Two-argument remove: a later request for the same pack has
                 // already replaced this entry, and dropping its token would
@@ -1035,7 +1072,7 @@ class ToolchainManager(private val context: Context) {
         val declaredBytes = conn.contentLengthLong
         val totalBytes = if (declaredBytes > 0) declaredBytes else estimatedSize
 
-        onStateChange?.invoke(packName, AssetPackStatus.DOWNLOADING, 0)
+        report(packName, AssetPackStatus.DOWNLOADING, 0)
 
         var bytesRead = 0L
         BufferedInputStream(conn.inputStream).use { input ->
@@ -1052,7 +1089,7 @@ class ToolchainManager(private val context: Context) {
                     val percent = if (totalBytes > 0) {
                         ((bytesRead * 85) / totalBytes).toInt().coerceAtMost(85)
                     } else 0
-                    onStateChange?.invoke(packName, AssetPackStatus.DOWNLOADING, percent)
+                    report(packName, AssetPackStatus.DOWNLOADING, percent)
                 }
             }
         }
@@ -1618,6 +1655,31 @@ internal fun isElfHeader(header: ByteArray): Boolean =
  */
 internal fun isCompleteTransfer(declaredBytes: Long, receivedBytes: Long): Boolean =
     declaredBytes <= 0L || receivedBytes == declaredBytes
+
+/**
+ * Why an install failed, in the terms the person looking at the screen can act in.
+ *
+ * The screen said "Failed" and nothing else, for every cause, while the reason
+ * sat in logcat where no user reads it. These are grouped by WHAT TO DO rather
+ * than by where the exception came from: a full disk and a failed state write
+ * are both [STORAGE] because both are answered by freeing space, and a truncated
+ * archive and a manifest missing its name are both [CORRUPT] because both are
+ * answered by retrying.
+ *
+ * [NOT_PUBLISHED] is deliberately not [NETWORK], although it arrives as an
+ * IOException on the same path: retrying on better signal cannot fix a file the
+ * release does not contain, and telling someone to check their connection when
+ * that is the problem sends them to look in the wrong place.
+ */
+enum class ToolchainFailure(@StringRes val message: Int) {
+    NETWORK(R.string.toolchain_failed_network),
+    STORAGE(R.string.toolchain_failed_storage),
+    NOT_PUBLISHED(R.string.toolchain_failed_not_published),
+    DIGEST(R.string.toolchain_failed_digest),
+    CORRUPT(R.string.toolchain_failed_corrupt),
+    PLAY_REQUIRED(R.string.toolchain_failed_play),
+    INTERNAL(R.string.toolchain_failed_internal),
+}
 
 /** The digest manifest's filename, as `release.yml` writes it beside the ZIPs. */
 private const val MANIFEST_NAME = "toolchains.sha256"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -62,6 +62,18 @@
     <string name="progress_installing">Installing\u2026</string>
     <string name="progress_done">Done</string>
     <string name="progress_failed">Failed</string>
+
+    <!-- Why an install failed. "Failed" alone was the same word for a full disk,
+         a dropped connection and a file the release never published, and the user
+         is the one person who can act on the difference. Each of these names the
+         thing they can do about it; ToolchainFailure decides which one is shown. -->
+    <string name="toolchain_failed_network">Download failed. Check your connection and try again.</string>
+    <string name="toolchain_failed_storage">Not enough storage. Free some space and try again.</string>
+    <string name="toolchain_failed_not_published">This toolchain is not in the current release. Try again after the next app update.</string>
+    <string name="toolchain_failed_digest">The download did not match what the release published. Try again.</string>
+    <string name="toolchain_failed_corrupt">The download was incomplete. Try again.</string>
+    <string name="toolchain_failed_play">This toolchain installs only on Play Store builds.</string>
+    <string name="toolchain_failed_internal">Install failed. The app log has the details.</string>
     <string name="progress_cancel">Cancel</string>
     <string name="progress_retry">Retry</string>
 

--- a/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainDigestInstallTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainDigestInstallTest.kt
@@ -184,6 +184,10 @@ class ToolchainDigestInstallTest {
         Collections.synchronizedList(mutableListOf())
     private val settled = CountDownLatch(1)
 
+    /** Every failure reason reported, so a test can assert on WHY and not only that. */
+    private val reasons: MutableList<ToolchainFailure> =
+        Collections.synchronizedList(mutableListOf())
+
     /** Both derived from one directory, so a test can move the release. */
     private var releaseDir = "/download"
     private val zipPath get() = "$releaseDir/toolchain_test.zip"
@@ -308,7 +312,8 @@ class ToolchainDigestInstallTest {
             .get(m) as Map<String, Any>
 
     private fun manager() = ToolchainManager(context).apply {
-        onStateChange = { pack, status, pct ->
+        onStateChange = { pack, status, pct, why ->
+            if (why != null) reasons.add(why)
             events.add(Triple(pack, status, pct))
             if (status == AssetPackStatus.COMPLETED || status == AssetPackStatus.FAILED) {
                 settled.countDown()
@@ -602,5 +607,38 @@ class ToolchainDigestInstallTest {
         )
         assertEquals(1, timesRequested(manifestPath), "the manifest was not fetched from the unpinned URL")
         assertEquals(1, timesRequested(zipPath), "the payload was not fetched from the unpinned URL")
+    }
+
+    @Test
+    fun `a release that does not publish the manifest says so, and does not blame the network`() {
+        // The manifest 404s, which arrives as MissingFromRelease. It extends
+        // IOException and used to be caught with it, so the user was told to
+        // check their connection for a file the release does not contain.
+        publishManifest(null)
+
+        installAndWait()
+
+        assertTrue(statuses().contains(AssetPackStatus.FAILED), "the install should have been refused")
+        assertEquals(
+            listOf(ToolchainFailure.NOT_PUBLISHED),
+            synchronized(reasons) { reasons.toList() },
+            "a file the release never published is not a network fault",
+        )
+    }
+
+    @Test
+    fun `a payload that does not match the published digest says that`() {
+        // A manifest that names the ZIP with someone else's digest. The bytes
+        // arrive complete and wrong, which is the one case Content-Length cannot
+        // see, and the reason has to distinguish it from a dropped connection.
+        publishManifest("${"0".repeat(64)}  toolchain_test.zip\n")
+
+        installAndWait()
+
+        assertEquals(
+            listOf(ToolchainFailure.DIGEST),
+            synchronized(reasons) { reasons.toList() },
+            "a complete body with the wrong digest is its own answer",
+        )
     }
 }

--- a/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainInstallTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainInstallTest.kt
@@ -97,7 +97,7 @@ class ToolchainInstallTest {
     fun tearDown() = unmockkAll()
 
     private fun manager() = ToolchainManager(context).apply {
-        onStateChange = { pack, status, pct ->
+        onStateChange = { pack, status, pct, _ ->
             events.add(Triple(pack, status, pct))
             if (status == AssetPackStatus.FAILED) failed.countDown()
         }


### PR DESCRIPTION
Both the first-run screen and Manage toolchains showed a red **Failed** and nothing else, for every cause. The real reason went to logcat, which is the one place the person looking at the screen cannot read.

A full disk, a dropped connection, a release that does not carry the file, and a payload that did not match its published digest were all the same word. Those are exactly the cases where the user is the only one who can act: free space, move to wifi, wait for a release, retry.

`ToolchainFailure` carries the reason to the callback. The causes are grouped by **what to do** rather than by which exception arrived: a failed state write and a failed disk pre-flight are both `STORAGE`; a truncated archive and a manifest missing its `name` are both `CORRUPT`.

`NOT_PUBLISHED` is deliberately separate from `NETWORK`, although it arrives as an `IOException` on the same path and used to be caught with it. Retrying on better signal cannot fix a file the release does not contain, and telling someone to check their connection sends them to look in the wrong place. The catch is split so the narrower type is seen first.

## Shape of the change

The callback grew a fourth argument rather than gaining a second callback beside it, which would have been two things to keep in sync. Every invocation now goes through one of two helpers:

- `report(pack, status, percent)` for progress and success
- `fail(pack, why)` for failures, with **no overload that omits the reason**

So the twelve failure sites each had to name one, and a thirteenth cannot be added without doing the same.

## Verification

Two tests assert the reason and not merely the failure, over the loopback server that already produces both cases for real: a release with no manifest, and a manifest naming the ZIP with someone else's digest. Collapsing `NOT_PUBLISHED` back into `NETWORK` turns one of them red.

924 tests pass, lint is green. Every enum case has a string and every string is used, checked in both directions.
