### PR TITLE
fix(auth): match a sign-in callback to the launch that asked for it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The session token is compared in constant time. Nothing was reachable through the old comparison; the point is that the property belongs in the comparison rather than in the token length.
 - Every one of the twenty-eight editor-to-Android calls now requires the session token. Six took none, and a test enumerates them so a new one cannot skip it.
 - Signing in to an extension only completes if this app started the sign-in, and only in the minutes after it sent you to a browser. An unsolicited callback could previously be answered on your behalf.
+- Callbacks are matched to the sign-in request they name, not to any recent browser launch, so opening a link no longer widens the window an unsolicited one is accepted in.
 - Content rendered inside the editor can only read files from directories the app publishes to it, rather than anywhere in app storage. Opening the home directory as a workspace now costs preview images rather than exposing the SSH key.
 - The loopback DNS proxy requires a per-boot token. Any installed app could previously use it as an open forwarder attributed to VSCodroid, and a rejected tunnel no longer leaves a connection pinned open.
 - The musl loader is anchored to Alpine's signing key and the signed chain followed to the payload. An Alpine index checksum covers only metadata, so the old check would have accepted a modified loader.
@@ -221,6 +222,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A browser launch that failed left the sign-in callback window open for ten minutes, during which any `vscodroid://callback` on the device was accepted.
 - A sign-in page on plain http now completes. Only the Custom Tabs hand-off was recording itself, so a self-hosted provider reached through the system browser had its return refused.
 - Signing in when Android has closed the app mid-browser now tells you what happened instead of silently doing nothing.
+- A sign-in that outlasts its window now says so instead of failing silently, and coming back after five minutes no longer discards a callback the editor was collecting.
 - The **Browse Extensions** step on Get Started could never complete, so the walkthrough stayed permanently unfinished. It waited on a view identifier the workbench does not register.
 - **Serve on Network** appears for people upgrading, not only on a clean install. The app now records which extensions it bundled last time, so a never-bundled identifier cannot read as one you removed.
 - **Serve on Network** can find your dev server again. It read a system file Android does not let an app open, and the failure was indistinguishable from finding nothing.

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -54,6 +54,8 @@ import com.vscodroid.webview.VSCodroidWebViewClient
 import com.vscodroid.webview.publishedResourceRoots
 import com.vscodroid.webview.redactToken
 import com.vscodroid.webview.sensitiveLocations
