### PR TITLE
feat(service): a server that will not come back says so, and offers a retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - An unreadable `toolchains.json` no longer deletes `toolchain-env.sh` on every launch, which took working Go and Ruby commands out of every new terminal.
 
 **Server lifecycle**
+- A server that has stopped for good now says so on the page, with a Try again button, instead of leaving "Starting server..." on screen for the life of the app.
 
 - A session that adopted a surviving server now says on its notification that extensions, git and npm cannot reach the network, and that restarting fixes it. It failed silently.
 - Reopening the app while the server is still coming up no longer lands on a connection-refused page. Readiness now comes from the health check rather than from whether a process exists.

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -18,6 +18,7 @@ import android.os.IBinder
 import android.os.SystemClock
 import android.view.View
 import android.webkit.RenderProcessGoneDetail
+import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.Toast
@@ -627,14 +628,7 @@ class MainActivity : AppCompatActivity() {
             wv.webViewClient = bootstrapClient()
             // Show a loading placeholder while Node.js starts
             // viewport-fit=cover enables rendering into display cutout area
-            wv.loadData(
-                """<html><head><meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover"></head>
-                   <body style="background:#1e1e1e;color:#888;font-family:sans-serif;
-                   display:flex;align-items:center;justify-content:center;height:100vh;margin:0;">
-                   <div style="text-align:center"><h2 style="color:#ccc;">VSCodroid</h2>
-                   <p>Starting server...</p></div></body></html>""",
-                "text/html", "utf-8"
-            )
+            wv.loadData(LOADING_PAGE, "text/html", "utf-8")
         }
     }
 
