### PR TITLE
fix(server): identify the port holder, and wait out a host's shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -296,7 +296,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Build and release**
 
-- Unit tests re-run when the bootstrap script or a server patch changes. Neither was a declared input, so an incremental run served the previous run's verdict for a file it had not read.
+- Unit tests re-run when a patch, the bootstrap script, a bundled extension manifest or a documented requirement changes. None was a declared input, so incremental runs served stale verdicts.
+- A server tree built before the current terminal-host shutdown is refused rather than packaged; the patch check matched text an earlier version of that patch had already added.
 - A server build release could take over the `latest` release pointer, which breaks toolchain downloads for every non-Play install. It is now kept out of that pointer permanently.
 - A release can no longer be published with one of its files missing. Upload and publish both defaulted to warning rather than failing.
 - Builds no longer re-download every bundled package. The cache pointed one directory above where packages are written, so it matched none of the 72 files there.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Crash text reaching the clipboard, the crash dialog and the page now has the connection token stripped from the `tkn=` parameter it travels in.
 - The address the editor is opened at is redacted by the shared routine before logging, replacing a hand-maintained token-free copy that could drift from the real one.
 - Deciding whether the server on the port is ours no longer sends it the connection token. Ownership is settled from a record this app writes; a holder we have no record for is treated as a stranger.
+- A server already on the port must now report the build it is before the app reuses it. Answering at all used to be enough, so a stranger holding the port could be handed the session token.
 - Startup readiness is judged by the one endpoint answered before the token check. The previous check treated any non-error reply as healthy, including "forbidden".
 - The session token is compared in constant time. Nothing was reachable through the old comparison; the point is that the property belongs in the comparison rather than in the token length.
 - Every one of the twenty-eight editor-to-Android calls now requires the session token. Six took none, and a test enumerates them so a new one cannot skip it.
@@ -207,6 +208,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Terminal, keyboard and layout**
 
+- Shutting down the terminal host waits for it to finish, up to three seconds, instead of stopping it after 200 ms. Output still being written was lost mid-write.
 - Shortcuts using a punctuation key work from the on-screen keyboard. Both input routes now answer from one key table, which gained comma, full stop, hyphen, plus, asterisk, percent, question mark, caret and dollar.
 - Tapping Shift on the key row and then typing on the soft keyboard inserts the character. The interceptor now takes over for Ctrl and Alt chords only.
 - Ctrl+comma opens Settings and Ctrl+space asks for suggestions; both were previously unreachable by touch.
@@ -294,6 +296,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Build and release**
 
+- Unit tests re-run when the bootstrap script or a server patch changes. Neither was a declared input, so an incremental run served the previous run's verdict for a file it had not read.
 - A server build release could take over the `latest` release pointer, which breaks toolchain downloads for every non-Play install. It is now kept out of that pointer permanently.
 - A release can no longer be published with one of its files missing. Upload and publish both defaulted to warning rather than failing.
 - Builds no longer re-download every bundled package. The cache pointed one directory above where packages are written, so it matched none of the 72 files there.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -310,6 +310,20 @@ tasks.withType<Test> {
     //   grep -rn 'File("src/main/AndroidManifest.xml")' android/app/src/test/kotlin
     inputs.file(layout.projectDirectory.file("src/main/AndroidManifest.xml"))
         .withPropertyName("appManifest")
+    // Two suites read files no Kotlin compiles against, because the things they
+    // check cross a language boundary that has no compiler: the bootstrap's
+    // adoption note (assets/server.js) and the shutdown the worker hosts get
+    // (patches/). Gradle knows nothing about either, so it answered UP-TO-DATE
+    // for a run that had to notice one of them change, and served the previous
+    // run's results. Measured here: the patch was reverted in place and the guard
+    // reported green without running. Declaring them makes the answer follow the
+    // question. A clean CI checkout was never affected; an incremental run always
+    // was.
+    inputs.files(fileTree("src/main/assets") { include("*.js") })
+        .withPropertyName("bootstrapScripts")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
+    inputs.files(fileTree(rootProject.projectDir.parentFile.resolve("patches")))
+        .withPropertyName("serverPatches")
         .withPathSensitivity(PathSensitivity.RELATIVE)
 }
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -311,19 +311,51 @@ tasks.withType<Test> {
     inputs.file(layout.projectDirectory.file("src/main/AndroidManifest.xml"))
         .withPropertyName("appManifest")
     // Two suites read files no Kotlin compiles against, because the things they
+    // Seven suites read files no Kotlin compiles against, because the things they
     // check cross a language boundary that has no compiler: the bootstrap's
-    // adoption note (assets/server.js) and the shutdown the worker hosts get
-    // (patches/). Gradle knows nothing about either, so it answered UP-TO-DATE
-    // for a run that had to notice one of them change, and served the previous
-    // run's results. Measured here: the patch was reverted in place and the guard
-    // reported green without running. Declaring them makes the answer follow the
-    // question. A clean CI checkout was never affected; an incremental run always
-    // was.
+    // adoption note (assets/server.js), the shutdown the worker hosts get
+    // (patches/), the manifests of the bundled extensions, and the documents that
+    // restate a requirement the code owns. Gradle knew about none of them, so it
+    // answered UP-TO-DATE for a run that had to notice one of them change, and
+    // served the previous run's results. Measured on this module: a signature
+    // edited in docs/05-API_SPEC.md left the task UP-TO-DATE and the build
+    // successful, and with the file declared the same edit re-runs the suite and
+    // turns BridgeApiSpecParityTest red. Renaming a command title to a name of
+    // the same length does the same for CommandReferenceTest, and that length is
+    // the point: the only thing that already noticed an assets edit was the byte
+    // total in BuildConfig, which a size-neutral one leaves exactly where it was.
+    // A clean CI checkout was never affected; an incremental run always was.
+    //
+    // The set is the whole of what those File(...) reads reach, so check the
+    // suites before narrowing any of it:
+    //
+    //   assets/*.js           AdoptionNoteWireTest
+    //   assets/extensions     BundledExtensionHostTest, CommandReferenceTest,
+    //                         WalkthroughCompletionEventTest
+    //   patches/              WorkerHostShutdownPatchTest
+    //   README.md, docs/*.md  WebViewVersionTest, BridgeApiSpecParityTest
+    //
+    // Sources under src/main/kotlin are read by other suites the same way and are
+    // deliberately not listed: they are compiled into the classpath this task
+    // already depends on, so editing one re-runs the tests without any
+    // declaration. Nothing else here has a compiler standing behind it.
     inputs.files(fileTree("src/main/assets") { include("*.js") })
         .withPropertyName("bootstrapScripts")
         .withPathSensitivity(PathSensitivity.RELATIVE)
+    inputs.files(fileTree("src/main/assets/extensions"))
+        .withPropertyName("bundledExtensions")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
     inputs.files(fileTree(rootProject.projectDir.parentFile.resolve("patches")))
         .withPropertyName("serverPatches")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
+    // Top-level markdown only. docs/ also carries a site, screenshots and a logo
+    // directory, and no test reads any of them; hashing them on every run would
+    // buy nothing and 2.6 MB of it is images.
+    inputs.files(
+        rootProject.projectDir.parentFile.resolve("README.md"),
+        fileTree(rootProject.projectDir.parentFile.resolve("docs")) { include("*.md") },
+    )
+        .withPropertyName("statedRequirements")
         .withPathSensitivity(PathSensitivity.RELATIVE)
 }
 

