### PR TITLE
fix(crash): keep the connection token out of crash logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The on-device editor server requires a connection token, generated on first start and kept in private storage. Binding to `127.0.0.1` is not access control on Android.
 - The connection token no longer reaches the Android system log, which other software on the device can read.
+- Crash logs leaving the app now have the connection token taken out. The bug report copied to the clipboard and the crash dialog both carried it verbatim.
 - The address the editor is opened at is redacted by the shared routine before logging, replacing a hand-maintained token-free copy that could drift from the real one.
 - Deciding whether the server on the port is ours no longer sends it the connection token. Ownership is settled from a record this app writes; a holder we have no record for is treated as a stranger.
 - Startup readiness is judged by the one endpoint answered before the token check. The previous check treated any non-error reply as healthy, including "forbidden".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The milestone checklist says a ticked box records what was true when it was ticked. It is the only planning document still tracking open work, so it carries a note rather than a historical marker.
 - The milestone log and implementation plan no longer record a process-liveness check as the fix for the white screen on reopen. A contributor could reintroduce it as precedent.
 - The milestone checklist no longer plans on-device CI as a hosted device lab. Nothing in the workflows starts the app, and arm64 runners cannot boot an emulator.
+- The bug report's documented contents match what it emits, and the logging table no longer names a server or extension-host log file that nothing in the app writes.
 - The requirements table's heap limit is no longer a flat 512 MB; the ceiling has been derived from device RAM since a fixed limit left 3-4 GB phones nothing to work with.
 - `CONTRIBUTING.md` no longer describes a URL allow-list the app does not have. VSCodroid is a development environment and reaches LAN hosts on purpose; the session token is what is checked.
 - `CONTRIBUTING.md` describes both toolchain delivery paths. It named only Play Asset Delivery, while every non-Play install takes the HTTP path that developers themselves run on.
@@ -103,7 +104,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The on-device editor server requires a connection token, generated on first start and kept in private storage. Binding to `127.0.0.1` is not access control on Android.
 - The connection token no longer reaches the Android system log, which other software on the device can read.
-- Crash logs leaving the app now have the connection token taken out. The bug report copied to the clipboard and the crash dialog both carried it verbatim.
+- Crash text reaching the clipboard, the crash dialog and the page now has the connection token stripped from the `tkn=` parameter it travels in.
 - The address the editor is opened at is redacted by the shared routine before logging, replacing a hand-maintained token-free copy that could drift from the real one.
 - Deciding whether the server on the port is ours no longer sends it the connection token. Ownership is settled from a record this app writes; a holder we have no record for is treated as a stranger.
 - Startup readiness is judged by the one endpoint answered before the token check. The previous check treated any non-error reply as healthy, including "forbidden".

--- a/android/app/src/main/kotlin/com/vscodroid/util/CrashReporter.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/util/CrashReporter.kt
@@ -1,6 +1,7 @@
 package com.vscodroid.util
 
 import android.content.Context
+import com.vscodroid.webview.redactToken
 import java.io.File
 import java.io.PrintWriter
 import java.io.StringWriter