+import org.json.JSONException
+import org.json.JSONObject
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -252,6 +254,14 @@ class MainActivity : AppCompatActivity() {
      * to be signed in is owed the reason, and "sign in again" is an instruction
      * they can act on; silently relaying into a page that drops it is the
      * failure that was already there, wearing a fix.
+     *
+     * The two refusals below are deliberately not alike. A request this app never
+     * launched is refused in the log and nowhere else: the filter is exported, so
+     * a message there would be one an outside caller could raise at will. A
+     * request it did launch, arriving past its window, is worth a message for the
+     * same reason the restart case is, and can only be reached by a sign-in this
+     * app really started. Both messages are fixed text; nothing from the callback
+     * reaches the screen.
      */
     private fun receiveCallbackIntent(intent: Intent?) {
         val uri = intent?.data ?: return
@@ -273,17 +283,38 @@ class MainActivity : AppCompatActivity() {
             ).show()
             return
         }
-        if (!authCallbackIsExpected(
-                AuthTabWindow.openedAt(),
-                SystemClock.elapsedRealtime(),
-                AUTH_TAB_WINDOW_MILLIS
-            )
-        ) {
+        // The id the callback names, matched against the launch that could have
+        // produced it. Null covers both a payload this cannot read and a request
+        // this app never launched, and the two deserve the same answer: there is
+        // no sign-in here to report on.
+        val armedAt = callbackRequestId(uri.getQueryParameter("data"))
+            ?.let { AuthTabWindow.armedAt(it) }
+        if (armedAt == null) {
             // Logged without the URI. It is the payload of a sign-in this app
             // did not start, and the log is readable by anything holding
             // READ_LOGS on a developer device. No toast either: a message here
             // would be one an outside caller could raise at will.
             Logger.w(tag, "Ignoring a sign-in callback that no sign-in was waiting for")
+            return
+        }
+        if (!authCallbackIsExpected(armedAt, SystemClock.elapsedRealtime(), AUTH_TAB_WINDOW_MILLIS)) {
+            // Said out loud, unlike the branch above, and only because of what
+            // was just established: this app launched this exact request itself,
+            // so the message cannot be raised by an outside caller. The user has
+            // been reading a consent screen or waiting on a second factor for
+            // longer than the window, and the alternative is an editor that
+            // simply never signs in and never says why.
+            //
+            // Fixed text, carrying nothing from the URI. What rides in the
+            // callback is attacker-shaped by construction, and a message that
+            // quoted any of it would be a way to put chosen words on the screen
+            // of an app the user trusts.
+            Logger.w(tag, "A sign-in callback arrived after its window had closed")
+            Toast.makeText(
+                this,
+                "Sign-in took too long to complete. Please sign in again.",
+                Toast.LENGTH_LONG
+            ).show()
             return
         }
         handleExtensionCallback(uri)
@@ -532,9 +563,16 @@ class MainActivity : AppCompatActivity() {
      * "Canceled" errors on gallery requests and IndexedDB connections closing.
      *
      * Strategy:
+     * - >5 min background with a sign-in in flight: hold the reload
      * - >5 min background: force reload (stale state almost certain)
      * - >1 min background: run JS health check, reload only if broken
      * - <1 min: no action needed (WebSocket survives short pauses)
+     *
+     * The first line is the one that is not about staleness at all. Five minutes
+     * in the background is the ordinary shape of a sign-in that needed a second
+     * factor or an organisation's consent screen, so the reload written for a
+     * stale WebSocket was firing precisely when the user came back from one, and
+     * it discards the page the callback has to land in.
      */
     private fun handleResumeFromBackground() {
         val ts = backgroundedAt
@@ -555,8 +593,21 @@ class MainActivity : AppCompatActivity() {
         if (!shouldActOnResume(nodeService?.isServerReady(), ts, serverPort)) return
 
         val bgMs = SystemClock.elapsedRealtime() - ts
-        when {
-            bgMs > FORCE_RELOAD_THRESHOLD_MS -> {
+        when (resumeAction(bgMs, signInIsPending())) {
+            ResumeAction.HOLD_FOR_SIGN_IN -> {
+                // Put the reading back, because nothing else will. This branch
+                // fires on the way back from a browser, which is exactly the
+                // moment the callback intent is being delivered, and the reload
+                // it is holding would throw that page away: the ids the workbench
+                // is waiting on live in an in-memory Set that does not survive a
+                // navigation, so a reload here loses a sign-in that had already
+                // succeeded. Restoring the reading leaves the decision to be made
+                // again on the next return from the background, by which time the
+                // window will have closed on its own.
+                backgroundedAt = ts
+                Logger.i(tag, "Holding the reload after ${bgMs / 1000}s: a sign-in is in flight")
+            }
+            ResumeAction.RELOAD -> {
                 Logger.i(tag, "Reloading after ${bgMs / 1000}s in background")
                 // reload(), not a rebuilt URL. The WebView URL is the only
                 // truthful record of what is open, and rebuilding reads only
@@ -578,9 +629,28 @@ class MainActivity : AppCompatActivity() {
                 // the cookie, never the value inside it.
                 webView?.reload()
             }
-            bgMs > HEALTH_CHECK_THRESHOLD_MS -> {
-                checkConnectionHealth(bgMs)
-            }
+            ResumeAction.PROBE_CONNECTION -> checkConnectionHealth(bgMs)
+            ResumeAction.NOTHING -> Unit
+        }
+    }
+
+    /**
+     * Whether a sign-in this app started is still able to come back.
+     *
+     * Asked of the same record the callback relay is judged against, so the two
+     * cannot drift: whatever [receiveCallbackIntent] would still accept is
+     * whatever the reload has to keep out of the way of.
+     *
+     * The record outlives the callback's arrival on purpose, which is what closes
+     * the narrower race. A callback delivered a moment ago is injected into the
+     * page and collected asynchronously by the workbench; a record consumed on
+     * arrival would answer "nothing pending" during exactly that gap and let the
+     * reload discard the value it had just been handed.
+     */
+    private fun signInIsPending(): Boolean {
+        val now = SystemClock.elapsedRealtime()
+        return AuthTabWindow.armedReadings().any {
+            authCallbackIsExpected(it, now, AUTH_TAB_WINDOW_MILLIS)
         }
     }
 
@@ -1581,13 +1651,14 @@ class MainActivity : AppCompatActivity() {
          * URL, and the bootstrap client is the only place it is recognised.
          */
         private const val RETRY_URL = "vscodroid://retry-server"
-        /** Run health check if backgrounded longer than this. */
-        private const val HEALTH_CHECK_THRESHOLD_MS = 60_000L   // 1 minute
-
-        /** Force page reload if backgrounded longer than this. */
-        private const val FORCE_RELOAD_THRESHOLD_MS = 300_000L  // 5 minutes
     }
 }
+
+/** Run health check if backgrounded longer than this. */
+internal const val HEALTH_CHECK_THRESHOLD_MS = 60_000L   // 1 minute
+
+/** Force page reload if backgrounded longer than this. */
+internal const val FORCE_RELOAD_THRESHOLD_MS = 300_000L  // 5 minutes
 
 // Severities the process monitor understands. Words rather than numbers so that
 // nothing downstream is tempted to compare them with >=, which is the defect
@@ -1694,6 +1765,35 @@ internal fun isExtensionCallback(scheme: String?, host: String?): Boolean =
     scheme == "vscodroid" && host == "callback"
 
 /**
+ * The workbench request id a callback payload names, or null if it names none.
+ *
+ * The payload is what `callback.html` builds before it navigates to the intent:
+ * `encodeURIComponent(JSON.stringify({ id, uri }))`, where `id` is the
+ * `vscode-reqid` the page was loaded with. `Uri.getQueryParameter` undoes the
+ * encoding, so what arrives here is the JSON object itself.
+ *
+ * Parsed rather than pattern-matched, and the difference is not style. A reader
+ * that searched the text for a number would find one in the `uri` half as
+ * readily as in the `id` half, and the value decides whether an exported entry
+ * point is answered. Parsing is also what makes malformed input a null instead
+ * of a guess: anything on the device can fire this intent, so the payload is
+ * attacker-shaped by construction and the parse has to be total.
+ *
+ * Takes the already-extracted parameter rather than the `Uri`, for the reason
+ * [isExtensionCallback] takes two strings: `Uri` is abstract with a private
+ * constructor, so it can be neither built nor mocked in a plain JVM test, and
+ * the decision here is about one string.
+ */
+internal fun callbackRequestId(data: String?): String? {
+    if (data.isNullOrEmpty()) return null
+    return try {
+        JSONObject(data).optString("id").ifEmpty { null }
+    } catch (e: JSONException) {
+        null
+    }
+}
+
+/**
  * What binding to an already-running service should do about it.
  *
  * Extracted so the decision is a value rather than a shape in the source.
@@ -1741,8 +1841,49 @@ internal fun bindDecision(notice: String?, port: Int, ready: Boolean): BindDecis
 internal fun shouldActOnResume(ready: Boolean?, backgroundedAt: Long, serverPort: Int): Boolean =
     backgroundedAt != 0L && serverPort != 0 && ready == true
 
+/** What returning from the background should do to the page. */
+internal enum class ResumeAction {
+    /** Short absence. The WebSocket survives those. */
+    NOTHING,
+
+    /** Long enough that the connection may be dead. Ask, reload only if it is. */
+    PROBE_CONNECTION,
+
+    /** Long enough that stale state is near certain. Reload unconditionally. */
+    RELOAD,
+
+    /** Long enough to reload, but a sign-in is still able to come back. */
+    HOLD_FOR_SIGN_IN,
+}
+
 /**
- * Whether a sign-in callback arriving now is one this app went looking for.
+ * Whether the page may be reloaded on the way back from the background.
+ *
+ * [signInPending] outranks the reload, and that ordering is the point of this
+ * function existing. The two conditions are not independent: a sign-in that takes
+ * more than five minutes is a sign-in that went through a second factor or an
+ * organisation's consent screen, which is the ordinary case rather than the
+ * exotic one, so the threshold written for a stale WebSocket lines up almost
+ * exactly with the moment a callback is being delivered. The workbench holds the
+ * requests it is waiting on in memory, so the reload discards them and the
+ * sign-in that had just succeeded is lost with no error anywhere.
+ *
+ * Held rather than skipped: the caller puts its reading back, so the decision is
+ * made again on the next return from the background, and the hold cannot outlast
+ * the callback window it is waiting on.
+ *
+ * The probe below is not held. It only reloads when IndexedDB is already
+ * unusable, and a page in that state has nothing left to collect a callback with.
+ */
+internal fun resumeAction(bgMs: Long, signInPending: Boolean): ResumeAction = when {
+    bgMs > FORCE_RELOAD_THRESHOLD_MS && signInPending -> ResumeAction.HOLD_FOR_SIGN_IN
+    bgMs > FORCE_RELOAD_THRESHOLD_MS -> ResumeAction.RELOAD
+    bgMs > HEALTH_CHECK_THRESHOLD_MS -> ResumeAction.PROBE_CONNECTION
+    else -> ResumeAction.NOTHING
+}
+
+/**
+ * Whether the launch a callback belongs to is still inside its window.
  *
  * Shape is all `isExtensionCallback` can judge, and shape is what anything on
  * the device can produce: the VIEW filter is exported and BROWSABLE. The value
@@ -1752,14 +1893,18 @@ internal fun shouldActOnResume(ready: Boolean?, backgroundedAt: Long, serverPort
  * sign-in this app started, which is the only thing that separates a return from
  * an invention.
  *
- * Timing, not identity, and deliberately so: the legitimate sender is a browser,
- * so there is no caller identity here that could be checked. This narrows an
- * always-open door to the minutes after this app opened one itself.
+ * That match is made before this: the caller looks the callback's own request id
+ * up in [com.vscodroid.bridge.AuthTabWindow] and gets the reading of the launch
+ * that carried it, or nothing. This half answers only the remaining question,
+ * which is how long ago that was.
  *
- * `openedAt == 0` means no tab has been opened in this process. The lower bound
- * on the elapsed time is not redundant with it: the caller passes a monotonic
- * clock, and a negative reading would mean the two came from different boots,
- * which is not an elapsed time at all.
+ * Timing, not identity, for the rest of it: the legitimate sender is a browser,
+ * so there is no caller identity here that could be checked either.
+ *
+ * `openedAtMillis == 0` means no launch, which is what a caller with no reading
+ * to pass would produce. The lower bound on the elapsed time is not redundant
+ * with it: the caller passes a monotonic clock, and a negative reading would mean
+ * the two came from different boots, which is not an elapsed time at all.
  *
  * Takes its clock readings rather than reading them, for the reason
  * `isExtensionCallback` takes two strings -- `SystemClock` is not answerable in

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -257,11 +257,19 @@ class MainActivity : AppCompatActivity() {
      *
      * The two refusals below are deliberately not alike. A request this app never
      * launched is refused in the log and nowhere else: the filter is exported, so
-     * a message there would be one an outside caller could raise at will. A
+     * a message there would be one an outside caller could raise at any moment. A
      * request it did launch, arriving past its window, is worth a message for the
-     * same reason the restart case is, and can only be reached by a sign-in this
-     * app really started. Both messages are fixed text; nothing from the callback
-     * reaches the screen.
+     * same reason the restart case is.
+     *
+     * That second message is bounded rather than gated, and the difference
+     * matters. It is not out of reach of an outside caller: the id is a small
+     * integer the workbench counts from one, and a record is kept past its own
+     * window on purpose, so anything on the device can name a request the user
+     * really did start. What it cannot do is repeat, because the record is taken
+     * back as the message goes up -- one explanation per launch, and every
+     * further arrival for that id lands in the silent branch above.
+     *
+     * Both messages are fixed text; nothing from the callback reaches the screen.
      */
     private fun receiveCallbackIntent(intent: Intent?) {
         val uri = intent?.data ?: return
@@ -287,9 +295,9 @@ class MainActivity : AppCompatActivity() {
         // produced it. Null covers both a payload this cannot read and a request
         // this app never launched, and the two deserve the same answer: there is
         // no sign-in here to report on.
-        val armedAt = callbackRequestId(uri.getQueryParameter("data"))
-            ?.let { AuthTabWindow.armedAt(it) }
-        if (armedAt == null) {
+        val requestId = callbackRequestId(uri.getQueryParameter("data"))
+        val armedAt = requestId?.let { AuthTabWindow.armedAt(it) }
+        if (requestId == null || armedAt == null) {
             // Logged without the URI. It is the payload of a sign-in this app
             // did not start, and the log is readable by anything holding
             // READ_LOGS on a developer device. No toast either: a message here
@@ -298,13 +306,24 @@ class MainActivity : AppCompatActivity() {
             return
         }
         if (!authCallbackIsExpected(armedAt, SystemClock.elapsedRealtime(), AUTH_TAB_WINDOW_MILLIS)) {
-            // Said out loud, unlike the branch above, and only because of what
-            // was just established: this app launched this exact request itself,
-            // so the message cannot be raised by an outside caller. The user has
-            // been reading a consent screen or waiting on a second factor for
+            // Said out loud, unlike the branch above, because of what was just
+            // established: this app launched this exact request itself. The user
+            // has been reading a consent screen or waiting on a second factor for
             // longer than the window, and the alternative is an editor that
             // simply never signs in and never says why.
             //
+            // Taken back as the message goes up, and that is what keeps the
+            // message from becoming something an outside caller can operate. The
+            // filter is exported and BROWSABLE and the id is an integer counted
+            // from one, so anything on the device can name a launch the user
+            // really made; with the record consumed here, each launch can produce
+            // this message once, and every repeat falls into the silent branch
+            // above. Only the arrival past the window consumes it -- an accepted
+            // callback leaves the record alone, because the forced reload asks
+            // whether a sign-in is still in flight and the workbench collects the
+            // relayed value asynchronously.
+            AuthTabWindow.disarm(listOf(requestId))
+
             // Fixed text, carrying nothing from the URI. What rides in the
             // callback is attacker-shaped by construction, and a message that
             // quoted any of it would be a way to put chosen words on the screen
@@ -563,7 +582,8 @@ class MainActivity : AppCompatActivity() {
      * "Canceled" errors on gallery requests and IndexedDB connections closing.
      *
      * Strategy:
-     * - >5 min background with a sign-in in flight: hold the reload
+     * - >5 min background with a sign-in in flight: health check instead of the
+     *   forced reload
      * - >5 min background: force reload (stale state almost certain)
      * - >1 min background: run JS health check, reload only if broken
      * - <1 min: no action needed (WebSocket survives short pauses)
@@ -594,19 +614,6 @@ class MainActivity : AppCompatActivity() {
 
         val bgMs = SystemClock.elapsedRealtime() - ts
         when (resumeAction(bgMs, signInIsPending())) {
-            ResumeAction.HOLD_FOR_SIGN_IN -> {
-                // Put the reading back, because nothing else will. This branch
-                // fires on the way back from a browser, which is exactly the
-                // moment the callback intent is being delivered, and the reload
-                // it is holding would throw that page away: the ids the workbench
-                // is waiting on live in an in-memory Set that does not survive a
-                // navigation, so a reload here loses a sign-in that had already
-                // succeeded. Restoring the reading leaves the decision to be made
-                // again on the next return from the background, by which time the
-                // window will have closed on its own.
-                backgroundedAt = ts
-                Logger.i(tag, "Holding the reload after ${bgMs / 1000}s: a sign-in is in flight")
-            }
             ResumeAction.RELOAD -> {
                 Logger.i(tag, "Reloading after ${bgMs / 1000}s in background")
                 // reload(), not a rebuilt URL. The WebView URL is the only
@@ -1851,9 +1858,6 @@ internal enum class ResumeAction {
 
     /** Long enough that stale state is near certain. Reload unconditionally. */
     RELOAD,
-
-    /** Long enough to reload, but a sign-in is still able to come back. */
-    HOLD_FOR_SIGN_IN,
 }
 
 /**
@@ -1868,15 +1872,23 @@ internal enum class ResumeAction {
  * requests it is waiting on in memory, so the reload discards them and the
  * sign-in that had just succeeded is lost with no error anywhere.
  *
- * Held rather than skipped: the caller puts its reading back, so the decision is
- * made again on the next return from the background, and the hold cannot outlast
- * the callback window it is waiting on.
+ * Downgraded to the probe rather than dropped, and that is the whole of what a
+ * pending sign-in buys. The absence really was long enough for the connection to
+ * have died, so answering it with nothing leaves the page in the state the
+ * five-minute rule exists to repair -- and nothing would come back to it, because
+ * this decision is only ever made on the way in from the background and each
+ * arrival is judged on its own absence. The probe is the strongest answer that is
+ * safe here: it only reloads when IndexedDB is already unusable, and a page in
+ * that state has nothing left to collect a callback with.
  *
- * The probe below is not held. It only reloads when IndexedDB is already
- * unusable, and a page in that state has nothing left to collect a callback with.
+ * An earlier shape of this held the reload for later by putting the caller's
+ * backgrounded reading back. That reading is written afresh by `onStop`, which
+ * Android always delivers before the next `onStart`, so the restored value was
+ * overwritten before its only consumer could read it and the reload was dropped
+ * rather than deferred.
  */
 internal fun resumeAction(bgMs: Long, signInPending: Boolean): ResumeAction = when {
-    bgMs > FORCE_RELOAD_THRESHOLD_MS && signInPending -> ResumeAction.HOLD_FOR_SIGN_IN
+    bgMs > FORCE_RELOAD_THRESHOLD_MS && signInPending -> ResumeAction.PROBE_CONNECTION
     bgMs > FORCE_RELOAD_THRESHOLD_MS -> ResumeAction.RELOAD
     bgMs > HEALTH_CHECK_THRESHOLD_MS -> ResumeAction.PROBE_CONNECTION
     else -> ResumeAction.NOTHING

--- a/android/app/src/main/kotlin/com/vscodroid/bridge/AndroidBridge.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/bridge/AndroidBridge.kt
@@ -83,10 +83,13 @@ private const val MAX_TRACKED_SIGN_INS = 32
  * number of rounds untouched, since every character in it is unreserved; only the
  * `=` moves, to `%3D`, then `%253D`.
  *
- * The cost of being wrong is asymmetric and worth stating. An id this misses is a
- * sign-in that gets refused, and the caller now says so rather than hanging. An
- * id it invents is not reachable: the value has to come out of a URL the
- * workbench asked this app to open, which already requires the session token.
+ * The cost of being wrong is asymmetric and worth stating. An id this misses
+ * arms nothing, so the callback that comes back for it is refused in the log and
+ * nowhere else: the message for a late arrival sits on the other side of that
+ * branch, and `openExternalUrl` still reports the launch as made, so the sign-in
+ * fails quietly. An id it invents is not reachable: the value has to come out of
+ * a URL the workbench asked this app to open, which already requires the session
+ * token.
  */
 private val AUTH_REQUEST_ID = Regex("""vscode-reqid(?:=|%(?:25)*3[Dd])(\d+)""")
 
@@ -121,6 +124,13 @@ internal fun authRequestIdsIn(url: String): List<String> =
  * still in flight, so consuming the entry on arrival would let that reload fire
  * into the moment the workbench is collecting the value.
  *
+ * They are removed once that explanation has been given, which is the bound on
+ * it. An entry kept for the life of the process is one an outside caller can
+ * name at will through the exported filter, and the id it has to guess is a
+ * small integer; taking the entry back as the message goes up means each launch
+ * can produce that message at most once, and every repeat lands in the branch
+ * that says nothing.
+ *
  * Time is supplied by callers from the monotonic clock, never from wall time, so
  * that changing the device clock mid-sign-in neither breaks a real return nor
  * reopens the window. No arithmetic happens here; the window is applied by
@@ -136,21 +146,40 @@ object AuthTabWindow {
     /**
      * Records a browser launch against the request ids it carries.
      *
-     * @return the ids this call newly recorded, which is what [disarm] takes back
-     *   if the launch then throws. An id already recorded keeps its original
-     *   reading rather than being pushed forward: the earlier reading is the
-     *   conservative one, it closes the window sooner, and a launch that fails
-     *   must not be able to extend a request already in flight.
+     * An id already recorded is moved forward to this launch's reading rather
+     * than keeping its earlier one, because ids repeat. The workbench mints them
+     * from a class static that is re-initialised with the page --
+     * `static{this.REQUEST_ID=0}`, then `++REQUEST_ID` per request -- so every
+     * reload, folder switch and renderer recreation starts counting at one again.
+     * "Already recorded" therefore does not mean the same request seen twice; it
+     * routinely means a launch from a page that no longer exists. Keeping that
+     * older reading let it decide the window for the sign-in actually in flight,
+     * and refused a callback that came back in seconds with a message saying it
+     * had taken too long.
+     *
+     * @return the ids this call recorded, which is what [disarm] takes back if
+     *   the launch then throws. Rolling a repeated id back removes it rather than
+     *   restoring the older reading: the request that reading belonged to was
+     *   minted by a page since replaced, and the workbench holds the ids it is
+     *   waiting on in memory, so nothing is left that could still satisfy it.
      */
     @Synchronized
     fun arm(requestIds: Collection<String>, nowMillis: Long): List<String> {
-        val added = requestIds.filterNot { launches.containsKey(it) }
-        added.forEach { launches[it] = nowMillis }
-        return added
+        val armed = requestIds.distinct()
+        armed.forEach {
+            // Taken out before being put back, so a repeated id counts as the
+            // newest entry instead of keeping the position of the launch it
+            // replaces. The cap below is documented to hold the most recent
+            // launches, and a plain overwrite leaves insertion order untouched.
+            launches.remove(it)
+            launches[it] = nowMillis
+        }
+        return armed
     }
 
     /**
-     * Takes back the ids a launch armed, for a launch that then threw.
+     * Takes back launch records: the ids a launch armed when that launch then
+     * threw, and an id whose late arrival has already been explained.
      *
      * Arming has to happen before the launch (see the caller), so a launch that
      * never happened had already opened the relay to the ids it named, and until

--- a/android/app/src/main/kotlin/com/vscodroid/bridge/AndroidBridge.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/bridge/AndroidBridge.kt
@@ -43,68 +43,120 @@ private const val KEYGEN_TIMEOUT_SECONDS = 60L
 private const val DRAIN_JOIN_MILLIS = 1_000L
 
 /**
- * How long after this app opens an authentication tab a callback is still taken.
+ * How long after this app launches a sign-in its callback is still taken.
  *
  * Chosen against the sign-in it has to survive rather than against the attack.
  * A real one is a person reading a consent screen, fetching a password manager
- * and possibly a second factor, so a tight window would reject genuine returns —
+ * and possibly a second factor, so a tight window would reject genuine returns,
  * and a rejected sign-in is a bug report, while the window being ten minutes
  * instead of one still leaves the relay shut for the rest of the day.
  */
 internal const val AUTH_TAB_WINDOW_MILLIS = 10 * 60 * 1000L
 
 /**
- * When this app last handed a URL to a browser.
+ * How many sign-in requests are remembered at once.
  *
- * Any of them, not only a sign-in, and that is not a slip: nothing here can tell
- * an authorisation page from a documentation link, since both arrive through the
- * same bridge method on either of its two launch paths. Opening a link therefore
- * widens the window as much as starting a sign-in does. It still bounds an entry
- * point that had no bound at all, to the ten minutes after the user last left
- * for a browser rather than to every moment the app is running.
+ * A bound, not a policy. Entries are kept past their own window on purpose, so
+ * that a callback arriving late can be told apart from one nobody asked for and
+ * the user given a reason for the first; something therefore has to stop the
+ * record growing for the life of the process. Signing in is a deliberate act a
+ * person performs a handful of times in a session, so the entry older than this
+ * many is the one least likely to still be owed an explanation.
+ */
+private const val MAX_TRACKED_SIGN_INS = 32
+
+/**
+ * The workbench request ids carried by a URL this app is about to open.
  *
- * The `vscodroid://callback` relay had nothing to test but the shape of the URI,
- * and its VIEW filter is exported and BROWSABLE, so the value it writes into the
- * workbench's storage could be supplied at any moment by anything on the device.
- * The one fact that separates a real return from an invented one is whether this
- * app asked for it, and until now nobody was recording that.
+ * This is what separates a sign-in launch from a documentation link, and it is a
+ * fact about the URL rather than a guess about it. `callback.html` refuses to run
+ * without a `vscode-reqid` (`throw new Error('Missing id')`), and the id it
+ * relays on to `vscodroid://callback` is that same parameter read back out of its
+ * own address. So a callback can only exist for a request whose id was carried
+ * out of this app in the address it opened, as `redirect_uri`, inside `state`, or
+ * wherever else the provider echoes it back, and a URL carrying none can produce
+ * no callback at all.
+ *
+ * Matched under percent-encoding as well as plain, because the callback address
+ * usually travels as a parameter of the authorisation address and is therefore
+ * encoded at least once, sometimes twice. `vscode-reqid` itself survives any
+ * number of rounds untouched, since every character in it is unreserved; only the
+ * `=` moves, to `%3D`, then `%253D`.
+ *
+ * The cost of being wrong is asymmetric and worth stating. An id this misses is a
+ * sign-in that gets refused, and the caller now says so rather than hanging. An
+ * id it invents is not reachable: the value has to come out of a URL the
+ * workbench asked this app to open, which already requires the session token.
+ */
+private val AUTH_REQUEST_ID = Regex("""vscode-reqid(?:=|%(?:25)*3[Dd])(\d+)""")
+
+internal fun authRequestIdsIn(url: String): List<String> =
+    AUTH_REQUEST_ID.findAll(url).map { it.groupValues[1] }.distinct().toList()
+
+/**
+ * The sign-in requests this app launched a browser for, and when.
+ *
+ * Keyed by request id rather than being a single reading, and that is the whole
+ * of the narrowing. It used to be one timestamp written by *every*
+ * `openExternalUrl` call, so opening a documentation link widened the window in
+ * which an unsolicited `vscodroid://callback` would be answered exactly as much
+ * as starting a sign-in did. Now a launch arms only the ids it actually carries
+ * out of the app, and a callback is judged against its own launch: an id nobody
+ * launched is refused however recently a browser was opened.
+ *
+ * The `vscodroid://callback` relay has nothing else to test. Its VIEW filter is
+ * exported and BROWSABLE, so any installed app or any page the user taps can fire
+ * it, and the id it names is a counter from one rather than a secret. What an
+ * outside caller cannot supply is a sign-in this app started.
  *
  * Deliberately process-scoped and not persisted. The ids the workbench waits on
  * live in an in-memory Set that does not survive the page, so after a restart
- * there is no pending request a relayed value could satisfy — persisting this
+ * there is no pending request a relayed value could satisfy; persisting this
  * would only widen the window for callbacks that could not be delivered anyway.
  *
- * Time is read from the monotonic clock by callers, not from wall time, so that
- * changing the device clock mid-sign-in neither breaks a real return nor
- * reopens the window.
+ * Entries are not removed when a callback is accepted. Two reasons, and the
+ * second is not obvious: a late callback has to stay distinguishable from an
+ * invented one so the user can be told why the sign-in failed, and the forced
+ * reload on returning from the background asks this object whether a sign-in is
+ * still in flight, so consuming the entry on arrival would let that reload fire
+ * into the moment the workbench is collecting the value.
+ *
+ * Time is supplied by callers from the monotonic clock, never from wall time, so
+ * that changing the device clock mid-sign-in neither breaks a real return nor
+ * reopens the window. No arithmetic happens here; the window is applied by
+ * `authCallbackIsExpected`, which this object deliberately does not call.
  */
 object AuthTabWindow {
-    // Named apart from the accessor on purpose. `private var openedAt` beside
-    // `fun openedAt()` compiles and resolves to the field, but the reader has to
-    // work that out, and "does this recurse?" is not a question worth leaving in
-    // a security check.
-    @Volatile
-    private var lastOpenedAtMillis = 0L
 
-    fun opened(nowMillis: Long) {
-        lastOpenedAtMillis = nowMillis
+    private val launches = object : LinkedHashMap<String, Long>() {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, Long>): Boolean =
+            size > MAX_TRACKED_SIGN_INS
     }
 
     /**
-     * Puts the window back where it was, for a launch that was armed and then
-     * threw.
+     * Records a browser launch against the request ids it carries.
      *
-     * Arming has to happen before the launch — see the caller — so a launch
-     * that never happened still widened the window, and until the launch could
-     * report failure nothing could tell. Ten minutes of an exported, BROWSABLE
-     * entry point accepting a `vscodroid://callback` from anything on the
-     * device, for a sign-in that was never started.
+     * @return the ids this call newly recorded, which is what [disarm] takes back
+     *   if the launch then throws. An id already recorded keeps its original
+     *   reading rather than being pushed forward: the earlier reading is the
+     *   conservative one, it closes the window sooner, and a launch that fails
+     *   must not be able to extend a request already in flight.
+     */
+    @Synchronized
+    fun arm(requestIds: Collection<String>, nowMillis: Long): List<String> {
+        val added = requestIds.filterNot { launches.containsKey(it) }
+        added.forEach { launches[it] = nowMillis }
+        return added
+    }
+
+    /**
+     * Takes back the ids a launch armed, for a launch that then threw.
      *
-     * Restores the previous reading rather than zeroing: an earlier launch may
-     * legitimately still be inside its own window, and this one failing is no
-     * reason to refuse that one's return.
+     * Arming has to happen before the launch (see the caller), so a launch that
+     * never happened had already opened the relay to the ids it named, and until
+     * the launch could report failure nothing could tell.
      *
-     * Named apart from [opened] so it does not read as a second launch site:
+     * Named apart from [arm] so it does not read as a second launch site:
      * `ExtensionCallbackTest` counts arming calls against browser launches to
      * catch a launch that forgets to arm, and a rollback spelled with the same
      * name would be counted as an arming. The two call names are deliberately
@@ -112,11 +164,18 @@ object AuthTabWindow {
      * counting, but a guard that only stays correct because a neighbour
      * filters prose is one bad refactor from a false count.
      */
-    fun disarm(previousMillis: Long) {
-        lastOpenedAtMillis = previousMillis
+    @Synchronized
+    fun disarm(requestIds: Collection<String>) {
+        requestIds.forEach { launches.remove(it) }
     }
 
-    fun openedAt(): Long = lastOpenedAtMillis
+    /** When this app launched a browser for [requestId], or null if it never did. */
+    @Synchronized
+    fun armedAt(requestId: String): Long? = launches[requestId]
+
+    /** Every launch reading held, for a caller asking whether any is still open. */
+    @Synchronized
+    fun armedReadings(): List<Long> = launches.values.toList()
 }
 
 class AndroidBridge(
@@ -182,11 +241,11 @@ class AndroidBridge(
     @JavascriptInterface
     fun openExternalUrl(url: String, authToken: String): Boolean {
         if (!security.validateToken(authToken)) return false
-        // Null until the auth window is armed, and the reading to put back if the
-        // launch that armed it then throws. Arming has to precede the launch, so
+        // Empty until the launch arms something, and then the ids to take back if
+        // the launch that armed them throws. Arming has to precede the launch, so
         // without this a launch nothing accepted still left the callback relay
-        // open for ten minutes with no sign-in in flight.
-        var armedFrom: Long? = null
+        // open to those ids for ten minutes with no sign-in in flight.
+        var armed: List<String> = emptyList()
         return try {
             val uri = Uri.parse(url)
             val isLocalhost = uri.host == "127.0.0.1" || uri.host == "localhost"
@@ -197,8 +256,12 @@ class AndroidBridge(
             // `vscodroid://callback`: a sign-in page on plain http, the shape this
             // method exists to serve on a LAN, that arms nothing hangs with the
             // callback refused and nothing said.
-            armedFrom = AuthTabWindow.openedAt()
-            AuthTabWindow.opened(SystemClock.elapsedRealtime())
+            //
+            // What is armed is the request ids this URL carries, not the fact that
+            // a browser opened. A documentation link carries none and so opens
+            // nothing: it used to widen the callback window by ten minutes exactly
+            // as a sign-in did.
+            armed = AuthTabWindow.arm(authRequestIdsIn(url), SystemClock.elapsedRealtime())
             // Use system browser for localhost URLs (dev server preview needs full browser),
             // Chrome Custom Tabs for https (keeps user in-app, handles OAuth redirects).
             if (uri.scheme == "https" && !isLocalhost) {
@@ -215,7 +278,7 @@ class AndroidBridge(
             }
             true
         } catch (e: Exception) {
-            armedFrom?.let { AuthTabWindow.disarm(it) }
+            AuthTabWindow.disarm(armed)
             Logger.e(tag, "Failed to open URL: $url", e)
             false
         }

--- a/android/app/src/test/kotlin/com/vscodroid/ExtensionCallbackTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/ExtensionCallbackTest.kt
@@ -2,6 +2,7 @@ package com.vscodroid
 
 import android.net.Uri
 import com.vscodroid.bridge.AuthTabWindow
+import com.vscodroid.bridge.authRequestIdsIn
 import com.vscodroid.webview.redactToken
 import io.mockk.every
 import io.mockk.mockkStatic
@@ -9,6 +10,8 @@ import io.mockk.unmockkAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -65,34 +68,246 @@ class ExtensionCallbackTest {
 }
 
 /**
- * That the window actually carries the value between the two halves.
+ * That the window actually carries the value between the two halves, and that it
+ * carries it per request rather than in bulk.
  *
  * `authCallbackIsExpected` is tested on numbers and the call sites are tested on
  * source text, so nothing in either touches the object that carries the reading
  * from the browser launch to the relay. An `AuthTabWindow` that returned a
- * constant, or whose accessor recursed into itself, would leave both sets green
- * and every sign-in broken on the device.
+ * constant, or that answered for an id it had never been given, would leave both
+ * sets green and either break every sign-in on the device or accept a callback
+ * nobody asked for.
  *
- * Plain JVM: the object holds a Long its callers supply and reads no Android API.
+ * Plain JVM: the object holds Longs its callers supply and reads no Android API.
+ *
+ * It is also a process-wide singleton shared with every other test in this JVM,
+ * so each case arms ids of its own and hands them back afterwards.
  */
 class AuthTabWindowTest {
 
+    /** Distinctive enough that no other test in this JVM could be arming them. */
+    private val ids = listOf("900001", "900002", "900003")
+
+    @AfterEach
+    fun handBack() = AuthTabWindow.disarm(ids)
+
     @Test
     fun `the reading handed in is the reading handed back`() {
-        AuthTabWindow.opened(123_456L)
-        assertEquals(123_456L, AuthTabWindow.openedAt())
+        AuthTabWindow.arm(listOf("900001"), 123_456L)
 
-        AuthTabWindow.opened(987_654L)
+        assertEquals(123_456L, AuthTabWindow.armedAt("900001"))
+    }
+
+    @Test
+    fun `an id nobody launched is not armed by a launch of another id`() {
+        // The narrowing itself. One timestamp for the whole process answered yes
+        // here, which is how opening a documentation link came to widen the
+        // window an unsolicited callback is accepted in.
+        AuthTabWindow.arm(listOf("900001"), 123_456L)
+
+        assertNull(AuthTabWindow.armedAt("900002"))
+    }
+
+    @Test
+    fun `a second launch arms its own id and leaves the first alone`() {
+        AuthTabWindow.arm(listOf("900001"), 100L)
+        AuthTabWindow.arm(listOf("900002"), 200L)
+
+        assertEquals(100L, AuthTabWindow.armedAt("900001"), "a later launch overwrote an earlier one")
+        assertEquals(200L, AuthTabWindow.armedAt("900002"))
+    }
+
+    @Test
+    fun `an id already in flight keeps its first reading and is not reported as newly armed`() {
+        // Both halves matter and they are the same fact seen twice. The earlier
+        // reading is the conservative one, it closes the window sooner; and
+        // reporting the id as newly armed would let a launch that then threw take
+        // back a request that was already in flight, refusing a real return.
+        AuthTabWindow.arm(listOf("900001"), 1_000L)
+
+        val added = AuthTabWindow.arm(listOf("900001"), 9_000L)
+
+        assertEquals(emptyList<String>(), added)
+        assertEquals(1_000L, AuthTabWindow.armedAt("900001"))
+    }
+
+    @Test
+    fun `a launch reports the ids it armed, and disarming takes back only those`() {
+        AuthTabWindow.arm(listOf("900001"), 100L)
+
+        val added = AuthTabWindow.arm(listOf("900002", "900003"), 200L)
+        assertEquals(listOf("900002", "900003"), added)
+
+        AuthTabWindow.disarm(added)
+        assertNull(AuthTabWindow.armedAt("900002"))
+        assertNull(AuthTabWindow.armedAt("900003"))
         assertEquals(
-            987_654L, AuthTabWindow.openedAt(),
-            "a second launch must move the window, not be ignored",
+            100L, AuthTabWindow.armedAt("900001"),
+            "a failed launch took back a request it had nothing to do with",
+        )
+    }
+
+    @Test
+    fun `every launch still held is reported, which is what the reload asks`() {
+        // The resume path asks whether ANY sign-in is still able to come back, and
+        // it can only ask that of the readings. An empty answer here would let the
+        // forced reload discard the page a callback was about to land in.
+        AuthTabWindow.arm(listOf("900001"), 100L)
+        AuthTabWindow.arm(listOf("900002"), 200L)
+
+        val readings = AuthTabWindow.armedReadings()
+
+        assertTrue(readings.contains(100L), "a launch is held but not reported: $readings")
+        assertTrue(readings.contains(200L), "a launch is held but not reported: $readings")
+    }
+
+    @Test
+    fun `the record does not grow for the life of the process`() {
+        // Entries outlive their own window on purpose, so that a late callback can
+        // be told apart from an invented one. Without a bound that is a leak in a
+        // process that stays alive for days.
+        val many = (1..200).map { "9100$it" }
+        try {
+            AuthTabWindow.arm(many, 500L)
+
+            assertNull(
+                AuthTabWindow.armedAt(many.first()),
+                "the oldest entry survived 200 launches; nothing is bounding this",
+            )
+            assertNotNull(
+                AuthTabWindow.armedAt(many.last()),
+                "the newest entry was evicted, which would refuse the sign-in just started",
+            )
+        } finally {
+            AuthTabWindow.disarm(many)
+        }
+    }
+}
+
+/**
+ * Which browser launches arm anything at all.
+ *
+ * This is the half that decides whether opening a link is treated as starting a
+ * sign-in. It used to be all of them: one timestamp, written by every
+ * `openExternalUrl` call, so following a documentation link opened a ten-minute
+ * window in which an unsolicited `vscodroid://callback` from anything on the
+ * device would be answered.
+ *
+ * What replaces it is not a guess about the URL. `callback.html` refuses to run
+ * without a `vscode-reqid` and relays that same parameter on as the id, so a
+ * callback can only exist for a request whose id left this app inside the address
+ * it opened. The addresses below are the real shapes that carries in.
+ */
+class AuthRequestIdTest {
+
+    @Test
+    fun `the callback address names its own request`() {
+        val ids = authRequestIdsIn(
+            "http://127.0.0.1:13337/callback?vscode-reqid=3&vscode-scheme=vscodroid" +
+                "&vscode-authority=vscode.github-authentication&vscode-path=/did-authenticate"
         )
 
-        // Back to the value a fresh process starts with. This object is a
-        // process-wide singleton and these are the only tests that touch it, but
-        // leaving it armed would hand the next test a state it did not set.
-        AuthTabWindow.opened(0L)
-        assertEquals(0L, AuthTabWindow.openedAt())
+        assertEquals(listOf("3"), ids)
+    }
+
+    @Test
+    fun `an authorisation address carrying the callback in state names it too`() {
+        // The shape the bundled GitHub provider actually sends: the callback
+        // address is encoded into `state`, and then the whole parameter list is
+        // encoded again on its way into the query. `=` becomes `%3D` and then
+        // `%253D`, which is why matching the plain spelling alone finds nothing
+        // and refuses every sign-in.
+        val ids = authRequestIdsIn(
+            "https://github.com/login/oauth/authorize?client_id=abc" +
+                "&redirect_uri=https%3A%2F%2Fvscode.dev%2Fredirect&scope=repo" +
+                "&state=http%253A%252F%252F127.0.0.1%253A13337%252Fcallback" +
+                "%253Fvscode-reqid%253D7%2526vscode-scheme%253Dvscodroid" +
+                "&code_challenge_method=S256"
+        )
+
+        assertEquals(listOf("7"), ids)
+    }
+
+    @Test
+    fun `a singly encoded callback address is read as well`() {
+        assertEquals(
+            listOf("11"),
+            authRequestIdsIn("https://login.example.com/authorize?redirect_uri=" +
+                "http%3A%2F%2F127.0.0.1%3A13337%2Fcallback%3Fvscode-reqid%3D11"),
+        )
+    }
+
+    @Test
+    fun `a link that is not a sign-in arms nothing`() {
+        // The whole point. Every one of these used to open the callback window as
+        // wide as a sign-in did.
+        for (link in listOf(
+            "https://code.visualstudio.com/docs/editor/extension-marketplace",
+            "http://192.168.1.50:5173/",
+            "https://example.com/?callback=1&reqid=4",
+            "https://example.com/vscode-reqid",
+            "https://example.com/?vscode-reqid=",
+        )) {
+            assertEquals(emptyList<String>(), authRequestIdsIn(link), "armed by: $link")
+        }
+    }
+
+    @Test
+    fun `an address naming the same request twice arms it once`() {
+        val ids = authRequestIdsIn(
+            "https://login.example.com/authorize?redirect_uri=" +
+                "http%3A%2F%2F127.0.0.1%3A13337%2Fcallback%3Fvscode-reqid%3D5" +
+                "&state=http%3A%2F%2F127.0.0.1%3A13337%2Fcallback%3Fvscode-reqid%3D5"
+        )
+
+        assertEquals(listOf("5"), ids)
+    }
+}
+
+/**
+ * Which request a callback payload claims to be for.
+ *
+ * The id is the whole of the match: it is compared against the launches this app
+ * made, and a value read out of the wrong place would either refuse every real
+ * sign-in or answer for one nobody started. The payload is built by
+ * `callback.html` as `JSON.stringify({ id, uri })`, and anything on the device
+ * can fire the intent that carries it, so the reader has to be total.
+ */
+class CallbackRequestIdTest {
+
+    @Test
+    fun `the id in a relay payload is read`() {
+        val payload = """{"id":"7","uri":{"scheme":"vscodroid","authority":"vscode.github-authentication"}}"""
+
+        assertEquals("7", callbackRequestId(payload))
+    }
+
+    @Test
+    fun `a number in the rest of the payload is not mistaken for the id`() {
+        // The reason this parses instead of searching the text. The `uri` half
+        // carries whatever the provider sent back, and a reader looking for the
+        // first number in the string would take a code or a state value and
+        // compare that against the launches instead.
+        val payload = """{"id":"7","uri":{"query":"code=12&state=99","path":"/did-authenticate"}}"""
+
+        assertEquals("7", callbackRequestId(payload))
+    }
+
+    @Test
+    fun `a payload with no id is refused rather than guessed at`() {
+        assertNull(callbackRequestId("""{"uri":{"scheme":"vscodroid"}}"""))
+        assertNull(callbackRequestId("""{"id":""}"""))
+    }
+
+    @Test
+    fun `text that is not a payload yields null rather than throwing`() {
+        // Reached from an exported, BROWSABLE filter, so this is ordinary input
+        // rather than a corner case. A throw here would take the whole intent
+        // handler with it.
+        for (text in listOf("", "not json", "[1,2,3]", "{", """{"id":}""")) {
+            assertNull(callbackRequestId(text), "accepted: $text")
+        }
+        assertNull(callbackRequestId(null))
     }
 }
 
@@ -196,12 +411,94 @@ class AuthCallbackCallSiteTest {
         check(method.any { it.contains("launchUrl(") }) { "no browser launch found in openExternalUrl" }
 
         val launches = method.count { it.contains("launchUrl(") || it.contains("startActivity(") }
-        val arms = method.count { it.contains("AuthTabWindow.opened(") }
+        val arms = method.count { it.contains("AuthTabWindow.arm(") }
 
         assertEquals(
             launches, arms,
             "each browser launch must record that it happened, or the callback it " +
                 "returns with is refused",
+        )
+    }
+
+    @Test
+    fun `the launch arms the ids the address carries, not the fact that it launched`() {
+        // The narrowing, at the one place it can be undone in a line. Passing
+        // anything other than the ids read out of the address puts the old
+        // behaviour back: every browser launch opening the callback window,
+        // whether or not a sign-in was involved.
+        check(bridge.isFile) { "AndroidBridge.kt not found" }
+
+        val arming = code(bridge).filter { it.contains("AuthTabWindow.arm(") }
+
+        assertEquals(1, arming.size, "expected exactly one arming site, found: $arming")
+        assertTrue(
+            arming.single().contains("authRequestIdsIn("),
+            "the arming must be keyed on the request ids in the address; found: ${arming.single()}",
+        )
+    }
+
+    @Test
+    fun `the relay matches a callback against the launch that could have produced it`() {
+        // Without this the timing gate is asked about a launch chosen by nothing:
+        // the most recent one, whatever it was for. Deleting the lookup and
+        // handing the gate any reading at all leaves every other test here green.
+        check(mainActivity.isFile) { "MainActivity.kt not found" }
+
+        val lookups = code(mainActivity).count { it.contains("AuthTabWindow.armedAt(") }
+
+        assertTrue(
+            lookups >= 1,
+            "the relay must look the callback's own request id up against the launches " +
+                "this app made; found $lookups",
+        )
+    }
+
+    @Test
+    fun `the message for a callback that arrived too late carries nothing from it`() {
+        // The message exists because a sign-in that took longer than the window
+        // used to die in silence. It is reached only after the id has been matched
+        // to a launch this app made, so it cannot be raised by an outside caller;
+        // what it must never do is put any part of the payload on the screen,
+        // since that payload is attacker-shaped by construction.
+        check(mainActivity.isFile) { "MainActivity.kt not found" }
+
+        val body = code(mainActivity)
+            .dropWhile { !it.contains("private fun receiveCallbackIntent(") }
+            .drop(1)
+            .takeWhile { it != "    }" }
+        check(body.isNotEmpty()) { "receiveCallbackIntent not found; this test is measuring nothing" }
+
+        val toasts = body.filter { it.contains("Toast.makeText(") }
+        assertEquals(
+            2, toasts.size,
+            "expected the restart message and the expiry message, found ${toasts.size}: $toasts",
+        )
+
+        val interpolated = body.filter { it.contains("\"") && it.contains("$") }
+        assertEquals(
+            emptyList<String>(), interpolated,
+            "a message shown here must be fixed text. Anything interpolated into it can " +
+                "be chosen by whoever fired the intent, and this app is the one the user " +
+                "trusts to be telling them about their sign-in.",
+        )
+    }
+
+    @Test
+    fun `the forced reload asks whether a sign-in is still able to come back`() {
+        // The race the hold exists for: returning after five minutes is the
+        // ordinary shape of a sign-in that needed a second factor, and the reload
+        // discards the page the callback has to land in. Dropping the argument
+        // leaves resumeAction correct and never reaching its holding branch.
+        check(mainActivity.isFile) { "MainActivity.kt not found" }
+
+        val decisions = code(mainActivity).filter { it.contains("resumeAction(") }
+            .filterNot { it.contains("fun resumeAction") }
+
+        assertEquals(1, decisions.size, "expected one resume decision, found: $decisions")
+        assertTrue(
+            decisions.single().contains("signInIsPending()"),
+            "the resume decision must be told whether a sign-in is in flight; found: " +
+                decisions.single(),
         )
     }
 }
@@ -966,6 +1263,65 @@ class ConnectionHealthProbeTest {
         assertTrue(
             connectionHealthProbe().contains("indexedDB.open"),
             "narrowing the probe must not empty it",
+        )
+    }
+}
+
+/**
+ * What returning from the background is allowed to do to the page.
+ *
+ * The reload above five minutes was written for a WebSocket that did not survive
+ * being frozen, and it collides with the one thing that routinely takes a user
+ * out of the app for more than five minutes: signing in. A second factor or an
+ * organisation's consent screen is minutes of reading and typing in another app,
+ * and the callback is delivered on the way back, into the same moment this
+ * decision is made. The workbench keeps the requests it is waiting on in memory,
+ * so a reload here throws away a sign-in that had already succeeded, silently.
+ */
+class ResumeActionTest {
+
+    private val long = FORCE_RELOAD_THRESHOLD_MS + 1
+    private val middling = HEALTH_CHECK_THRESHOLD_MS + 1
+
+    @Test
+    fun `a long absence with a sign-in in flight holds the reload`() {
+        assertEquals(ResumeAction.HOLD_FOR_SIGN_IN, resumeAction(long, signInPending = true))
+    }
+
+    @Test
+    fun `a long absence with nothing in flight still reloads`() {
+        // The control, and the half that matters more often: holding
+        // unconditionally would leave a page stale for the rest of the session,
+        // which is the failure the reload was added for in the first place.
+        assertEquals(ResumeAction.RELOAD, resumeAction(long, signInPending = false))
+    }
+
+    @Test
+    fun `a sign-in in flight does not stop the connection probe`() {
+        // Narrower than "do nothing while signing in", deliberately. The probe
+        // only reloads when IndexedDB is already unusable, and a page in that
+        // state has nothing left to collect a callback with, so suppressing it
+        // would trade a real recovery for a callback that cannot be delivered.
+        assertEquals(ResumeAction.PROBE_CONNECTION, resumeAction(middling, signInPending = true))
+        assertEquals(ResumeAction.PROBE_CONNECTION, resumeAction(middling, signInPending = false))
+    }
+
+    @Test
+    fun `a short absence does nothing, with or without a sign-in`() {
+        assertEquals(ResumeAction.NOTHING, resumeAction(1_000L, signInPending = true))
+        assertEquals(ResumeAction.NOTHING, resumeAction(1_000L, signInPending = false))
+    }
+
+    @Test
+    fun `the hold is tested before the reload, not after`() {
+        // The mutation is reordering the two branches, which compiles, reads
+        // fine, and makes the holding branch unreachable. At exactly the
+        // threshold neither fires, which is the boundary worth stating too.
+        assertEquals(ResumeAction.HOLD_FOR_SIGN_IN, resumeAction(long, signInPending = true))
+        assertEquals(
+            ResumeAction.PROBE_CONNECTION,
+            resumeAction(FORCE_RELOAD_THRESHOLD_MS, signInPending = true),
+            "the reload threshold is exclusive; at the boundary there is nothing to hold",
         )
     }
 }

--- a/android/app/src/test/kotlin/com/vscodroid/ExtensionCallbackTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/ExtensionCallbackTest.kt
@@ -1,6 +1,7 @@
 package com.vscodroid
 
 import android.net.Uri
+import com.vscodroid.bridge.AUTH_TAB_WINDOW_MILLIS
 import com.vscodroid.bridge.AuthTabWindow
 import com.vscodroid.bridge.authRequestIdsIn
 import com.vscodroid.webview.redactToken
@@ -118,17 +119,49 @@ class AuthTabWindowTest {
     }
 
     @Test
-    fun `an id already in flight keeps its first reading and is not reported as newly armed`() {
-        // Both halves matter and they are the same fact seen twice. The earlier
-        // reading is the conservative one, it closes the window sooner; and
-        // reporting the id as newly armed would let a launch that then threw take
-        // back a request that was already in flight, refusing a real return.
+    fun `a repeated id is moved forward to the launch that is actually in flight`() {
+        // Ids repeat, which is what makes keeping the first reading the wrong
+        // answer rather than the cautious one. The workbench counts them from one
+        // out of a class static that is re-initialised with the page, so a
+        // reload, a folder switch or a renderer recreation hands the same id to
+        // the next sign-in. Holding the older reading meant a launch from a page
+        // that no longer exists decided the window for the sign-in in flight: the
+        // callback came back in seconds and was refused, with a message telling
+        // the user their sign-in had taken too long.
         AuthTabWindow.arm(listOf("900001"), 1_000L)
 
-        val added = AuthTabWindow.arm(listOf("900001"), 9_000L)
+        val armed = AuthTabWindow.arm(listOf("900001"), 9_000L)
 
-        assertEquals(emptyList<String>(), added)
-        assertEquals(1_000L, AuthTabWindow.armedAt("900001"))
+        assertEquals(
+            9_000L, AuthTabWindow.armedAt("900001"),
+            "the window is still being judged from a launch the user has already left behind",
+        )
+        assertEquals(
+            listOf("900001"), armed,
+            "the ids a launch records are the ids its rollback has to take back",
+        )
+    }
+
+    @Test
+    fun `a sign-in started after a page reload is judged from its own launch`() {
+        // The same fact as the case above, carried through to the answer the
+        // relay actually gives, because that is where it was costing something.
+        // A sign-in in the morning arms 900001. Hours later the page reloads --
+        // after a folder switch, a renderer recreation or the resume path -- the
+        // workbench counter starts again, and the next sign-in is handed 900001
+        // too. Its callback comes back thirty seconds later.
+        AuthTabWindow.arm(listOf("900001"), 1_000L)
+
+        AuthTabWindow.arm(listOf("900001"), 1_201_000L)
+
+        val armedAt = AuthTabWindow.armedAt("900001")
+        assertNotNull(armedAt, "the launch just made was not recorded at all")
+        assertTrue(
+            authCallbackIsExpected(armedAt!!, 1_231_000L, AUTH_TAB_WINDOW_MILLIS),
+            "a callback thirty seconds after its own launch was refused, because the id was " +
+                "still carrying the reading of a sign-in from two hours before. The user is " +
+                "told the sign-in took too long, and every retry in that page repeats it.",
+        )
     }
 
     @Test
@@ -340,6 +373,86 @@ class AuthCallbackCallSiteTest {
             t.startsWith("//") || t.startsWith("*") || t.startsWith("/*")
         }
 
+    private companion object {
+        /** What [skeleton] leaves behind where a string literal stood. */
+        const val LITERAL = "STR"
+
+        const val TOAST = "Toast.makeText("
+    }
+
+    /**
+     * [source] with every string literal collapsed to [LITERAL].
+     *
+     * What is left is the shape of the expression, which is the property worth
+     * measuring: a message built from literals alone reads as `STR + STR`, and
+     * anything else reaching it -- a variable, a call, a template hole -- leaves
+     * a name or a marker behind. Searching the text for one composition operator
+     * measures the operator rather than the property, and misses the other.
+     *
+     * A literal that interpolates is collapsed to `STR$`, because a hole inside a
+     * literal takes its value from outside it exactly as `+` does. An escaped
+     * character is skipped whole: `\$` is a dollar sign, not a hole, and `\"`
+     * does not end the literal.
+     */
+    private fun skeleton(source: String): String {
+        val out = StringBuilder()
+        val literal = StringBuilder()
+        var inLiteral = false
+        var i = 0
+        while (i < source.length) {
+            val c = source[i]
+            when {
+                inLiteral && c == '\\' -> i++
+                c == '"' -> {
+                    if (inLiteral) {
+                        out.append(if (literal.contains('$')) "$LITERAL\$" else LITERAL)
+                        literal.clear()
+                    }
+                    inLiteral = !inLiteral
+                }
+                inLiteral -> literal.append(c)
+                else -> out.append(c)
+            }
+            i++
+        }
+        return out.toString()
+    }
+
+    /**
+     * The message argument of every [TOAST] call in a [skeleton]ised source.
+     *
+     * Balanced rather than line-based: the calls here are written over four lines
+     * and the message is the one argument that is allowed to vary.
+     */
+    private fun toastMessages(skeletonised: String): List<String> {
+        val messages = mutableListOf<String>()
+        var from = 0
+        while (true) {
+            val start = skeletonised.indexOf(TOAST, from)
+            if (start < 0) return messages
+            val args = mutableListOf<String>()
+            var i = start + TOAST.length
+            var argStart = i
+            var depth = 1
+            while (i < skeletonised.length && depth > 0) {
+                when (skeletonised[i]) {
+                    '(' -> depth++
+                    ')' -> {
+                        depth--
+                        if (depth == 0) args += skeletonised.substring(argStart, i)
+                    }
+                    ',' -> if (depth == 1) {
+                        args += skeletonised.substring(argStart, i)
+                        argStart = i + 1
+                    }
+                }
+                i++
+            }
+            messages += args.getOrElse(1) { "" }
+            from = i
+        }
+    }
+
     @Test
     fun `the relay asks whether a sign-in was in flight`() {
         check(mainActivity.isFile) {
@@ -456,10 +569,18 @@ class AuthCallbackCallSiteTest {
     @Test
     fun `the message for a callback that arrived too late carries nothing from it`() {
         // The message exists because a sign-in that took longer than the window
-        // used to die in silence. It is reached only after the id has been matched
-        // to a launch this app made, so it cannot be raised by an outside caller;
-        // what it must never do is put any part of the payload on the screen,
-        // since that payload is attacker-shaped by construction.
+        // used to die in silence. Reaching it needs an id this app really did
+        // launch a browser for, which is a bound rather than a gate: the id is an
+        // integer the workbench counts from one and the filter is exported, so an
+        // outside caller can reach this once per launch the user made. What it
+        // must never do is put any part of the payload on the screen, since that
+        // payload is attacker-shaped by construction.
+        //
+        // Measured on the expression, not on the line. The predecessor of this
+        // assertion looked for a `$` beside a quote, which is one of the two ways
+        // to build a message out of a value: `"too long: " + payload` carries no
+        // `$` at all, and the mutation that inlines the intent's own `data`
+        // parameter that way left every case here green.
         check(mainActivity.isFile) { "MainActivity.kt not found" }
 
         val body = code(mainActivity)
@@ -474,21 +595,75 @@ class AuthCallbackCallSiteTest {
             "expected the restart message and the expiry message, found ${toasts.size}: $toasts",
         )
 
-        val interpolated = body.filter { it.contains("\"") && it.contains("$") }
+        val messages = toastMessages(skeleton(body.joinToString("\n")))
         assertEquals(
-            emptyList<String>(), interpolated,
-            "a message shown here must be fixed text. Anything interpolated into it can " +
-                "be chosen by whoever fired the intent, and this app is the one the user " +
-                "trusts to be telling them about their sign-in.",
+            2, messages.size,
+            "expected to read two message arguments, found ${messages.size}: $messages",
+        )
+        messages.forEach { message ->
+            val beyondLiterals = message
+                .replace(LITERAL, "")
+                .filterNot { it.isWhitespace() || it == '+' }
+            assertEquals(
+                "", beyondLiterals,
+                "a message shown here must be fixed text, and this one is assembled from " +
+                    "something else: `$message` ($LITERAL stands for a string literal, and a " +
+                    "trailing \$ for a template hole inside one). Whatever reaches it can be " +
+                    "chosen by whoever fired the intent, and this app is the one the user " +
+                    "trusts to be telling them about their sign-in.",
+            )
+        }
+    }
+
+    @Test
+    fun `the late message is given once per launch, not on every arrival`() {
+        // What keeps that message from being something an outside caller can
+        // operate. Records are kept past their own window on purpose, so once the
+        // user has signed in, an id this app launched stays known for the life of
+        // the process, and the id is a small integer through an exported
+        // BROWSABLE filter. Without the record being taken back as the message
+        // goes up, anything on the device can raise "Sign-in took too long" in a
+        // loop, branded as this app and nagging the user to re-authenticate on
+        // someone else's cue.
+        //
+        // Asserted on the source because the branch lives in an Activity method,
+        // which cannot be built in a plain JVM test. Position is the property:
+        // taking the record back before the timing gate would refuse the sign-in
+        // the user is actually completing, and taking it back after the gate has
+        // passed would consume a callback that is about to be relayed.
+        check(mainActivity.isFile) { "MainActivity.kt not found" }
+
+        val body = code(mainActivity)
+            .dropWhile { !it.contains("private fun receiveCallbackIntent(") }
+            .drop(1)
+            .takeWhile { it != "    }" }
+        check(body.isNotEmpty()) { "receiveCallbackIntent not found; this test is measuring nothing" }
+
+        val gate = body.indexOfFirst { it.contains("authCallbackIsExpected(") }
+        val relay = body.indexOfFirst { it.contains("handleExtensionCallback(") }
+        val taken = body.indexOfFirst { it.contains("AuthTabWindow.disarm(") }
+
+        assertTrue(gate >= 0, "the timing gate is gone")
+        assertTrue(relay >= 0, "the relay itself is gone")
+        assertTrue(
+            taken > gate,
+            "the launch record must be taken back inside the branch that shows the expiry " +
+                "message; found the timing gate at line $gate and the take-back at $taken",
+        )
+        assertTrue(
+            taken < relay,
+            "the take-back must sit in the refusing branch, not on the accepting one: a " +
+                "callback that is being relayed is still being collected by the workbench, " +
+                "and the forced reload asks this same record whether to stay out of the way",
         )
     }
 
     @Test
     fun `the forced reload asks whether a sign-in is still able to come back`() {
-        // The race the hold exists for: returning after five minutes is the
-        // ordinary shape of a sign-in that needed a second factor, and the reload
-        // discards the page the callback has to land in. Dropping the argument
-        // leaves resumeAction correct and never reaching its holding branch.
+        // The race the sign-in branch exists for: returning after five minutes is
+        // the ordinary shape of a sign-in that needed a second factor, and the
+        // reload discards the page the callback has to land in. Dropping the
+        // argument leaves resumeAction correct and its first branch unreachable.
         check(mainActivity.isFile) { "MainActivity.kt not found" }
 
         val decisions = code(mainActivity).filter { it.contains("resumeAction(") }
@@ -1284,15 +1459,22 @@ class ResumeActionTest {
     private val middling = HEALTH_CHECK_THRESHOLD_MS + 1
 
     @Test
-    fun `a long absence with a sign-in in flight holds the reload`() {
-        assertEquals(ResumeAction.HOLD_FOR_SIGN_IN, resumeAction(long, signInPending = true))
+    fun `a long absence with a sign-in in flight probes instead of reloading`() {
+        // Not NOTHING, and that is the half worth stating. The absence really was
+        // long enough for the connection to have died, and no later resume comes
+        // back to it: each one is judged on its own absence, so an action skipped
+        // here is an action never taken. The probe is what can be answered safely
+        // -- it reloads only when IndexedDB is already unusable, and such a page
+        // has nothing left to collect a callback with.
+        assertEquals(ResumeAction.PROBE_CONNECTION, resumeAction(long, signInPending = true))
     }
 
     @Test
     fun `a long absence with nothing in flight still reloads`() {
-        // The control, and the half that matters more often: holding
-        // unconditionally would leave a page stale for the rest of the session,
-        // which is the failure the reload was added for in the first place.
+        // The control, and the half that matters more often: downgrading every
+        // long absence to the probe would leave a page stale for the rest of the
+        // session, which is the failure the reload was added for in the first
+        // place.
         assertEquals(ResumeAction.RELOAD, resumeAction(long, signInPending = false))
     }
 
@@ -1313,15 +1495,16 @@ class ResumeActionTest {
     }
 
     @Test
-    fun `the hold is tested before the reload, not after`() {
+    fun `the sign-in case is tested before the reload, not after`() {
         // The mutation is reordering the two branches, which compiles, reads
-        // fine, and makes the holding branch unreachable. At exactly the
-        // threshold neither fires, which is the boundary worth stating too.
-        assertEquals(ResumeAction.HOLD_FOR_SIGN_IN, resumeAction(long, signInPending = true))
+        // fine, and makes the sign-in branch unreachable -- so a return from a
+        // second factor reloads the page the callback has to land in. At exactly
+        // the threshold neither fires, which is the boundary worth stating too.
+        assertEquals(ResumeAction.PROBE_CONNECTION, resumeAction(long, signInPending = true))
         assertEquals(
             ResumeAction.PROBE_CONNECTION,
             resumeAction(FORCE_RELOAD_THRESHOLD_MS, signInPending = true),
-            "the reload threshold is exclusive; at the boundary there is nothing to hold",
+            "the reload threshold is exclusive; at the boundary there is no reload to spare",
         )
     }
 }

--- a/android/app/src/test/kotlin/com/vscodroid/bridge/OpenExternalUrlRefusalTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/bridge/OpenExternalUrlRefusalTest.kt
@@ -18,8 +18,9 @@ import io.mockk.mockkStatic
 import io.mockk.verify
 import io.mockk.verifyOrder
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -73,34 +74,47 @@ class OpenExternalUrlRefusalTest {
     private lateinit var context: Context
     private lateinit var bridge: AndroidBridge
 
-    /**
-     * What [AuthTabWindow] held before this class ran.
-     *
-     * It is an object, this suite runs in one JVM, and one test here writes to
-     * it. Restoring means whatever runs next reads what it would have read had
-     * this class not existed -- mockk's own cleanup covers mocks, not the state
-     * a test wrote through a real API.
-     */
-    private var authWindowBefore = 0L
-
     private companion object {
         /** Named so a failure says the launch was attempted, not that something broke. */
         const val UNREACHABLE = "a browser launch is not reachable from a JVM test"
 
         const val LOCAL = "http://localhost:3000"
 
-        /** An https URL, which is the branch that arms the auth callback window. */
-        const val REMOTE = "https://github.com/login/oauth/authorize"
+        /**
+         * An https sign-in address, which is the branch that goes through Custom
+         * Tabs. It carries a request id because that, and not the fact that a
+         * browser opened, is what arms the callback window: the workbench mints
+         * `vscode-reqid` for the callback it is waiting on, and the address the
+         * provider is given has to carry it back.
+         */
+        const val REMOTE =
+            "https://github.com/login/oauth/authorize?client_id=abc" +
+                "&state=http%253A%252F%252F127.0.0.1%253A13337%252Fcallback%253Fvscode-reqid%253D707"
+
+        /** The id [REMOTE] carries, matched against what the window recorded. */
+        const val REMOTE_REQUEST_ID = "707"
+
+        /** A plain-http sign-in, the LAN shape that leaves through ACTION_VIEW. */
+        const val REMOTE_HTTP =
+            "http://192.168.1.50/signin?redirect_uri=" +
+                "http%3A%2F%2F127.0.0.1%3A13337%2Fcallback%3Fvscode-reqid%3D808"
+
+        const val REMOTE_HTTP_REQUEST_ID = "808"
     }
 
+    /**
+     * [AuthTabWindow] is an object, this suite runs in one JVM, and the cases here
+     * write to it through the real bridge. Handing the ids back means whatever
+     * runs next reads what it would have read had this class not existed; mockk's
+     * own cleanup covers mocks, not state a test wrote through a real API.
+     */
     @AfterEach
-    fun restoreAuthWindow() {
-        AuthTabWindow.disarm(authWindowBefore)
+    fun handBackArmedRequests() {
+        AuthTabWindow.disarm(listOf(REMOTE_REQUEST_ID, REMOTE_HTTP_REQUEST_ID))
     }
 
     @BeforeEach
     fun setUp() {
-        authWindowBefore = AuthTabWindow.openedAt()
         mockkObject(Logger)
         every { Logger.w(any(), any()) } just Runs
         every { Logger.e(any(), any(), any()) } just Runs
@@ -199,9 +213,7 @@ class OpenExternalUrlRefusalTest {
      */
     @Test
     fun `a launch that fails puts the auth callback window back`() {
-        val before = 4_242L
         val armedAt = 999_999L
-        AuthTabWindow.opened(before)
 
         mockkStatic(SystemClock::class)
         every { SystemClock.elapsedRealtime() } returns armedAt
@@ -211,9 +223,9 @@ class OpenExternalUrlRefusalTest {
         every { remote.scheme } returns "https"
         every { Uri.parse(REMOTE) } returns remote
 
-        // Watched, not inferred. The final reading cannot tell "armed then rolled
-        // back" from "never armed": both leave the value this test just wrote.
-        // Two earlier attempts at a control here were satisfied without the
+        // Watched as well as read, because the two see different mutations. The
+        // final state cannot tell "armed then rolled back" from "never armed",
+        // and two earlier attempts at a control here were satisfied without the
         // production code doing anything -- the first because the real clock
         // throws before the arming it was meant to observe, the second because
         // `verify { SystemClock.elapsedRealtime() }` counted this test's OWN call
@@ -230,15 +242,35 @@ class OpenExternalUrlRefusalTest {
         )
 
         verifyOrder {
-            AuthTabWindow.opened(armedAt)
-            AuthTabWindow.disarm(before)
+            AuthTabWindow.arm(listOf(REMOTE_REQUEST_ID), armedAt)
+            AuthTabWindow.disarm(listOf(REMOTE_REQUEST_ID))
         }
-        assertEquals(
-            before, AuthTabWindow.openedAt(),
+        assertNull(
+            AuthTabWindow.armedAt(REMOTE_REQUEST_ID),
             "a launch that threw left the callback window armed. For the next ten minutes any " +
-                "app on the device can post a vscodroid://callback that this app will accept, " +
-                "with no sign-in in flight to justify it.",
+                "app on the device can post a vscodroid://callback naming that request and this " +
+                "app will accept it, with no sign-in in flight to justify it.",
         )
+    }
+
+    @Test
+    fun `an address with no request in it arms nothing`() {
+        // The narrowing, from the outside. Opening a documentation link used to
+        // widen the window an unsolicited callback is accepted in by ten minutes,
+        // exactly as starting a sign-in did, because the window recorded that a
+        // browser had opened rather than what it had been sent to do.
+        val uri = mockk<Uri>(relaxed = true)
+        every { uri.host } returns "code.visualstudio.com"
+        every { uri.scheme } returns "https"
+        every { Uri.parse(any()) } returns uri
+
+        mockkObject(AuthTabWindow)
+
+        bridge.openExternalUrl(
+            "https://code.visualstudio.com/docs", security.getSessionToken()
+        )
+
+        verify(exactly = 1) { AuthTabWindow.arm(emptyList(), any()) }
     }
 
     /*
@@ -289,14 +321,14 @@ class OpenExternalUrlRefusalTest {
             t.startsWith("//") || t.startsWith("*") || t.startsWith("/*")
         }
 
-        val arm = lines.indexOfFirst { it.contains("AuthTabWindow.opened(") }
+        val arm = lines.indexOfFirst { it.contains("AuthTabWindow.arm(") }
         val launch = lines.indexOfFirst { it.contains("launchUrl(") }
         assertTrue(arm >= 0, "the auth window is no longer armed anywhere in AndroidBridge.kt")
         assertTrue(launch >= 0, "no browser launch found in AndroidBridge.kt")
 
         assertTrue(
             arm < launch,
-            "AuthTabWindow.opened() must precede launchUrl(): the launch hands off to another " +
+            "AuthTabWindow.arm() must precede launchUrl(): the launch hands off to another " +
                 "process, and a browser that returns instantly would otherwise arrive before " +
                 "the window it is judged against exists. A failed launch is handled by the " +
                 "rollback in the catch, not by arming later — arming later also makes that " +
@@ -321,14 +353,14 @@ class OpenExternalUrlRefusalTest {
         every { anyConstructed<Intent>().addFlags(any()) } returns mockk(relaxed = true)
 
         assertTrue(
-            bridge.openExternalUrl("http://192.168.1.50/signin", security.getSessionToken()),
+            bridge.openExternalUrl(REMOTE_HTTP, security.getSessionToken()),
             "the system browser branch must report the launch it made"
         )
         verify(exactly = 1) { context.startActivity(any()) }
-        assertTrue(
-            AuthTabWindow.openedAt() != 0L,
-            "every browser hand-off has to record itself, or the callback it " +
-                "returns with is refused"
+        assertNotNull(
+            AuthTabWindow.armedAt(REMOTE_HTTP_REQUEST_ID),
+            "every browser hand-off has to record the request it carries, or the callback " +
+                "it returns with is refused"
         )
     }
 

--- a/android/app/src/test/kotlin/com/vscodroid/bridge/OpenExternalUrlRefusalTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/bridge/OpenExternalUrlRefusalTest.kt
@@ -192,13 +192,13 @@ class OpenExternalUrlRefusalTest {
     /**
      * A launch that threw must not leave the sign-in callback window armed.
      *
-     * `AuthTabWindow.opened()` is called before `launchUrl` on purpose -- a
+     * `AuthTabWindow.arm()` is called before `launchUrl` on purpose -- a
      * browser that answers instantly could otherwise return before the window
      * it needs is open -- so a launch that then fails had already widened it.
-     * For ten minutes after that, `vscodroid://callback` is accepted from
-     * anything on the device, through an exported BROWSABLE filter, for a
-     * sign-in nobody started. Nothing could tell before, because the method
-     * could not report that the launch had failed.
+     * For ten minutes after that, a `vscodroid://callback` naming that request
+     * is accepted from anything on the device, through an exported BROWSABLE
+     * filter, for a sign-in nobody started. Nothing could tell before, because
+     * the method could not report that the launch had failed.
      *
      * The launch itself is not stubbed: the https branch reaches
      * `CustomTabsIntent`, whose Intent work throws from android.jar's stub,
@@ -206,8 +206,8 @@ class OpenExternalUrlRefusalTest {
      *
      * `SystemClock.elapsedRealtime()` must be, though, and leaving it out is
      * how this test first passed against the bug. It is an android.jar stub
-     * that throws, and it is evaluated as the argument to `opened()` -- so the
-     * window was never armed, `openedAt()` was still the value this test had
+     * that throws, and it is evaluated as the argument to the arming call -- so
+     * the window was never armed, the record still held whatever this test had
      * just written, and removing the rollback changed nothing. A stubbed clock
      * is what makes the arming real and the assertion able to fail.
      */

--- a/docs/05-API_SPEC.md
+++ b/docs/05-API_SPEC.md
@@ -314,12 +314,12 @@ sequenceDiagram
   participant C as Chrome Custom Tabs
   participant P as Identity provider
   W->>K: openExternalUrl(authUrl, authToken)
-  K->>K: AuthTabWindow.opened(elapsedRealtime)
+  K->>K: AuthTabWindow.arm(authRequestIdsIn(authUrl), elapsedRealtime)
   K->>C: CustomTabsIntent.launchUrl (https only)
   C->>P: user login + consent
   P-->>C: redirect to the workbench callback page
   C-->>K: VIEW intent, vscodroid://callback?data=ENCODED_JSON
-  K->>K: gate: workbenchLoaded, then authCallbackIsExpected(...)
+  K->>K: gate: workbenchLoaded, then armedAt(id), then authCallbackIsExpected(...)
   K-->>W: evaluateJavascript, writes vscode-web.url-callbacks[id]
 ```
 
@@ -327,29 +327,42 @@ The scheme is `vscodroid://callback`, not `vscodroid://oauth/<provider>`, and th
 payload is a single `data` parameter carrying the workbench's own JSON — no
 provider, code or state is parsed on the Kotlin side.
 
-**Two gates, and both refuse rather than relay.** The VIEW filter is exported and
-`BROWSABLE`, so any app or web page on the device can fire this intent:
+**Four gates, and all of them refuse rather than relay.** The VIEW filter is
+exported and `BROWSABLE`, so any app or web page on the device can fire this
+intent:
 
 | Gate | Where | What it rejects |
 |---|---|---|
 | `isExtensionCallback(scheme, host)` | `MainActivity.kt` | Anything that is not exactly scheme `vscodroid` **and** host `callback` |
 | `workbenchLoaded` | `MainActivity.receiveCallbackIntent` | A callback arriving with no workbench page to receive it. Shows a "sign in again" toast rather than injecting — deliberately ahead of the timing gate, because a process killed while the browser had the foreground has no record of opening a tab |
-| `authCallbackIsExpected(openedAt, now, AUTH_TAB_WINDOW_MILLIS)` | `MainActivity.kt` | A callback arriving outside the window since this app last handed an https URL to a browser. `AUTH_TAB_WINDOW_MILLIS` is 10 minutes (`AndroidBridge.kt`) |
+| `AuthTabWindow.armedAt(callbackRequestId(data))` | `MainActivity.kt` | A callback whose payload cannot be parsed, or whose `vscode-reqid` this app never launched a browser for. Logged only; a message here would be one an outside caller could raise at will |
+| `authCallbackIsExpected(armedAt, now, AUTH_TAB_WINDOW_MILLIS)` | `MainActivity.kt` | A callback for a request this app did launch, arriving more than `AUTH_TAB_WINDOW_MILLIS` (10 minutes, `AndroidBridge.kt`) after that launch. Shows a fixed "sign-in took too long" toast, since a slow consent screen or second factor otherwise fails in silence |
 
-The timing gate tests whether *this app* went looking for a sign-in, which is the
-only thing separating a genuine return from an invented one — the legitimate sender
-is a browser, so there is no caller identity to check, and the callback id is a
-counter the workbench hands out from one rather than a secret. `AuthTabWindow`
-records any https hand-off, not only a sign-in, because `openExternalUrl` cannot
-tell an authorisation page from a documentation link.
+The last two gates together test whether *this app* went looking for **this**
+sign-in, which is the only thing separating a genuine return from an invented one.
+The legitimate sender is a browser, so there is no caller identity to check, and
+the callback id is a counter the workbench hands out from one rather than a
+secret.
 
-A rejected callback is logged **without** the URI and raises no toast: it is the
-payload of a sign-in this app did not start, and a message there would be one an
-outside caller could raise at will.
+What a launch arms is the set of request ids the outgoing address carries, not
+the fact that a browser opened. `callback.html` refuses to run without a
+`vscode-reqid` and relays that same parameter on as the id, so a callback can only
+exist for a request whose id left this app inside the address it opened;
+`authRequestIdsIn` reads them out, under one or two rounds of percent-encoding,
+because the callback address usually travels as a parameter of the authorisation
+address. A documentation link carries none and arms nothing.
+
+Neither message carries any part of the callback. The payload arrives through an
+exported filter, so quoting it would be a way to put chosen words in front of a
+user who trusts this app.
 
 Relaying is also the end of the recovery, not a repair. The workbench keeps the ids
 it is waiting for in an in-memory `Set` that is never persisted, so a relayed value
-is consumable only by the page instance that began the sign-in.
+is consumable only by the page instance that began the sign-in. That is also why
+the forced reload after five minutes in the background is held while any launch is
+still inside its window: reloading discards the very requests the callback is
+coming back to, and five minutes away is the ordinary shape of a sign-in that
+needed a second factor.
 
 #### Logging
 

--- a/docs/05-API_SPEC.md
+++ b/docs/05-API_SPEC.md
@@ -336,13 +336,27 @@ intent:
 | `isExtensionCallback(scheme, host)` | `MainActivity.kt` | Anything that is not exactly scheme `vscodroid` **and** host `callback` |
 | `workbenchLoaded` | `MainActivity.receiveCallbackIntent` | A callback arriving with no workbench page to receive it. Shows a "sign in again" toast rather than injecting — deliberately ahead of the timing gate, because a process killed while the browser had the foreground has no record of opening a tab |
 | `AuthTabWindow.armedAt(callbackRequestId(data))` | `MainActivity.kt` | A callback whose payload cannot be parsed, or whose `vscode-reqid` this app never launched a browser for. Logged only; a message here would be one an outside caller could raise at will |
-| `authCallbackIsExpected(armedAt, now, AUTH_TAB_WINDOW_MILLIS)` | `MainActivity.kt` | A callback for a request this app did launch, arriving more than `AUTH_TAB_WINDOW_MILLIS` (10 minutes, `AndroidBridge.kt`) after that launch. Shows a fixed "sign-in took too long" toast, since a slow consent screen or second factor otherwise fails in silence |
+| `authCallbackIsExpected(armedAt, now, AUTH_TAB_WINDOW_MILLIS)` | `MainActivity.kt` | A callback for a request this app did launch, arriving more than `AUTH_TAB_WINDOW_MILLIS` (10 minutes, `AndroidBridge.kt`) after that launch. Shows a fixed "sign-in took too long" toast, since a slow consent screen or second factor otherwise fails in silence, and takes the launch record back as it does so |
 
 The last two gates together test whether *this app* went looking for **this**
 sign-in, which is the only thing separating a genuine return from an invented one.
 The legitimate sender is a browser, so there is no caller identity to check, and
 the callback id is a counter the workbench hands out from one rather than a
 secret.
+
+That makes the last gate a bound on the message rather than a wall in front of
+it. Records are deliberately kept past their own window, and the id is a small
+integer, so an outside caller naming a request the user really did start reaches
+that toast once. Taking the record back as the message goes up means every
+further arrival for that id falls through to the gate above it, which says
+nothing. An accepted callback does **not** consume its record: the workbench
+collects the relayed value asynchronously, and the resume path asks this same
+record whether to leave the page alone.
+
+A launch carrying no readable request id arms nothing, so its callback is refused
+by the gate above and nothing is shown. `openExternalUrl` still reports the launch
+as made, so a provider that echoes the callback address back in a form
+`authRequestIdsIn` cannot read fails quietly rather than loudly.
 
 What a launch arms is the set of request ids the outgoing address carries, not
 the fact that a browser opened. `callback.html` refuses to run without a
@@ -359,10 +373,21 @@ user who trusts this app.
 Relaying is also the end of the recovery, not a repair. The workbench keeps the ids
 it is waiting for in an in-memory `Set` that is never persisted, so a relayed value
 is consumable only by the page instance that began the sign-in. That is also why
-the forced reload after five minutes in the background is held while any launch is
-still inside its window: reloading discards the very requests the callback is
-coming back to, and five minutes away is the ordinary shape of a sign-in that
-needed a second factor.
+the forced reload after five minutes in the background is downgraded to the
+IndexedDB health check while any launch is still inside its window: reloading
+discards the very requests the callback is coming back to, and five minutes away
+is the ordinary shape of a sign-in that needed a second factor. Downgraded rather
+than skipped, because the decision is taken on each return from the background
+and judged on that return's own absence, so nothing comes back later to answer
+one that was skipped. The health check only reloads when IndexedDB is already
+unusable, and such a page has nothing left to collect a callback with.
+
+Request ids do not survive the page. The workbench counts them from a class
+static that is re-initialised on every load, so the same id is handed out again
+after a reload, a folder switch or a renderer recreation. A launch therefore
+moves an id already recorded forward to its own reading rather than keeping the
+earlier one, which would otherwise judge the sign-in in flight by the window of
+one the user had already left behind.
 
 #### Logging
 


### PR DESCRIPTION
The window that accepts a `vscodroid://callback` intent was opened by every `openExternalUrl` call, so following a documentation link widened it exactly as starting a sign-in did. A callback was judged only on how recently *a* browser had been opened, never on which request it named.

Two failures followed: a callback arriving after the window closed was refused with nothing on screen, and the forced reload after five minutes in the background discarded sign-ins that had already succeeded.

## Changes

- Arming is per request. `authRequestIdsIn` reads the `vscode-reqid` values out of the address being opened; an address carrying none arms nothing.
- The relay matches a callback to its own launch before applying the time window. A request this app never made is refused.
- A late callback for a launch this app did make shows one fixed-text message, once per launch. No part of the payload reaches the screen.
- A long absence with a sign-in in flight runs the connection probe instead of the unconditional reload.

## Notes

The workbench restarts its request counter on every page load, so ids repeat. A repeated id moves forward to the launch actually in flight rather than keeping an older reading.

The message is bounded to once per launch because the VIEW filter is exported: an unbounded message would be a nuisance surface for any app on the device.

A sign-in whose outbound address carries no request id is refused where it previously succeeded. Verified against the bundled GitHub provider, which carries it; not verified for third-party providers.

## Verification

951 unit tests, lint clean.