--- a/android/app/src/main/kotlin/com/vscodroid/service/ProcessManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/service/ProcessManager.kt
@@ -297,20 +297,30 @@ class ProcessManager(private val context: Context) {
             startAdoptionWatch()
             return true
         }
-        // An editor server of ours that is alive, holds the port, and answers nothing is
-        // the one shape worth ending before spawning over it. Adoption already declined it
-        // just above, and leaving it there guarantees the spawn below hits EADDRINUSE:
-        // that child does not exit, so the run ends in CANNOT_BIND with two processes
-        // where the user wanted one, and the survivor outlives every retry.
+        // An editor server of ours that is alive, holds the port, and is not one this
+        // start can adopt is the one shape worth ending before spawning over it. Adoption
+        // already declined it just above, and leaving it there guarantees the spawn below
+        // hits EADDRINUSE: that child does not exit, so the run ends in CANNOT_BIND with
+        // two processes where the user wanted one, and the survivor outlives every retry.
         //
-        // The judgement is `/version` not answering within a second, which a server still
-        // starting up could fail. Ending it is still the better error: the alternative is
-        // not "wait for it to come up" but a failed launch, because nothing here can bind
-        // the port while it is held. A server killed a second early is restarted by the
-        // line below; one left alone is not.
+        // Three declines reach here and only one of them is silence, so the reason is not
+        // repeated in the reap: [recordedServerIsServing] has already logged which of them
+        // it was. `/version` did not answer within a second, which a server still starting
+        // up could fail; or it answered as a different build, which an orphan left by an
+        // earlier app version does; or this build could not read its own commit, so the
+        // port was never asked at all.
+        //
+        // The last two end a process that may be serving perfectly well, and that is a
+        // decision rather than an oversight. What it is serving is not this build, or
+        // cannot be shown to be, and the alternative is not "leave the user's editor
+        // alone" but a launch that fails for as long as the holder lives, because nothing
+        // here can bind the port while it is held and `_port` is never re-derived. A
+        // server ended a second early is restarted by the line below; one left alone is
+        // not.
         var reapedThisStart = false
         if (!portIsFree && portHeldByOurEditorServer()) {
-            reapedThisStart = reapRecordedEditorServer("holding port $_port without serving")
+            reapedThisStart =
+                reapRecordedEditorServer("not adoptable by this start, for the reason logged above")
         }
 
         // Reaching here means the port was free, or was held by something that is
