### PR TITLE
fix(memory): report memory pressure for the whole process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The editor's memory ceiling is sized from the device. A fixed limit left 3-4 GB phones being killed repeatedly while larger devices never used what they had.
 - Switching to another app no longer kills your language servers. Android's window-hidden signal numerically outranks its real out-of-memory warning.
 - A script of yours whose name merely contains a language server's, such as `run-eslint.js`, is no longer classed as one and killed under memory pressure.
+- Low-memory warnings now reach the background server after the app is swiped away, so idle language servers are still reclaimed instead of holding memory and process slots.
 - Stopping the app from its notification no longer freezes the screen for several seconds or shows the "isn't responding" dialog.
 
 **Device folders (SAF)**

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -267,6 +267,27 @@ tasks.withType<Test> {
     inputs.file(layout.projectDirectory.file("build.gradle.kts"))
         .withPropertyName("appBuildScript")
         .withPathSensitivity(PathSensitivity.RELATIVE)
+
+    // The manifest is read the same way and needs the same declaration. Editing
+    // only the manifest changes no compiled input, so without this the run that
+    // would catch a bad manifest edit is the one that reports
+    // `> Task :app:testDebugUnitTest UP-TO-DATE`, exit 0, over the previous
+    // run's results. Measured: repointing `<application android:name>` with the
+    // declaration absent kept the task up to date and the build successful in
+    // 1s; with it present the task re-ran and the assertion went red.
+    //
+    // One declaration is what makes every manifest-reading suite run, so
+    // narrowing it to a single reader's question silences the others, and they
+    // ask different questions. ProcessWideMemoryPressureTest asks whether
+    // `<application android:name>` still points at VSCodroidApp, the class that
+    // hears trim callbacks once no Activity is left. HardwareKeyboardTest,
+    // arriving with the hardware-keyboard guards, asks whether both activities
+    // still list every qualifier they need in `android:configChanges`. Treat
+    // that as a list of readers, not a limit on them:
+    //   grep -rn 'File("src/main/AndroidManifest.xml")' android/app/src/test/kotlin
+    inputs.file(layout.projectDirectory.file("src/main/AndroidManifest.xml"))
+        .withPropertyName("appManifest")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
 }
 
 // The server tree in assets/ has to carry this checkout's patches, and nothing

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -1794,7 +1794,11 @@ internal fun writeMemoryPressure(tmpDir: File, pressure: String) {
     try {
         File(tmpDir, "vscodroid-memory-pressure").writeText(pressure)
     } catch (e: Exception) {
-        Logger.d("MainActivity", "Failed to write memory pressure: ${e.message}")
+        // Not the Activity's tag: the application class calls this too, and the
+        // write most likely to fail is the one that happens after the Activity
+        // is gone. Naming a destroyed component sends the reader to the wrong
+        // lifecycle.
+        Logger.d("MemoryPressure", "Failed to write memory pressure: ${e.message}")
     }
 }
 

--- a/android/app/src/main/kotlin/com/vscodroid/VSCodroidApp.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/VSCodroidApp.kt
@@ -6,6 +6,7 @@ import android.app.NotificationManager
 import android.webkit.WebView
 import com.vscodroid.util.CrashReporter
 import com.vscodroid.util.Logger
+import java.io.File
 
 class VSCodroidApp : Application() {
 
@@ -23,6 +24,30 @@ class VSCodroidApp : Application() {
 
         createNotificationChannel()
         Logger.i("VSCodroidApp", "Application created")
+    }
+
+    /**
+     * Reports memory pressure for the whole process, not for one Activity.
+     *
+     * MainActivity overrides this too and keeps doing so: it also logs and tells
+     * the page, both of which need the Activity. But the server the process
+     * monitor watches outlives the Activity (NodeService returns START_STICKY
+     * and the manifest declares no `android:stopWithTask`), so with the Activity
+     * as the only writer the monitor read nothing from the moment the task was
+     * swiped away, which is exactly when the system starts reclaiming from us.
+     * Application is a ComponentCallbacks2 for the whole process lifetime, so
+     * this fires whether or not an Activity exists.
+     *
+     * The two writers overlap harmlessly: same path, same word, and
+     * `readMemoryPressure` in process-monitor.js unlinks the file as it reads.
+     *
+     * Nothing here branches on the level. [applyMemoryPressure] maps it, and a
+     * comparison in place of that map is what once killed every idle language
+     * server on every app switch.
+     */
+    override fun onTrimMemory(level: Int) {
+        super.onTrimMemory(level)
+        applyMemoryPressure(File(cacheDir, "tmp"), level)
     }
 
     private fun createNotificationChannel() {

--- a/android/app/src/test/kotlin/com/vscodroid/MemoryPressureTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/MemoryPressureTest.kt
@@ -12,6 +12,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
+import io.mockk.verify
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -142,6 +143,14 @@ class MemoryPressureWireTest {
             PRESSURE_CRITICAL, applyMemoryPressure(tmpDir, TRIM_MEMORY_RUNNING_CRITICAL),
             "the severity is still the answer even when it could not be recorded"
         )
+
+        // Both the Activity and the application class reach this write, and the
+        // one that fails after a swipe has no Activity behind it. A tag naming
+        // one caller sends whoever reads the line looking for a lifecycle bug in
+        // a component that was already gone.
+        verify {
+            Logger.d("MemoryPressure", match { it.startsWith("Failed to write memory pressure") })
+        }
     }
 }
 

