### PR TITLE
feat(legal): ship the notices, and check the whole tree against them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Berkeley DB (AGPL-3.0-only) is no longer bundled. Nothing linked it. Four libraries that are used were added to the source offer, and `NOTICE.md` now lists all 39 components.
 - Attribution is now checked against every binary in the asset tree, not just the top two directories: 195 more files, including the WebAssembly, Windows and macOS objects an ELF-only scan walks past.
 - A binary that moves can no longer be recorded under the wrong licence in silence. An attribution entry that stops matching is reported even when the move took its own directory with it.
+- The check that the licences screen's documents are packaged now runs when the build script changes, which is the edit that can drop them.
 - The About dialog's Source Code link moved onto the new licenses screen, beside the offer of source it answers.
 
 - Builds now verify the packaged server tree carries every patch this repository applies, not just the downloaded copy. The two trees had already diverged on a working checkout.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed an origin check on the Android bridge that nothing called and nothing could satisfy. The session token gates that surface, and every bridge method now validates it.
 - Asking the terminal host or extension host to stop immediately no longer gets the graceful path instead. Nothing escalates today, which is why this was invisible.
 - Berkeley DB (AGPL-3.0-only) is no longer bundled. Nothing linked it. Four libraries that are used were added to the source offer, and `NOTICE.md` now lists all 39 components.
+- Every binary in the asset tree is now checked against the attribution record, not just the top two directories: 111 more files, and six components neither notice named.
+- The About dialog's Source Code link moved onto the new licenses screen, beside the offer of source it answers.
 
 - Builds now verify the packaged server tree carries every patch this repository applies, not just the downloaded copy. The two trees had already diverged on a working checkout.
 - The build refuses a server tree missing any Android adaptation, rather than checking only the ones someone listed.
@@ -73,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Open Source Licenses**, on the About dialog: the notices now ship inside the app and read offline, so the GPL written offer of source reaches every device holding those binaries.
 - VSCodroid warns when the installed Android System WebView is older than Chrome 105, the version it is tested against. It warns and continues rather than refusing to start, and a version it cannot read is not treated as an old one.
 - **Serve on Network**: lists the ports your dev servers are listening on, shows the address other devices can reach them at, and copies it. Loopback-only servers are called out.
 - You can preview your own dev server at the device's network address from inside the editor, not only at `localhost`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Asking the terminal host or extension host to stop immediately no longer gets the graceful path instead. Nothing escalates today, which is why this was invisible.
 - Berkeley DB (AGPL-3.0-only) is no longer bundled. Nothing linked it. Four libraries that are used were added to the source offer, and `NOTICE.md` now lists all 39 components.
 - Attribution is now checked against every binary in the asset tree, not just the top two directories: 195 more files, including the WebAssembly, Windows and macOS objects an ELF-only scan walks past.
+- A binary that moves can no longer be recorded under the wrong licence in silence. An attribution entry that stops matching is reported even when the move took its own directory with it.
 - The About dialog's Source Code link moved onto the new licenses screen, beside the offer of source it answers.
 
 - Builds now verify the packaged server tree carries every patch this repository applies, not just the downloaded copy. The two trees had already diverged on a working checkout.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed an origin check on the Android bridge that nothing called and nothing could satisfy. The session token gates that surface, and every bridge method now validates it.
 - Asking the terminal host or extension host to stop immediately no longer gets the graceful path instead. Nothing escalates today, which is why this was invisible.
 - Berkeley DB (AGPL-3.0-only) is no longer bundled. Nothing linked it. Four libraries that are used were added to the source offer, and `NOTICE.md` now lists all 39 components.
-- Every binary in the asset tree is now checked against the attribution record, not just the top two directories: 111 more files, and six components neither notice named.
+- Attribution is now checked against every binary in the asset tree, not just the top two directories: 195 more files, including the WebAssembly, Windows and macOS objects an ELF-only scan walks past.
 - The About dialog's Source Code link moved onto the new licenses screen, beside the offer of source it answers.
 
 - Builds now verify the packaged server tree carries every patch this repository applies, not just the downloaded copy. The two trees had already diverged on a working checkout.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -21,6 +21,14 @@ Versions are deliberately not listed unless pinned in this repository: most comp
 | OpenSSH | BSD | Termux build, https://www.openssh.com |
 | node-pty | MIT | https://github.com/microsoft/node-pty — native addon rebuilt for Android/Bionic |
 | @parcel/watcher | MIT | https://github.com/parcel-bundler/watcher — native addon rebuilt for Android/Bionic |
+| @vscode/sqlite3 | BSD-3-Clause (SQLite itself is public domain) | https://github.com/microsoft/vscode-node-sqlite3, native addon rebuilt for Android/Bionic |
+| @vscode/native-watchdog | MIT | https://github.com/microsoft/node-native-watchdog, bundled by the Code - OSS build |
+| @vscode/deviceid | MIT | https://github.com/microsoft/vscode-deviceid, bundled by the Code - OSS build |
+| @vscode/sandbox-runtime | Apache-2.0 | https://github.com/anthropic-experimental/sandbox-runtime, bundled by the Code - OSS build |
+| kerberos (Node addon) | Apache-2.0 | https://github.com/mongodb-js/kerberos. The npm addon, not the MIT Kerberos 5 C libraries listed below |
+| @microsoft/mxc-sdk | MIT | https://www.npmjs.com/package/@microsoft/mxc-sdk, bundled by the Code - OSS build |
+| js-debug | MIT | https://github.com/microsoft/vscode-js-debug, the built-in JavaScript debugger produced by the Code - OSS build |
+| @github/copilot (GitHub Copilot CLI) | GitHub Copilot CLI License, proprietary | Redistributed under GitHub, Inc.'s own terms as a dependency of the Copilot extension. The full text ships in the server tree; the reasoning is in `docs/LEGAL_NOTICES.md` |
 | musl (dynamic loader) | MIT | Alpine Linux package, https://musl.libc.org — bundled so the Claude Code CLI can run; the CLI itself is installed by the user and is not redistributed here |
 
 ## Bundled Native Components
@@ -28,11 +36,17 @@ Versions are deliberately not listed unless pinned in this repository: most comp
 Licences here are Termux's own `TERMUX_PKG_LICENSE` for the package each binary
 comes from, and the "Linked by" column is read out of the shipped ELF headers
 rather than written by hand. `scripts/check-library-attribution.py` fails the build
-when a shipped binary is missing from this table, when it is missing from the
-matching table in `docs/LEGAL_NOTICES.md`, or when a copyleft component is missing
-from the source offer that file carries. Both documents are read: this one said
-the build was gated on it while only the other was, so the two agreed by habit
-rather than by anything enforcing it.
+when a shipped binary is attributed nowhere in this file, when it is missing from
+`docs/LEGAL_NOTICES.md`, or when a copyleft component is missing from the source
+offer that file carries. Both documents are read: this one said the build was
+gated on it while only the other was, so the two agreed by habit rather than by
+anything enforcing it.
+
+This table covers the Termux libraries and executables at the top level of
+`assets/usr/lib` and `jniLibs/arm64-v8a`. The binaries that sit deeper in the
+asset tree are attributed under **Core Components** above, and the gate holds
+them to the same rules: it walks the tree to its leaves, recognising a binary by
+ELF magic or a `.node` extension.
 
 Excluded as first-party: `libglibc-shim.so` and its companion stubs, which carry
 glibc's soname but are built from this repository's own source.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -28,6 +28,13 @@ Versions are deliberately not listed unless pinned in this repository: most comp
 | kerberos (Node addon) | Apache-2.0 | https://github.com/mongodb-js/kerberos. The npm addon, not the MIT Kerberos 5 C libraries listed below |
 | @microsoft/mxc-sdk | MIT | https://www.npmjs.com/package/@microsoft/mxc-sdk, bundled by the Code - OSS build |
 | js-debug | MIT | https://github.com/microsoft/vscode-js-debug, the built-in JavaScript debugger produced by the Code - OSS build |
+| vscode-js-profile-visualizer | MIT | https://github.com/microsoft/vscode-js-profile-visualizer, the built-in profile viewer produced by the Code - OSS build. Its tables are WebAssembly |
+| @vscode/tree-sitter-wasm | MIT | https://github.com/microsoft/vscode-tree-sitter-wasm, bundled by the Code - OSS build. WebAssembly builds of tree-sitter (https://github.com/tree-sitter/tree-sitter) and its grammars |
+| web-tree-sitter | MIT | https://github.com/tree-sitter/tree-sitter, the WebAssembly binding, bundled by the Copilot Chat extension |
+| vscode-oniguruma | MIT | https://github.com/microsoft/vscode-oniguruma, bundled by the Code - OSS build. The regex engine it compiles to WebAssembly is Oniguruma (BSD-2-Clause, https://github.com/kkos/oniguruma) and its notice ships in the package |
+| @github/blackbird-external-ingest-utils | MIT | https://www.npmjs.com/package/@github/blackbird-external-ingest-utils, a WebAssembly dependency of the Copilot Chat extension |
+| PSReadLine | BSD-2-Clause | https://github.com/PowerShell/PSReadLine. Prebuilt .NET assemblies carried by the terminal's PowerShell shell integration; they have no use on Android and are listed because they are redistributed |
+| distlib | PSF-2.0 | https://github.com/pypa/distlib, vendored inside the bundled pip. Ships six prebuilt Windows launchers, redistributed unused |
 | @github/copilot (GitHub Copilot CLI) | GitHub Copilot CLI License, proprietary | Redistributed under GitHub, Inc.'s own terms as a dependency of the Copilot extension. The full text ships in the server tree; the reasoning is in `docs/LEGAL_NOTICES.md` |
 | musl (dynamic loader) | MIT | Alpine Linux package, https://musl.libc.org — bundled so the Claude Code CLI can run; the CLI itself is installed by the user and is not redistributed here |
 