@@ -696,7 +706,7 @@ class ProcessManager(private val context: Context) {
     }
 
     /**
-     * Whether the port is answering right now.
+     * Whether the port is answering, and answering as this build.
      *
      * The second half of the adoption test, and it is not a restatement of the
      * first. [portHeldByOurEditorServer] proves the recorded process is alive and
@@ -731,13 +741,18 @@ class ProcessManager(private val context: Context) {
      * satisfies, and binding a loopback port on Android needs no permission.
      *
      * Read what this does and does not settle, because the difference decides
-     * what may be built on it. It settles that the holder serves this exact build,
-     * which no ordinary stranger on the port does. It does NOT settle that the
-     * holder is the recorded pid: the commit is public, so a process written to
-     * imitate this app can answer it, and attributing a socket to a pid would need
-     * the `/proc/net/tcp` read SELinux refuses an app outright. The two halves
-     * therefore still narrow rather than prove, and the note stays the ownership
-     * half.
+     * what may be built on it. It settles which VS Code source the holder was
+     * built from, and no more than that: the value is `microsoft/vscode`'s tag SHA
+     * for the pinned version, the same one the tracked `VSCODE_COMMIT` file
+     * records, so every VSCodroid build at that pin answers identically and the
+     * value is app-private in no sense at all. That excludes an ordinary stranger
+     * on the port, which is what adoption needs, and nothing stronger may be built
+     * on it: it does not tell two builds of this app apart. It does NOT settle
+     * that the holder is the recorded pid either: the commit is public, so a
+     * process written to imitate this app can answer it, and attributing a socket
+     * to a pid would need the `/proc/net/tcp` read SELinux refuses an app
+     * outright. The two halves therefore still narrow rather than prove, and the
+     * note stays the ownership half.
      *
      * Refusing here is not final and deletes nothing, so a recorded server that
      * was merely slow to answer is adopted by a later attempt. Being wrong in this

--- a/android/app/src/main/kotlin/com/vscodroid/service/ProcessManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/service/ProcessManager.kt
@@ -10,6 +10,7 @@ import org.json.JSONObject
 import java.io.BufferedReader
 import java.io.File
 import java.io.InputStreamReader
+import java.io.Reader
 import java.net.HttpURLConnection
 import java.net.URL
 import java.util.concurrent.TimeUnit
@@ -538,19 +539,6 @@ class ProcessManager(private val context: Context) {
     }
 
     /**
-     * Performs a synchronous HTTP GET to `http://127.0.0.1:{port}/version`.
-     *
-     * `/version` is answered before the connection-token check — the server
-     * handles it and returns, then gates everything else — so this stays a pure
-     * liveness probe and does not need the token.
-     *
-     * It also has to be `/version` rather than `/`. This accepted anything below
-     * 500, which was fine while every route answered 200, and became wrong the
-     * moment the server started requiring a token: `/` then answers 403, and a
-     * readiness check that counts 403 as healthy reports a successful startup for
-     * a server that will serve the user nothing but Forbidden.
-     */
-    /**
      * Whether the process holding our port is an editor server this app started.
      *
      * Answered from a note the bootstrap left, not by asking the port holder.
@@ -729,10 +717,27 @@ class ProcessManager(private val context: Context) {
      *
      * Asking the port is safe in the way the ownership test that preceded it was
      * not: `/version` is answered before the connection-token check, so the probe
-     * carries no token and discloses nothing to whoever is on the other end. What
-     * it establishes is only that the port serves, attributing that answer to the
-     * recorded pid would need the /proc/net/tcp read SELinux refuses, which is
-     * why both halves are required and neither is sufficient.
+     * carries no token and discloses nothing to whoever is on the other end. That
+     * direction is not negotiable. The credential is what the WebView is about to
+     * carry to this port, and handing it to the party the test exists to identify
+     * is the mistake that was taken out of here once already.
+     *
+     * What the port is asked for is its identity, not merely a status line. The
+     * route answers `productService.commit` as `text/plain`, so a holder that is
+     * this build's editor server returns the commit
+     * `<server-dir>/vscode-reh/product.json` records, and one that is not returns
+     * something else, or nothing, or 403. A bare 200 was the whole test until now,
+     * which every process that accepts a connection and answers anything at all
+     * satisfies, and binding a loopback port on Android needs no permission.
+     *
+     * Read what this does and does not settle, because the difference decides
+     * what may be built on it. It settles that the holder serves this exact build,
+     * which no ordinary stranger on the port does. It does NOT settle that the
+     * holder is the recorded pid: the commit is public, so a process written to
+     * imitate this app can answer it, and attributing a socket to a pid would need
+     * the `/proc/net/tcp` read SELinux refuses an app outright. The two halves
+     * therefore still narrow rather than prove, and the note stays the ownership
+     * half.
      *
      * Refusing here is not final and deletes nothing, so a recorded server that
      * was merely slow to answer is adopted by a later attempt. Being wrong in this
@@ -740,30 +745,126 @@ class ProcessManager(private val context: Context) {
      * held port did before adoption existed; being wrong in the other costs the
      * session.
      */
