### PR TITLE
test(keyboard,device): cover the trackpad gesture and add toolchain and terminal phases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The loopback bind on the editor server's command line is pinned by a test. A wildcard bind would have put the editor on the phone's network without failing anything.
 - Test suites stopped reporting results they had not measured: skipped device tests read as passing, one slept a minute and asserted nothing, and the four toolchain delivery functions had no test at all.
 - The on-device suite states when it is meant to run, checks that what shipped actually runs, and reads versions from the build rather than from literals two releases stale.
+- The on-device suite now checks toolchain installs and the terminal's shell configuration, and reports skipped rather than passed where adb cannot reach, instead of leaving both to a human checklist.
+- The extra key row's trackpad now has tests covering its speed gears and arrow output. It is the only way a touch user moves the cursor, and nothing guarded it.
 - Removed twenty-six tracked files that nothing built, ran or opened, including the cross-compilation scripts replaced when binaries began coming from Termux.
 - Six releases that shipped without a changelog entry now have one, reconstructed from commit history and marked as such. Two footer links named a tag that never existed.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,7 +208,8 @@ VSCodroid/
 | `bridge/AndroidBridge.kt` | JS interface: clipboard, file picker, OAuth, SSH, storage, toolchains |
 | `bridge/SecurityManager.kt` | The bridge session token: issues it, and validates it on every `@JavascriptInterface` call. It judges the caller, never the destination — there is no URL allow-list, and WebView navigation is decided in `VSCodroidWebViewClient.shouldOverrideUrlLoading` |
 | `keyboard/ExtraKeyRow.kt` | Multi-page key bar with ViewPager2 and dot indicators |
-| `keyboard/GestureTrackpad.kt` | 3-speed drag-to-cursor-navigate widget |
+| `keyboard/GestureTrackpad.kt` | 3-speed drag-to-cursor-navigate widget: touch plumbing and drawing |
+| `keyboard/TrackpadGesture.kt` | The gears and the arrows a drag earns, with no Android types, so it can be tested on the JVM |
 | `keyboard/KeyInjector.kt` | Injects KeyboardEvent into WebView via JS |
 | `service/NodeService.kt` | Foreground Service (specialUse) to keep Node.js alive |
 | `service/ProcessManager.kt` | Node.js process lifecycle, health check, auto-restart |
@@ -307,7 +308,15 @@ place. This one costs more precisely because it passes every gate first.
 
 `scripts/device-test.sh` installs the APK and checks that what shipped actually
 runs: the server answers, every bundled tool starts, and Python imports the ten
-modules that need a bundled library behind them.
+modules that need a bundled library behind them. It also reads what a toolchain
+install left behind and how the terminal is configured to start.
+
+Two limits are worth knowing before reading a green run. Almost everything goes
+through `run-as`, which is a different SELinux domain than the app and may
+execute files the app itself is refused, so no result there says a command works
+in the app's own terminal. And a default run clears app data, which removes any
+installed toolchain: the toolchain checks then report skipped, and only
+`--skip-install` on a device that has one makes them measure anything.
 
 **Nothing runs it automatically, and that is a measured conclusion rather than an
 oversight.** GitHub's arm64 runners expose no `/dev/kvm`, so an emulator there

--- a/android/app/src/main/kotlin/com/vscodroid/keyboard/GestureTrackpad.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/keyboard/GestureTrackpad.kt
@@ -11,16 +11,14 @@ import android.view.HapticFeedbackConstants
 import android.view.MotionEvent
 import android.view.View
 import com.vscodroid.R