@@ -659,6 +653,26 @@ class MainActivity : AppCompatActivity() {
      * intercept.
      */
     private fun bootstrapClient() = object : WebViewClient() {
+        /**
+         * The one URL this client acts on, and the reason the error page uses a
+         * link rather than a script.
+         *
+         * The page it serves is a `data:` URL with no bridge on it: `initBridge`
+         * runs once per WebView for the editor, and registering a second
+         * JavaScript interface here to carry one button would widen the surface
+         * that the session token exists to gate. A navigation the client
+         * recognises costs nothing and reaches the same place.
+         */
+        override fun shouldOverrideUrlLoading(
+            view: WebView,
+            request: WebResourceRequest,
+        ): Boolean {
+            if (request.url.toString() != RETRY_URL) return false
+            Logger.i(tag, "Retrying the server from the error page")
+            retryServerStart()
+            return true
+        }
+
         override fun onRenderProcessGone(view: WebView, detail: RenderProcessGoneDetail): Boolean {
             Logger.e(tag, "Render process gone before the workbench loaded: " +
                 "didCrash=${detail.didCrash()}")
@@ -782,6 +796,13 @@ class MainActivity : AppCompatActivity() {
                 Toast.makeText(this, message, Toast.LENGTH_LONG).show()
             }
         }
+        // A toast lasts three and a half seconds; this state lasts until the app
+        // is killed. What was on screen behind it read "Starting server...", and
+        // went on reading that for ever, so the one thing the screen said was the
+        // one thing that was no longer true.
+        nodeService?.onServerGaveUp = {
+            runOnUiThread { showServerGaveUp() }
+        }
         // Stopping the server from the notification leaves this activity showing
         // an editor whose backend is gone, and — because the binding it holds is
         // what keeps a started service alive — leaves the service unable to
@@ -848,6 +869,50 @@ class MainActivity : AppCompatActivity() {
             }
             BindDecision.Wait -> Unit
         }
+    }
+
+    /**
+     * Replaces the loading placeholder with what actually happened.
+     *
+     * Deliberately not a dialog. A dialog is dismissed and leaves the same lie
+     * underneath it; this is the page, so there is nothing to fall back to and
+     * nothing that can be missed by looking away.
+     *
+     * The retry is real rather than decorative: [NodeService.enterTerminalState]
+     * calls `stopServingRecoverably` before raising this, so `isServiceRunning`
+     * is false and the next `startForegroundService` reaches a body that starts
+     * again. The binding is untouched, so readiness arrives through the callbacks
+     * already installed.
+     */
+    private fun showServerGaveUp() {
+        val message = getString(R.string.error_server_gave_up)
+        val retry = getString(R.string.error_server_retry)
+        webView?.loadDataWithBaseURL(
+            null,
+            """<html><head><meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover"></head>
+               <body style="background:#1e1e1e;color:#ccc;font-family:sans-serif;
+               display:flex;align-items:center;justify-content:center;height:100vh;margin:0;">
+               <div style="text-align:center;max-width:32em;padding:1.5em">
+               <h2 style="color:#ccc;margin:0 0 .6em">VSCodroid</h2>
+               <p style="color:#aaa;line-height:1.5">${escapeHtml(message)}</p>
+               <p><a href="$RETRY_URL" style="display:inline-block;margin-top:.8em;padding:.6em 1.4em;
+               background:#0e639c;color:#fff;text-decoration:none;border-radius:4px">${escapeHtml(retry)}</a></p>
+               </div></body></html>""",
+            "text/html", "utf-8", null,
+        )
+    }
+
+    /**
+     * Starts the service again without rebinding.
+     *
+     * `bindService` is not repeated: this activity never unbound, so the
+     * connection and every callback on it are still live, and binding a second
+     * time with the same `ServiceConnection` would not deliver `onServiceConnected`
+     * again anyway. Only the start is missing, and only the start is sent.
+     */
+    private fun retryServerStart() {
+        webView?.loadData(LOADING_PAGE, "text/html", "utf-8")
+        startForegroundService(Intent(this, NodeService::class.java))
     }
 
     private fun loadVSCode(port: Int, folderPath: String? = null) {
@@ -1494,6 +1559,28 @@ class MainActivity : AppCompatActivity() {
 
 
     companion object {
+
+        /**
+         * The page shown while the server starts, in one place.
+         *
+         * Two callers load it now: the first setup, and a retry from the error
+         * page. Written twice they would drift, and the second copy is the one a
+         * user sees only after something has already gone wrong.
+         */
+        private const val LOADING_PAGE =
+            """<html><head><meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover"></head>
+               <body style="background:#1e1e1e;color:#888;font-family:sans-serif;
+               display:flex;align-items:center;justify-content:center;height:100vh;margin:0;">
+               <div style="text-align:center"><h2 style="color:#ccc;">VSCodroid</h2>
+               <p>Starting server...</p></div></body></html>"""
+
+        /**
+         * The navigation the error page's button makes.
+         *
+         * A scheme nothing else answers, so it cannot collide with a workbench
+         * URL, and the bootstrap client is the only place it is recognised.
+         */
+        private const val RETRY_URL = "vscodroid://retry-server"
         /** Run health check if backgrounded longer than this. */
         private const val HEALTH_CHECK_THRESHOLD_MS = 60_000L   // 1 minute
 
@@ -1760,3 +1847,18 @@ internal fun connectionHealthProbe(): String =
         return 'ok';
     })()
     """.trimIndent()
+
+/**
+ * The five characters that change the meaning of surrounding HTML.
+ *
+ * The strings this escapes come from this app's own resources, so nothing
+ * hostile reaches it today. It is here because the page is built by string
+ * interpolation, and the next person to interpolate something into it may be
+ * carrying a filename or an exception message.
+ */
+internal fun escapeHtml(s: String): String = s
+    .replace("&", "&amp;")
+    .replace("<", "&lt;")
+    .replace(">", "&gt;")
+    .replace("\"", "&quot;")
+    .replace("'", "&#39;")

--- a/android/app/src/main/kotlin/com/vscodroid/service/NodeService.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/service/NodeService.kt
@@ -117,6 +117,21 @@ class NodeService : Service() {
      */
     var onServerStopped: (() -> Unit)? = null
 
+    /**
+     * Invoked when the restart budget is spent and nothing further will be tried.
+     *
+     * Separate from [onServerError], which fires for a single failed attempt with
+     * retries still to come, and separate from [onServerStopped], which is the
+     * user asking. A client cannot tell those apart from the message alone, and
+     * they call for opposite responses: wait, close, or say the server is not
+     * coming and offer a way to try again.
+     *
+     * Reached only from [enterTerminalState], which has already called
+     * [stopServingRecoverably], so the service is alive and startable. That is
+     * what makes a retry an honest offer rather than a button that does nothing.
+     */
+    var onServerGaveUp: (() -> Unit)? = null
+
     // -- Binder --
 
     inner class LocalBinder : Binder() {
@@ -819,6 +834,7 @@ class NodeService : Service() {
         // that binds after it has to be told too. The notification says the same
         // thing, but the notification is not on screen while the editor is.
         reportStartupNotice(getString(R.string.notification_text_stopped))
+        onServerGaveUp?.invoke()
     }
 
     /**

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -43,6 +43,13 @@
          failed in the same place. See FirstRunSetup.requiredStorageMb(). -->
     <string name="error_storage_full">Not enough storage space. Free at least %1$d MB and try again.</string>
     <string name="error_setup_failed">Setup failed. Tap Retry or reinstall the app.</string>
+
+    <!-- Shown on the page itself, not in a toast, when the restart budget is
+         spent. The screen behind it read "Starting server..." and went on
+         reading that for ever, so the only thing it said was the only thing
+         that was no longer true. -->
+    <string name="error_server_gave_up">The development server stopped and could not be restarted. Your files are safe. Trying again usually works; if it does not, close and reopen the app.</string>
+    <string name="error_server_retry">Try again</string>
     <string name="legal_disclaimer">VSCodroid is built from the MIT-licensed Code - OSS source code.\nNot affiliated with or endorsed by Microsoft Corporation.\n\"Visual Studio Code\" and \"VS Code\" are trademarks of Microsoft.\nUses Open VSX extension registry, not Microsoft Marketplace.</string>
 
     <!-- About dialog -->

--- a/android/app/src/test/kotlin/com/vscodroid/ServerGaveUpPageTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/ServerGaveUpPageTest.kt
@@ -1,0 +1,63 @@
+package com.vscodroid
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * The page shown when the server will not come back, and the escaping it rests on.
+ *
+ * The page itself needs a device: it replaces a WebView's content and its button
+ * is a navigation the bootstrap client answers, neither of which a JVM can build.
+ * What can be checked here is the part that would fail silently rather than
+ * visibly, which is the interpolation. The page is assembled with string
+ * templates, so a message carrying a quote or an angle bracket would not throw,
+ * it would change the markup around it, and the retry button is inside that
+ * markup.
+ *
+ * Nothing hostile reaches it today: both strings come from this app's resources.
+ * It is covered because the next person to interpolate something here may be
+ * carrying a filename, a path, or an exception message.
+ */
+class ServerGaveUpPageTest {
+
+    @Test
+    fun `the five characters that change surrounding markup are escaped`() {
+        assertEquals("&amp;", escapeHtml("&"))
+        assertEquals("&lt;", escapeHtml("<"))
+        assertEquals("&gt;", escapeHtml(">"))
+        assertEquals("&quot;", escapeHtml("\""))
+        assertEquals("&#39;", escapeHtml("'"))
+    }
+
+    @Test
+    fun `the ampersand is escaped first, so an escape is not escaped twice`() {
+        // Kills the ordering bug this is most likely to acquire: replacing "<"
+        // before "&" turns a plain "<" into "&amp;lt;", which renders as the
+        // text "&lt;" instead of a bracket. Ordering is invisible in the output
+        // of every single-character case above.
+        assertEquals("&amp;lt;", escapeHtml("&lt;"))
+        assertEquals("&lt;a&gt;", escapeHtml("<a>"))
+    }
+
+    @Test
+    fun `text with nothing to escape is returned unchanged`() {
+        val plain = "The development server stopped and could not be restarted."
+        assertEquals(plain, escapeHtml(plain))
+    }
+
+    @Test
+    fun `a message cannot close the anchor the retry button lives in`() {
+        // The concrete harm, stated as the assertion. The button is an <a> tag
+        // in the same document as the message, so a message able to emit a tag
+        // could take the only way out off the page.
+        val hostile = """</p><a href="#">not the retry button</a><p>"""
+
+        val escaped = escapeHtml(hostile)
+
+        assertFalse(escaped.contains("<a"), "an anchor survived escaping: $escaped")
+        assertFalse(escaped.contains("</p>"), "a closing tag survived escaping: $escaped")
+        assertTrue(escaped.contains("&lt;a"), "the text should still be readable as text")
+    }
+}

--- a/docs/DEVICE_TEST_CHECKLIST.md
+++ b/docs/DEVICE_TEST_CHECKLIST.md
@@ -95,6 +95,7 @@
 | BG-5 | Foreground notification | Check notification shade while app runs | "VSCodroid running" notification visible | | |
 | BG-6 | Return after screen off | Lock screen, wait 2min, unlock | App resumes without crash | | |
 | BG-7 | Adopted session says its network is gone | `adb shell ps -A \| grep libnode` shows two processes; **`kill -9` the parent** (the lower PID, the one the other lists as its PPID), then relaunch the app. It must be SIGKILL: the bootstrap handles SIGTERM and kills its child on the way out, so a plain `kill` leaves nothing to adopt. `ps` shows `libnode` rather than `server.js` because that is argv[0] | Editor loads against the surviving server, and the foreground notification reads "No network for extensions, git or npm". Confirm the claim: the marketplace and `npm view express` both fail in that session, and both work again after a full restart | | |
+| BG-8 | A server that will not come back says so | With the editor open, `adb shell kill -9` the `libnode` process repeatedly until the notification reads "Server crashed repeatedly" | The page stops reading "Starting server..." and states that the server could not be restarted, that files are safe, and offers **Try again**. Tapping it returns to the loading page and starts a new attempt; nothing requires force-stopping the app | | |
 
 BG-7 is the one case where the editor being healthy is the problem. An adopted
 server outlived the bootstrap that forked it, and the DNS proxy died with that


### PR DESCRIPTION
When the restart budget ran out, the editor kept the loading placeholder. The one sentence on screen read **Starting server...** and went on reading it for the life of the app, which was the one statement that had stopped being true.

The only account of what happened was a toast, three and a half seconds against a state that does not end, plus a notification the user is not looking at while the editor is in front of them.

The page now states it, with a **Try again** button. Deliberately not a dialog: a dialog is dismissed and leaves the same lie underneath it.

## The activity could not tell this state apart

`reportFailure` and `enterTerminalState` both raise `onServerError`, and the only difference was the wording of the message. `onServerGaveUp` is a separate signal raised where the decision is actually made, so the three cases a client has to answer differently, **wait**, **close**, and **this one**, are three signals rather than one string to inspect.

## The retry is real, not decorative

`enterTerminalState` already calls `stopServingRecoverably`, so `isServiceRunning` is false and the next `startForegroundService` reaches a body that starts again. `bindService` is not repeated: this activity never unbound, the callbacks are still installed, and binding again with the same `ServiceConnection` would not redeliver `onServiceConnected` anyway.

The button is a link the bootstrap client recognises rather than a script. Registering a second JavaScript interface to carry one button would widen the surface the session token exists to gate, and a navigation reaches the same place for nothing.

The loading page moves into one constant, because two callers load it now and the second is the one a user only ever sees after something has already gone wrong.

## Verification

Four tests cover the escaping the page is assembled with, including that a message cannot emit an anchor and take the only way out off the page, and that `&` is escaped before `<` so an escape is not escaped twice. The page itself needs a device, so it also gets checklist row **BG-8**.

928 tests pass, lint is green, `device-test.sh --self-check` passes.