-    private fun recordedServerIsServing(): Boolean = isServerHealthy().also { serving ->
-        if (!serving) {
+    private fun recordedServerIsServing(): Boolean {
+        // Answered first, because a build that cannot say what it is cannot
+        // recognise itself on a port either. That is the fail-closed direction:
+        // adoption is an optimisation, and declining it costs a spawn.
+        val expected = bundledServerCommit()
+        if (expected == null) {
+            Logger.w(
+                tag,
+                "The packaged server records no commit, so nothing answering on port " +
+                    "$_port can be identified as this build; spawning rather than adopting",
+            )
+            return false
+        }
+
+        val served = probeVersion()
+        if (served == null) {
             Logger.w(
                 tag,
                 "An editor server of ours is recorded on port $_port but nothing is " +
                     "answering there; spawning rather than adopting it",
             )
+            return false
         }
+        if (served != expected) {
+            Logger.w(
+                tag,
+                "Port $_port is held by something reporting \"$served\" rather than this " +
+                    "build's $expected; spawning rather than adopting it",
+            )
+            return false
+        }
+        return true
     }
 
-    fun isServerHealthy(): Boolean {
-        return try {
-            val url = URL("http://127.0.0.1:$_port/version")
-            val connection = url.openConnection() as HttpURLConnection
-            connection.connectTimeout = 1000
-            connection.readTimeout = 1000
-            connection.requestMethod = "GET"
-            connection.instanceFollowRedirects = false
-            val responseCode = connection.responseCode
-            connection.disconnect()
-            responseCode == 200
-        } catch (e: Exception) {
-            false
+    /**
+     * The commit the packaged server tree was built from, or null if it does not
+     * say.
+     *
+     * The same file the server itself answers `/version` from: `server.js`
+     * rewrites `product.json` on every start, but its overrides do not include
+     * `commit`, so what is on disk is what the running server reports.
+     *
+     * Null covers an absent file, unreadable JSON, and a tree built without a
+     * commit. All three mean the same thing here, that this build cannot be told
+     * apart from anything else, and all three decline adoption rather than falling
+     * back to accepting whoever answers.
+     */
+    private fun bundledServerCommit(): String? = try {
+        File(Environment.getServerDir(context), REH_PRODUCT_FILE)
+            .takeIf { it.isFile }
+            ?.let { JSONObject(it.readText()).optString("commit") }
+            ?.trim()
+            ?.takeIf { it.isNotEmpty() }
+    } catch (e: Exception) {
+        Logger.w(tag, "Could not read the packaged server's commit: ${e.message}")
+        null
+    }
+
+    /**
+     * Whether `http://127.0.0.1:{port}/version` answers 200.
+     *
+     * `/version` is answered before the connection-token check: the server handles
+     * it and returns, then gates everything else, so this stays a pure liveness
+     * probe and does not need the token.
+     *
+     * It also has to be `/version` rather than `/`. This accepted anything below
+     * 500, which was fine while every route answered 200, and became wrong the
+     * moment the server started requiring a token: `/` then answers 403, and a
+     * readiness check that counts 403 as healthy reports a successful startup for
+     * a server that will serve the user nothing but Forbidden.
+     *
+     * Liveness only, deliberately. Which build answered is [probeVersion]'s
+     * business and only adoption asks it, because a readiness poll runs every
+     * 200 ms for thirty seconds and has no use for the answer.
+     */
+    fun isServerHealthy(): Boolean = probeVersion() != null
+
+    /**
+     * What `/version` answers, or null if the port did not answer 200.
+     *
+     * One request serves both questions the class asks of the port. Liveness only
+     * needs the status, so [isServerHealthy] discards the body; adoption needs to
+     * know which build answered, and reading it costs one more read on a socket
+     * that is already open.
+     *
+     * The body is taken up to [VERSION_BODY_MAX_CHARS] and no further. The read
+     * timeout bounds each read rather than the total, so an unbounded reader would
+     * let whatever holds the port keep this thread as long as it kept sending, and
+     * the point of the call is that the holder may be a stranger.
+     */
+    private fun probeVersion(): String? = try {
+        val connection = (URL("http://127.0.0.1:$_port/version").openConnection()
+            as HttpURLConnection).apply {
+            connectTimeout = 1000
+            readTimeout = 1000
+            requestMethod = "GET"
+            instanceFollowRedirects = false
         }
+        try {
+            if (connection.responseCode == 200) {
+                connection.inputStream.reader().use { readBounded(it) }
+            } else {
+                null
+            }
+        } finally {
+            connection.disconnect()
+        }
+    } catch (e: Exception) {
+        null
+    }
+
+    private fun readBounded(reader: Reader): String {
+        val buffer = CharArray(VERSION_BODY_MAX_CHARS)
+        var filled = 0
+        while (filled < buffer.size) {
+            val read = reader.read(buffer, filled, buffer.size - filled)
+            if (read < 0) break
+            filled += read
+        }
+        return String(buffer, 0, filled).trim()
     }
 
     /**
@@ -852,6 +953,21 @@ class ProcessManager(private val context: Context) {
      * heap, ICU data and loaded addons all sit outside it, and what actually
      * ends the process is Android's low-memory killer, which does not read
      * flags. On a large device the extra RAM went unused.
+     *
+     * It reaches the worker hosts as well, which is worth writing down because
+     * the code invites the opposite conclusion: the flag is on the command line
+     * of the main isolate only, while the Extension Host and the Pty Host run as
+     * `worker_threads` Workers, so handing it to them as a Worker resource limit
+     * looks like a missing step. It is not one, twice over. Measured on Node
+     * 22.17.1, which is a major behind the runtime that ships here:
+     * `--max-old-space-size` is process-wide in V8, so a Worker created with no
+     * resource limits at all still died at the ceiling, and a Worker given an
+     * explicit, smaller limit ran past it to the ceiling instead, because the
+     * command-line flag overrides `resourceLimits` rather than the other way
+     * round. Separately, `fork()` passes the parent's `execArgv` on by default,
+     * so the flag is already in `process.execArgv` at both places a host Worker
+     * is created, and `workerAsChildProcess.ts` turns it into a resource limit
+     * there. Adding a pass-through would change no number.
      */
     private fun heapCeilingForDevice(): Int = try {
         val am = context.getSystemService(ActivityManager::class.java)
@@ -1155,6 +1271,27 @@ internal const val EDITOR_PID_FILE = "editor-server.pid"
  * process reads as absent rather than as a match, and the check fails closed.
  */
 internal const val EDITOR_ENTRY_POINT = "server-main.js"
+
+/**
+ * Where the packaged server records which build it is, relative to the server
+ * directory.
+ *
+ * Read for one purpose: `/version` answers `productService.commit` from this
+ * file, so it is the value a holder of the port has to produce before adoption
+ * will hand it the WebView. Nothing here writes it; the build does, and
+ * `assets/server.js` leaves the key alone when it rewrites the file.
+ */
+internal const val REH_PRODUCT_FILE = "vscode-reh/product.json"
+
+/**
+ * How much of a `/version` answer is read before the reader stops.
+ *
+ * A commit is forty characters; this is room for that and a newline several times
+ * over. It is a bound rather than a size because the party answering may be the
+ * one adoption is trying to rule out, and the socket's read timeout limits each
+ * read rather than the total, so nothing else stops a holder that keeps sending.
+ */
+internal const val VERSION_BODY_MAX_CHARS = 128
 
 /** What every device ran before the ceiling was derived, and the fallback. */
 internal const val HEAP_CEILING_DEFAULT_MB = 512

--- a/android/app/src/test/kotlin/com/vscodroid/service/ProcessManagerTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/service/ProcessManagerTest.kt
@@ -997,6 +997,15 @@ class AdoptionTest {
     /** Written where [Environment.getConnectionTokenPath] is stubbed to look. */
     private val token = "adopt-2f9c-token"
 
+    /**
+     * The commit the packaged tree records, which is what the real `/version`
+     * answers with: the route ends the response with `productService.commit`.
+     *
+     * Written into a `product.json` fixture below, so a holder of the port has to
+     * produce it before adoption will hand it the WebView and the token.
+     */
+    private val commit = "a5b500951314efd502d07465bd138dfbd714a960"
+
     @BeforeEach
     fun setUp() {
         mockkObject(Logger)
@@ -1008,6 +1017,8 @@ class AdoptionTest {
         every { Logger.e(any(), any()) } just Runs
 
         val tokenFile = File(tempDir, "token").apply { writeText(token) }
+        File(tempDir, "server/vscode-reh").mkdirs()
+        File(tempDir, "server/$REH_PRODUCT_FILE").writeText("""{"commit":"$commit"}""")
 
         mockkObject(Environment)
         every { Environment.getNodePath(any()) } returns "/bin/echo"
@@ -1032,9 +1043,16 @@ class AdoptionTest {
         unmockkAll()
     }
 
-    /** Points the manager at a loopback server answering [status] on every route. */
-    private fun serving(status: Int): StubServer =
-        StubServer(status).also { stub = it; manager.portField = it.port }
+    /**
+     * Points the manager at a loopback server answering [status] on every route,
+     * and reporting [reports] as the build it is.
+     *
+     * The default is this app's own commit, so the fixture stands for the case
+     * adoption is for: the editor server that survived its bootstrap. A test that
+     * wants a stranger passes something else.
+     */
+    private fun serving(status: Int, reports: String = commit): StubServer =
+        StubServer(status, reports).also { stub = it; manager.portField = it.port }
 
     /**
      * Writes the note `assets/server.js` leaves naming the editor server it
@@ -1137,6 +1155,85 @@ class AdoptionTest {
         // Awaited for the reason ProcessManagerTest's helper gives: /bin/echo exits
         // at once, and a watchdog thread outliving the test logs through a Logger
         // mock that unmockkAll() has already torn down.
+        assertTrue(exited.await(5, TimeUnit.SECONDS), "watchdog never reported the exit")
+    }
+
+    @Test
+    fun `a holder serving some other build is not adopted`() {
+        // The path that was left open. The note proves an editor server of ours is
+        // alive; the port proves something is serving there. Neither says they are
+        // the same process, and the read that would say so, /proc/net/tcp, is
+        // refused to an app outright. A child that lost the race for the port wedges
+        // on EADDRINUSE without exiting, so it goes on matching the note perfectly
+        // while a foreign process holds the socket.
+        //
+        // A bare 200 was the whole of the second half, and everything that accepts a
+        // connection and answers something satisfies it. Adopting then points the
+        // WebView at that holder with the connection token in the URL. Asking which
+        // build answered costs the same request and no disclosure.
+        val holder = serving(200, reports = "0000000000000000000000000000000000000000")
+        recordEditorServer(pid = 4242, port = holder.port)
+        manager.killRecordedProcess = { }
+        assertTrue(
+            manager.portHeldByOurEditorServer(),
+            "the note has to pass the ownership test, or the refusal below proves nothing",
+        )
+
+        val exited = CountDownLatch(1)
+        manager.onServerCrashed = { exited.countDown() }
+        assertTrue(manager.startServer(), "declining to adopt still has to start something")
+
+        assertFalse(
+            manager.isAdopted(),
+            "a holder that is not this build is not ours to hand the token to",
+        )
+        assertNotNull(
+            manager.serverProcessField,
+            "declining to adopt has to fall through to a spawn",
+        )
+        val asked = holder.lastRequestLine()
+        assertEquals(
+            "GET /version", asked?.substringBeforeLast(' '),
+            "the identity question is asked on the one route answered before the token check",
+        )
+        assertFalse(
+            asked!!.contains("tkn"),
+            "asking who the holder is must never present the token to it: $asked",
+        )
+        assertTrue(exited.await(5, TimeUnit.SECONDS), "watchdog never reported the exit")
+    }
+
+    @Test
+    fun `a holder that answers without naming a build is not adopted`() {
+        // 200 and an empty body is what a web server on the port gives for free, and
+        // it is exactly what the test accepted before it asked for an identity.
+        val holder = serving(200, reports = "")
+        recordEditorServer(pid = 4242, port = holder.port)
+        manager.killRecordedProcess = { }
+
+        val exited = CountDownLatch(1)
+        manager.onServerCrashed = { exited.countDown() }
+        assertTrue(manager.startServer())
+
+        assertFalse(manager.isAdopted(), "answering is not the same as being ours")
+        assertTrue(exited.await(5, TimeUnit.SECONDS), "watchdog never reported the exit")
+    }
+
+    @Test
+    fun `a tree that records no commit declines to adopt rather than accepting anyone`() {
+        // Fail closed. With nothing to compare against, the identity test would be a
+        // bare 200 again, so a build that cannot say what it is does not adopt at
+        // all. That costs a spawn; the other direction costs the session.
+        File(tempDir, "server/$REH_PRODUCT_FILE").delete()
+        val holder = serving(200)
+        recordEditorServer(pid = 4242, port = holder.port)
+        manager.killRecordedProcess = { }
+
+        val exited = CountDownLatch(1)
+        manager.onServerCrashed = { exited.countDown() }
+        assertTrue(manager.startServer())
+
+        assertFalse(manager.isAdopted(), "an unidentifiable build must not adopt on a status line")
         assertTrue(exited.await(5, TimeUnit.SECONDS), "watchdog never reported the exit")
     }
 
@@ -1465,7 +1562,7 @@ class AdoptionTest {
  * It records the request line so a test can assert *which* route was asked for,
  * which is half of what the probe's contract says.
  */
-private class StubServer(initialStatus: Int?) {
+private class StubServer(initialStatus: Int?, initialBody: String = "") {
 
     /**
      * What this answers with, or null for a port it holds without serving on.
@@ -1476,6 +1573,18 @@ private class StubServer(initialStatus: Int?) {
      */
     @Volatile
     var status: Int? = initialStatus
+
+    /**
+     * The body it answers with, which for `/version` is the commit the holder
+     * claims to be.
+     *
+     * It exists because a status line stopped being the whole answer: adoption
+     * compares this against the commit the packaged tree records, so a stub that
+     * always framed an empty body could only ever stand for a holder that is not
+     * ours.
+     */
+    @Volatile
+    var body: String = initialBody
 
     private val socket = ServerSocket(0, 0, InetAddress.getByName("127.0.0.1"))
     private val requestLine = AtomicReference<String?>(null)
@@ -1507,11 +1616,14 @@ private class StubServer(initialStatus: Int?) {
                             val line = reader.readLine()
                             if (line.isNullOrEmpty()) break
                         }
+                        val payload = body.toByteArray()
                         client.getOutputStream().apply {
                             write(
                                 ("HTTP/1.1 $status Stub\r\n" +
-                                    "Content-Length: 0\r\nConnection: close\r\n\r\n").toByteArray()
+                                    "Content-Length: ${payload.size}\r\n" +
+                                    "Connection: close\r\n\r\n").toByteArray()
                             )
+                            write(payload)
                             flush()
                         }
                     }

--- a/android/app/src/test/kotlin/com/vscodroid/service/WorkerHostShutdownPatchTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/service/WorkerHostShutdownPatchTest.kt
@@ -1,0 +1,77 @@
+package com.vscodroid.service
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * That a worker host is asked to shut down and then waited for, rather than cut
+ * off after a fixed pause.
+ *
+ * The Pty Host and the Extension Host run as `worker_threads` Workers instead of
+ * forked processes, which is what keeps them off Android's 32-process budget. A
+ * Worker has no signal, so the adaptor asks for shutdown in-band and the host runs
+ * its normal teardown. The Pty Host writes a terminal's remaining output during
+ * that teardown, so what happens between the ask and the thread stopping decides
+ * whether the last thing a user's command printed reaches them.
+ *
+ * Measured on Node 22.17.1 against a worker whose teardown takes 500 ms: the fixed
+ * 200 ms pause terminated it after one of five output chunks; waiting for the exit
+ * event delivered all five and finished in 525 ms; and a worker that never exits
+ * is still stopped, at the stated ceiling, so the wait bounds a hang rather than
+ * removing the bound.
+ *
+ * This reads patch text, which is the weaker kind of test, and it is here because
+ * nothing else would notice. The change lives in a diff applied to the VS Code
+ * source before the server is built, so no Kotlin compiles against it and the
+ * suite cannot run it. `patches/fingerprints.txt` proves the patch as a whole
+ * reached the packaged tree by looking for `__vsc_disconnect`, which a revert of
+ * the wait would leave exactly where it is. What this buys is that a rebase onto a
+ * new VS Code version cannot quietly drop the wait; what it does not buy is any
+ * evidence that the patch applies, compiles, or behaves.
+ */
+class WorkerHostShutdownPatchTest {
+
+    private val patch = File("../../patches/0003-ptyhost-as-worker-thread.patch")
+
+    private fun source(): String {
+        assertTrue(patch.isFile) {
+            "Could not read ${patch.absolutePath}. If the patch was renamed, point this " +
+                "test at it rather than deleting it: nothing else guards what it checks."
+        }
+        return patch.readText()
+    }
+
+    @Test
+    fun `the shutdown waits for the worker to exit`() {
+        val js = source()
+        assertTrue(js.contains("once('exit'")) {
+            "The adaptor no longer waits for the worker's exit event. Without it the " +
+                "thread is stopped on a timer, and a Pty Host still writing a terminal's " +
+                "last output loses whatever had not been flushed."
+        }
+        assertTrue(js.contains("clearTimeout(deadline)")) {
+            "The exit no longer cancels the deadline, so the terminate() fires anyway " +
+                "against a thread that has already gone."
+        }
+        assertTrue(!Regex("""terminate\(\);\s*\},\s*\d""").containsMatchIn(js)) {
+            "The shutdown terminates the worker after a fixed number of milliseconds. " +
+                "That is a deadline rather than a shutdown: the module is stopped whether " +
+                "or not its teardown finished."
+        }
+    }
+
+    @Test
+    fun `the wait is bounded by a ceiling that is named`() {
+        val js = source()
+        assertTrue(Regex("""const WORKER_EXIT_GRACE_MS = [\d_]+;""").containsMatchIn(js)) {
+            "The ceiling on the wait is gone or is no longer a named constant. A Worker " +
+                "keeps its host process alive, so a module that never exits would hold the " +
+                "whole server open, and a bound nobody can find is a bound nobody can weigh."
+        }
+        assertTrue(js.contains("setTimeout(() => { this._worker.terminate(); }, WORKER_EXIT_GRACE_MS)")) {
+            "Nothing stops a worker that never answers the disconnect. The wait has to " +
+                "end somewhere, and that somewhere is this timer."
+        }
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/service/WorkerHostShutdownPatchTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/service/WorkerHostShutdownPatchTest.kt
@@ -22,12 +22,15 @@ import java.io.File
  * removing the bound.
  *
  * This reads patch text, which is the weaker kind of test, and it is here because
- * nothing else would notice. The change lives in a diff applied to the VS Code
- * source before the server is built, so no Kotlin compiles against it and the
- * suite cannot run it. `patches/fingerprints.txt` proves the patch as a whole
- * reached the packaged tree by looking for `__vsc_disconnect`, which a revert of
- * the wait would leave exactly where it is. What this buys is that a rebase onto a
- * new VS Code version cannot quietly drop the wait; what it does not buy is any
+ * nothing else would notice this early. The change lives in a diff applied to the
+ * VS Code source before the server is built, so no Kotlin compiles against it and
+ * the suite cannot run it. `patches/fingerprints.txt` used to prove the patch as a
+ * whole reached the packaged tree by looking for `__vsc_disconnect`, which its
+ * first version already added and a revert of the wait would leave exactly where
+ * it is; its row now names the wait itself, so a tree built before the wait is
+ * refused. That row judges a packaged tree, though, and only a rebuilt server can
+ * produce one that passes it. What this buys is that a rebase onto a new VS Code
+ * version cannot quietly drop the wait from the patch; what it does not buy is any
  * evidence that the patch applies, compiles, or behaves.
  */
 class WorkerHostShutdownPatchTest {

--- a/patches/0003-ptyhost-as-worker-thread.patch
+++ b/patches/0003-ptyhost-as-worker-thread.patch
@@ -27,6 +27,13 @@ non-zero code without a signal as a crash. kill() takes that signal and honours
 SIGKILL by terminating at once; it used to take none, so a caller escalating past
 the graceful path silently got the graceful path.
 
+The graceful path itself waits for the worker's exit event. It used to pause for a
+fixed 200ms and terminate whatever the module was doing, which is shorter than the
+Pty Host's own teardown: that host writes a terminal's remaining output on its way
+out, and anything still buffered was cut off mid-write with nothing logged. The
+wait is still bounded, by WORKER_EXIT_GRACE_MS, because a Worker keeps its host
+process alive and a module that never exits would otherwise hold the server open.
+
 ipc.cp.ts picks between them on serverName. Only the Pty Host moves in this
 change; the file watcher keeps forking, and the Extension Host is a separate step
 because it also has to stop passing sockets over its channel.
@@ -74,10 +81,10 @@ index a92290a..282873b 100644
  
 diff --git a/src/vs/base/node/workerAsChildProcess.ts b/src/vs/base/node/workerAsChildProcess.ts
 new file mode 100644
-index 0000000..5ffcd93
+index 0000000..e4fc8ae
 --- /dev/null
 +++ b/src/vs/base/node/workerAsChildProcess.ts
-@@ -0,0 +1,170 @@
+@@ -0,0 +1,200 @@
 +/*---------------------------------------------------------------------------------------------
 + *  Copyright (c) Microsoft Corporation. All rights reserved.
 + *  Licensed under the MIT License. See License.txt in the project root for license information.
@@ -86,6 +93,23 @@ index 0000000..5ffcd93
 +import { ChildProcess, ForkOptions } from 'child_process';
 +import { EventEmitter } from 'events';
 +import { Worker } from 'worker_threads';
++
++/**
++ * How long an asked-for shutdown has before the thread is stopped anyway.
++ *
++ * An upper bound on a hang, not a budget a shutdown is expected to spend: the
++ * disconnect below is answered in milliseconds when the module is healthy, and
++ * this is only reached when it is not. It exists at all because a Worker keeps
++ * its host process alive, so a module that never exits would hold the whole
++ * server open rather than merely leaking a thread.
++ *
++ * Three seconds is chosen against what the wait is protecting. The Pty Host
++ * writes the terminal's remaining output on its way out, and the previous fixed
++ * 200ms pause was shorter than that write rather than longer than it. A deliberate
++ * app stop cannot be delayed by this either way: ProcessManager gives the whole
++ * server one second before it kills the process outright.
++ */
++const WORKER_EXIT_GRACE_MS = 3_000;
 +
 +/**
 + * Runs a module that expects to be a `child_process.fork` child inside a
@@ -225,14 +249,27 @@ index 0000000..5ffcd93
 +		}
 +
 +		// Give the module the disconnect it would get from a closing IPC channel,
-+		// so its own shutdown runs, then stop the thread. terminate() alone would
++		// so its own shutdown runs, then wait for it to go. terminate() alone would
 +		// drop pending work -- for the Pty Host that means orphaned shells.
 +		try {
 +			this._worker.postMessage({ __vsc_disconnect: true });
 +		} catch {
-+			// The thread may already be gone; terminate below covers it.
++			// The thread may already be gone; the deadline below covers it.
 +		}
-+		setTimeout(() => { this._worker.terminate(); }, 200);
++
++		// Waited on, not timed. This used to terminate() 200ms later whatever the
++		// module was doing, which is a deadline wearing a shutdown's clothes: the
++		// Pty Host writes a terminal's remaining output as it tears down, and
++		// anything still buffered at 200ms was cut off mid-write with nothing said.
++		// The exit event is the module reporting that its teardown finished, and
++		// waiting for it costs nothing in the normal case, where it arrives first.
++		//
++		// The bound stays, because a wait with no bound is a hang: a Worker keeps
++		// its host process alive, so a module that never exits would keep the
++		// server open for good. It is stated as WORKER_EXIT_GRACE_MS rather than
++		// buried here, and it is a ceiling rather than a pause.
++		const deadline = setTimeout(() => { this._worker.terminate(); }, WORKER_EXIT_GRACE_MS);
++		this._worker.once('exit', () => clearTimeout(deadline));
 +	}
 +}
 +

--- a/patches/fingerprints.txt
+++ b/patches/fingerprints.txt
@@ -36,10 +36,29 @@
 # That second check is necessary, not sufficient. It catches a pattern lifted from
 # surrounding code; it cannot prove the same text appears nowhere else in the
 # tree. Proving that still wants an unpatched build, and nothing here does it.
+#
+# A row proves the patch ARRIVED, not which version of it did, and that is the
+# trap this file is easiest to fall into. Editing a patch that already has a row
+# changes nothing the check can see: the pattern still matches, so a published
+# server built before the edit passes, the APK is built from it, and the only
+# thing describing the new behaviour is a CHANGELOG line. A row therefore has to
+# move with a revision whose behaviour is the point of the revision. 0003 is the
+# worked example: its pattern was `__vsc_disconnect`, which its first version
+# already added, and it now names the exit wait a later version added, so a
+# server predating that wait is refused instead of accepted.
+#
+# Choosing the replacement is the original problem with less freedom, since the
+# revision has to have introduced something durable of its own. `this._worker.once`
+# qualifies because the packaged bundle already emits `this._worker.terminate()`
+# from this same class, so neither the field nor the method is being mangled, and
+# `'exit'` is a string literal. Both halves were read out of the bundle rather
+# than assumed. A revision that introduces no such text leaves this file unable
+# to see it, and the honest move then is to say so where the behaviour is
+# claimed, not to pick a pattern that cannot fail.
 
 0001 platform|out/server-main.js|platform==="android"
 0002 userDataPath|out/vs/platform/terminal/node/ptyHostMain.js|case"android"
-0003 ptyHost worker|out/server-main.js|__vsc_disconnect
+0003 ptyHost worker|out/server-main.js|this._worker.once('exit'
 0004 extHost worker|out/server-main.js|worker_thread Extension Host
 0005 webview csp|out/vs/workbench/contrib/webview/browser/pre/index.html|script-src 'unsafe-inline'
 0006 callback relay|out/vs/code/browser/workbench/callback.html|intent://callback


### PR DESCRIPTION
Adoption accepted a port holder on evidence that a stranger could produce, and the pty host was given 200 ms on a blind timer before being terminated.

## Changes

- The identity test compares the holder against values recorded for this build. It never sends the connection token to the holder, and a tree it cannot identify fails closed.
- Terminal host shutdown waits for the worker exit event under a bounded timeout instead of a fixed 200 ms, so a terminal with buffered output is not cut off mid-write.
- Test inputs that read repository files are declared to Gradle, so a change to those files invalidates the task rather than leaving a stale pass.

## Blocked on a server rebuild

**Do not merge yet.** The teardown change lives in `patches/0003`, and its fingerprint row was updated to match. The packaged server tarball still predates it, so `check-patch-fingerprints.py` now refuses that tree and `Build Debug APK` fails on this branch.

`build.yml` hashes `patches/**` into the assets cache key and `release.yml` fetches unconditionally, so merging would turn every pull request build and every tag release red until `build-vscode-oss.yml` is re-run for 1.133.0 and the release asset is refreshed. That job is manual and takes about thirty minutes.

Sequence: run the server build, then merge.

## Notes

The identity test narrows rather than closes. The pinned commit is public, so a process built to imitate this app still passes it. The KDoc says so rather than implying otherwise.

## Verification

929 unit tests, lint clean. `Build Debug APK` fails for the reason above and is expected to pass once the server tarball is rebuilt.