-import kotlin.math.abs
-import kotlin.math.sign
 
 /**
  * Drag-to-navigate trackpad that replaces 4 arrow key buttons with a single gesture area.
  *
- * Three speed gears activate based on cumulative drag distance:
- * - Precise (0dp): 24dp per arrow — character-by-character
- * - Moderate (100dp): 14dp per arrow — word navigation
- * - Fast (250dp): 6dp per arrow — line/file traversal
+ * Three speed gears activate based on cumulative drag distance; the distances
+ * and the arrows a drag earns live in [TrackpadGesture], which has no Android
+ * types in it and is tested on the JVM. What is left here is touch plumbing and
+ * drawing.
  */
 @SuppressLint("ClickableViewAccessibility")
 class GestureTrackpad @JvmOverloads constructor(
@@ -43,18 +41,11 @@ class GestureTrackpad @JvmOverloads constructor(
         style = Paint.Style.FILL
     }
 
-    private enum class Gear(val activationDp: Float, val thresholdDp: Float) {
-        PRECISE(0f, 24f),
-        MODERATE(100f, 14f),
-        FAST(250f, 6f)
-    }
+    private val gesture = TrackpadGesture()
 
     private var tracking = false
     private var lastX = 0f
     private var lastY = 0f
-    private var accumulatedDx = 0f
-    private var accumulatedDy = 0f
-    private var totalDistance = 0f
     private var touchOffsetX = 0f
     private var touchOffsetY = 0f
 
@@ -103,9 +94,7 @@ class GestureTrackpad @JvmOverloads constructor(
                 tracking = true
                 lastX = event.x
                 lastY = event.y
-                accumulatedDx = 0f
-                accumulatedDy = 0f
-                totalDistance = 0f
+                gesture.reset()
                 touchOffsetX = 0f
                 touchOffsetY = 0f
                 parent.requestDisallowInterceptTouchEvent(true)
@@ -120,27 +109,13 @@ class GestureTrackpad @JvmOverloads constructor(
                 lastX = event.x
                 lastY = event.y
 
-                totalDistance += abs(dx) + abs(dy)
-                val threshold = dpToPx(getCurrentGear().thresholdDp)
-
-                accumulatedDx += dx
-                accumulatedDy += dy
-
                 touchOffsetX = event.x - width / 2f
                 touchOffsetY = event.y - height / 2f
 
-                // Emit horizontal arrows
-                while (abs(accumulatedDx) >= threshold) {
-                    val direction = if (accumulatedDx > 0) "ArrowRight" else "ArrowLeft"
+                val directions =
+                    gesture.accumulate(dx, dy, resources.displayMetrics.density)
+                for (direction in directions) {
                     onArrowKey?.invoke(direction)
-                    accumulatedDx -= sign(accumulatedDx) * threshold
-                }
-
-                // Emit vertical arrows
-                while (abs(accumulatedDy) >= threshold) {
-                    val direction = if (accumulatedDy > 0) "ArrowDown" else "ArrowUp"
-                    onArrowKey?.invoke(direction)
-                    accumulatedDy -= sign(accumulatedDy) * threshold
                 }
 
                 invalidate()
@@ -157,15 +132,6 @@ class GestureTrackpad @JvmOverloads constructor(
             }
         }
         return super.onTouchEvent(event)
-    }
-
-    private fun getCurrentGear(): Gear {
-        val totalDp = totalDistance / resources.displayMetrics.density
-        return when {
-            totalDp >= Gear.FAST.activationDp -> Gear.FAST
-            totalDp >= Gear.MODERATE.activationDp -> Gear.MODERATE
-            else -> Gear.PRECISE
-        }
     }
 
     private fun dpToPx(dp: Float): Float =

--- a/android/app/src/main/kotlin/com/vscodroid/keyboard/TrackpadGesture.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/keyboard/TrackpadGesture.kt
@@ -1,0 +1,99 @@
+package com.vscodroid.keyboard
+
+import kotlin.math.abs
+import kotlin.math.sign
+
+/**
+ * How far the finger travels per emitted arrow, and how far it has to have
+ * travelled in total before the next gear takes over.
+ *
+ * [activationDp] is cumulative path length since the drag began, so a gear is
+ * reached by moving a lot rather than by moving fast.
+ */
+enum class TrackpadGear(val activationDp: Float, val thresholdDp: Float) {
+    /** Character by character. */
+    PRECISE(0f, 24f),
+
+    /** Word-sized steps. */
+    MODERATE(100f, 14f),
+
+    /** Line and file traversal. */
+    FAST(250f, 6f);
+
+    companion object {
+        /** The gear a drag of [totalDp] cumulative dp is in. */
+        fun forTotalDp(totalDp: Float): TrackpadGear = when {
+            totalDp >= FAST.activationDp -> FAST
+            totalDp >= MODERATE.activationDp -> MODERATE
+            else -> PRECISE
+        }
+    }
+}
+
+/**
+ * The arrow-key half of [GestureTrackpad], with no Android types in it.
+ *
+ * It holds the two leftover deltas and the running path length, and turns each
+ * touch delta into the arrow keys that delta earned. Kept apart from the View so
+ * gear thresholds, direction choice, accumulator carry-over and the diagonal
+ * case can be asserted without a device or a MotionEvent: this widget is the
+ * only way a touch user moves the cursor, so a silent regression here costs them
+ * arrow keys entirely.
+ */
+class TrackpadGesture {
+
+    /** Cumulative path length of the current drag, in pixels. */
+    var totalDistancePx: Float = 0f
+        private set
+
+    /** Horizontal travel not yet paid out as an arrow, in pixels. */
+    var pendingDxPx: Float = 0f
+        private set
+
+    /** Vertical travel not yet paid out as an arrow, in pixels. */
+    var pendingDyPx: Float = 0f
+        private set
+
+    /** Starts a new drag. Leftover travel from the previous one is dropped. */
+    fun reset() {
+        totalDistancePx = 0f
+        pendingDxPx = 0f
+        pendingDyPx = 0f
+    }
+
+    /** The gear the drag so far has reached, at screen [density]. */
+    fun gear(density: Float): TrackpadGear =
+        TrackpadGear.forTotalDp(totalDistancePx / density)
+
+    /**
+     * Folds one touch delta in and returns the arrow keys it earned, in the
+     * order they should be sent: horizontal first, then vertical, so a diagonal
+     * drag yields both rather than only its dominant axis.
+     *
+     * [dx] and [dy] are pixels, [density] is `DisplayMetrics.density` and must be
+     * positive. Travel below the current gear's step is kept, not discarded, so
+     * many small deltas still add up to an arrow.
+     */
+    fun accumulate(dx: Float, dy: Float, density: Float): List<String> {
+        totalDistancePx += abs(dx) + abs(dy)
+        val thresholdPx = gear(density).thresholdDp * density
+
+        pendingDxPx += dx
+        pendingDyPx += dy
+
+        if (abs(pendingDxPx) < thresholdPx && abs(pendingDyPx) < thresholdPx) {
+            return emptyList()
+        }
+
+        val directions = ArrayList<String>(2)
+        while (abs(pendingDxPx) >= thresholdPx) {
+            directions.add(if (pendingDxPx > 0) "ArrowRight" else "ArrowLeft")
+            pendingDxPx -= sign(pendingDxPx) * thresholdPx
+        }
+        while (abs(pendingDyPx) >= thresholdPx) {
+            directions.add(if (pendingDyPx > 0) "ArrowDown" else "ArrowUp")
+            pendingDyPx -= sign(pendingDyPx) * thresholdPx
+        }
+        return directions
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/keyboard/TrackpadGestureTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/keyboard/TrackpadGestureTest.kt
@@ -1,0 +1,245 @@
+package com.vscodroid.keyboard
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for [TrackpadGesture] and [TrackpadGear].
+ *
+ * The trackpad is the only arrow-key affordance the extra key row has, so an
+ * accumulator that stops paying out, or a gear that never engages, takes cursor
+ * movement away from every touch user. None of that is reachable from the View,
+ * which needs MotionEvents and a display; it is all reachable from here.
+ */
+class TrackpadGestureTest {
+
+    /**
+     * Moves the finger back and forth in 5dp steps, which is below the smallest
+     * step any gear asks for (FAST wants 6dp), so path length builds up without
+     * a single arrow being emitted and without leaving anything pending.
+     * Each call adds 10dp of travel.
+     */
+    private fun driveDp(gesture: TrackpadGesture, dp: Float, density: Float) {
+        val steps = (dp / 10f).toInt()
+        repeat(steps) {
+            gesture.accumulate(5f * density, 0f, density)
+            gesture.accumulate(-5f * density, 0f, density)
+        }
+    }
+
+    @Nested
+    inner class GearThresholds {
+
+        @Test
+        fun `a drag starts in the precise gear`() {
+            assertEquals(TrackpadGear.PRECISE, TrackpadGear.forTotalDp(0f))
+        }
+
+        @Test
+        fun `moderate engages at exactly 100dp of travel, not before`() {
+            assertEquals(TrackpadGear.PRECISE, TrackpadGear.forTotalDp(99.9f))
+            assertEquals(TrackpadGear.MODERATE, TrackpadGear.forTotalDp(100f))
+        }
+
+        @Test
+        fun `fast engages at exactly 250dp of travel, not before`() {
+            assertEquals(TrackpadGear.MODERATE, TrackpadGear.forTotalDp(249.9f))
+            assertEquals(TrackpadGear.FAST, TrackpadGear.forTotalDp(250f))
+            assertEquals(TrackpadGear.FAST, TrackpadGear.forTotalDp(5000f))
+        }
+
+        @Test
+        fun `each gear asks for a shorter step than the one before it`() {
+            // The whole point of the gears: the further the finger has already
+            // travelled, the fewer pixels each arrow costs. Equal steps would
+            // leave three gears that behave as one.
+            assertTrue(
+                TrackpadGear.PRECISE.thresholdDp > TrackpadGear.MODERATE.thresholdDp,
+                "precise should cost more travel per arrow than moderate"
+            )
+            assertTrue(
+                TrackpadGear.MODERATE.thresholdDp > TrackpadGear.FAST.thresholdDp,
+                "moderate should cost more travel per arrow than fast"
+            )
+        }
+
+        @Test
+        fun `the gear is read from travel so far, at this screen density`() {
+            val gesture = TrackpadGesture()
+            assertEquals(TrackpadGear.PRECISE, gesture.gear(2f))
+
+            driveDp(gesture, 100f, 2f)
+            assertEquals(200f, gesture.totalDistancePx, "100dp at density 2 is 200px")
+            assertEquals(TrackpadGear.MODERATE, gesture.gear(2f))
+
+            driveDp(gesture, 150f, 2f)
+            assertEquals(TrackpadGear.FAST, gesture.gear(2f))
+        }
+
+        @Test
+        fun `a shorter step in a higher gear turns the same delta into an arrow`() {
+            val density = 2f
+            val fourteenDp = 14f * density
+
+            val cold = TrackpadGesture()
+            assertEquals(
+                emptyList<String>(), cold.accumulate(fourteenDp, 0f, density),
+                "14dp is under the precise gear's 24dp step"
+            )
+
+            val warm = TrackpadGesture()
+            driveDp(warm, 100f, density)
+            assertEquals(
+                listOf("ArrowRight"), warm.accumulate(fourteenDp, 0f, density),
+                "14dp is exactly the moderate gear's step"
+            )
+        }
+    }
+
+    @Nested
+    inner class DirectionSelection {
+
+        private val density = 1f
+        private val step = TrackpadGear.PRECISE.thresholdDp // 24px at density 1
+
+        @Test
+        fun `dragging right emits ArrowRight`() {
+            assertEquals(listOf("ArrowRight"), TrackpadGesture().accumulate(step, 0f, density))
+        }
+
+        @Test
+        fun `dragging left emits ArrowLeft`() {
+            assertEquals(listOf("ArrowLeft"), TrackpadGesture().accumulate(-step, 0f, density))
+        }
+
+        @Test
+        fun `dragging down emits ArrowDown`() {
+            // Screen coordinates grow downward, so a positive dy is ArrowDown.
+            // Inverting this pair is the regression that makes the trackpad feel
+            // broken while still emitting arrows.
+            assertEquals(listOf("ArrowDown"), TrackpadGesture().accumulate(0f, step, density))
+        }
+
+        @Test
+        fun `dragging up emits ArrowUp`() {
+            assertEquals(listOf("ArrowUp"), TrackpadGesture().accumulate(0f, -step, density))
+        }
+
+        @Test
+        fun `the emitted names are the ones the injector knows`() {
+            // KeyMapping is what turns these strings into key events; a rename on
+            // one side and not the other emits arrows that inject nothing.
+            for (direction in listOf("ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown")) {
+                assertTrue(
+                    KeyMapping.getKeyDef(direction) != null,
+                    "$direction is emitted by the trackpad but unknown to KeyMapping"
+                )
+            }
+        }
+    }
+
+    @Nested
+    inner class Accumulation {
+
+        @Test
+        fun `travel under the step emits nothing but is kept`() {
+            val gesture = TrackpadGesture()
+            assertEquals(emptyList<String>(), gesture.accumulate(20f, 0f, 1f))
+            assertEquals(20f, gesture.pendingDxPx)
+            // Discarding the leftover would make a slow drag emit nothing at all.
+            assertEquals(listOf("ArrowRight"), gesture.accumulate(4f, 0f, 1f))
+        }
+
+        @Test
+        fun `one large delta pays out every whole step in it`() {
+            val gesture = TrackpadGesture()
+            // 70px at density 1, precise gear: two arrows, 22px still owed.
+            assertEquals(listOf("ArrowRight", "ArrowRight"), gesture.accumulate(70f, 0f, 1f))
+            assertEquals(22f, gesture.pendingDxPx, "the remainder carries into the next delta")
+        }
+
+        @Test
+        fun `the remainder carries rather than resetting to zero`() {
+            val gesture = TrackpadGesture()
+            gesture.accumulate(30f, 0f, 1f) // one arrow, 6px owed
+            assertEquals(6f, gesture.pendingDxPx)
+            // Zeroing instead of subtracting would need 24 more px here, not 18.
+            assertEquals(listOf("ArrowRight"), gesture.accumulate(18f, 0f, 1f))
+        }
+
+        @Test
+        fun `reversing direction spends the leftover rather than compounding it`() {
+            val gesture = TrackpadGesture()
+            gesture.accumulate(20f, 0f, 1f)
+            assertEquals(emptyList<String>(), gesture.accumulate(-20f, 0f, 1f))
+            assertEquals(0f, gesture.pendingDxPx)
+            // Path length still grew, even though the finger came back.
+            assertEquals(40f, gesture.totalDistancePx)
+        }
+    }
+
+    @Nested
+    inner class Diagonal {
+
+        @Test
+        fun `a diagonal drag emits both axes, horizontal first`() {
+            val gesture = TrackpadGesture()
+            assertEquals(
+                listOf("ArrowRight", "ArrowUp"),
+                gesture.accumulate(30f, -30f, 1f),
+                "a diagonal drag must move the cursor on both axes"
+            )
+            assertEquals(6f, gesture.pendingDxPx)
+            assertEquals(-6f, gesture.pendingDyPx)
+        }
+
+        @Test
+        fun `an axis under the step waits while the other one pays out`() {
+            val gesture = TrackpadGesture()
+            assertEquals(listOf("ArrowRight"), gesture.accumulate(30f, 10f, 1f))
+            assertEquals(10f, gesture.pendingDyPx, "the vertical travel is owed, not dropped")
+        }
+
+        @Test
+        fun `both axes can pay out more than once in a single delta`() {
+            val gesture = TrackpadGesture()
+            // 60px each way at density 1: the 100dp of path puts this in the
+            // moderate gear (14px step), so four arrows on each axis.
+            val directions = gesture.accumulate(60f, 60f, 1f)
+            assertEquals(TrackpadGear.MODERATE, gesture.gear(1f))
+            assertEquals(4, directions.count { it == "ArrowRight" })
+            assertEquals(4, directions.count { it == "ArrowDown" })
+        }
+    }
+
+    @Nested
+    inner class DragBoundary {
+
+        @Test
+        fun `reset clears travel, leftovers and the gear`() {
+            val gesture = TrackpadGesture()
+            driveDp(gesture, 300f, 1f)
+            gesture.accumulate(10f, 10f, 1f)
+            assertEquals(TrackpadGear.FAST, gesture.gear(1f))
+
+            gesture.reset()
+
+            assertEquals(0f, gesture.totalDistancePx)
+            assertEquals(0f, gesture.pendingDxPx)
+            assertEquals(0f, gesture.pendingDyPx)
+            assertEquals(TrackpadGear.PRECISE, gesture.gear(1f), "a new drag starts precise")
+        }
+
+        @Test
+        fun `leftover travel does not survive into the next drag`() {
+            val gesture = TrackpadGesture()
+            assertEquals(emptyList<String>(), gesture.accumulate(20f, 0f, 1f))
+            gesture.reset()
+            // Carrying the 20px across the lift would emit an arrow the user did
+            // not ask for, from a finger that has only just touched down.
+            assertEquals(emptyList<String>(), gesture.accumulate(20f, 0f, 1f))
+        }
+    }
+}

--- a/docs/DEVICE_TEST_CHECKLIST.md
+++ b/docs/DEVICE_TEST_CHECKLIST.md
@@ -46,7 +46,7 @@
 | KB-6 | Extra Key Row — Esc | Press Esc with menu open | Menu/dialog closes | | |
 | KB-7 | Extra Key Row — Ctrl+S | Press Ctrl on EKR then S on keyboard | File saves (no error) | | |
 | KB-8 | Extra Key Row — Ctrl+P | Press Ctrl on EKR then P | Quick Open dialog appears | | |
-| KB-9 | Extra Key Row — arrows | Press arrow keys on EKR | Cursor moves in editor | | |
+| KB-9 | Extra Key Row trackpad | Drag on the trackpad: slowly first, then keep going without lifting, then diagonally | Cursor steps character by character at first and speeds up the longer the drag gets; a diagonal drag moves on both axes. There are no arrow buttons to press: the trackpad replaced them, so it is the only way a touch user moves the cursor | | |
 | KB-10 | Extra Key Row — brackets | Press {, }, (, ) on EKR | Characters inserted in editor | | |
 
 ## 4. Screen & Orientation
@@ -210,13 +210,13 @@ as a known outcome keeps an unchecked box meaning "not tested" rather than
 | Screen & Orientation | 6 | | | |
 | Editor Operations | 8 | | | |
 | Extensions | 6 | | | |
-| Background/Foreground | 6 | | | |
+| Background/Foreground | 7 | | | |
 | Low Memory & Stress | 4 | | | |
 | Performance | 10 | | | |
-| Toolchains | 6 | | | |
+| Toolchains | 7 | | | |
 | Terminal & Tools | 10 | | | |
 | SAF & Files | 8 | | | |
-| **Total** | **82** | | | |
+| **Total** | **84** | | | |
 
 **Overall Result**: [ ] PASS / [ ] FAIL
 

--- a/scripts/device-test.sh
+++ b/scripts/device-test.sh
@@ -57,12 +57,19 @@
 # Nothing here can drive the workbench: it lives in a WebView, and the editor,
 # the terminal's contents, the extension marketplace and the SAF picker are all
 # out of reach. Those are what docs/DEVICE_TEST_CHECKLIST.md is for. Where a
-# check cannot run, it reports SKIP and says why -- a phase that reports PASS
-# for something it did not run is worse than one that admits it.
+# check cannot run, it reports SKIP and says why. A phase that reports PASS for
+# something it did not run is worse than one that admits it, and a phase that
+# reports FAIL for something it could not read is worse still: it blames the
+# device for the workstation, and it teaches the reader to skim past red. So
+# where an instrument can simply be absent from this host, its silence is
+# reported as its own absence: curl, python3, `ps`, the dumpsys sections and
+# `input keycombination` each say whether they can see anything at all before
+# their answer is read as a verdict about the device.
 
-# The blank line above is what -h stops at: its `sed -n '2,/^$/'` had no empty
-# line to find and printed every commented line in the file, header and phase
-# notes alike.
+# The blank line above is where -h stops: it prints `sed -n '2,/^$/'`, so the
+# first empty line in the file bounds the help text. Keep the header one
+# unbroken comment block, or everything after the break silently stops being
+# printed by -h.
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -111,6 +118,110 @@ derive_toolchain_release_urls() {
     # second one in this file would be free to drift from it.
     sed -n 's/.*downloadUrl = "\(https:[^"]*\)".*/\1/p' \
         "$ROOT_DIR/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainRegistry.kt"
+}
+
+# ── Readers of files the app writes ────────────────────────────────
+# python3 is an instrument like adb or curl, and its absence is a fact about
+# this host, never evidence about the device. Both readers below consult this
+# flag instead of probing for themselves, so --self-check can drive the
+# python-less path on a machine that does have python3.
+if command -v python3 >/dev/null 2>&1; then
+    HAVE_PYTHON3=true
+else
+    HAVE_PYTHON3=false
+fi
+
+read_toolchain_names() {
+    # Reads toolchains.json on stdin and prints the installed names, space
+    # separated. Non-zero exit means "python3 read this file and could not parse
+    # it", which is the only condition that is evidence of damage. Without
+    # python3 the names come from grep and no parse verdict is offered at all:
+    # reporting the app's record as unreadable JSON because the host has no
+    # interpreter blames the device for the workstation. Same fallback shape as
+    # derive_npm_expected().
+    if $HAVE_PYTHON3; then
+        python3 -c "
+import json, sys
+try:
+    entries = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+print(' '.join(e.get('name', '?') for e in entries))
+"
+    else
+        { grep -o '"name"[[:space:]]*:[[:space:]]*"[^"]*"' || true; } \
+            | sed 's/.*"\([^"]*\)"$/\1/' | tr '\n' ' ' | sed 's/ *$//'
+    fi
+}
+
+read_terminal_profile_path() {
+    # Reads settings.json on stdin and prints the bash profile's path. The file
+    # is JSONC once the workbench has rewritten it, so a plain parse is tried
+    # first and a regex is the fallback rather than the method. The regex has a
+    # shell twin here, outside the python program, because inside it it could
+    # not help with the one thing that silences both: no python3 on the host.
+    # Both take the first "bash" object in the file, so the two readings of the
+    # same bytes cannot disagree about which profile they are reporting.
+    if $HAVE_PYTHON3; then
+        python3 -c "
+import json, re, sys
+raw = sys.stdin.read()
+try:
+    profiles = json.loads(raw).get('terminal.integrated.profiles.linux', {})
+    print(profiles.get('bash', {}).get('path', ''))
+except Exception:
+    m = re.search(r'\"bash\"\s*:\s*\{[^}]*?\"path\"\s*:\s*\"([^\"]+)\"', raw, re.S)
+    print(m.group(1) if m else '')
+"
+    else
+        tr -d '\n' \
+            | { grep -o '"bash"[[:space:]]*:[[:space:]]*{[^}]*}' || true; } \
+            | head -1 \
+            | sed -n 's|.*"path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*|\1|p'
+    fi
+}
+
+extract_wrapper_targets() {
+    # Reads toolchain-env.sh on stdin and prints the file each wrapper hands to
+    # the loader, one per line, deduplicated. PREFIX is filesDir/usr
+    # (Environment.kt), so $PREFIX/.. is filesDir.
+    #
+    # Anchored on the whole generated wrapper line rather than on the
+    # "$PREFIX/../" substring alone. ToolchainManager.regenerateEnvFileLocked()
+    # writes that substring into three shapes and only the first names a file:
+    # a wrapper function; an `export` whose value may hold several entries
+    # (RUBYLIB does); and the `export PATH=` list it appends whenever a manifest
+    # declares pathDirs. Matching the substring took all three, and the two that
+    # are lists come back carrying a `:` and a second unexpanded $PREFIX. That is
+    # not a path, so it can never be on disk, so the phase reported the payload
+    # missing on an install where every wrapper target was present.
+    sed -n 's|^[^ "]*() { [^"]* "\$PREFIX/\.\./\([^"]*\)" "\$@"; }$|\1|p' | sort -u
+}
+
+derive_wrapper_line_samples() {
+    # The wrapper lines ToolchainManager.regenerateEnvFileLocked() writes,
+    # rendered from the generator's own Kotlin string literals with sample
+    # values substituted for the interpolations. extract_wrapper_targets is
+    # asserted against these rather than against a copy of the format kept
+    # here, so a change to how the generator spells a wrapper turns up as a
+    # failed --self-check instead of as a phase that skips forever.
+    awk '
+/\$PREFIX\/\.\.\// && (/lines\.add\(/ || /sb\.appendLine\(/) {
+    line = $0
+    sub(/^[^(]*\("/, "", line)
+    sub(/"\)[ \t]*$/, "", line)
+    gsub(/\\"/, "\"", line)
+    gsub(/\\\$/, "@@DOLLAR@@", line)
+    n = 0
+    while (match(line, /\$\{[^}]*\}|\$[A-Za-z_][A-Za-z0-9_]*/)) {
+        n++
+        repl = (n == 1) ? "sample" : (n == 2) ? "/system/bin/loader" : "usr/lib/sample/bin/sample"
+        line = substr(line, 1, RSTART - 1) repl substr(line, RSTART + RLENGTH)
+    }
+    gsub(/@@DOLLAR@@/, "$", line)
+    print line
+}
+' "$ROOT_DIR/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt"
 }
 
 # Auto-detect adb if not in PATH
@@ -295,6 +406,70 @@ if $SELF_CHECK; then
     else
         fail "toolchain release URLs" \
             "no downloadUrl readable in ToolchainRegistry.kt; the toolchain phase would check nothing"
+    fi
+
+    # The three readings the device phases make of files the app writes. Each is
+    # asserted for the same reason as the URLs above: a reading that stops
+    # matching does not announce itself, it turns into a permanent SKIP or into
+    # a verdict about the wrong thing.
+    #
+    # The sample below is one wrapper line per shape the generator emits,
+    # rendered from ToolchainManager.kt itself, followed by the two shapes that
+    # carry the same "$PREFIX/../" substring and must be ignored: a multi-valued
+    # export (ToolchainManager.kt writes RUBYLIB this way) and the PATH list it
+    # appends whenever a manifest declares pathDirs. Only the first kind names a
+    # file, and a reader that returns any of the others reports a healthy
+    # install as a payload that is gone.
+    WRAP_SAMPLE=$(derive_wrapper_line_samples)
+    WRAP_RENDERED=$(printf '%s\n' "$WRAP_SAMPLE" | grep -c . || true)
+    WRAP_INPUT=$(printf '%s\nexport RUBYLIB="$PREFIX/../usr/lib/ruby/3.4.0:$PREFIX/../usr/lib/ruby/3.4.0/aarch64-linux-android"\nexport PATH="$PREFIX/../usr/bin:$PATH"\n' "$WRAP_SAMPLE")
+    WRAP_GOT=$(printf '%s\n' "$WRAP_INPUT" | extract_wrapper_targets | tr '\n' ' ' | sed 's/ *$//')
+    if [ "$WRAP_RENDERED" -eq 0 ]; then
+        fail "wrapper target reading" \
+            "no wrapper line readable in ToolchainManager.kt; the toolchain payload check would have nothing to compare against"
+    elif [ "$WRAP_GOT" = "usr/lib/sample/bin/sample" ]; then
+        pass "wrapper target reading ($WRAP_RENDERED generated shapes, exports and PATH ignored)"
+    else
+        fail "wrapper target reading" \
+            "reading ToolchainManager.kt's own wrapper lines yielded '$WRAP_GOT', not the single file they name"
+    fi
+
+    # Read twice on purpose: as this host will run it, and again on a host with
+    # no python3. The second run is not just a flag flip. It also shadows python3
+    # with a function that fails the way a missing command does, so a reader that
+    # reaches for the interpreter anyway comes back empty and this goes red.
+    # Without that, the flag alone would be satisfied by a reader that ignores it
+    # entirely, and the fallback would be asserted without ever being run.
+    TC_SAMPLE='[{"name":"go","displayName":"Go"},{"name":"ruby","displayName":"Ruby"}]'
+    TC_NAMES_PY=$(printf '%s' "$TC_SAMPLE" | read_toolchain_names)
+    TC_NAMES_NOPY=$(
+        HAVE_PYTHON3=false
+        python3() { return 127; }
+        printf '%s' "$TC_SAMPLE" | read_toolchain_names
+    )
+    if [ "$TC_NAMES_PY" = "go ruby" ] && [ "$TC_NAMES_NOPY" = "go ruby" ]; then
+        pass "toolchains.json reading (with python3, and with none)"
+    else
+        fail "toolchains.json reading" \
+            "expected 'go ruby' from both readings, got '$TC_NAMES_PY' with python3 and '$TC_NAMES_NOPY' without"
+    fi
+
+    ST_SAMPLE='{"terminal.integrated.defaultProfile.linux": "bash",
+    "terminal.integrated.profiles.linux": {
+        "bash": { "path": "/data/user/0/p/files/usr/bin/bash", "args": [], "icon": "terminal-bash" }
+    }}'
+    ST_WANT="/data/user/0/p/files/usr/bin/bash"
+    ST_PATH_PY=$(printf '%s' "$ST_SAMPLE" | read_terminal_profile_path)
+    ST_PATH_NOPY=$(
+        HAVE_PYTHON3=false
+        python3() { return 127; }
+        printf '%s' "$ST_SAMPLE" | read_terminal_profile_path
+    )
+    if [ "$ST_PATH_PY" = "$ST_WANT" ] && [ "$ST_PATH_NOPY" = "$ST_WANT" ]; then
+        pass "settings.json profile reading (with python3, and with none)"
+    else
+        fail "settings.json profile reading" \
+            "expected '$ST_WANT' from both readings, got '$ST_PATH_PY' with python3 and '$ST_PATH_NOPY' without"
     fi
 
     printf "\n  ${GREEN}%d passed${RESET}, ${RED}%d failed${RESET}, ${YELLOW}%d skipped${RESET}\n\n" \
@@ -927,14 +1102,7 @@ TC_STATE=$($ADB shell run-as "$PKG" cat files/home/.vscodroid/toolchains.json 2>
 TC_NAMES=""
 TC_STATE_OK=false
 if [ -n "$TC_STATE" ]; then
-    TC_NAMES=$(printf '%s' "$TC_STATE" | python3 -c "
-import json, sys
-try:
-    entries = json.load(sys.stdin)
-except Exception:
-    sys.exit(1)
-print(' '.join(e.get('name', '?') for e in entries))
-" 2>/dev/null)
+    TC_NAMES=$(printf '%s' "$TC_STATE" | read_toolchain_names 2>/dev/null)
     if [ $? -eq 0 ]; then
         TC_STATE_OK=true
     fi
@@ -953,6 +1121,10 @@ elif ! $TC_STATE_OK; then
     # it cannot parse makes it keep the last good toolchain-env.sh rather than
     # delete it, because the file on disk is the only working record of how to
     # run what is still installed.
+    #
+    # Only reachable when python3 was here and rejected the file. Without it
+    # read_toolchain_names offers no parse verdict, so a host with no
+    # interpreter cannot land here and blame the device for it.
     fail "toolchain_record" "toolchains.json is present but is not readable JSON"
     skip "toolchain_env_file" "the record is unreadable"
     skip "toolchain_env_sourced" "the record is unreadable"
@@ -988,9 +1160,11 @@ else
     # Every wrapper hands a file under filesDir to the system loader. A wrapper
     # whose file is gone is a command that reports a loader error instead of
     # running, which is what a half-removed or partly-copied install looks like.
-    # PREFIX is filesDir/usr (Environment.kt), so $PREFIX/.. is filesDir.
-    TC_TARGETS=$(printf '%s\n' "$TC_ENV" \
-        | sed -n 's|.*"\$PREFIX/\.\./\([^"]*\)".*|\1|p' | sort -u)
+    # extract_wrapper_targets reads only the wrapper lines, and --self-check
+    # asserts that reading against the generator's own spelling, so this can
+    # neither judge an `export` value as a missing file nor skip in silence when
+    # the generated format moves.
+    TC_TARGETS=$(printf '%s\n' "$TC_ENV" | extract_wrapper_targets)
     TC_TARGET_TOTAL=$(printf '%s\n' "$TC_TARGETS" | grep -c . || true)
     if [ "$TC_TARGET_TOTAL" -eq 0 ]; then
         skip "toolchain_payload" "toolchain-env.sh defines no wrappers to check"
@@ -1035,22 +1209,22 @@ printf "\n${BOLD}Phase 7: Terminal Through The App${RESET}\n"
 TERM_PROFILE_PATH=""
 SETTINGS_JSON=$($ADB shell run-as "$PKG" cat files/home/.vscodroid/data/Machine/settings.json 2>/dev/null | tr -d '\r')
 if [ -n "$SETTINGS_JSON" ]; then
-    # JSONC once the workbench has rewritten it, so a plain parse is tried first
-    # and a regex is the fallback rather than the method.
-    TERM_PROFILE_PATH=$(printf '%s' "$SETTINGS_JSON" | python3 -c "
-import json, re, sys
-raw = sys.stdin.read()
-try:
-    profiles = json.loads(raw).get('terminal.integrated.profiles.linux', {})
-    print(profiles.get('bash', {}).get('path', ''))
-except Exception:
-    m = re.search(r'\"bash\"\s*:\s*\{[^}]*?\"path\"\s*:\s*\"([^\"]+)\"', raw, re.S)
-    print(m.group(1) if m else '')
-" 2>/dev/null)
+    TERM_PROFILE_PATH=$(printf '%s' "$SETTINGS_JSON" | read_terminal_profile_path 2>/dev/null)
 fi
 
 # Test 30: the workbench is pointed at a shell that exists.
-if [ -z "$TERM_PROFILE_PATH" ]; then
+#
+# Three ways to have no path, and they are not the same fact. The file being
+# absent is about the device. The file being there with no bash profile is about
+# the app. An empty answer from the shell fallback on a host with no python3 is
+# about the host, and the one thing it must not do is name the app's settings.
+if [ -z "$SETTINGS_JSON" ]; then
+    fail "terminal_profile" \
+        "no Machine/settings.json on this device; the workbench has no terminal profile to open"
+elif [ -z "$TERM_PROFILE_PATH" ] && ! $HAVE_PYTHON3; then
+    skip "terminal_profile" \
+        "no python3 on this host and the fallback read of settings.json matched nothing; an empty answer here is about this machine"
+elif [ -z "$TERM_PROFILE_PATH" ]; then
     fail "terminal_profile" \
         "no terminal.integrated.profiles.linux.bash.path in settings.json; the terminal has no shell to start"
 else

--- a/scripts/device-test.sh
+++ b/scripts/device-test.sh
@@ -45,6 +45,24 @@
 # are now read from the tree instead of written here, and --self-check verifies
 # those readings still resolve -- but neither of those is a substitute for
 # running it.
+#
+# WHAT IT CANNOT ANSWER
+#
+# Every check below either runs through `run-as` or reads a file. `run-as` is a
+# different SELinux domain (runas_app, not untrusted_app) and is allowed to
+# execute files the app itself is refused, so no result here is evidence that a
+# command works in the app's own terminal. Phase 7 measures the app's own exec
+# path once, indirectly, by looking for a bash process the app spawned.
+#
+# Nothing here can drive the workbench: it lives in a WebView, and the editor,
+# the terminal's contents, the extension marketplace and the SAF picker are all
+# out of reach. Those are what docs/DEVICE_TEST_CHECKLIST.md is for. Where a
+# check cannot run, it reports SKIP and says why -- a phase that reports PASS
+# for something it did not run is worse than one that admits it.
+
+# The blank line above is what -h stops at: its `sed -n '2,/^$/'` had no empty
+# line to find and printed every commented line in the file, header and phase
+# notes alike.
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -84,6 +102,15 @@ derive_py_expected() {
     # library that actually shipped.
     ls "$ROOT_DIR"/android/app/src/main/assets/usr/lib/libpython3.*.so 2>/dev/null \
         | head -1 | sed 's/.*libpython\(3\.[0-9]*\)\.so/\1/'
+}
+
+derive_toolchain_release_urls() {
+    # Where a non-Play install gets its toolchains. Read from the registry the
+    # app itself ships rather than written here, for the same reason as every
+    # other expectation above: these URLs are the only copy that matters, and a
+    # second one in this file would be free to drift from it.
+    sed -n 's/.*downloadUrl = "\(https:[^"]*\)".*/\1/p' \
+        "$ROOT_DIR/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainRegistry.kt"
 }
 
 # Auto-detect adb if not in PATH
@@ -255,6 +282,19 @@ if $SELF_CHECK; then
     else
         skip "python expectation" \
             "no assets tree in this checkout; resolvable only where the build ran"
+    fi
+
+    # Not reachability -- that needs a network and belongs to a device run. This
+    # is the reading itself: a rename or a reformat of ToolchainRegistry.kt would
+    # otherwise leave the toolchain phase checking an empty list of URLs and
+    # calling it clean.
+    TC_URLS=$(derive_toolchain_release_urls)
+    TC_URL_COUNT=$(printf '%s\n' "$TC_URLS" | grep -c 'https' || true)
+    if [ "$TC_URL_COUNT" -gt 0 ]; then
+        pass "toolchain release URLs ($TC_URL_COUNT, from ToolchainRegistry.kt)"
+    else
+        fail "toolchain release URLs" \
+            "no downloadUrl readable in ToolchainRegistry.kt; the toolchain phase would check nothing"
     fi
 
     printf "\n  ${GREEN}%d passed${RESET}, ${RED}%d failed${RESET}, ${YELLOW}%d skipped${RESET}\n\n" \
@@ -785,6 +825,353 @@ if echo "$FILE_CHECK" | grep -q "EXISTS"; then
     $ADB shell "run-as $PKG rm $TEST_FILE" 2>/dev/null
 else
     fail "file_creation" "Could not create/verify file"
+fi
+
+# ═══════════════════════════════════════════════════════════════════
+# TESTS 24-29: Toolchains
+# ═══════════════════════════════════════════════════════════════════
+printf "\n${BOLD}Phase 6: Toolchains${RESET}\n"
+
+# What this phase answers, and what it deliberately does not:
+#
+#   * It can read what an install left behind -- the record, the generated
+#     environment, and whether the payload those name is still on disk -- and it
+#     can ask whether the screen that installs one is reachable at all.
+#   * It cannot run a toolchain. `go`, `ruby` and `java` are bash *functions*
+#     defined in toolchain-env.sh, which only an interactive shell has sourced,
+#     and `run-as` is a different SELinux domain (runas_app, not untrusted_app)
+#     that may execute files the app itself is refused. A version string
+#     obtained through it would be evidence about run-as. Checklist rows TC-4
+#     and TC-5 stay a person's job.
+#   * It cannot drive an install. ToolchainActivity is not exported, so `am
+#     start` from the shell uid is refused, and the first-run picker is shown
+#     once per install.
+#
+# Consequence for a default run: `pm clear` empties filesDir, so nothing is
+# installed and the installed-state checks report SKIP with that reason. To make
+# them measure anything, install a toolchain by hand and re-run with
+# --skip-install.
+
+# Test 24: the toolchain screen has a way in.
+#
+# It has exactly one: the dynamic launcher shortcut publishToolchainShortcut()
+# pushes from launchMain(). The activity is not exported and no bundled
+# extension sends openToolchainSettings, so if the push is refused -- rate
+# limiting is the documented case -- the screen becomes unreachable and only a
+# log line says so. Read rather than launched, because the shortcut cannot be
+# started from the shell uid either.
+#
+# The control is the dump having any Package section at all: without one, this
+# cannot tell "no shortcut" from "cannot see shortcuts on this Android version".
+SHORTCUT_DUMP=$($ADB shell dumpsys shortcut 2>/dev/null | tr -d '\r')
+if ! echo "$SHORTCUT_DUMP" | grep -q "Package:"; then
+    skip "toolchain_shortcut" \
+        "dumpsys shortcut listed no packages here, so an empty result proves nothing"
+else
+    PKG_SHORTCUTS=$(echo "$SHORTCUT_DUMP" | awk -v pkg="$PKG" '
+        /Package:/ { inpkg = ($2 == pkg) }
+        inpkg { print }
+    ')
+    if echo "$PKG_SHORTCUTS" | grep -q "id=toolchains"; then
+        pass "toolchain_shortcut (the launcher shortcut is published)"
+    else
+        fail "toolchain_shortcut" \
+            "no id=toolchains shortcut for $PKG; the toolchain screen has no entry point"
+    fi
+fi
+
+# Test 25: the release still carries the ZIPs a non-Play install downloads.
+#
+# ToolchainRegistry points every sideloaded install at releases/latest, so a
+# release published without the toolchain assets breaks installation for every
+# non-Play user, including ones who already have the app. Nothing on the device
+# can detect that; it is a property of the release, checked from the host.
+#
+# A range request rather than a HEAD, so a redirect to a signed asset URL is
+# followed without pulling 179 MB. No network means SKIP: this is the one check
+# here that can fail for a reason that has nothing to do with the build.
+TC_URLS=$(derive_toolchain_release_urls)
+if [ -z "$TC_URLS" ]; then
+    fail "toolchain_release_assets" \
+        "no downloadUrl readable in ToolchainRegistry.kt"
+elif ! command -v curl >/dev/null 2>&1; then
+    skip "toolchain_release_assets" "no curl on this host"
+else
+    TC_URL_BAD=""
+    TC_URL_UNREACHED=""
+    TC_URL_OK=0
+    for url in $TC_URLS; do
+        CODE=$(curl -sL -o /dev/null -r 0-0 --max-time 30 -w "%{http_code}" "$url" 2>/dev/null)
+        RC=$?
+        if [ $RC -ne 0 ] || [ "$CODE" = "000" ]; then
+            TC_URL_UNREACHED="$TC_URL_UNREACHED $(basename "$url")"
+        elif [ "$CODE" = "200" ] || [ "$CODE" = "206" ]; then
+            TC_URL_OK=$((TC_URL_OK + 1))
+        else
+            TC_URL_BAD="$TC_URL_BAD $(basename "$url")=$CODE"
+        fi
+    done
+    if [ -n "$TC_URL_BAD" ]; then
+        fail "toolchain_release_assets" \
+            "the current release does not serve:$TC_URL_BAD"
+    elif [ -n "$TC_URL_UNREACHED" ]; then
+        skip "toolchain_release_assets" \
+            "could not reach github.com for:$TC_URL_UNREACHED"
+    else
+        pass "toolchain_release_assets ($TC_URL_OK served by releases/latest)"
+    fi
+fi
+
+# Tests 26-29: what an install left on this device.
+TC_STATE=$($ADB shell run-as "$PKG" cat files/home/.vscodroid/toolchains.json 2>/dev/null | tr -d '\r')
+TC_NAMES=""
+TC_STATE_OK=false
+if [ -n "$TC_STATE" ]; then
+    TC_NAMES=$(printf '%s' "$TC_STATE" | python3 -c "
+import json, sys
+try:
+    entries = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+print(' '.join(e.get('name', '?') for e in entries))
+" 2>/dev/null)
+    if [ $? -eq 0 ]; then
+        TC_STATE_OK=true
+    fi
+fi
+
+if [ -z "$TC_STATE" ]; then
+    # Absence, not damage. Either nothing was ever installed or this run cleared
+    # app data, and neither is a defect.
+    skip "toolchain_record" \
+        "no toolchains.json on this device; install one and re-run with --skip-install"
+    skip "toolchain_env_file" "no toolchain installed"
+    skip "toolchain_env_sourced" "no toolchain installed"
+    skip "toolchain_payload" "no toolchain installed"
+elif ! $TC_STATE_OK; then
+    # Damage is a different thing, and the app treats it as one: a toolchains.json
+    # it cannot parse makes it keep the last good toolchain-env.sh rather than
+    # delete it, because the file on disk is the only working record of how to
+    # run what is still installed.
+    fail "toolchain_record" "toolchains.json is present but is not readable JSON"
+    skip "toolchain_env_file" "the record is unreadable"
+    skip "toolchain_env_sourced" "the record is unreadable"
+    skip "toolchain_payload" "the record is unreadable"
+elif [ -z "$TC_NAMES" ]; then
+    skip "toolchain_record" \
+        "toolchains.json is an empty list; install one and re-run with --skip-install"
+    skip "toolchain_env_file" "no toolchain installed"
+    skip "toolchain_env_sourced" "no toolchain installed"
+    skip "toolchain_payload" "no toolchain installed"
+else
+    pass "toolchain_record ($TC_NAMES)"
+
+    # The record without the environment is an install nothing can use: the
+    # commands simply are not names any terminal knows.
+    TC_ENV=$($ADB shell run-as "$PKG" cat files/home/.vscodroid/toolchain-env.sh 2>/dev/null | tr -d '\r')
+    if [ -n "$TC_ENV" ]; then
+        pass "toolchain_env_file (toolchain-env.sh regenerated)"
+    else
+        fail "toolchain_env_file" \
+            "toolchains.json names $TC_NAMES but toolchain-env.sh is missing or empty"
+    fi
+
+    # And the environment nothing sources is the same install, one layer out.
+    BASHRC=$($ADB shell run-as "$PKG" cat files/home/.bashrc 2>/dev/null | tr -d '\r')
+    if echo "$BASHRC" | grep -q "toolchain-env.sh"; then
+        pass "toolchain_env_sourced (.bashrc sources it)"
+    else
+        fail "toolchain_env_sourced" \
+            ".bashrc does not source toolchain-env.sh; no terminal gets the toolchain environment"
+    fi
+
+    # Every wrapper hands a file under filesDir to the system loader. A wrapper
+    # whose file is gone is a command that reports a loader error instead of
+    # running, which is what a half-removed or partly-copied install looks like.
+    # PREFIX is filesDir/usr (Environment.kt), so $PREFIX/.. is filesDir.
+    TC_TARGETS=$(printf '%s\n' "$TC_ENV" \
+        | sed -n 's|.*"\$PREFIX/\.\./\([^"]*\)".*|\1|p' | sort -u)
+    TC_TARGET_TOTAL=$(printf '%s\n' "$TC_TARGETS" | grep -c . || true)
+    if [ "$TC_TARGET_TOTAL" -eq 0 ]; then
+        skip "toolchain_payload" "toolchain-env.sh defines no wrappers to check"
+    else
+        # Capped: the whole list goes onto one adb command line, and Java alone
+        # contributes dozens. Checking a bounded prefix of it is enough to catch
+        # a payload that is gone, and the count says how much was looked at.
+        TC_CHECKED=$(printf '%s\n' "$TC_TARGETS" | head -20)
+        TC_CHECK_COUNT=$(printf '%s\n' "$TC_CHECKED" | grep -c . || true)
+        TC_ARGS=$(printf '%s\n' "$TC_CHECKED" | sed "s|^|$DATA_DIR/files/|" | tr '\n' ' ')
+        TC_MISSING=$($ADB shell "run-as $PKG sh -c 'for f in $TC_ARGS; do [ -e \$f ] || echo \$f; done'" 2>/dev/null | tr -d '\r')
+        if [ -z "$TC_MISSING" ]; then
+            pass "toolchain_payload ($TC_CHECK_COUNT of $TC_TARGET_TOTAL wrapper targets present)"
+        else
+            fail "toolchain_payload" \
+                "toolchain-env.sh names files that are not on disk: $(echo "$TC_MISSING" | tr '\n' ' ')"
+        fi
+    fi
+fi
+
+# ═══════════════════════════════════════════════════════════════════
+# TESTS 30-33: The terminal, as the app opens it
+# ═══════════════════════════════════════════════════════════════════
+printf "\n${BOLD}Phase 7: Terminal Through The App${RESET}\n"
+
+# Phase 4 runs the bundled tools through `run-as`, which answers "is the binary
+# there and does it work", and cannot answer "does the app's own terminal open".
+# Those are different questions with different failure modes, and the second one
+# is the one a user meets. What is reachable from adb:
+#
+#   * the profile the workbench will use, and whether the shell it names is
+#     still on disk -- a dangling path means every terminal fails to open, and
+#     it dangles for a mundane reason (a reinstall moves nativeLibraryDir);
+#   * whether the two files a new shell sources still parse, because a syntax
+#     error in either takes out every terminal at once rather than one command;
+#   * whether a terminal can actually be opened, which is attempted rather than
+#     assumed, and reports SKIP when it cannot be confirmed.
+#
+# What stays out of reach: everything inside the terminal. TT-1 through TT-10 on
+# the checklist need a person, because the output only exists inside the WebView.
+
+TERM_PROFILE_PATH=""
+SETTINGS_JSON=$($ADB shell run-as "$PKG" cat files/home/.vscodroid/data/Machine/settings.json 2>/dev/null | tr -d '\r')
+if [ -n "$SETTINGS_JSON" ]; then
+    # JSONC once the workbench has rewritten it, so a plain parse is tried first
+    # and a regex is the fallback rather than the method.
+    TERM_PROFILE_PATH=$(printf '%s' "$SETTINGS_JSON" | python3 -c "
+import json, re, sys
+raw = sys.stdin.read()
+try:
+    profiles = json.loads(raw).get('terminal.integrated.profiles.linux', {})
+    print(profiles.get('bash', {}).get('path', ''))
+except Exception:
+    m = re.search(r'\"bash\"\s*:\s*\{[^}]*?\"path\"\s*:\s*\"([^\"]+)\"', raw, re.S)
+    print(m.group(1) if m else '')
+" 2>/dev/null)
+fi
+
+# Test 30: the workbench is pointed at a shell that exists.
+if [ -z "$TERM_PROFILE_PATH" ]; then
+    fail "terminal_profile" \
+        "no terminal.integrated.profiles.linux.bash.path in settings.json; the terminal has no shell to start"
+else
+    SHELL_THERE=$($ADB shell "run-as $PKG sh -c 'test -e $TERM_PROFILE_PATH && echo EXISTS'" 2>/dev/null | tr -d '\r')
+    if echo "$SHELL_THERE" | grep -q "EXISTS"; then
+        pass "terminal_profile ($TERM_PROFILE_PATH)"
+    else
+        # updateSettingsNativeLibPaths() rewrites this on every launch precisely
+        # because a reinstall moves nativeLibraryDir underneath it. `test -e`
+        # follows the symlink, so a dangling usr/bin/bash fails here too.
+        fail "terminal_profile" \
+            "$TERM_PROFILE_PATH does not resolve; no terminal can open"
+    fi
+fi
+
+# Test 31: shell integration can still recognise the shell.
+#
+# The ptyHost picks injection arguments from a table keyed by the *basename* of
+# the profile's executable: `bash` matches, `libbash.so` matches nothing and the
+# injection is skipped in silence. That is why the profile names the symlink and
+# not the library it points at (Environment.getTerminalShellPath), and pointing
+# it at the library is a change that breaks nothing visibly.
+if [ -z "$TERM_PROFILE_PATH" ]; then
+    skip "terminal_shell_basename" "no profile path to read"
+elif [ "$(basename "$TERM_PROFILE_PATH")" = "bash" ]; then
+    pass "terminal_shell_basename (bash)"
+else
+    fail "terminal_shell_basename" \
+        "the profile names $(basename "$TERM_PROFILE_PATH"); shell integration is keyed on the basename and would be skipped in silence"
+fi
+
+# Test 32: the files every new shell sources still parse.
+#
+# `bash -n` parses without executing, so the answer does not depend on which
+# SELinux domain asks -- unlike anything that runs a toolchain. It is worth its
+# own test because the blast radius is not one command: toolchain-env.sh is
+# generated from manifests regenerated at build time, and one name bash cannot
+# use as a function is a parse error that takes out every terminal.
+PARSE_FAILURES=""
+PARSE_CHECKED=0
+for rc_file in files/home/.bashrc files/home/.vscodroid/toolchain-env.sh; do
+    RC_PRESENT=$($ADB shell "run-as $PKG sh -c 'test -f $rc_file && echo EXISTS'" 2>/dev/null | tr -d '\r')
+    echo "$RC_PRESENT" | grep -q "EXISTS" || continue
+    PARSE_CHECKED=$((PARSE_CHECKED + 1))
+    PARSE_OUT=$(run_tool "files/usr/bin/bash" -n "$DATA_DIR/$rc_file")
+    PARSE_RC=$?
+    if [ "$PARSE_RC" -ne 0 ]; then
+        PARSE_FAILURES="$PARSE_FAILURES $rc_file(rc=$PARSE_RC: $PARSE_OUT)"
+    fi
+done
+if [ "$PARSE_CHECKED" -eq 0 ]; then
+    fail "terminal_startup_files" \
+        "neither .bashrc nor toolchain-env.sh is present; a terminal would open with no environment"
+elif [ -z "$PARSE_FAILURES" ]; then
+    pass "terminal_startup_files ($PARSE_CHECKED parsed)"
+else
+    fail "terminal_startup_files" "syntax error in:$PARSE_FAILURES"
+fi
+
+# Test 33: a terminal actually opens, and bash runs in the app's own domain.
+#
+# This is the only check in the suite that measures the exec path the app itself
+# takes rather than the one run-as takes. It is also the least certain to run:
+# Ctrl+backtick has to reach the workbench inside the WebView, and nothing here
+# can confirm the workbench received a keystroke.
+#
+# So the result is PASS on positive evidence -- a bash process under this
+# package -- and SKIP otherwise, never FAIL. A failure to drive the UI and a
+# broken terminal look identical from out here, and reporting the first as the
+# second is how a suite starts lying in the other direction.
+#
+# ARGS is the command line with argv[0]'s directory stripped, which is what makes
+# both spellings visible: node-pty may name the usr/bin/bash symlink or the
+# libbash.so it resolves to, and "bash" occurs in either.
+APP_UID=$($ADB shell run-as "$PKG" id -u 2>/dev/null | tr -d '\r')
+app_process_lines() {
+    $ADB shell ps -A -o UID,ARGS 2>/dev/null | tr -d '\r' \
+        | awk -v uid="$APP_UID" '$1 == uid'
+}
+bash_process_count() {
+    app_process_lines | grep -c "bash" || true
+}
+
+# The control, and it has to come first: an empty answer below means "no bash"
+# only if this can see the app's processes at all. The server was reported ready
+# in Phase 2, so its Node process is there to be found -- if that is not visible
+# either, the reading is about `ps`, not about the terminal.
+APP_PROCS=$(app_process_lines)
+if [ -z "$APP_UID" ] || ! echo "$APP_PROCS" | grep -q "node"; then
+    skip "terminal_opens" \
+        "could not read this app's processes out of ps (uid='$APP_UID'), so an empty result would prove nothing"
+else
+    BASH_BEFORE=$(bash_process_count)
+    if [ "$BASH_BEFORE" -gt 0 ]; then
+        pass "terminal_opens ($BASH_BEFORE bash process(es) running under $PKG)"
+    else
+        FOCUS=$($ADB shell "dumpsys window 2>/dev/null | grep -E 'mCurrentFocus|mFocusedApp'" 2>/dev/null | tr -d '\r')
+        if [ -z "$FOCUS" ]; then
+            skip "terminal_opens" \
+                "could not read which app is in front, so a keystroke would go somewhere unknown"
+        elif ! echo "$FOCUS" | grep -q "$PKG"; then
+            skip "terminal_opens" \
+                "$PKG is not the focused app; a keystroke would land elsewhere"
+        else
+            # keycombination is Android 12+. An older `input` answers with usage
+            # text rather than a non-zero exit, so the output is what gets read.
+            COMBO_OUT=$($ADB shell input keycombination KEYCODE_CTRL_LEFT KEYCODE_GRAVE 2>&1 | tr -d '\r')
+            if echo "$COMBO_OUT" | grep -qiE "error|unknown command|usage"; then
+                skip "terminal_opens" "input keycombination is unavailable here: $COMBO_OUT"
+            else
+                sleep 6
+                BASH_AFTER=$(bash_process_count)
+                if [ "$BASH_AFTER" -gt "$BASH_BEFORE" ]; then
+                    pass "terminal_opens (bash spawned in the app's own domain)"
+                else
+                    skip "terminal_opens" \
+                        "no bash appeared after Ctrl+backtick; the workbench may not have had keyboard focus. Not evidence of a broken terminal -- open one by hand (checklist TT-1)"
+                fi
+            fi
+        fi
+    fi
 fi
 
 # ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
`GestureTrackpad` carries the speed-gear and arrow-emission logic that replaced four arrow buttons, and had no tests. The device harness had no toolchain phase and no terminal phase, so both were guarded only by a human checklist.

## Changes

- The accumulation and gear decision move to a pure function, `TrackpadGesture`, with tests for the gear thresholds, direction selection, accumulator reset and the diagonal case. Behaviour is unchanged.
- `device-test.sh` gains a toolchain phase and a terminal phase.

## Notes

A phase that cannot run reports SKIPPED and says why. None of them reports a pass for something it did not execute, and none reports a failure for a healthy install: every check that depends on an instrument asks first whether that instrument can see anything.

Installing a toolchain cannot be driven from adb: the activity is not exported and the first-run picker is gated by a preference. The script says so rather than pretending to cover it.

## Verification

944 unit tests, lint clean. `--self-check` passes with no device attached.