@@ -46,7 +53,10 @@ This table covers the Termux libraries and executables at the top level of
 `assets/usr/lib` and `jniLibs/arm64-v8a`. The binaries that sit deeper in the
 asset tree are attributed under **Core Components** above, and the gate holds
 them to the same rules: it walks the tree to its leaves, recognising a binary by
-ELF magic or a `.node` extension.
+its magic number (ELF, WebAssembly, PE or Mach-O) or a `.node` extension. The
+formats this device cannot execute are counted too. A Windows launcher or a .NET
+assembly is redistributed inside the APK on its own terms whether or not
+anything here can run it.
 
 Excluded as first-party: `libglibc-shim.so` and its companion stubs, which carry
 glibc's soname but are built from this repository's own source.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -46,10 +46,16 @@ android {
         // "Setup failed" rather than "not enough room". Measuring it here instead
         // removes the way that goes wrong rather than restating the number.
         //
-        // Every file under assets/ is extracted: extractAssetDir copies whole
-        // trees for vscode-reh and usr, extractBundledExtensions unpacks all of
-        // extensions/, and the bootstrap scripts are copied individually. So the
-        // whole tree is the right thing to measure, not a subset.
+        // Every file under src/main/assets is extracted: extractAssetDir copies
+        // whole trees for vscode-reh and usr, extractBundledExtensions unpacks
+        // all of extensions/, and the bootstrap scripts are copied individually.
+        // So the whole tree is the right thing to measure, not a subset.
+        //
+        // The APK's assets are that tree plus the notices bundled by
+        // `bundleNotices` below, and those are deliberately outside this sum:
+        // they are read straight out of the APK by the licences dialog and never
+        // written to disk, so charging a device for room to unpack them would
+        // ask for space nothing is going to use.
         //
         // Jobs that build without a real asset tree (lint, unit tests, R8) get a
         // small number here, which is correct rather than a gap: their APK has no
@@ -152,6 +158,11 @@ android {
 
     // On-demand toolchain asset packs (Play Asset Delivery)
     assetPacks += listOf(":toolchain_go", ":toolchain_ruby", ":toolchain_java")
+
+    // The attribution documents, packaged so they reach the device. See
+    // `bundleNotices` at the foot of this file for why they are copied rather
+    // than committed here.
+    sourceSets["main"].assets.srcDir(layout.buildDirectory.dir("generated/notices"))
 
     lint {
         // The baseline is what makes this affordable: the 59 issues recorded in
@@ -484,10 +495,44 @@ val verifyBundledBinaries = tasks.register<Exec>("verifyBundledBinaries") {
     }
 }
 
+// The attribution documents, copied into the APK so a person holding the
+// binaries can read the notices that have to travel with them.
+//
+// This matters most for the copyleft ones. Bash, Git, Make, readline, libiconv,
+// gdbm, liblzma and zstd are all GPL or LGPL, and the GPL's written offer of
+// source has to accompany the binary rather than sit in a repository the holder
+// of an APK has no reason to know exists. NOTICE.md and docs/LEGAL_NOTICES.md
+// carried that offer and shipped nowhere; every device ran the binaries with no
+// notice of any kind on it.
+//
+// Copied from the repository root rather than committed under src/main/assets,
+// because a second copy is a copy that goes stale, and a stale licence notice is
+// worse than an absent one: it is a claim about terms that is no longer true.
+// The two files are ~37 KiB of markdown, which deflates to roughly 12 KiB in the
+// APK, about 0.01% of the base module.
+//
+// They are read out of the APK by MainActivity's licences dialog and never
+// extracted, which is why they are a separate assets source directory: it keeps
+// them out of the src/main/assets sum that sizes first-run extraction.
+val bundleNotices = tasks.register<Copy>("bundleNotices") {
+    group = "build"
+    description = "Copies the attribution documents into the APK's assets."
+
+    val repoRoot = rootProject.projectDir.parentFile
+    from(File(repoRoot, "NOTICE.md"))
+    from(File(repoRoot, "docs/LEGAL_NOTICES.md"))
+    into(layout.buildDirectory.dir("generated/notices"))
+
+    // The names the app opens. Kept beside the copy so a rename here fails the
+    // build rather than emptying the dialog on a device: com.vscodroid.util
+    // .Notices.BUNDLED lists the same two, and NoticesTest compares the lists.
+}
+
 // A dependency of the merge, not of the package or the assemble: the point is
 // to stop the wrong tree getting into an APK rather than to describe one that
 // already did.
 tasks.matching { it.name.startsWith("merge") && it.name.endsWith("Assets") }
     .configureEach {
         dependsOn(checkPatchFingerprints, verifyServerTree, verifyBundledBinaries)
+        dependsOn(bundleNotices)
     }

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -251,6 +251,22 @@ dependencies {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+
+    // This build script is a genuine input to the unit tests, because one of
+    // them reads it: NoticesTest parses the `bundleNotices` task to check that
+    // what the build copies into the APK is what `Notices.BUNDLED` opens. Gradle
+    // cannot see a `File("build.gradle.kts").readText()` from inside a test, so
+    // without this declaration the task stays UP-TO-DATE whenever the build
+    // script is the only thing that changed.
+    //
+    // Which is exactly the edit the test exists to catch. Deleting a `from(...)`
+    // line and re-running left `> Task :app:testDebugUnitTest UP-TO-DATE`, exit
+    // 0, and the results XML untouched from the previous run; only
+    // `--rerun-tasks` turned it red. A guard that cannot run on the change it
+    // guards against is not a guard.
+    inputs.file(layout.projectDirectory.file("build.gradle.kts"))
+        .withPropertyName("appBuildScript")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
 }
 
 // The server tree in assets/ has to carry this checkout's patches, and nothing

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -524,8 +524,10 @@ val verifyBundledBinaries = tasks.register<Exec>("verifyBundledBinaries") {
 // Copied from the repository root rather than committed under src/main/assets,
 // because a second copy is a copy that goes stale, and a stale licence notice is
 // worse than an absent one: it is a claim about terms that is no longer true.
-// The two files are ~37 KiB of markdown, which deflates to roughly 12 KiB in the
-// APK, about 0.01% of the base module.
+// The two files are ~44 KiB of markdown, which deflates to roughly 15 KiB in the
+// APK, about 0.01% of the base module. They grow as the tree does, since every
+// binary in it has to be named in both, so treat those as the order of magnitude
+// rather than as figures to check against.
 //
 // They are read out of the APK by MainActivity's licences dialog and never
 // extracted, which is why they are a separate assets source directory: it keeps

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -12,14 +12,18 @@ import android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL
 import android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW
 import android.content.pm.PackageManager
 import android.graphics.Color
+import android.graphics.Typeface
 import android.os.Bundle
 import android.net.Uri
 import android.os.IBinder
 import android.os.SystemClock
+import android.text.util.Linkify
 import android.view.View
 import android.webkit.RenderProcessGoneDetail
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import android.widget.ScrollView
+import android.widget.TextView
 import android.widget.Toast
 import java.io.File
 import androidx.activity.OnBackPressedCallback
@@ -47,6 +51,7 @@ import com.vscodroid.service.NodeService
 import com.vscodroid.setup.FirstRunSetup
 import com.vscodroid.storage.SafStorageManager
 import com.vscodroid.util.Logger
+import com.vscodroid.util.Notices
 import com.vscodroid.webview.VSCodroidWebChromeClient
 import com.vscodroid.webview.VSCodroidWebView
 import com.vscodroid.webview.VSCodroidWebViewClient
@@ -1322,15 +1327,54 @@ class MainActivity : AppCompatActivity() {
         val version = getString(R.string.about_version_format, versionName)
         val disclaimer = getString(R.string.legal_disclaimer)
 
+        // An AlertDialog has three button slots and this dialog needs four
+        // destinations, so "Source Code" moved one level in, onto the licences
+        // dialog. That is where it belongs rather than a place it was pushed to:
+        // what the licences dialog carries is the GPL's written offer of source,
+        // and the repository link is the answer to the question that offer
+        // raises.
         AlertDialog.Builder(this)
             .setTitle(getString(R.string.about_title))
             .setMessage("$version\n\n$disclaimer")
             .setPositiveButton("OK", null)
-            .setNeutralButton("Source Code") { _, _ ->
-                startActivity(Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/rmyndharis/VSCodroid")))
-            }
+            .setNeutralButton(getString(R.string.about_licenses)) { _, _ -> showLicensesDialog() }
             .setNegativeButton("Privacy Policy") { _, _ ->
                 startActivity(Intent(Intent.ACTION_VIEW, Uri.parse("https://rmyndharis.github.io/VSCodroid/privacy-policy.html")))
+            }
+            .show()
+    }
+
+    /**
+     * Shows the bundled third-party notices, read from the APK.
+     *
+     * Offline on purpose. The app redistributes GPL and LGPL binaries, and the
+     * written offer of source that has to travel with them reaches the device
+     * only through this screen; a link to a web page would discharge nothing on
+     * a device with no network, which is the state this app is built to be
+     * usable in.
+     *
+     * [Notices.read] never throws and never returns empty: a document it could
+     * not open is replaced in place by a line naming it.
+     */
+    private fun showLicensesDialog() {
+        val body = TextView(this).apply {
+            // Before setText: autoLinkMask is applied when the text is set, and
+            // linkifying is the point. The offer names repositories to fetch
+            // source from, and a URL nobody can tap is a URL nobody follows.
+            autoLinkMask = Linkify.WEB_URLS
+            typeface = Typeface.MONOSPACE
+            textSize = 11f
+            val pad = (16 * resources.displayMetrics.density).toInt()
+            setPadding(pad, pad, pad, pad)
+            text = Notices.read { assets.open(it) }
+        }
+
+        AlertDialog.Builder(this)
+            .setTitle(getString(R.string.licenses_title))
+            .setView(ScrollView(this).apply { addView(body) })
+            .setPositiveButton("OK", null)
+            .setNeutralButton("Source Code") { _, _ ->
+                startActivity(Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/rmyndharis/VSCodroid")))
             }
             .show()
     }

--- a/android/app/src/main/kotlin/com/vscodroid/util/Notices.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/util/Notices.kt
@@ -1,0 +1,60 @@
+package com.vscodroid.util
+
+import java.io.InputStream
+
+/**
+ * The third-party attribution documents, as they are carried inside the APK.
+ *
+ * The app redistributes GPL and LGPL binaries: Bash, Git, GNU Make, readline,
+ * libiconv, gdbm, liblzma and zstd, among others. The GPL's written offer of
+ * corresponding source has to accompany the binary, and until these were bundled
+ * it accompanied nothing. Both documents existed, both were complete, and both
+ * lived only in the repository, which is not somewhere the holder of an installed
+ * APK has any reason to look.
+ *
+ * The files are packaged by the `bundleNotices` task in `app/build.gradle.kts`,
+ * which copies them from the repository root rather than keeping a second copy in
+ * `src/main/assets`. They are read from the APK on demand and never extracted, so
+ * they cost nothing on disk and nothing in the first-run storage pre-flight.
+ */
+object Notices {
+
+    /**
+     * Asset names, in reading order.
+     *
+     * These are basenames because that is what a Gradle `Copy` produces: the
+     * sources are `NOTICE.md` at the repository root and `docs/LEGAL_NOTICES.md`.
+     * `NoticesTest` holds this list and the task's `from(...)` lines to each
+     * other, because a rename on either side is silent otherwise. The dialog
+     * would simply come up empty, on a device, with every gate green.
+     */
+    val BUNDLED = listOf("NOTICE.md", "LEGAL_NOTICES.md")
+
+    /**
+     * Every bundled document, concatenated.
+     *
+     * [open] is the asset reader, normally `context.assets::open`. It is a
+     * parameter so this can be exercised without an `AssetManager`.
+     *
+     * A document that cannot be read is replaced by a line saying so rather than
+     * skipped. Skipping is the dangerous behaviour here: dropping
+     * `LEGAL_NOTICES.md` would remove the source offer while still producing a
+     * plausible-looking notices screen, and nobody reading it would know that
+     * half of it was missing. The replacement goes on the screen rather than into
+     * logcat for the same reason, and it is why nothing here logs.
+     */
+    fun read(open: (String) -> InputStream): String =
+        BUNDLED.joinToString(SEPARATOR) { name ->
+            try {
+                open(name).bufferedReader().use { it.readText() }
+            } catch (_: Exception) {
+                missingMarker(name)
+            }
+        }
+
+    /** What stands in for a document this build did not package. */
+    fun missingMarker(name: String) = "[$name is missing from this build]"
+
+    /** Blank lines between documents, so two markdown files do not run together. */
+    private const val SEPARATOR = "\n\n\n"
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -48,6 +48,8 @@
     <!-- About dialog -->
     <string name="about_title">About VSCodroid</string>
     <string name="about_version_format">Version %s</string>
+    <string name="about_licenses">Licenses</string>
+    <string name="licenses_title">Open Source Licenses</string>
 
     <!-- Toolchain picker (first-run) -->
     <string name="picker_title">What do you code in?</string>

--- a/android/app/src/test/kotlin/com/vscodroid/util/NoticesTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/util/NoticesTest.kt
@@ -1,0 +1,99 @@
+package com.vscodroid.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.io.IOException
+
+/**
+ * The attribution documents have to reach the device, and the pieces that make
+ * that happen sit in three files that nothing else holds together.
+ *
+ * `app/build.gradle.kts` names the repository paths to copy. [Notices.BUNDLED]
+ * names the asset basenames to open. `MainActivity.showLicensesDialog` opens
+ * them. Rename `docs/LEGAL_NOTICES.md`, or drop a `from(...)` line, and the
+ * build stays green, the APK still installs, and the licences dialog quietly
+ * comes up half empty on a device. There is no compiler relationship between the
+ * three, which is what this test supplies.
+ *
+ * The stake is not cosmetic. The GPL requires its written offer of source to
+ * accompany the binary, and this screen is the only place it does.
+ */
+class NoticesTest {
+
+    // Unit tests run with app/ as the working directory.
+    private val repoRoot = File("../..")
+    private val buildScript = File("build.gradle.kts")
+
+    /** The `from(File(repoRoot, "..."))` arguments of the bundleNotices task. */
+    private fun copiedPaths(): List<String> {
+        val script = buildScript.readText()
+        val task = script.substringAfter("tasks.register<Copy>(\"bundleNotices\")", "")
+        assertFalse(task.isEmpty(), "bundleNotices task is gone from build.gradle.kts")
+        val body = task.substringBefore("\n}")
+        return Regex("""from\(File\(repoRoot,\s*"([^"]+)"\)\)""")
+            .findAll(body).map { it.groupValues[1] }.toList()
+    }
+
+    @Test
+    fun `every bundled name is a document the build actually copies`() {
+        val copied = copiedPaths()
+        assertEquals(
+            Notices.BUNDLED.sorted(),
+            copied.map { File(it).name }.sorted(),
+            "Notices.BUNDLED and bundleNotices disagree about which documents ship. " +
+                "The app opens assets by basename; the task decides which basenames exist."
+        )
+        for (path in copied) {
+            val source = File(repoRoot, path)
+            assertTrue(source.isFile, "bundleNotices copies $path, which does not exist")
+            assertTrue(source.length() > 0, "$path is empty")
+        }
+    }
+
+    @Test
+    fun `the written offer of source is among what reaches the device`() {
+        // The one clause that is a legal obligation rather than a courtesy.
+        // Bundling the attribution table alone would look like compliance and
+        // discharge nothing, so the heading is asserted rather than assumed from
+        // the file being present.
+        val offer = copiedPaths().map { File(repoRoot, it) }
+            .filter { it.isFile }
+            .any { it.readText().contains("## GPL Source Code Availability") }
+        assertTrue(
+            offer,
+            "No bundled document carries the '## GPL Source Code Availability' " +
+                "section. The GPL binaries in this APK would ship with no written offer."
+        )
+    }
+
+    @Test
+    fun `read returns every document, in order`() {
+        val text = Notices.read { name -> ByteArrayInputStream("body of $name".toByteArray()) }
+        var cursor = -1
+        for (name in Notices.BUNDLED) {
+            val at = text.indexOf("body of $name")
+            assertTrue(at > cursor, "$name is missing from the joined text, or out of order")
+            cursor = at
+        }
+    }
+
+    @Test
+    fun `a document that cannot be read is named, not dropped`() {
+        val missing = Notices.BUNDLED.last()
+        val text = Notices.read { name ->
+            if (name == missing) throw IOException("not packaged")
+            ByteArrayInputStream("body of $name".toByteArray())
+        }
+        // Named on screen rather than swallowed: a silently shortened notices
+        // screen reads exactly like a complete one.
+        assertTrue(
+            text.contains(Notices.missingMarker(missing)),
+            "An unreadable document vanished from the notices text instead of saying so"
+        )
+        assertTrue(text.contains("body of ${Notices.BUNDLED.first()}"), "The readable document was lost too")
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/util/NoticesTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/util/NoticesTest.kt
@@ -2,6 +2,7 @@ package com.vscodroid.util
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.io.ByteArrayInputStream
@@ -18,6 +19,13 @@ import java.io.IOException
  * build stays green, the APK still installs, and the licences dialog quietly
  * comes up half empty on a device. There is no compiler relationship between the
  * three, which is what this test supplies.
+ *
+ * It supplies it only because the build script is declared an input to the test
+ * task. These tests read `build.gradle.kts` through the file system, which Gradle
+ * cannot see: before that declaration existed, editing the build script left the
+ * task UP-TO-DATE and every mutation to it passed. The `inputs.file` line in
+ * `tasks.withType<Test>` is what makes the assertions below reachable, and
+ * deleting it makes them silent rather than wrong.
  *
  * The stake is not cosmetic. The GPL requires its written offer of source to
  * accompany the binary, and this screen is the only place it does.
@@ -52,6 +60,35 @@ class NoticesTest {
             assertTrue(source.isFile, "bundleNotices copies $path, which does not exist")
             assertTrue(source.length() > 0, "$path is empty")
         }
+    }
+
+    @Test
+    fun `what the copy writes is packaged, and something makes the copy run`() {
+        val script = buildScript.readText()
+        val body = script.substringAfter("tasks.register<Copy>(\"bundleNotices\")", "")
+            .substringBefore("\n}")
+        val destination = Regex("""into\(layout\.buildDirectory\.dir\("([^"]+)"\)\)""")
+            .find(body)?.groupValues?.get(1)
+        assertNotNull(destination, "bundleNotices names no destination directory")
+
+        // Copying the documents is not packaging them. The destination has to be
+        // an assets source directory or they land in build/ and stop there,
+        // leaving the dialog with nothing but its two missing-document markers.
+        assertTrue(
+            Regex("assets\\.srcDir\\([^)]*" + Regex.escape(destination!!) + "[^)]*\\)")
+                .containsMatchIn(script),
+            "bundleNotices writes to $destination, which no assets.srcDir(...) " +
+                "registers. The documents would be copied and never packaged."
+        )
+
+        // And the copy has to be made to run. Nothing infers it from the source
+        // directory: on a clean build the directory is simply empty, and every
+        // gate stays green while the APK ships no notices at all.
+        assertTrue(
+            Regex("dependsOn\\([^)]*bundleNotices").containsMatchIn(script),
+            "Nothing depends on bundleNotices, so a clean build packages an empty " +
+                "notices directory."
+        )
     }
 
     @Test

--- a/docs/LEGAL_NOTICES.md
+++ b/docs/LEGAL_NOTICES.md
@@ -187,6 +187,92 @@ build rather than downloaded from a gallery.
 - **Copyright**: Copyright (c) Microsoft Corporation. All rights reserved.
 - **Ships**: two `win32-app-container-tokens.win32-*-msvc-*.node` addons. These are Windows PE binaries with no use on Android; they are listed because they are redistributed.
 
+### vscode-js-profile-visualizer
+
+The built-in viewer for CPU and heap profiles, produced by the Code - OSS build.
+
+- **Project**: https://github.com/microsoft/vscode-js-profile-visualizer
+- **Version**: whatever the Code - OSS tag in `VSCODE_VERSION` pins
+- **License**: MIT License. The full text and the extension's own `ThirdPartyNotices.txt` ship inside `extensions/ms-vscode.vscode-js-profile-table/`.
+- **Copyright**: Copyright (c) Microsoft Corporation. All rights reserved.
+- **Ships**: two `*.module.wasm` table renderers under `out/`.
+
+### @vscode/tree-sitter-wasm
+
+The incremental parser behind syntax-aware editing, compiled to WebAssembly
+rather than to a native addon. Two copies ship: the server's own, and the one the
+Copilot Chat extension resolves.
+
+- **Project**: https://github.com/microsoft/vscode-tree-sitter-wasm
+- **Upstream**: https://github.com/tree-sitter/tree-sitter, MIT, recorded with its commit in the package's `cgmanifest.json`
+- **License**: MIT License. The full text ships as `LICENSE` inside the package.
+- **Ships**: `tree-sitter.wasm` and the grammar modules beside it (bash, css, ini, powershell, regex, typescript in the server copy).
+
+### web-tree-sitter
+
+tree-sitter's own WebAssembly binding, bundled by the Copilot Chat extension.
+
+- **Project**: https://github.com/tree-sitter/tree-sitter
+- **License**: MIT License. The full text ships as `LICENSE` inside the package.
+- **Copyright**: Copyright (c) 2018-2024 Max Brunsfeld
+- **Ships**: `tree-sitter.wasm`.
+
+### vscode-oniguruma
+
+The regex engine TextMate grammars are matched with, compiled to WebAssembly.
+
+- **Project**: https://github.com/microsoft/vscode-oniguruma
+- **Upstream**: Oniguruma, https://github.com/kkos/oniguruma, **BSD-2-Clause**. The wrapper's licence does not cover the engine inside it, so both are recorded; Oniguruma's own notice ships as `NOTICES.txt` in the package.
+- **License**: MIT License for the wrapper. The full text ships as `LICENSE.txt` inside the package.
+- **Copyright**: Copyright (c) Microsoft Corporation (wrapper); Copyright (c) 2002-2020 K. Kosako (Oniguruma)
+- **Ships**: `release/onig.wasm`.
+
+### @github/blackbird-external-ingest-utils
+
+A WebAssembly helper the Copilot Chat extension uses for code indexing.
+
+- **Project**: https://www.npmjs.com/package/@github/blackbird-external-ingest-utils. The package declares no repository.
+- **Version**: whatever the Copilot Chat extension pins at the Code - OSS tag in `VSCODE_VERSION`
+- **License**: MIT License, declared by the package
+- **Ships**: `external_ingest_utils_bg.wasm`, both inside the package and inlined into the extension's `dist/`.
+
+### GitHub Copilot Chat extension
+
+The extension itself, which is open source and MIT, and a different component
+from the proprietary `@github/copilot` CLI it depends on. Its `dist/` bundle
+carries the tree-sitter grammars and the blackbird WebAssembly listed above,
+inlined by its build.
+
+- **Project**: https://github.com/microsoft/vscode-copilot-chat
+- **Version**: whatever the Code - OSS tag in `VSCODE_VERSION` pins
+- **License**: MIT License. The full text ships as `LICENSE.txt` inside `extensions/copilot/`.
+- **Copyright**: Copyright (c) Microsoft Corporation. All rights reserved.
+- **Ships**: `dist/tree-sitter*.wasm` and `dist/external_ingest_utils_bg.wasm`.
+
+### PSReadLine
+
+Prebuilt .NET assemblies carried by the terminal's PowerShell shell integration.
+Nothing on Android can load them; they are inside the APK, which is the only fact
+the licence turns on.
+
+- **Project**: https://github.com/PowerShell/PSReadLine
+- **Version**: whatever the Code - OSS tag in `VSCODE_VERSION` pins. The server tree's own `ThirdPartyNotices.txt` records it and reproduces the licence text.
+- **License**: BSD-2-Clause License
+- **Copyright**: Copyright (c) 2013, Jason Shirk
+- **Ships**: `Microsoft.PowerShell.PSReadLine.dll`, `Microsoft.PowerShell.Pager.dll` and the two `Microsoft.PowerShell.PSReadLine.Polyfiller.dll` builds, under `out/vs/workbench/contrib/terminal/common/scripts/psreadline/`.
+
+### distlib
+
+Vendored inside the bundled pip. Listed separately from Python because the
+licence is the same but the copyright is not, and PSF-2.0 is precisely the
+licence that asks for the notice to travel with the copy.
+
+- **Project**: https://github.com/pypa/distlib
+- **Version**: recorded in `usr/lib/python*/site-packages/pip/_vendor/vendor.txt`
+- **License**: Python Software Foundation License, Version 2. The full text ships as `LICENSE.txt` inside the package.
+- **Copyright**: Copyright (c) 2012-2024 Vinay Sajip
+- **Ships**: six prebuilt Windows launchers (`t32.exe`, `t64.exe`, `t64-arm.exe`, `w32.exe`, `w64.exe`, `w64-arm.exe`), redistributed unused.
+
 ### npm
 
 - **Project**: https://www.npmjs.com
@@ -235,18 +321,29 @@ under. The licence column is taken from Termux's own `TERMUX_PKG_LICENSE`, which
 is what these packages are built from, rather than from upstream project pages
 that may describe a different version.
 
-This is not every binary in the APK, and the heading here claimed it was. The
-rest live deeper in the asset tree and are attributed by the sections above:
-Git's helper executables under `usr/lib/git-core/`, CPython's extension modules
-under `usr/lib/python*/lib-dynload/`, and the server tree's native addons and
-bundled tools under `assets/vscode-reh/`. 111 files against the 64 listed below,
-redistributed on identical terms.
+This is not every binary in the APK, and the heading here claimed it was. Most of
+them are not below: they live deeper in the asset tree and are attributed by the
+sections above. Git's helper executables under `usr/lib/git-core/`, CPython's
+extension modules under `usr/lib/python*/lib-dynload/`, pip's vendored launchers,
+the server tree's native addons and bundled tools under `assets/vscode-reh/`, the
+WebAssembly its editor services load, and the .NET assemblies its terminal
+integration carries. 195 files against the 64 listed below, measured on the tree
+that built this release, redistributed on identical terms.
+
+That figure is a measurement rather than a fixed property, and the gate prints it
+on every run: a Python module leaving `lib-dynload` or a package adding a grammar
+moves it. What has to stay true is that every one of those files is attributed
+somewhere, which is what the gate enforces rather than what this sentence claims.
 
 `scripts/check-library-attribution.py` regenerates the basis for this table from the
 files actually present in the build tree and fails when a shipped binary is absent
 from it, or when a copyleft component is missing from the source offer below. It
-walks the whole asset tree, recognising a binary by ELF magic or a `.node`
-extension, and holds every component it finds to both this file and `NOTICE.md`.
+walks the whole asset tree, recognising a binary by its magic number (ELF,
+WebAssembly, PE or Mach-O) or a `.node` extension, and holds every component it
+finds to both this file and `NOTICE.md`. Formats this device cannot execute are
+counted too: a Windows launcher and a .NET assembly are redistributed on their
+own terms whether or not anything here can load them, and reading only ELF magic
+walked past 84 of the files now counted.
 It runs on every pull request. Before it existed, Berkeley DB shipped under **AGPL-3.0-only**
 in every release with no attribution and no source offer, having arrived as a
 transitive dependency of Kerberos that nobody classified; it is no longer bundled,

--- a/docs/LEGAL_NOTICES.md
+++ b/docs/LEGAL_NOTICES.md
@@ -135,6 +135,58 @@ Node.js includes V8 (BSD-3-Clause), libuv (MIT), OpenSSL (Apache-2.0), ICU (Unic
 - **License**: BSD-3-Clause (fork of node-sqlite3, Copyright (c) MapBox); SQLite itself is public domain
 - **Full license**: https://github.com/microsoft/vscode-node-sqlite3/blob/main/LICENSE
 
+### @vscode/native-watchdog
+
+- **Project**: https://github.com/microsoft/node-native-watchdog
+- **Version**: whatever the server tree ships (`node_modules/@vscode/native-watchdog/package.json`)
+- **License**: MIT License
+- **Copyright**: Copyright (c) Microsoft Corporation. All rights reserved.
+- **Ships**: `build/Release/watchdog.node`
+
+### @vscode/deviceid
+
+- **Project**: https://github.com/microsoft/vscode-deviceid
+- **Version**: whatever the server tree ships (`node_modules/@vscode/deviceid/package.json`)
+- **License**: MIT License
+- **Copyright**: Copyright (c) Microsoft Corporation.
+- **Ships**: `build/Release/windows.node`. The name is the package's own and is not a description of the platform; the file in this tree is an ARM64 ELF addon.
+
+### @vscode/sandbox-runtime
+
+- **Project**: https://github.com/anthropic-experimental/sandbox-runtime, as declared by the package's own `repository` field
+- **Version**: whatever the server tree ships (`node_modules/@vscode/sandbox-runtime/package.json`)
+- **License**: Apache License 2.0. The full text ships at `node_modules/@vscode/sandbox-runtime/LICENSE` and carries no filled-in copyright line.
+- **Ships**: `vendor/seccomp/x64/apply-seccomp`, an x86-64 helper that cannot run on an ARM64 device. It is listed because it is redistributed, not because it is used.
+
+### kerberos (Node addon)
+
+The npm package, not the MIT Kerberos 5 C libraries listed further down. Different
+project, different licence, nearly the same name.
+
+- **Project**: https://github.com/mongodb-js/kerberos
+- **Version**: whatever the server tree ships (`node_modules/kerberos/package.json`)
+- **License**: Apache License 2.0. The full text ships at `node_modules/kerberos/LICENSE`.
+- **Ships**: `build/Release/kerberos.node`, and a second copy under `build/Release/obj.target/`
+
+### @microsoft/mxc-sdk
+
+- **Project**: https://www.npmjs.com/package/@microsoft/mxc-sdk. The package declares no repository.
+- **Version**: whatever the server tree ships (`node_modules/@microsoft/mxc-sdk/package.json`)
+- **License**: MIT License
+- **Copyright**: Copyright (c) Microsoft Corporation.
+- **Ships**: `bin/arm64/linux-test-proxy` and `bin/arm64/lxc-exec`
+
+### js-debug
+
+The built-in JavaScript and Node.js debugger extension, produced by the Code - OSS
+build rather than downloaded from a gallery.
+
+- **Project**: https://github.com/microsoft/vscode-js-debug
+- **Version**: whatever the Code - OSS tag in `VSCODE_VERSION` pins
+- **License**: MIT License. The full text and the extension's own `ThirdPartyNotices.txt` ship inside `extensions/ms-vscode.js-debug/`.
+- **Copyright**: Copyright (c) Microsoft Corporation. All rights reserved.
+- **Ships**: two `win32-app-container-tokens.win32-*-msvc-*.node` addons. These are Windows PE binaries with no use on Android; they are listed because they are redistributed.
+
 ### npm
 
 - **Project**: https://www.npmjs.com
@@ -177,15 +229,25 @@ Node.js includes V8 (BSD-3-Clause), libuv (MIT), OpenSSL (Apache-2.0), ICU (Unic
 
 ## Complete Bundled Native Library Inventory
 
-Every shared library and executable redistributed inside the APK, with the licence
-each is distributed under. The licence column is taken from Termux's own
-`TERMUX_PKG_LICENSE`, which is what these packages are built from, rather than from
-upstream project pages that may describe a different version.
+The shared libraries and executables that sit at the top level of
+`assets/usr/lib` and `jniLibs/arm64-v8a`, with the licence each is distributed
+under. The licence column is taken from Termux's own `TERMUX_PKG_LICENSE`, which
+is what these packages are built from, rather than from upstream project pages
+that may describe a different version.
+
+This is not every binary in the APK, and the heading here claimed it was. The
+rest live deeper in the asset tree and are attributed by the sections above:
+Git's helper executables under `usr/lib/git-core/`, CPython's extension modules
+under `usr/lib/python*/lib-dynload/`, and the server tree's native addons and
+bundled tools under `assets/vscode-reh/`. 111 files against the 64 listed below,
+redistributed on identical terms.
 
 `scripts/check-library-attribution.py` regenerates the basis for this table from the
 files actually present in the build tree and fails when a shipped binary is absent
-from it, or when a copyleft component is missing from the source offer below. It runs
-on every pull request. Before it existed, Berkeley DB shipped under **AGPL-3.0-only**
+from it, or when a copyleft component is missing from the source offer below. It
+walks the whole asset tree, recognising a binary by ELF magic or a `.node`
+extension, and holds every component it finds to both this file and `NOTICE.md`.
+It runs on every pull request. Before it existed, Berkeley DB shipped under **AGPL-3.0-only**
 in every release with no attribution and no source offer, having arrived as a
 transitive dependency of Kerberos that nobody classified; it is no longer bundled,
 because measurement showed nothing linked it.

--- a/scripts/check-library-attribution.py
+++ b/scripts/check-library-attribution.py
@@ -431,12 +431,12 @@ def nested_pattern(rel):
     return None
 
 
-def subtree_present(pattern):
-    """Whether the directory a pattern covers is on disk.
+def subtree_present(prefix):
+    """Whether a directory prefix is on disk.
 
-    The pattern minus its trailing `/*`, resolved with `Path.glob` rather than
-    tested as a literal, because `usr/lib/python*` has to find whichever version
-    the Termux index resolved to at build time.
+    Resolved with `Path.glob` rather than tested as a literal, because
+    `usr/lib/python*` has to find whichever version the Termux index resolved to
+    at build time.
 
     Resolving it matters, and the literal-prefix version of this got it wrong:
     truncating `usr/lib/python*/*` at its first glob leaves `usr/lib`, which
@@ -444,18 +444,70 @@ def subtree_present(pattern):
     not also run download-python.sh was then told its Python entry was stale,
     when Python was simply not there. Measured on exactly that tree.
     """
-    return any(p.is_dir() for p in ASSETS.glob(pattern.rsplit("/*", 1)[0]))
+    return any(p.is_dir() for p in ASSETS.glob(prefix))
+
+
+def inner_patterns(pattern):
+    """The entries nested strictly inside this one.
+
+    Every pattern is `<prefix>/*`, so containment is a string prefix test on
+    `<prefix>/` -- the same relation the longest-match ordering resolves.
+    """
+    return [p for p in NESTED_LIBRARIES if p != pattern and p.startswith(pattern[:-1])]
+
+
+def outer_pattern(pattern):
+    """The entry that would claim this one's files if it stopped matching them,
+    or None if nothing contains it.
+
+    The innermost such entry, because that is the one the longest-match ordering
+    would hand the files to.
+    """
+    outer = [p for p in NESTED_LIBRARIES if p != pattern and pattern.startswith(p[:-1])]
+    return max(outer, key=len) if outer else None
+
+
+def stale_anchor(pattern):
+    """The directory whose presence on disk makes this entry's silence worth
+    reporting.
+
+    For an entry that nothing contains, that is its own directory. A tree can
+    hold `usr/` without `vscode-reh/` or the reverse, because two scripts fetch
+    them and a checkout may have run only one, so an entry whose package is
+    simply not here is not stale; it is not this tree's business. Nothing else in
+    the map could have claimed its files either, so if the package IS here and
+    moved, the files surface at the `not classified` check instead.
+
+    For an override -- an entry nested inside a broader one -- it is the
+    CONTAINING package's directory instead, and the difference is the whole
+    reason this function exists. An override goes silent exactly when its files
+    move out from under it, and the move takes its own directory with it. Anchor
+    on that directory and the check goes quiet at the one moment it is needed:
+    the files are still in the tree, still shipped, now swallowed by the broader
+    entry and attributed to the wrong component, with nothing reported. The
+    containing directory survives the move, so it is what the question has to be
+    asked about.
+
+    Concretely: Copilot ships ripgrep at `.../copilot-linux-arm64/ripgrep/rg`,
+    and the override there records it as ripgrep/MIT rather than as the
+    proprietary CLI around it. Move it to `.../copilot-linux-arm64/bin/rg` and
+    the container wins it; anchored on `ripgrep/` nothing would notice, anchored
+    on `copilot-linux-arm64/` the override is reported as claiming nothing.
+    """
+    return (outer_pattern(pattern) or pattern).rsplit("/*", 1)[0]
 
 
 def stale_patterns(nest):
-    """Allowlist entries whose subtree is on disk but which claim nothing.
+    """Allowlist entries that claim nothing in a tree that should have work for
+    them.
 
     An entry that matches no file is not harmless. It is the state a rename
     leaves behind, and the rename is what makes the binaries invisible: the
     package moves, its files stop matching, they arrive at the classifier as
     unknown paths -- or, worse, are swallowed by a broader entry that still
-    matches and attributed to the wrong component. Either way the entry that
-    should have caught the move sits there matching nothing and saying nothing.
+    matches and attributed to the wrong component. The first half fails the build
+    on its own, at the `not classified` check. The second half is silent, and it
+    is what `stale_anchor` is built around.
 
     So an entry has to earn its place by WINNING for at least one file, not
     merely by being satisfiable. The difference is the whole point of the
@@ -463,13 +515,21 @@ def stale_patterns(nest):
     around it, and if the longest-first ordering were lost it would still
     "match" every one of those files while never being consulted.
 
-    Anchored on the subtree's presence, because a tree can hold `usr/` without
-    `vscode-reh/` or the reverse: two scripts fetch them and a checkout may have
-    run only one. A pattern whose anchor is absent is not stale, it is just not
-    this tree's business.
+    One exemption, for the opposite error. A container whose every file was taken
+    by an override inside it wins nothing either, and it is not stale: that is
+    the ordering working as designed, and failing there would refuse a tree whose
+    attribution is complete and correct.
     """
     won = {nested_pattern(rel) for rel in nest}
-    return [p for p in sorted(NESTED_LIBRARIES) if p not in won and subtree_present(p)]
+    stale = []
+    for pattern in sorted(NESTED_LIBRARIES):
+        if pattern in won:
+            continue
+        if any(inner in won for inner in inner_patterns(pattern)):
+            continue  # shadowed by its own overrides, not left behind
+        if subtree_present(stale_anchor(pattern)):
+            stale.append(pattern)
+    return stale
 
 
 def attributed_in(text):

--- a/scripts/check-library-attribution.py
+++ b/scripts/check-library-attribution.py
@@ -14,17 +14,28 @@ Those two directories are not the whole of what ships. They are the top level of
 two directories, and the scan read only that: `assets/usr/lib/git-core/` holds
 twelve GPL-2.0 Git executables, `assets/usr/lib/python*/lib-dynload/` holds
 seventy-five CPython extension modules, and `assets/vscode-reh/` carries the
-server's native addons and the binaries the built-in extensions bundle. 111
-redistributed binaries against the 64 the flat scan saw, and every one of them is
-in the APK on exactly the same terms as the 64. So the tree is walked to its
-leaves, and the allowlist below maps each subtree to the component that already
-carries its attribution.
+server's native addons, the WebAssembly its editor services load, and the
+binaries the built-in extensions bundle. So the tree is walked to its leaves, and
+the allowlist below maps each subtree to the component that already carries its
+attribution.
 
-Two ways of recognising a binary, not one, because either alone has a hole. ELF
-magic finds the Git helpers, `rg`, `tgrep`, `apply-seccomp` and `python.o`, none
-of which have a telling name. The `.node` extension finds what ELF magic cannot:
-`ms-vscode.js-debug` ships two `win32-*-msvc-*.node` addons that are PE, not ELF,
-and a scan keyed on ELF alone walks straight past them.
+A file is recognised as a binary by its magic number, plus one extension.
+
+ELF alone is not enough, and reading it as though it were is how a scan can walk
+a tree to its leaves and still miss more than it finds. Most of what ships here
+below the two flat directories is not ELF at all: tree-sitter's grammars and
+oniguruma are WebAssembly, PSReadLine is .NET assemblies, pip vendors distlib's
+Windows launchers, and several npm packages carry the Windows and macOS builds of
+a helper beside the Linux one. None of those can execute on this device. That
+changes nothing about the obligation: they are inside the APK, redistributed on
+their own terms, and a notice has to travel with them. So WebAssembly, PE and
+Mach-O are tested for alongside ELF.
+
+The `.node` extension is kept beside the magic numbers even though every `.node`
+in the tree today is ELF or PE and would be caught anyway. A file with that
+suffix is a loadable native addon whatever container it turns out to be in, and
+the union is deliberately generous: a false positive costs one line in
+NESTED_LIBRARIES, a false negative costs an unattributed binary in a shipped APK.
 
 One did. `libdb-18.1.so` -- Berkeley DB, **AGPL-3.0-only**, the strongest
 copyleft in common use -- shipped in every release with no attribution anywhere
@@ -87,6 +98,25 @@ COPYLEFT = (
     "GPL", "AGPL", "LGPL", "MPL", "EPL", "CDDL",
     "MOZILLA PUBLIC", "ECLIPSE PUBLIC", "COMMON DEVELOPMENT",
     "GENERAL PUBLIC LICENSE",
+)
+
+# The object formats redistributed in this tree, by the first bytes of the file.
+#
+# All four appear under assets/ today. Mach-O and PE are here because npm
+# packages ship every platform's build of a helper and the whole package lands in
+# the APK; WebAssembly because tree-sitter, oniguruma and two of js-debug's
+# panels are compiled to it rather than to native code.
+#
+# `MZ` is two bytes rather than four, which is as specific as a DOS header gets.
+# It is the weakest test here, and it is still the right trade: over-matching
+# costs one allowlist line, under-matching ships an unattributed binary.
+BINARY_MAGIC = (
+    b"\x7fELF",                                  # ELF
+    b"\x00asm",                                  # WebAssembly
+    b"MZ",                                       # PE/COFF, .NET assemblies included
+    b"\xfe\xed\xfa\xce", b"\xce\xfa\xed\xfe",    # Mach-O 32-bit, either endianness
+    b"\xfe\xed\xfa\xcf", b"\xcf\xfa\xed\xfe",    # Mach-O 64-bit, either endianness
+    b"\xca\xfe\xba\xbe", b"\xbe\xba\xfe\xca",    # Mach-O universal
 )
 
 # soname (or executable) -> (component name as written in LEGAL_NOTICES, licence)
@@ -218,6 +248,12 @@ NESTED_LIBRARIES = {
     # the Termux index at build time, so a literal here goes stale on a rebuild
     # nobody connects to this file.
     "usr/lib/python*/*": ("Python", "PSF-2.0"),
+    # pip vendors distlib, which ships six prebuilt Windows launchers. The
+    # licence is the same PSF-2.0 as CPython's, so the entry above discharges the
+    # terms either way; the copyright holder is Vinay Sajip rather than the
+    # PSF, and PSF-2.0 is precisely the licence that asks for the notice to
+    # travel, so the file is named for what it is.
+    "usr/lib/python*/site-packages/pip/_vendor/distlib/*": ("distlib", "PSF-2.0"),
     # --- the server tree's native addons ---
     "vscode-reh/node_modules/node-pty/*": ("node-pty", "MIT"),
     "vscode-reh/node_modules/@parcel/watcher/*": ("@parcel/watcher", "MIT"),
@@ -235,8 +271,29 @@ NESTED_LIBRARIES = {
     "vscode-reh/node_modules/@github/copilot-linux-arm64/ripgrep/*": ("ripgrep", "MIT"),
     "vscode-reh/extensions/copilot/node_modules/@github/copilot/sdk/ripgrep/*":
         ("ripgrep", "MIT"),
+    # --- WebAssembly the editor loads at run time ---
+    # Grammars, not native code, and shipped in three copies: the server's own,
+    # the Copilot extension's node_modules, and the grammars bundled into that
+    # extension's `dist`. Each is attributed to the package that redistributes
+    # it, which is the same rule the native entries above follow.
+    "vscode-reh/node_modules/@vscode/tree-sitter-wasm/*": ("@vscode/tree-sitter-wasm", "MIT"),
+    "vscode-reh/extensions/copilot/node_modules/@vscode/tree-sitter-wasm/*":
+        ("@vscode/tree-sitter-wasm", "MIT"),
+    "vscode-reh/extensions/copilot/node_modules/web-tree-sitter/*": ("web-tree-sitter", "MIT"),
+    # `onig.wasm` is Oniguruma compiled to WebAssembly. The npm wrapper is MIT
+    # and the regex engine inside it is BSD-2-Clause; both are recorded, because
+    # the wrapper's licence does not cover the code it carries.
+    "vscode-reh/node_modules/vscode-oniguruma/*": ("vscode-oniguruma", "MIT, BSD-2-Clause"),
     # --- built-in extensions that carry binaries of their own ---
     "vscode-reh/extensions/ms-vscode.js-debug/*": ("js-debug", "MIT"),
+    "vscode-reh/extensions/ms-vscode.vscode-js-profile-table/*":
+        ("vscode-js-profile-visualizer", "MIT"),
+    # --- .NET assemblies, carried by the terminal's shell integration ---
+    # PSReadLine and its pager ship prebuilt for the PowerShell integration.
+    # They cannot run here, and they are in the APK, which is the only fact the
+    # licence cares about.
+    "vscode-reh/out/vs/workbench/contrib/terminal/common/scripts/psreadline/*":
+        ("PSReadLine", "BSD-2-Clause"),
     # --- redistributed under GitHub's own terms, not an open source licence ---
     # Its full reasoning is the "Proprietary Redistributed Components" section of
     # LEGAL_NOTICES.md; what this line adds is that the binaries are counted.
@@ -244,11 +301,31 @@ NESTED_LIBRARIES = {
         ("@github/copilot (GitHub Copilot CLI)", "GitHub Copilot CLI License (proprietary)"),
     "vscode-reh/extensions/copilot/node_modules/@github/copilot/*":
         ("@github/copilot (GitHub Copilot CLI)", "GitHub Copilot CLI License (proprietary)"),
+    # --- the Copilot Chat extension's own bundle ---
+    # MIT, and a different component from the proprietary CLI two lines up
+    # despite sharing a directory tree. `dist/` holds the tree-sitter grammars
+    # and the blackbird WebAssembly that the extension's build inlines, so this
+    # entry stands for the extension as redistributor rather than for one
+    # upstream project.
+    "vscode-reh/extensions/copilot/dist/*": ("GitHub Copilot Chat extension", "MIT"),
+    "vscode-reh/extensions/copilot/node_modules/@github/blackbird-external-ingest-utils/*":
+        ("@github/blackbird-external-ingest-utils", "MIT"),
 }
 
 # Longest pattern first, so a subtree entry beats the package entry containing
 # it. Sorted once rather than per file.
 NESTED_ORDER = sorted(NESTED_LIBRARIES, key=len, reverse=True)
+
+# Every entry is a whole subtree, `<prefix>/*`. Three things depend on that shape
+# and none of them can tell when it is broken: longest-match ordering is only a
+# correct proxy for containment when overlap is prefix-based, containment is
+# tested as a string prefix, and the staleness anchor is the pattern minus its
+# `/*`. An entry ending anywhere else would quietly get all three wrong, so it is
+# refused here instead, where the answer is one line long.
+_odd = [p for p in NESTED_LIBRARIES if not p.endswith("/*")]
+if _odd:
+    raise SystemExit("NESTED_LIBRARIES entries must cover a whole subtree "
+                     f"and end in '/*': {', '.join(sorted(_odd))}")
 
 
 def toolchain_libs():
@@ -323,11 +400,10 @@ def nested():
     `tgrep` and `kerberos.node` each ship more than once from more than one
     package, and a failure has to say which copy it means.
 
-    A file counts as a binary if it starts with ELF magic or ends in `.node`.
-    Neither test subsumes the other -- see the module docstring -- and the union
-    is deliberately generous, since the cost of a false positive is one line in
-    NESTED_LIBRARIES and the cost of a false negative is an unattributed binary
-    in a shipped APK.
+    A file counts as a binary if it opens with one of BINARY_MAGIC or ends in
+    `.node`. Testing ELF alone would walk past most of what ships here: see the
+    module docstring for the formats and why an object this device cannot execute
+    still has to be attributed.
     """
     out = []
     if not ASSETS.is_dir():
@@ -339,10 +415,10 @@ def nested():
             continue  # counted by shipped()
         try:
             with p.open("rb") as f:
-                elf = f.read(4) == b"\x7fELF"
+                head = f.read(4)
         except OSError:
             continue
-        if elf or p.suffix == ".node":
+        if head.startswith(BINARY_MAGIC) or p.suffix == ".node":
             out.append(p.relative_to(ASSETS).as_posix())
     return out
 

--- a/scripts/check-library-attribution.py
+++ b/scripts/check-library-attribution.py
@@ -10,6 +10,22 @@ their notice to travel with the binary; GPL and LGPL additionally require an
 offer of the corresponding source. Neither obligation is discharged by code, so
 nothing in the build could previously notice when one went unmet.
 
+Those two directories are not the whole of what ships. They are the top level of
+two directories, and the scan read only that: `assets/usr/lib/git-core/` holds
+twelve GPL-2.0 Git executables, `assets/usr/lib/python*/lib-dynload/` holds
+seventy-five CPython extension modules, and `assets/vscode-reh/` carries the
+server's native addons and the binaries the built-in extensions bundle. 111
+redistributed binaries against the 64 the flat scan saw, and every one of them is
+in the APK on exactly the same terms as the 64. So the tree is walked to its
+leaves, and the allowlist below maps each subtree to the component that already
+carries its attribution.
+
+Two ways of recognising a binary, not one, because either alone has a hole. ELF
+magic finds the Git helpers, `rg`, `tgrep`, `apply-seccomp` and `python.o`, none
+of which have a telling name. The `.node` extension finds what ELF magic cannot:
+`ms-vscode.js-debug` ships two `win32-*-msvc-*.node` addons that are PE, not ELF,
+and a scan keyed on ELF alone walks straight past them.
+
 One did. `libdb-18.1.so` -- Berkeley DB, **AGPL-3.0-only**, the strongest
 copyleft in common use -- shipped in every release with no attribution anywhere
 and no source offer, because it arrived as a transitive dependency of krb5 and
@@ -42,12 +58,14 @@ read is printed, because "0 toolchain libraries" from a tree that has no packs
 and from a tree whose packs were never recorded print the same otherwise.
 """
 
+import fnmatch
 import json
 import pathlib
 import re
 import sys
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
+ASSETS = ROOT / "android/app/src/main/assets"
 USR_LIB = ROOT / "android/app/src/main/assets/usr/lib"
 JNILIBS = ROOT / "android/app/src/main/jniLibs/arm64-v8a"
 LEGAL_NOTICES = ROOT / "docs/LEGAL_NOTICES.md"
@@ -169,6 +187,69 @@ TOOLCHAIN_LIBRARIES = {
     "libffi.so": ("libffi", "MIT"),
 }
 
+# Binaries that ship deeper in the asset tree than the two directories above,
+# keyed by a glob over the path relative to `assets/`.
+#
+# By subtree rather than by file name, for two reasons the tree makes plain. The
+# names repeat -- four different `rg` binaries and four `tgrep`, in four
+# directories -- so a name says nothing about which component redistributes it.
+# And the names churn: `lib-dynload` alone is 75 modules that come and go with
+# the Python build, and js-debug's addons carry a content hash in the file name.
+# What is stable is the package the file sits inside, which is also the thing an
+# attribution names.
+#
+# `fnmatch`'s `*` spans `/`, so `<prefix>/*` covers a whole subtree at any depth.
+# The longest matching pattern wins, which is what lets a vendored copy be
+# attributed to its own upstream rather than to the package around it: Copilot
+# ships ripgrep inside its own tree, and ripgrep's licence is not Copilot's.
+# Verified rather than assumed -- the SDK copy's `rg` is byte-identical to
+# `@vscode/ripgrep-universal`'s (sha256 e152ea68...), the `copilot-linux-arm64`
+# copy is a different ripgrep build, and both are ripgrep.
+#
+# Every component here is one the documents already carry, or now carry: the
+# point of the widening is to check what ships against the record, not to invent
+# a second record.
+NESTED_LIBRARIES = {
+    # --- Termux packages, below the top level of usr/lib ---
+    # git's helper executables: `git-http-fetch`, `git-daemon` and the rest.
+    "usr/lib/git-core/*": ("Git", "GPL-2.0"),
+    # CPython's extension modules and the `python.o` beside its build config.
+    # Globbed on the version, never spelled: download-python.sh resolves it from
+    # the Termux index at build time, so a literal here goes stale on a rebuild
+    # nobody connects to this file.
+    "usr/lib/python*/*": ("Python", "PSF-2.0"),
+    # --- the server tree's native addons ---
+    "vscode-reh/node_modules/node-pty/*": ("node-pty", "MIT"),
+    "vscode-reh/node_modules/@parcel/watcher/*": ("@parcel/watcher", "MIT"),
+    "vscode-reh/node_modules/@vscode/sqlite3/*": ("@vscode/sqlite3", "BSD-3-Clause"),
+    "vscode-reh/node_modules/@vscode/deviceid/*": ("@vscode/deviceid", "MIT"),
+    "vscode-reh/node_modules/@vscode/native-watchdog/*": ("@vscode/native-watchdog", "MIT"),
+    "vscode-reh/node_modules/@vscode/sandbox-runtime/*": ("@vscode/sandbox-runtime", "Apache-2.0"),
+    "vscode-reh/node_modules/@microsoft/mxc-sdk/*": ("@microsoft/mxc-sdk", "MIT"),
+    # The npm addon, not the Termux C libraries. Different project, different
+    # licence, confusingly similar name -- hence the qualifier, which has to
+    # read the same way in both documents for the attribution check to find it.
+    "vscode-reh/node_modules/kerberos/*": ("kerberos (Node addon)", "Apache-2.0"),
+    # --- the search binary, wherever it is bundled from ---
+    "vscode-reh/node_modules/@vscode/ripgrep-universal/*": ("ripgrep", "MIT"),
+    "vscode-reh/node_modules/@github/copilot-linux-arm64/ripgrep/*": ("ripgrep", "MIT"),
+    "vscode-reh/extensions/copilot/node_modules/@github/copilot/sdk/ripgrep/*":
+        ("ripgrep", "MIT"),
+    # --- built-in extensions that carry binaries of their own ---
+    "vscode-reh/extensions/ms-vscode.js-debug/*": ("js-debug", "MIT"),
+    # --- redistributed under GitHub's own terms, not an open source licence ---
+    # Its full reasoning is the "Proprietary Redistributed Components" section of
+    # LEGAL_NOTICES.md; what this line adds is that the binaries are counted.
+    "vscode-reh/node_modules/@github/copilot-linux-arm64/*":
+        ("@github/copilot (GitHub Copilot CLI)", "GitHub Copilot CLI License (proprietary)"),
+    "vscode-reh/extensions/copilot/node_modules/@github/copilot/*":
+        ("@github/copilot (GitHub Copilot CLI)", "GitHub Copilot CLI License (proprietary)"),
+}
+
+# Longest pattern first, so a subtree entry beats the package entry containing
+# it. Sorted once rather than per file.
+NESTED_ORDER = sorted(NESTED_LIBRARIES, key=len, reverse=True)
+
 
 def toolchain_libs():
     """Libraries the toolchain manifests declare, which manifests were read, and
@@ -211,7 +292,16 @@ def toolchain_libs():
 
 
 def shipped():
-    """Every redistributed binary, by file name."""
+    """The redistributed binaries at the top level of the two flat directories,
+    by file name.
+
+    Everything deeper is `nested()`'s, and the two must not overlap or a file
+    would be reported twice with two different identifiers. The split is drawn
+    at exactly what this function accepts -- top level of `usr/lib` AND `.so` in
+    the name -- so an ELF at the top of `usr/lib` whose name says nothing (there
+    are none today, measured) still reaches `nested()` rather than falling
+    between them.
+    """
     out = []
     for root in (USR_LIB, JNILIBS):
         if not root.is_dir():
@@ -223,6 +313,87 @@ def shipped():
                 continue
             out.append(p.name)
     return out
+
+
+def nested():
+    """Every other redistributed binary in the asset tree, by path relative to
+    `assets/`.
+
+    The path, not the name, because the name is not an identifier here: `rg`,
+    `tgrep` and `kerberos.node` each ship more than once from more than one
+    package, and a failure has to say which copy it means.
+
+    A file counts as a binary if it starts with ELF magic or ends in `.node`.
+    Neither test subsumes the other -- see the module docstring -- and the union
+    is deliberately generous, since the cost of a false positive is one line in
+    NESTED_LIBRARIES and the cost of a false negative is an unattributed binary
+    in a shipped APK.
+    """
+    out = []
+    if not ASSETS.is_dir():
+        return out
+    for p in sorted(ASSETS.rglob("*")):
+        if p.is_symlink() or not p.is_file():
+            continue
+        if p.parent == USR_LIB and ".so" in p.name:
+            continue  # counted by shipped()
+        try:
+            with p.open("rb") as f:
+                elf = f.read(4) == b"\x7fELF"
+        except OSError:
+            continue
+        if elf or p.suffix == ".node":
+            out.append(p.relative_to(ASSETS).as_posix())
+    return out
+
+
+def nested_pattern(rel):
+    """The allowlist entry that claims a nested path, or None."""
+    for pattern in NESTED_ORDER:
+        if fnmatch.fnmatchcase(rel, pattern):
+            return pattern
+    return None
+
+
+def subtree_present(pattern):
+    """Whether the directory a pattern covers is on disk.
+
+    The pattern minus its trailing `/*`, resolved with `Path.glob` rather than
+    tested as a literal, because `usr/lib/python*` has to find whichever version
+    the Termux index resolved to at build time.
+
+    Resolving it matters, and the literal-prefix version of this got it wrong:
+    truncating `usr/lib/python*/*` at its first glob leaves `usr/lib`, which
+    exists in any tree that ran download-termux-tools.sh. A checkout that had
+    not also run download-python.sh was then told its Python entry was stale,
+    when Python was simply not there. Measured on exactly that tree.
+    """
+    return any(p.is_dir() for p in ASSETS.glob(pattern.rsplit("/*", 1)[0]))
+
+
+def stale_patterns(nest):
+    """Allowlist entries whose subtree is on disk but which claim nothing.
+
+    An entry that matches no file is not harmless. It is the state a rename
+    leaves behind, and the rename is what makes the binaries invisible: the
+    package moves, its files stop matching, they arrive at the classifier as
+    unknown paths -- or, worse, are swallowed by a broader entry that still
+    matches and attributed to the wrong component. Either way the entry that
+    should have caught the move sits there matching nothing and saying nothing.
+
+    So an entry has to earn its place by WINNING for at least one file, not
+    merely by being satisfiable. The difference is the whole point of the
+    overrides: `@github/copilot .../ripgrep/*` is contained by the Copilot entry
+    around it, and if the longest-first ordering were lost it would still
+    "match" every one of those files while never being consulted.
+
+    Anchored on the subtree's presence, because a tree can hold `usr/` without
+    `vscode-reh/` or the reverse: two scripts fetch them and a checkout may have
+    run only one. A pattern whose anchor is absent is not stale, it is just not
+    this tree's business.
+    """
+    won = {nested_pattern(rel) for rel in nest}
+    return [p for p in sorted(NESTED_LIBRARIES) if p not in won and subtree_present(p)]
 
 
 def attributed_in(text):
@@ -254,9 +425,13 @@ def attributed_in(text):
 
 def main():
     names = shipped()
-    if not names:
+    nest = nested()
+    if not names and not nest:
         # Neither tree is committed, so an empty run means the assets were never
         # downloaded. Saying so beats reporting that nothing is unattributed.
+        # Both halves, because a tree can hold one without the other: the server
+        # tree is fetched by a different script than the Termux libraries, and a
+        # checkout that has only run one of the two still ships binaries.
         print("skip -- no built assets present (run the download scripts first)")
         return 0
 
@@ -291,6 +466,22 @@ def main():
     for_check = [(n, LIBRARIES.get(n)) for n in names]
     tc, manifests, unrecorded = toolchain_libs()
     for_check += [(n, TOOLCHAIN_LIBRARIES.get(n)) for n in tc]
+    # Everything below the top level of those two directories, held to exactly
+    # the same three checks. Identified by path, so the three lists cannot
+    # collide on a shared file name.
+    for_check += [(r, NESTED_LIBRARIES.get(nested_pattern(r))) for r in nest]
+
+    stale = stale_patterns(nest)
+    if stale:
+        print(f"FAIL {len(stale)} allowlist entr(ies) match nothing in a tree that "
+              "has the subtree:", file=sys.stderr)
+        for pattern in stale:
+            print(f"  {pattern}", file=sys.stderr)
+        print("  -> the package moved, was renamed, or stopped shipping binaries."
+              " Point the entry at where its files are now, or delete it -- but"
+              " check first that the binaries did not simply move under an entry"
+              " that attributes them to something else", file=sys.stderr)
+        return 1
 
     if unrecorded:
         # The pack was downloaded on this machine and is about to be zipped, so
@@ -326,7 +517,9 @@ def main():
          "fill in the licence Termux's build.sh declares; an empty field silently "
          "answers the copyleft question with 'no'"),
         ("not classified", unknown,
-         "add it to LIBRARIES with the licence Termux's build.sh declares"),
+         "a bare file name belongs in LIBRARIES with the licence Termux's build.sh "
+         "declares; a path belongs in NESTED_LIBRARIES, keyed on the subtree of the "
+         "package that redistributes it"),
         ("not attributed", unattributed,
          "add a section naming the project and its licence to each file listed"),
         ("copyleft, absent from the source offer", unoffered,
@@ -347,9 +540,9 @@ def main():
     # also what a run before the download step prints, and those are opposite
     # facts. Naming the documents for the same reason, the count of components
     # says nothing about which files were held to it.
-    print(f"ok: {len(names)} shipped binaries + {len(tc)} toolchain libraries "
-          f"from {len(manifests)} manifest(s), {len(covered)} components, "
-          f"all attributed in {' and '.join(docs)}")
+    print(f"ok: {len(names)} shipped binaries + {len(nest)} nested + "
+          f"{len(tc)} toolchain libraries from {len(manifests)} manifest(s), "
+          f"{len(covered)} components, all attributed in {' and '.join(docs)}")
     # The names, not just the count. A count alone cannot answer the question that
     # actually matters when two trees disagree -- *which* file is missing -- and
     # some of these are found by `dlopen` at run time rather than through
@@ -357,6 +550,16 @@ def main():
     # of the bug that left five Python modules dead on shipped builds. Printing the
     # list costs a line of log and makes any two builds directly comparable.
     print("   " + " ".join(sorted(names)))
+    # The nested set by component and count rather than by path: 111 paths is
+    # eight kilobytes of log, and the question the flat list answers -- do two
+    # builds ship the same thing -- is answered here by any count that moves. A
+    # Python module dropping out of lib-dynload takes `Python` from 76 to 75.
+    if nest:
+        tally = {}
+        for rel in nest:
+            component = NESTED_LIBRARIES[nested_pattern(rel)][0]
+            tally[component] = tally.get(component, 0) + 1
+        print("   nested: " + ", ".join(f"{c} {n}" for c, n in sorted(tally.items())))
     return 0
 
 

--- a/scripts/check-library-attribution.py
+++ b/scripts/check-library-attribution.py
@@ -605,7 +605,16 @@ def main():
     # Everything below the top level of those two directories, held to exactly
     # the same three checks. Identified by path, so the three lists cannot
     # collide on a shared file name.
-    for_check += [(r, NESTED_LIBRARIES.get(nested_pattern(r))) for r in nest]
+    #
+    # Classified once and kept, because the tally at the end of this function
+    # needs the same answer. Looking it up a second time there had to index
+    # NESTED_LIBRARIES with whatever nested_pattern returned, and that is None
+    # for an unclassified path: a KeyError and a traceback in place of the
+    # report. It could not fire only because the `not classified` check returns
+    # first, which is a fact about the order of two blocks eighty lines apart
+    # rather than about this line.
+    nested_entries = [(r, NESTED_LIBRARIES.get(nested_pattern(r))) for r in nest]
+    for_check += nested_entries
 
     stale = stale_patterns(nest)
     if stale:
@@ -686,14 +695,19 @@ def main():
     # of the bug that left five Python modules dead on shipped builds. Printing the
     # list costs a line of log and makes any two builds directly comparable.
     print("   " + " ".join(sorted(names)))
-    # The nested set by component and count rather than by path: 111 paths is
-    # eight kilobytes of log, and the question the flat list answers -- do two
-    # builds ship the same thing -- is answered here by any count that moves. A
-    # Python module dropping out of lib-dynload takes `Python` from 76 to 75.
-    if nest:
+    # The nested set by component and count rather than by path: two hundred
+    # paths is eight kilobytes of log, and the question the flat list answers --
+    # do two builds ship the same thing -- is answered here by any count that
+    # moves. A Python module dropping out of lib-dynload takes `Python` from 76
+    # to 75.
+    if nested_entries:
         tally = {}
-        for rel in nest:
-            component = NESTED_LIBRARIES[nested_pattern(rel)][0]
+        for _, entry in nested_entries:
+            # Reusing the classification made above rather than repeating it.
+            # Nothing unclassified can reach here today, and the fallback is not
+            # a guess about that: it keeps a reordering of the checks above
+            # printing a report instead of raising.
+            component = entry[0] if entry else "unclassified"
             tally[component] = tally.get(component, 0) + 1
         print("   nested: " + ", ".join(f"{c} {n}" for c, n in sorted(tally.items())))
     return 0


### PR DESCRIPTION
No licence text reached the device, so a recipient of a GPL binary had no written offer with it. The attribution gate scanned only the top level of `usr/lib` and `jniLibs`, leaving the whole of `assets/vscode-reh` and every subdirectory of `usr/` unchecked.

## Changes

- `NOTICE.md` and `LEGAL_NOTICES.md` ship in the APK, reachable offline from About.
- `check-library-attribution.py` walks the asset tree recursively and classifies anything that is ELF or `.node`.
- The two notices documents gained the components the widened scan found.

## Counts on a built tree

64 shipped binaries, 195 nested, 6 toolchain libraries from 3 manifests, across 63 components. All attributed.

## Notes

A future Code - OSS version that adds a native payload will fail this gate as unclassified until someone records where it came from. That is the intended trade: a build that stops is cheaper than an APK that ships an unattributed binary.

Assets grow by the size of the two documents; the figure is in the commit.

## Verification

929 unit tests, lint clean. The gate was exercised against a tree with the assets present, not only against an empty checkout.