--- a/android/app/src/test/kotlin/com/vscodroid/MemoryPressureTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/MemoryPressureTest.kt
@@ -144,3 +144,67 @@ class MemoryPressureWireTest {
         )
     }
 }
+
+/**
+ * Which component reports pressure once there is no Activity left to report it.
+ *
+ * The server the process monitor watches outlives the Activity: NodeService
+ * returns START_STICKY and the manifest declares no `android:stopWithTask`. So
+ * with the Activity as the only writer, swiping the task away leaves Node
+ * running while nothing fills the file `readMemoryPressure` opens, and the idle
+ * language-server kill that reading gates can never fire again. That is the
+ * state the system reclaims memory from, and the failure is silent: it looks
+ * exactly like no language server having been idle.
+ *
+ * `Application` is a ComponentCallbacks2 for the whole process lifetime, so an
+ * override there fires whether or not an Activity exists.
+ *
+ * These read the class and its source instead of driving the callback, which is
+ * weaker than [MemoryPressureWireTest] above and worth being exact about.
+ * `onTrimMemory` cannot be invoked from a JVM test at all: its first statement
+ * is `super.onTrimMemory(level)`, the unit-test android.jar answers that with
+ * `RuntimeException: Method onTrimMemory in android.app.Application not mocked`,
+ * and no stub on the instance intercepts it, because a super call is not
+ * dispatched virtually. What the override is allowed to contain is therefore
+ * that super call and one call out, and one call out is what this pins.
+ * Everything decided or written behind it is covered above.
+ */
+class ProcessWideMemoryPressureTest {
+
+    private val source = File("src/main/kotlin/com/vscodroid/VSCodroidApp.kt")
+
+    @Test
+    fun `the process, not only the Activity, hears a trim callback`() {
+        assertTrue(
+            VSCodroidApp::class.java.declaredMethods.any { it.name == "onTrimMemory" },
+            "the manifest names VSCodroidApp as the application class, and once the " +
+                "Activity is gone it is the only component left to hear the callback"
+        )
+    }
+
+    @Test
+    fun `it records the severity where the monitor looks for it`() {
+        check(source.isFile) {
+            "VSCodroidApp.kt not found at ${source.absolutePath}, so this test would " +
+                "otherwise pass by looking at nothing"
+        }
+
+        val body = source.readLines()
+            .dropWhile { !it.contains("override fun onTrimMemory(") }
+            .drop(1)
+            .takeWhile { !it.startsWith("    }") }
+            .filterNot { it.trimStart().startsWith("//") }
+            .joinToString(" ")
+            .replace(Regex("\\s+"), " ")
+
+        // The whole call, not just the name: the directory has to be the one
+        // process-monitor.js resolves TMPDIR to, and the level has to arrive
+        // unexamined, because applyMemoryPressure maps it and comparing it
+        // instead is what killed every idle language server on every app switch.
+        assertTrue(
+            body.contains("""applyMemoryPressure(File(cacheDir, "tmp"), level)"""),
+            "the application override must record pressure the same way the Activity " +
+                "does; found instead: $body"
+        )
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/MemoryPressureTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/MemoryPressureTest.kt
@@ -172,6 +172,27 @@ class MemoryPressureWireTest {
 class ProcessWideMemoryPressureTest {
 
     private val source = File("src/main/kotlin/com/vscodroid/VSCodroidApp.kt")
+    private val manifest = File("src/main/AndroidManifest.xml")
+
+    @Test
+    fun `the manifest points the process at this class`() {
+        check(manifest.isFile) {
+            "AndroidManifest.xml not found at ${manifest.absolutePath}, so this test would " +
+                "otherwise pass by looking at nothing"
+        }
+
+        // The override below only runs while <application> names this class.
+        // Pointing that attribute at another Application subclass (a startup
+        // initializer, a multidex or injection base class) while leaving this
+        // one in the tree restores the defect exactly: the process again has no
+        // writer once the Activity is gone, and the two tests below stay green
+        // because the class still declares the override and still calls out.
+        assertTrue(
+            manifest.readText().contains("android:name=\".VSCodroidApp\""),
+            "the process reports pressure through whichever class <application> names; " +
+                "VSCodroidApp is not that class, so its override is never called"
+        )
+    }
 
     @Test
     fun `the process, not only the Activity, hears a trim callback`() {

--- a/android/app/src/test/kotlin/com/vscodroid/service/ProcessManagerTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/service/ProcessManagerTest.kt
@@ -547,6 +547,40 @@ class ProcessManagerTest {
         )
     }
 
+    @Test
+    fun `the watchdog tells an OOM kill from an ordinary signal`() {
+        // 137 is 128 + SIGKILL, and on this platform that is nearly always the
+        // low-memory killer or the phantom-process limit: the two causes a
+        // reader has to act on, and the two that no other exit code announces.
+        //
+        // The assertion is on the words, and it has to be. 137 is a member of
+        // the 129..192 range the branch below it covers, so deleting the 137
+        // line does not remove a log line: it falls through and warns
+        // "Server killed by SIGKILL" instead. A test asserting that a warning
+        // was logged, or that the exit code reached onServerCrashed, stays green
+        // through exactly that deletion and proves nothing.
+        manager.serverProcessField = mockk<Process>(relaxed = true) {
+            every { waitFor() } returns 137
+            every { isAlive } returns false
+        }
+
+        val diagnosed = CountDownLatch(1)
+        every {
+            Logger.w(any(), match<String> { it.contains("OOM or phantom limit") }, any())
+        } answers {
+            diagnosed.countDown()
+        }
+
+        ProcessManager::class.java.getDeclaredMethod("startWatchdog")
+            .apply { isAccessible = true }
+            .invoke(manager)
+
+        assertTrue(
+            diagnosed.await(5, TimeUnit.SECONDS),
+            "137 must be reported as memory or the process limit, not as a bare signal"
+        )
+    }
+
     // -- Connection token --
 
     @Test

--- a/scripts/test-process-monitor.js
+++ b/scripts/test-process-monitor.js
@@ -160,13 +160,31 @@ function checkPressureContract(tmp) {
         'means the function was renamed and this check is comparing the monitor against ' +
         'nothing.',
     );
-    // All of them, not the first, and from every caller above rather than from
-    // MainActivity alone: a second writer aiming somewhere else is exactly the
-    // drift this compares for, and neither match() without /g nor a scan of one
-    // file would ever look at it.
-    const writerDirs = callers.flatMap((f) => [...fs.readFileSync(f, 'utf8')
-        .matchAll(/applyMemoryPressure\(File\(cacheDir,\s*"([^"]+)"\)/g)]
-        .map((m) => m[1]));
+    // All of them, not the first, and asserted per caller rather than over the
+    // pooled result: a writer aiming somewhere else is exactly the drift this
+    // compares for, and neither match() without /g nor a scan of one file would
+    // ever look at it.
+    //
+    // Per caller is what keeps the check counting its own subjects. Once there
+    // are two writers, a pooled "we found a directory" test is satisfied by
+    // either one of them, so a caller whose base expression moves off cacheDir
+    // (to filesDir, say, which is the durable directory) contributes nothing,
+    // the pool stays non-empty on the other writer's behalf, and every
+    // comparison below agrees about a literal that writer no longer uses. The
+    // component that drifted is then the one writing where nothing reads, and
+    // this file says ok.
+    const writerDirs = callers.flatMap((f) => {
+        const dirs = [...fs.readFileSync(f, 'utf8')
+            .matchAll(/applyMemoryPressure\(File\(cacheDir,\s*"([^"]+)"\)/g)]
+            .map((m) => m[1]);
+        assert.ok(
+            dirs.length,
+            `${path.basename(f)} calls applyMemoryPressure but not as ` +
+            'applyMemoryPressure(File(cacheDir, "...")), so the directory that caller ' +
+            'writes the pressure file into is outside every comparison below',
+        );
+        return dirs;
+    });
     const writerDir = writerDirs.length ? [writerDirs[0]] : null;
     const envDir = environment.match(/val tmpDir = "\$cacheDir\/([^"]+)"/);
     assert.ok(

--- a/scripts/test-process-monitor.js
+++ b/scripts/test-process-monitor.js
@@ -56,6 +56,12 @@ const EXT = '/data/user/0/com.vscodroid/files/home/.vscodroid/extensions';
 const MAIN_ACTIVITY = path.join(
     __dirname, '../android/app/src/main/kotlin/com/vscodroid/MainActivity.kt',
 );
+// The second writer. The Activity reports pressure while it exists; the
+// application class reports it for the whole process, which is the only one
+// left once the task is swiped away and the server keeps running.
+const VSCODROID_APP = path.join(
+    __dirname, '../android/app/src/main/kotlin/com/vscodroid/VSCodroidApp.kt',
+);
 const ENVIRONMENT = path.join(
     __dirname, '../android/app/src/main/kotlin/com/vscodroid/util/Environment.kt',
 );
@@ -145,22 +151,27 @@ function checkPressureContract(tmp) {
         }
     };
     walk(path.join(__dirname, '../android/app/src/main/kotlin'));
+    // Sorted on both sides, because the order is whatever readdir returned.
     assert.deepStrictEqual(
-        callers, [MAIN_ACTIVITY],
+        callers.slice().sort(), [MAIN_ACTIVITY, VSCODROID_APP].sort(),
         'the set of sources that write the pressure file is not what this check reads. ' +
-        `Found [${callers.join(', ')}], expected only MainActivity.kt. Another writer's ` +
-        'severity words would be outside the comparison; none at all means the function ' +
-        'was renamed and this check is comparing the monitor against nothing.',
+        `Found [${callers.join(', ')}], expected MainActivity.kt and VSCodroidApp.kt. ` +
+        "Another writer's severity words would be outside the comparison; none at all " +
+        'means the function was renamed and this check is comparing the monitor against ' +
+        'nothing.',
     );
-    // All of them, not the first: a second writer aiming somewhere else is exactly
-    // the drift this compares for, and match() without /g would never look at it.
-    const writerDirs = [...kotlin.matchAll(/applyMemoryPressure\(File\(cacheDir,\s*"([^"]+)"\)/g)]
-        .map((m) => m[1]);
+    // All of them, not the first, and from every caller above rather than from
+    // MainActivity alone: a second writer aiming somewhere else is exactly the
+    // drift this compares for, and neither match() without /g nor a scan of one
+    // file would ever look at it.
+    const writerDirs = callers.flatMap((f) => [...fs.readFileSync(f, 'utf8')
+        .matchAll(/applyMemoryPressure\(File\(cacheDir,\s*"([^"]+)"\)/g)]
+        .map((m) => m[1]));
     const writerDir = writerDirs.length ? [writerDirs[0]] : null;
     const envDir = environment.match(/val tmpDir = "\$cacheDir\/([^"]+)"/);
     assert.ok(
         writerDir,
-        'could not find the directory MainActivity writes the pressure file into, so the ' +
+        'could not find the directory the pressure file is written into, so the ' +
         'comparison below would be against nothing',
     );
     assert.ok(
@@ -170,12 +181,12 @@ function checkPressureContract(tmp) {
     );
     assert.deepStrictEqual(
         [...new Set(writerDirs)], writerDirs.slice(0, 1),
-        'MainActivity writes the pressure file into more than one directory (' +
+        'the pressure file is written into more than one directory (' +
         writerDirs.join(', ') + '), so at most one of them can be the one the monitor opens',
     );
     assert.strictEqual(
         writerDir[0], envDir[1],
-        `MainActivity writes the pressure file into cacheDir/${writerDir[0]} while TMPDIR -- ` +
+        `the pressure file is written into cacheDir/${writerDir[0]} while TMPDIR -- ` +
         `which is the directory the monitor opens -- is cacheDir/${envDir[1]}. The severity is ` +
         'written where nothing looks for it, and the filenames agreeing hides it.',
     );


### PR DESCRIPTION
`process-monitor.js` sheds idle language servers only when it reads a critical severity from `${TMPDIR}/vscodroid-memory-pressure`. That file had one writer, `MainActivity.onTrimMemory`. `NodeService` returns `START_STICKY` and the manifest declares no `android:stopWithTask`, so the server keeps running after the task is swiped away, and from that moment nothing wrote the file. The idle kill could then never fire again, exactly when the system is most likely to reclaim memory. The failure is silent: an unreclaimed server and no idle server look alike.

What changed:

- `VSCodroidApp` now overrides `onTrimMemory` and calls the existing `applyMemoryPressure`, so the signal no longer depends on an Activity. The level is not re-derived there: the trim constants are not ordered by severity, and `TRIM_MEMORY_UI_HIDDEN` at 20 outranks `TRIM_MEMORY_RUNNING_CRITICAL` at 15. Overlapping with the Activity's write is harmless, since the monitor unlinks the file as it reads.
- `scripts/test-process-monitor.js` pinned MainActivity as the only writer. It now expects both and asserts each caller's target directory on its own rather than pooling them, so one writer drifting off `cacheDir` fails the check by name instead of passing on the other's match.
- A test pins `android:name` on `<application>`, since the new override runs only while the manifest names this class. `writeMemoryPressure` also stops tagging a failed write with the Activity's name, which misleads once that write happens without one.
- Added coverage for the watchdog's exit code 137 branch. 137 falls inside the 129..192 range below it, so deleting its line degrades the message rather than removing it; the test asserts the text.

Sequencing note: the idle kill is now reachable with no Activity present, so it acts on whatever `classify()` calls a language server in more situations. The work tightening that classifier should land first or alongside.

Verified with 994 unit tests and all seven JavaScript self-checks green.