@@ -39,13 +40,20 @@ object CrashReporter {
 
     /**
      * Returns the most recent crash log, or null if no crashes have been recorded.
+     *
+     * The text goes through [redactToken] on the way out. This is the boundary
+     * the log crosses: it reaches the dialog `MainActivity.checkPreviousCrash`
+     * puts on screen and the `AndroidBridge.getLastCrash` method the page can
+     * call, and redacting here covers both without either caller having to
+     * remember. `MainActivity` cuts its preview at 500 characters after this
+     * returns, so the substitution shifts where that cut lands.
      */
     fun getLastCrash(): String? {
         if (!::crashDir.isInitialized) return null
         return crashDir.listFiles()
             ?.sortedByDescending { it.lastModified() }
             ?.firstOrNull()
-            ?.readText()
+            ?.let { redactToken(it.readText()) }
     }
 
     /**
@@ -61,6 +69,13 @@ object CrashReporter {
      * - Device info (model, Android version, app version)
      * - Recent crash logs
      * - Last 200 lines of Node.js server output
+     *
+     * The report is copied to the clipboard and handed back across the JS
+     * bridge, so everything read off disk goes through [redactToken] first: the
+     * server's connection token authenticates every route but `/version`,
+     * `/delay-shutdown` and `/callback`. The containment stops where that
+     * function's does, at the literal `tkn=` parameter, so a bare token in no
+     * parameter at all still passes through.
      */
     fun generateBugReport(context: Context): String {
         val sb = StringBuilder()
@@ -96,7 +111,7 @@ object CrashReporter {
                 sb.appendLine("--- Crash Logs (${logs.size}) ---")
                 for (log in logs.take(3)) {
                     sb.appendLine()
-                    sb.appendLine(log.readText())
+                    sb.appendLine(redactToken(log.readText()))
                     sb.appendLine("---")
                 }
             } else {
@@ -105,13 +120,15 @@ object CrashReporter {
         }
         sb.appendLine()
 
-        // Node.js server log (last 200 lines)
+        // Node.js server log (last 200 lines). Nothing in this repository writes
+        // that file, so the block never fires today; it is redacted with the
+        // rest so it is not the one raw path left if something starts to.
         val serverLog = File(Environment.getLogsDir(context), "server.log")
         if (serverLog.exists()) {
             sb.appendLine("--- Server Log (last 200 lines) ---")
             val lines = serverLog.readLines()
             val tail = if (lines.size > 200) lines.takeLast(200) else lines
-            tail.forEach { sb.appendLine(it) }
+            tail.forEach { sb.appendLine(redactToken(it)) }
         }
 
         return sb.toString()

--- a/android/app/src/main/kotlin/com/vscodroid/util/CrashReporter.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/util/CrashReporter.kt
@@ -67,8 +67,12 @@ object CrashReporter {
     /**
      * Generates a bug report bundle containing:
      * - Device info (model, Android version, app version)
-     * - Recent crash logs
-     * - Last 200 lines of Node.js server output
+     * - Memory usage
+     * - How many crash logs exist, plus the text of the three most recent
+     *
+     * Not the server's output: the block below reads a `server.log` that
+     * nothing writes, so that section never appears. `docs/05-API_SPEC.md`
+     * and the logging table in `docs/03-ARCHITECTURE.md` say the same.
      *
      * The report is copied to the clipboard and handed back across the JS
      * bridge, so everything read off disk goes through [redactToken] first: the

--- a/android/app/src/test/kotlin/com/vscodroid/util/CrashReporterTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/util/CrashReporterTest.kt
@@ -1,13 +1,16 @@
 package com.vscodroid.util
 
+import android.content.Context
 import io.mockk.every
 import io.mockk.just
+import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import io.mockk.Runs
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -155,6 +158,30 @@ class CrashReporterTest {
             val lastCrash = CrashReporter.getLastCrash()
             assertEquals("Newer crash", lastCrash, "Should return the most recent crash log")
         }
+
+        @Test
+        fun `the crash offered on screen does not carry the connection token`() {
+            // Two callers share this one return value: the dialog
+            // MainActivity.checkPreviousCrash shows, and AndroidBridge.getLastCrash,
+            // which hands it to the page.
+            val crashDir = initCrashDir()
+            val token = "7f3a2b1c-9d8e-4f60-b5a4-2c1d0e9f8a7b"
+            val crash = File(crashDir, "crash_20260214_120000.txt")
+            crash.writeText(
+                "Thread: main (id=1)\n" +
+                    "java.io.IOException: GET http://127.0.0.1:41234/?tkn=$token failed\n"
+            )
+            check(crash.readText().contains(token)) {
+                "the fixture has to hold a token, or redacting nothing passes"
+            }
+
+            val shown = CrashReporter.getLastCrash()
+
+            assertNotNull(shown, "there is a crash log on disk to read")
+            assertFalse(shown!!.contains(token), "the token must not be shown or handed out:\n$shown")
+            assertTrue(shown.contains("tkn=<redacted>"), "the parameter stays visible:\n$shown")
+            assertTrue(shown.contains("java.io.IOException"), "the failure itself has to survive:\n$shown")
+        }
     }
 
     @Nested
@@ -208,6 +235,94 @@ class CrashReporterTest {
             assertTrue(File(crashDir, "crash_15.txt").exists(), "Newest log should be kept")
         }
     }
+
+    /**
+     * The bundle behind **Copy Report**, which `MainActivity.checkPreviousCrash`
+     * puts on the clipboard and `AndroidBridge.generateBugReport` hands back to
+     * the page. Nothing here reads `android.os.Build`: those fields answer null
+     * and 0 on a plain JVM, so asserting on them would describe the stub.
+     */
+    @Nested
+    inner class BugReportTest {
+
+        /**
+         * A shape a real crash log carries, not a value the app holds: the URL
+         * the WebView was loading when it failed goes into the stack trace.
+         */
+        private val token = "7f3a2b1c-9d8e-4f60-b5a4-2c1d0e9f8a7b"
+
+        private val context = mockk<Context>(relaxed = true)
+
+        @BeforeEach
+        fun pointTheServerLogSomewhereEmpty() {
+            mockkObject(Environment)
+            every { Environment.getLogsDir(any()) } returns File(tempDir, "logs").absolutePath
+        }
+
+        @Test
+        fun `the copied bug report does not carry the connection token`() {
+            val crashDir = initCrashDir()
+            val crash = File(crashDir, "crash_20260214_120000.txt")
+            crash.writeText(
+                "Crash at 2026-02-14 12:00:00 +0700\n" +
+                    "Thread: main (id=1)\n\n" +
+                    "java.io.IOException: GET " +
+                    "http://127.0.0.1:41234/vscode-remote-resource?tkn=$token failed\n" +
+                    "\tat com.vscodroid.webview.VSCodroidWebViewClient.proxy(VSCodroidWebViewClient.kt:554)\n"
+            )
+            // Without this the test would be green against a report that simply
+            // never reached the crash log, which is the failure it exists to rule out.
+            check(crash.readText().contains(token)) {
+                "the fixture has to hold a token, or redacting nothing passes"
+            }
+
+            val report = CrashReporter.generateBugReport(context)
+
+            assertFalse(
+                report.contains(token),
+                "the clipboard is readable by anything the user pastes into:\n$report",
+            )
+            assertTrue(
+                report.contains("tkn=<redacted>"),
+                "the parameter has to stay visible, so the reader knows what was taken out:\n$report",
+            )
+            assertTrue(
+                report.contains(
+                    "at com.vscodroid.webview.VSCodroidWebViewClient.proxy(VSCodroidWebViewClient.kt:554)"
+                ),
+                "this is the only diagnostic channel there is; the trace has to survive:\n$report",
+            )
+        }
+
+        @Test
+        fun `the bug report counts every crash log and embeds the newest three`() {
+            val crashDir = initCrashDir()
+            for (i in 1..4) {
+                File(crashDir, "crash_0$i.txt").apply {
+                    writeText("crash number $i")
+                    setLastModified(i * 1000L)
+                }
+            }
+
+            val report = CrashReporter.generateBugReport(context)
+
+            assertTrue(report.contains("--- Crash Logs (4) ---"), "all four exist:\n$report")
+            assertTrue(report.contains("crash number 4"), "the newest has to be there:\n$report")
+            assertTrue(report.contains("crash number 3"), "$report")
+            assertTrue(report.contains("crash number 2"), "$report")
+            assertFalse(report.contains("crash number 1"), "only three are embedded:\n$report")
+        }
+
+        @Test
+        fun `the crash section says so when there is nothing to report`() {
+            initCrashDir()
+
+            val report = CrashReporter.generateBugReport(context)
+
+            assertTrue(report.contains("--- No crash logs ---"), "$report")
+        }
+    }
+
 }
 
 /**

--- a/android/app/src/test/kotlin/com/vscodroid/util/CrashReporterTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/util/CrashReporterTest.kt
@@ -12,12 +12,14 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Tests for [CrashReporter] — crash log management and lifecycle.
@@ -323,6 +325,64 @@ class CrashReporterTest {
         }
     }
 
+    /**
+     * The handler `init` installs, and the log it writes. Everything else in
+     * this file fabricates crash files by hand, so the producer itself has never
+     * run: it swallows every throwable, which means a writer that wrote nothing
+     * would look exactly like one that worked.
+     */
+    @Nested
+    inner class UncaughtExceptionHandlerTest {
+
+        private var previousDefault: Thread.UncaughtExceptionHandler? = null
+
+        @BeforeEach
+        fun rememberDefaultHandler() {
+            previousDefault = Thread.getDefaultUncaughtExceptionHandler()
+        }
+
+        /**
+         * The default handler is JVM-wide and this suite runs in a single JVM
+         * with no forking, so one left installed here would still be there for
+         * every class that runs afterwards.
+         */
+        @AfterEach
+        fun restoreDefaultHandler() {
+            Thread.setDefaultUncaughtExceptionHandler(previousDefault)
+        }
+
+        @Test
+        fun `an uncaught exception is written down and still reaches the handler it replaced`() {
+            val chained = AtomicReference<Throwable>()
+            Thread.setDefaultUncaughtExceptionHandler { _, thrown -> chained.set(thrown) }
+            val context = mockk<Context>(relaxed = true)
+            every { context.cacheDir } returns tempDir
+
+            CrashReporter.init(context)
+
+            val installed = Thread.getDefaultUncaughtExceptionHandler()
+            assertNotNull(installed, "init has to install a handler")
+            val boom = IllegalStateException("boom")
+            installed!!.uncaughtException(Thread("worker-7"), boom)
+
+            val written = File(tempDir, "crash-logs").listFiles()?.toList().orEmpty()
+            assertEquals(1, written.size, "one crash, one log: $written")
+            val text = written.single().readText()
+            assertTrue(text.contains("Thread: worker-7"), "the crashing thread is named: $text")
+            assertTrue(
+                text.contains("java.lang.IllegalStateException: boom"),
+                "the exception has to be in there: $text",
+            )
+            assertTrue(
+                text.contains("at com.vscodroid.util.CrashReporterTest"),
+                "the stack trace is what makes the log worth keeping: $text",
+            )
+            assertSame(
+                boom, chained.get(),
+                "the handler that was there before still has to run, or the process never dies",
+            )
+        }
+    }
 }
 
 /**

--- a/docs/03-ARCHITECTURE.md
+++ b/docs/03-ARCHITECTURE.md
@@ -488,9 +488,13 @@ flowchart TD
 | Component | Log Destination | Level |
 |-----------|----------------|-------|
 | Kotlin | Android Logcat (tag: VSCodroid) | INFO (release), DEBUG (debug) |
-| Node.js server | File: ~/.vscodroid/logs/server.log | INFO |
-| Extension Host | File: ~/.vscodroid/logs/exthost.log | WARN |
+| Node.js server | stdout/stderr, read by `ProcessManager.startOutputReader` and written to Logcat | DEBUG (debug builds only) |
+| Extension Host | worker_thread inside the server process (patch `0004`), not a file this app writes | as above |
 | WebView | Chrome DevTools (debug builds only) | ALL |
+
+Nothing writes `server.log` or `exthost.log`. `CrashReporter.generateBugReport` looks for
+the first under `Environment.getLogsDir` (`filesDir/home/.vscodroid/data/logs`) and never
+finds it, so a bug report carries no server-log section.
 
 ### 8.3 Configuration
 

--- a/docs/05-API_SPEC.md
+++ b/docs/05-API_SPEC.md
@@ -408,11 +408,15 @@ fun getLastCrash(authToken: String): String?
 
 @JavascriptInterface
 fun generateBugReport(authToken: String): String
-// Generates a comprehensive bug report containing:
+// Generates a bug report containing:
 // - Device info (model, Android version, app version)
 // - Memory usage
-// - Recent crash logs (up to 3)
-// - Last 200 lines of Node.js server output
+// - How many crash logs exist, plus the text of the three most recent
+// Node.js server output is not in it, despite the section the code still
+// builds for it: ProcessManager reads the server's stdout and logs it in
+// debug builds, and no file is written for this to read.
+// Everything read off disk has the connection token replaced wherever it
+// appears as a `tkn=` parameter.
 
 @JavascriptInterface
 fun clearCrashLogs(authToken: String)


### PR DESCRIPTION
The server's connection token authenticates every route but `/version`, `/delay-shutdown` and `/callback`, and every logging site already strips it before printing. The crash path did not. `CrashReporter.getLastCrash()` and `CrashReporter.generateBugReport()` read crash files straight off disk, so a token that reached a stack trace would travel out with them: onto the clipboard behind **Copy Report**, into the previous-crash dialog, and back across the JS bridge to the page.

Changes:

- Both readers pass what they read through the shared `redactToken`. Redacting where `CrashReporter` hands text out, rather than at each caller, means a new caller is not a new leak, and `getLastCrash()` alone covers the dialog and the bridge method.
- The server-log tail is redacted for the same reason, but nothing writes that file, so it is inert today and no leak is closed there.
- `docs/05-API_SPEC.md` no longer advertises 200 lines of Node output in the report, and the logging table in `docs/03-ARCHITECTURE.md` no longer names `server.log` and `exthost.log` at a path that does not exist: `Environment.getLogsDir` resolves to `filesDir/home/.vscodroid/data/logs`, and nothing writes either file.
- New tests: the bug report and the on-screen crash each hold `tkn=<redacted>` and not the token, with the stack frame intact.
- New test for the uncaught-exception handler, which had never run in this suite. It swallows every throwable, so a writer that wrote nothing looked identical to one that worked. It now has to name the crashing thread, carry the exception and its stack, and still hand the throwable to the handler it replaced.

Containment is bounded: redaction keys on the literal `tkn=` parameter, so a bare token passes through. Widening it would risk the stack traces this report exists to carry.

Verified with the full unit suite (995 tests), `lintDebug`, and the repository self-checks.