### PR TITLE
docs: correct the readiness record and retire the dead development guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - README, the user guide and the requirements specification now carry storage figures that match the gate: 810 MB of assets, 875 MB required before extraction, about 1.15 GB with all toolchains. The README promised 500 MB while setup refuses under 875 MB.
 - The milestone checklist says a ticked box records what was true when it was ticked. It is the only planning document still tracking open work, so it carries a note rather than a historical marker.
-- The milestone log and the implementation plan no longer record a process-liveness check as the fix for the white screen on reopen. A contributor reading them as precedent would reintroduce it.
+- The milestone log and implementation plan no longer record a process-liveness check as the fix for the white screen on reopen. A contributor could reintroduce it as precedent.
+- The milestone checklist no longer plans on-device CI as a hosted device lab. Nothing in the workflows starts the app, and arm64 runners cannot boot an emulator.
 - The requirements table's heap limit is no longer a flat 512 MB; the ceiling has been derived from device RAM since a fixed limit left 3-4 GB phones nothing to work with.
 - `CONTRIBUTING.md` no longer describes a URL allow-list the app does not have. VSCodroid is a development environment and reaches LAN hosts on purpose; the session token is what is checked.
 - `CONTRIBUTING.md` describes both toolchain delivery paths. It named only Play Asset Delivery, while every non-Play install takes the HTTP path that developers themselves run on.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `CONTRIBUTING.md` describes both toolchain delivery paths. It named only Play Asset Delivery, while every non-Play install takes the HTTP path that developers themselves run on.
 - The contributing guide's repository map matches the shipped binaries: Python never lived in `jniLibs`, while git's HTTPS helper and the musl loader do.
 - The contributing guide records that findings not fixed in the same pull request get an issue, and rejected ones a stated reason.
+- The planning-era development guide is now a pointer at `CONTRIBUTING.md`. It named a build script that no longer exists and a launch command that skips first-run extraction.
+- The contributing guide covers device debugging and the version bump: which log carries the server's output, how to probe readiness, and why `versionCode` alone does not re-extract assets.
 - README realigned with how the project builds: local builds fetch the prebuilt server, SSH ships as OpenSSH plus `ssh-keygen`, toolchains install on sideloaded devices, and the size table is measured.
 - The user guide no longer documents Command Palette entries that were never registered. Each now describes a route that works or says plainly it is not reachable.
 - The user guide no longer claims sideloaded builds carry every toolchain inside the APK. They download on demand and land in app storage.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The contributing guide's repository map matches the shipped binaries: Python never lived in `jniLibs`, while git's HTTPS helper and the musl loader do.
 - The contributing guide records that findings not fixed in the same pull request get an issue, and rejected ones a stated reason.
 - The planning-era development guide is now a pointer at `CONTRIBUTING.md`. It named a build script that no longer exists and a launch command that skips first-run extraction.
+- `CONTRIBUTING.md`'s asset steps now start with `./scripts/setup.sh`. It refuses a missing NDK before the downloads rather than after them, and nothing else documented the script.
 - The contributing guide covers device debugging and the version bump: which log carries the server's output, how to probe readiness, and why `versionCode` alone does not re-extract assets.
 - README realigned with how the project builds: local builds fetch the prebuilt server, SSH ships as OpenSSH plus `ssh-keygen`, toolchains install on sideloaded devices, and the size table is measured.
 - The user guide no longer documents Command Palette entries that were never registered. Each now describes a route that works or says plainly it is not reachable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - README, the user guide and the requirements specification now carry storage figures that match the gate: 810 MB of assets, 875 MB required before extraction, about 1.15 GB with all toolchains. The README promised 500 MB while setup refuses under 875 MB.
 - The milestone checklist says a ticked box records what was true when it was ticked. It is the only planning document still tracking open work, so it carries a note rather than a historical marker.
+- The milestone log and the implementation plan no longer record a process-liveness check as the fix for the white screen on reopen. A contributor reading them as precedent would reintroduce it.
 - The requirements table's heap limit is no longer a flat 512 MB; the ceiling has been derived from device RAM since a fixed limit left 3-4 GB phones nothing to work with.
 - `CONTRIBUTING.md` no longer describes a URL allow-list the app does not have. VSCodroid is a development environment and reaches LAN hosts on purpose; the session token is what is checked.
 - `CONTRIBUTING.md` describes both toolchain delivery paths. It named only Play Asset Delivery, while every non-Play install takes the HTTP path that developers themselves run on.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -451,6 +451,14 @@ cd android && ./gradlew assembleDebug
 
 Output: `android/app/build/outputs/apk/debug/app-debug.apk` (debug package name: `com.vscodroid.debug`)
 
+### Version Bump
+
+`versionCode` and `versionName` both live in `android/app/build.gradle.kts`, and both have
+to move. They are not interchangeable: `FirstRunSetup.isFirstRun()` compares the stored
+`versionName` against the installed one, so a release that bumps only `versionCode` never
+re-extracts the assets, while `getPreviousVersionCode()` and the migrations it feeds read
+`versionCode`. `markSetupComplete()` stores the pair together.
+
 ### Release Build
 
 Release builds require a signing keystore configured via environment variables:
@@ -518,6 +526,49 @@ After deploying, verify these core flows:
 5. **Git** works in terminal and SCM panel
 6. **Extra Key Row** appears when keyboard is open, Ctrl+S / Ctrl+P work
 7. **Crash recovery** -- kill Node.js process (`adb shell kill <PID>`), app auto-restarts
+
+### Debugging on Device
+
+```bash
+# The app's own log lines, by component
+adb logcat -s VSCodroid.MainActivity VSCodroid.NodeService VSCodroid.ProcessManager VSCodroid.ToolchainManager
+
+# Everything the app process writes
+adb logcat --pid=$(adb shell pidof com.vscodroid.debug)
+
+# Memory
+adb shell dumpsys meminfo com.vscodroid.debug
+
+# The Node process the server runs in
+adb shell ps -A | grep libnode
+```
+
+There is no `server.log`; nothing here writes one. The Node process's stdout and stderr are
+merged and forwarded line by line to logcat by `ProcessManager`, under
+`VSCodroid.ProcessManager` with a `[node]` prefix. That goes through `Logger.d`, which emits
+only when the package is debuggable, so the lines are in a debug build and not in a release
+one. The editor server keeps its own logs on device, in the directory `ProcessManager` hands
+it as `--logsPath` (`Environment.getLogsDir`):
+
+```bash
+adb shell run-as com.vscodroid.debug ls files/home/.vscodroid/data/logs
+```
+
+To probe the server yourself, take the port from logcat (`Server is ready on port NNNN`,
+logged by `NodeService` at info level, so it is there in both build types) and reach it
+through a forward:
+
+```bash
+adb forward tcp:$PORT tcp:$PORT
+curl -s -o /dev/null -w '%{http_code}\n' "http://127.0.0.1:$PORT/version"
+adb forward --remove tcp:$PORT
+```
+
+`/version` specifically, and only a `200` counts. There is no `/healthz`. `/` is not a
+substitute: the server requires a connection token on every route but `/version`,
+`/delay-shutdown` and `/callback`, so an unauthenticated `/` answers 403, and a check that
+accepts anything below 500 calls a server healthy while it refuses every request it gets.
+`scripts/device-test.sh` probes it exactly this way.
 
 ## How to Add a New Bundled Tool
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,11 @@ Run the download scripts in this order:
 This is the order CI uses, and the order matters — each step below notes why.
 
 ```bash
+# 0. Prerequisites. Checks node, git and python3, and exits on a missing
+#    ANDROID_NDK_HOME rather than letting steps 9 and 10 discover it after
+#    twenty minutes of downloading. REQUIRE_NDK=0 skips that one check.
+./scripts/setup.sh
+
 # 1. Fetch the Code - OSS server tree built by the build-vscode-oss workflow.
 #    This leaves it in server/, not in assets/.
 ./scripts/fetch-vscode-oss.sh
@@ -104,7 +109,7 @@ This is the order CI uses, and the order matters — each step below notes why.
 ./scripts/download-java.sh
 ```
 
-Alternatively, run steps 1–10 and the APK build in one go:
+Alternatively, run steps 0 to 10 and the APK build in one go:
 
 ```bash
 ./scripts/build-all.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -559,11 +559,24 @@ it as `--logsPath` (`Environment.getLogsDir`):
 adb shell run-as com.vscodroid.debug ls files/home/.vscodroid/data/logs
 ```
 
+Those `[node]` lines come from a reader `ProcessManager` attaches to the process it spawned.
+A server it adopted instead, which is what happens when the app process is killed and the
+editor server it forked survives holding the port, has no such process behind it and
+produces none. That is the state a post-crash session starts in, so read silence under this
+tag with the `Port ... already served by a server of ours; adopting it` line above it as an
+adopted server rather than a dead one.
+
 To probe the server yourself, take the port from logcat (`Server is ready on port NNNN`,
 logged by `NodeService` at info level, so it is there in both build types) and reach it
-through a forward:
+through a forward. On a session that has been up for hours the line has usually rolled out
+of the ring buffer; `assets/server.js` writes the same port down beside the pid of the
+server it forked, and removes it when that server exits, so the file answers whenever there
+is a server to probe:
 
 ```bash
+# The port again, when the log line is gone
+adb shell run-as com.vscodroid.debug cat files/server/editor-server.pid
+
 adb forward tcp:$PORT tcp:$PORT
 curl -s -o /dev/null -w '%{http_code}\n' "http://127.0.0.1:$PORT/version"
 adb forward --remove tcp:$PORT

--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -14,9 +14,13 @@ M6 (Release)   → Play Store release
 
 > A ticked box records what was true when it was ticked, not what is true now. Several
 > carry figures the build has since moved past: the V8 heap is no longer the flat 512 MB
-> under M4, and the size measurements under M5 predate later asset growth. Six boxes are
-> still open, so this is a live checklist rather than a historical document; treat the
+> under M4, and the size measurements under M5 predate later asset growth. Boxes are still
+> open under M6, so this is a live checklist rather than a historical document; treat the
 > ticked ones as dated entries and verify any number against the code before quoting it.
+> Most of what is open is operational (Play Console monitoring, store reviews, adoption
+> numbers) and no state of this repository can ever close it, so do not read an open box
+> here as work waiting in the tree. The count is deliberately not written down: a number
+> in this note is wrong the moment a box moves, and nothing makes it fail loudly.
 
 ---
 
@@ -441,7 +445,7 @@ _Ordered by dependency: fix bugs → verify features → harden → brand → sh
 1. **Stability & auth fixes** _(discovered during device testing)_
    - [x] Extension OAuth callback relay: Chrome Custom Tabs → Android Intent → WebView (`vscodroid://callback`)
    - [x] Persist extension secrets across app restarts: patch `isEncryptionAvailable()` → `true` in workbench.js so `SecretStorageService` uses IndexedDB instead of in-memory Map
-   - [x] White screen on app reopen: `isServerHealthy()` (synchronous HTTP) threw `NetworkOnMainThreadException` on main thread when reconnecting to already-running server; replaced with `isServerRunning()` (process liveness check, no I/O)
+   - [x] White screen on app reopen: `isServerHealthy()` (synchronous HTTP) threw `NetworkOnMainThreadException` on the main thread when reconnecting to an already-running server. The activity now asks `NodeService.isServerReady()`, which reports what the health probe already found and costs no I/O. Do not read this as an endorsement of a process-liveness check: the wrapper that first replaced it forwarded `Process.isAlive`, which is true from the moment the process is spawned and for the whole of a post-crash restart, so navigating on it points the WebView at a port with nothing listening. That wrapper is gone, and `ServerReadinessCallSiteTest` fails the build if it comes back
    - [x] Mobile menu CSS: touch-friendly hamburger dropdown (44px touch targets, 14px font, 280px min-width) appended to workbench.css
    - [x] Keyboard/ExtraKeyRow positioning: fix double-compensation (adjustResize + bottomMargin). Switch to edge-to-edge (`setDecorFitsSystemWindows=false`) with manual insets padding for consistent behavior on Android 13-16
 
@@ -535,7 +539,7 @@ _Order: audit code → configure release build → test on devices → validate 
 11. **CI/CD pipeline**
     - [x] GitHub Actions: build debug APK on PR (`build.yml`), lint on PR (`lint.yml`)
     - [x] Release workflow: tag → build → sign → GitHub Release (`release.yml`)
-    - [ ] Automated testing on Firebase Test Lab (physical ARM64 devices)
+    - [ ] Automated on-device testing in CI. Not started, and the hosted-lab plan it was written as is not the shape it would take: nothing under `.github/workflows/` starts the app, and the harness that does, `scripts/device-test.sh`, needs an attached device or a booted arm64 emulator, which GitHub's arm64 runners cannot provide (no `/dev/kvm`). On-device runs are on a person today, before a tag and after a change to what gets bundled
     - [x] Build toolchain zips and upload as GitHub Release assets — `scripts/package-toolchains.sh` + `release.yml`
     - [x] Fallback download URL served from GitHub Releases — README links to releases page
     - [x] CI fix: node-pty subshell path resolved with ROOT_DIR — Build + Unit Tests green

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ Quick links:
 | [Security](docs/06-SECURITY.md)                                              | Security model and threat analysis                         |
 | [Testing Strategy](docs/07-TESTING_STRATEGY.md)                              | Test plan and quality assurance                            |
 | [Risk Matrix](docs/08-RISK_MATRIX.md)                                        | Known risks and mitigation strategies                      |
-| [Development Guide](docs/09-DEVELOPMENT_GUIDE.md)                            | How to set up and build the project                        |
+| [Development Guide](docs/09-DEVELOPMENT_GUIDE.md)                            | Superseded; points at CONTRIBUTING.md, which is kept current |
 | [Release Plan](docs/10-RELEASE_PLAN.md)                                      | Release strategy, CI/CD, Play Store                        |
 | [User Guide](docs/USER_GUIDE.md)                                             | How to use VSCodroid (keyboard, terminal, extensions, SSH) |
 | [Milestones](MILESTONES.md)                                                  | Development milestones M0–M6                               |

--- a/docs/09-DEVELOPMENT_GUIDE.md
+++ b/docs/09-DEVELOPMENT_GUIDE.md
@@ -11,10 +11,11 @@ have: a code-server fork checked out as a git submodule, `yarn gulp vscode-web-m
 against it, patches applied as inline Python replacements inside
 `scripts/download-vscode-server.sh`, feature branches merged into a `develop` branch. None
 of that is how this repository works. There is no submodule and no `.gitmodules`, no
-`develop` branch, no `scripts/download-vscode-server.sh`, no `server/lib/`, and nothing here
-uses yarn. The server is built from MIT Code - OSS source by
-`.github/workflows/build-vscode-oss.yml` with unified diffs from `patches/`, and app builds
-fetch the result with `scripts/fetch-vscode-oss.sh`.
+`develop` branch, no `scripts/download-vscode-server.sh`, no `server/lib/`, and no script
+under `scripts/` or workflow under `.github/` invokes yarn. Older planning documents still
+name it, and they are stale in the same way this one was. The server is built from MIT
+Code - OSS source by `.github/workflows/build-vscode-oss.yml` with unified diffs from
+`patches/`, and app builds fetch the result with `scripts/fetch-vscode-oss.sh`.
 
 The instructions have been removed rather than rewritten. The rest of the planning suite is
 kept as written, because a plan, an ADR or a risk score records what was thought at the time

--- a/docs/09-DEVELOPMENT_GUIDE.md
+++ b/docs/09-DEVELOPMENT_GUIDE.md
@@ -4,359 +4,43 @@
 **Version**: 1.0-draft
 **Date**: 2026-02-10
 
-> **Historical document — describes the plan as of 2026-02-10, not the code.**
-> The server is built from the MIT Code - OSS source by `.github/workflows/build-vscode-oss.yml`,
-> with unified diffs in `patches/` applied before the build; app builds fetch the result with
-> `scripts/fetch-vscode-oss.sh`. Anything here about downloading a pre-built server from Microsoft's
-> CDN, or about inline regex patches in `download-vscode-server.sh`, describes a path that was
-> removed on 2026-08-12. For what the code actually does, read the code — `scripts/build-vscode-oss.sh`,
-> `patches/`, and the Kotlin under `android/app/src/main/kotlin/com/vscodroid/`. `CONTRIBUTING.md` is
-> the prose kept current alongside it.
->
-> Note also that `toolchains/` no longer holds any checked-in build scripts and `test/` no
-> longer exists: both were removed on 2026-08-14. Bundled binaries come from Termux via
-> `scripts/download-*.sh`, and the test suites live in `android/app/src/test/` and
-> `android/app/src/androidTest/`.
-
----
-
-## 1. Prerequisites
-
-### 1.1 Hardware
-
-| Requirement         | Minimum                     | Recommended                     |
-| ------------------- | --------------------------- | ------------------------------- |
-| Development machine | Any x86_64 with 16GB RAM    | macOS/Linux, 32GB RAM, SSD      |
-| Android device      | ARM64, Android 13+, 4GB RAM | Pixel 7/8, 8GB RAM, Android 14+ |
-| USB cable           | For ADB debugging           | USB-C to USB-C                  |
-
-> **Note**: x86_64 Android emulators cannot run ARM64 binaries. You MUST have a physical ARM64 device for integration testing.
-
-### 1.2 Software
-
-| Tool           | Version                                   | Purpose                          |
-| -------------- | ----------------------------------------- | -------------------------------- |
-| Android Studio | Latest stable with Android API 36 support | IDE, build tools, ADB            |
-| Android SDK    | API 33-36                                 | Compilation targets              |
-| Android NDK    | r27+                                      | Native binary cross-compilation  |
-| JDK            | 17                                        | Android build system             |
-| Node.js        | 20 LTS                                    | VS Code build, development tools |
-| Yarn           | 1.x (Classic)                             | VS Code build dependency         |
-| Python         | 3.11+                                     | Build scripts                    |
-| Git            | 2.40+                                     | Version control                  |
-| Docker         | Latest (optional)                         | Reproducible cross-compilation   |
-
-### 1.3 Installation
-
-```bash
-# macOS
-brew install node@20 yarn python git
-
-# Android SDK/NDK — install via Android Studio SDK Manager:
-# - Android SDK Platform API 33, 34, 36
-# - Android SDK Build-Tools
-# - NDK (Side by side) r27
-# - CMake
-```
-
----
-
-## 2. Project Structure
-
-```mermaid
-flowchart TD
-  ROOT["VSCodroid/"] --> C1["CONTRIBUTING.md (Build, test, contribute)"]
-  ROOT --> C2["MILESTONES.md (Development milestones)"]
-  ROOT --> C3["docs/ (Documentation)"]
-
-  ROOT --> ANDROID["android/ (Android app)"]
-  ANDROID --> A1["app/src/main/kotlin/com/vscodroid/"]
-  ANDROID --> A2["app/src/main/res/"]
-  ANDROID --> A3["app/src/main/assets/ (VS Code server + web client)"]
-  ANDROID --> A4["app/src/main/jniLibs/ (.so binaries)"]
-  ANDROID --> A5["app/build.gradle.kts, build.gradle.kts, settings.gradle.kts"]
-
-  ROOT --> SERVER["server/ (download staging, not a submodule)"]
-  SERVER --> S1["vscode-reh/ (extracted reh-web download)"]
-  SERVER --> S2["vscode-server-linux-arm64-web.tar.gz"]
-
-  ROOT --> TOOL["toolchains/ (cross-compilation scripts)"]
-  TOOL --> T1["build-node.sh, build-node-pty.sh"]
-  TOOL --> T2["build-git.sh, build-bash.sh, build-tmux.sh"]
-  TOOL --> T3["Dockerfile"]
-
-  ROOT --> SCRIPT["scripts/ (development scripts)"]
-  SCRIPT --> SC1["setup.sh, build-all.sh, download-vscode-server.sh"]
-  SCRIPT --> SC2["package-assets.sh, deploy.sh"]
-
-  ROOT --> TEST["test/ (test suites)"]
-  TEST --> TE1["projects/ (fixtures)"]
-  TEST --> TE2["extensions/ (fixtures)"]
-
-  ROOT --> GH[".github/workflows/"]
-  GH --> G1["build.yml"]
-  GH --> G2["lint.yml"]
-  GH --> G3["release.yml"]
-  GH --> G4["pages.yml"]
-```
-
----
-
-## 3. Getting Started
-
-### 3.1 Clone and Setup
-
-```bash
-# Clone repository
-git clone https://github.com/rmyndharis/VSCodroid.git
-cd VSCodroid
-
-# Initialize submodules (code-server)
-git submodule update --init --recursive
-
-# Run setup script
-./scripts/setup.sh
-```
-
-### 3.2 Build Pipeline Overview
-
-```mermaid
-flowchart TD
-  S1["Step 1: Cross-compile native binaries (one-time, then cache)<br/>Node.js, Python, Git, bash, tmux, node-pty"] --> S2["Step 2: Build VS Code (code-server fork)<br/>Apply patches<br/>Build vscode-web and vscode-reh"]
-  S2 --> S3["Step 3: Package into Android project<br/>Copy binaries to jniLibs/arm64-v8a/<br/>Copy VS Code assets<br/>Build APK/AAB"]
-  S3 --> S4["Step 4: Deploy to device (adb install)"]
-```
-
-### 3.3 Quick Build (Development)
-
-```bash
-# Build everything (first time — takes ~30-60 minutes)
-./scripts/build-all.sh
-
-# Build and install on connected device
-./scripts/deploy.sh
-
-# Rebuild only Android app (after code changes, ~2 minutes)
-cd android && ./gradlew assembleDebug && adb install -r app/build/outputs/apk/debug/app-debug.apk
-```
-
-### 3.4 Incremental Development
-
-For rapid iteration on the Android app (Kotlin changes):
-
-```bash
-# Only rebuild and deploy Android app
-cd android
-./gradlew installDebug
-```
-
-For VS Code server/client changes:
-
-```bash
-# Re-fetch and re-patch the server, repackage, deploy
-./scripts/download-vscode-server.sh
-./scripts/package-assets.sh
-./scripts/deploy.sh
-```
-
----
-
-## 4. Development Workflow
-
-### 4.1 Branch Strategy
-
-```mermaid
-flowchart TD
-  MAIN["main (stable, releasable)"] --> DEV["develop (integration branch)"]
-  DEV --> F1["feature/extra-key-row"]
-  DEV --> F2["feature/clipboard-bridge"]
-  DEV --> F3["fix/webview-crash-recovery"]
-  DEV --> F4["chore/update-node-20.x"]
-```
-
-**Rules**:
-
-- `main` is always releasable
-- Feature branches from `develop`
-- PRs require at least 1 review
-- Squash merge to `develop`
-- Merge `develop` to `main` for releases
-
-### 4.2 Commit Convention
-
-```
-<type>(<scope>): <description>
-
-Types: feat, fix, chore, docs, refactor, test, perf, build
-Scopes: android, server, patches, toolchain, ci
-
-Examples:
-feat(android): add Extra Key Row with Ctrl/Alt toggles
-fix(server): handle tmux session cleanup on server restart
-build(toolchain): update Node.js to 20.11.0
-chore(patches): rebase code-server patches on VS Code 1.96
-docs: add testing strategy document
-```
-
-### 4.3 Code Review Checklist
-
-- [ ] Code compiles without warnings
-- [ ] Unit tests pass
-- [ ] No hardcoded paths or secrets
-- [ ] Follows Kotlin/JS style conventions
-- [ ] Relevant documentation updated
-- [ ] Patch changes are minimal and focused
-- [ ] New features have corresponding tests
-- [ ] Performance impact considered (especially for hot paths)
-
----
-
-## 5. Coding Conventions
-
-### 5.1 Kotlin
-
-- Style: [Kotlin Coding Conventions](https://kotlinlang.org/docs/coding-conventions.html)
-- Linter: ktlint
-- Coroutines for async operations (not callbacks)
-- Prefer `val` over `var`
-- Use sealed classes for state management
-- Android-specific: Follow [Android Kotlin Style Guide](https://developer.android.com/kotlin/style-guide)
-
-### 5.2 JavaScript / TypeScript
-
-- Style: VS Code's own style (inherited from code-server)
-- Linter: ESLint (VS Code config)
-- Formatter: Prettier (if configured)
-- TypeScript strict mode
-
-### 5.3 Patches
-
-Every patch is an **inline Python string replacement** in `scripts/download-vscode-server.sh`,
-applied to the downloaded server. There are no `.diff` files anywhere in the build path.
-
-  - Extension Host → `worker_thread` (3 patches)
-  - ptyHost → `worker_thread` (2 patches)
-  - IPC bridge injection for `worker_threads` compatibility
-
-- Include descriptive header comments for each patch section
-- Keep patches as small and focused as possible
-- ⚠️ Most patches match **minified identifiers** and print `SKIP` without failing the script when
-  the pattern stops matching. Re-verify every one of them when raising `VSCODE_VERSION`; a green
-  CI run is not evidence that they applied.
-
----
-
-## 6. Debugging
-
-### 6.1 Android App (Kotlin)
-
-```bash
-# View logs
-adb logcat -s VSCodroid.MainActivity VSCodroid.NodeService VSCodroid.ProcessManager VSCodroid.ToolchainManager
-
-# View all app logs
-adb logcat --pid=$(adb shell pidof com.vscodroid)
-
-# Memory info
-adb shell dumpsys meminfo com.vscodroid
-
-# Process list (check phantom processes)
-adb shell ps -A | grep vscodroid
-```
-
-### 6.2 WebView (Chrome DevTools)
-
-1. Enable debug builds: `WebView.setWebContentsDebuggingEnabled(true)`
-2. Open Chrome on desktop: `chrome://inspect/#devices`
-3. Find VSCodroid WebView → Click "inspect"
-4. Full Chrome DevTools available (Console, Network, Elements, etc.)
-
-### 6.3 Node.js Server
-
-```bash
-# View server logs
-adb shell cat /data/data/com.vscodroid/files/home/.vscodroid/logs/server.log
-
-# Interactive shell into app directory
-adb shell run-as com.vscodroid
-
-# Test server health
-adb shell curl http://localhost:PORT/healthz
-
-# Check Node.js process
-adb shell ps -A | grep libnode
-```
-
-### 6.4 Common Issues
-
-| Issue                   | Diagnosis                              | Solution                                            |
-| ----------------------- | -------------------------------------- | --------------------------------------------------- |
-| Server won't start      | Check Logcat for Node.js errors        | Verify libnode.so exists and has execute permission |
-| WebView blank screen    | Chrome DevTools → Console              | Check if server is running, correct port            |
-| Extension won't install | Chrome DevTools → Network              | Check Open VSX connectivity                         |
-| Terminal not working    | Server logs                            | Verify libtmux.so and libbash.so present            |
-| Phantom process killed  | `adb shell dumpsys activity processes` | Reduce child process count                          |
-| OOM crash               | `adb shell dumpsys meminfo`            | Reduce V8 heap, close unused features               |
-
----
-
-## 7. Release Process
-
-### 7.1 Version Bump
-
-```bash
-# In android/app/build.gradle.kts
-versionCode = <increment>
-versionName = "X.Y.Z"
-```
-
-### 7.2 Release Build
-
-```bash
-# Build signed AAB
-cd android
-./gradlew bundleRelease
-
-# Output: app/build/outputs/bundle/release/app-release.aab
-```
-
-### 7.3 Release Checklist
-
-- [ ] All tests pass (unit + integration + E2E)
-- [ ] Performance targets met on reference device
-- [ ] Version number bumped
-- [ ] CHANGELOG updated
-- [ ] Release notes written
-- [ ] Signed AAB built
-- [ ] Tested on 4 devices (see Testing Strategy §7)
-- [ ] No S1/S2 open bugs
-- [ ] Security tests pass
-
----
-
-## 8. Useful Commands
-
-```bash
-# --- Android ---
-adb devices                              # List connected devices
-adb install -r app-debug.apk            # Install APK
-adb shell am start com.vscodroid/.MainActivity  # Launch app
-adb shell am force-stop com.vscodroid    # Force stop app
-adb shell pm clear com.vscodroid         # Clear app data
-
-# --- Cross-compilation ---
-$NDK/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android28-clang --version
-# Note: android28 is NDK compile target ABI baseline; app minSdk remains API 33.
-file libnode.so                          # Verify ARM64 ELF
-
-# --- VS Code build ---
-cd server/lib/vscode
-yarn                                     # Install dependencies
-yarn gulp vscode-web-min                 # Build web client
-yarn gulp vscode-reh-min                 # Build server
-
-# --- Patches ---
-# All patches are applied inline in scripts/download-vscode-server.sh
-# Verify worker_thread patches applied:
-grep -q 'worker_threads' server/vscode-reh/out/vs/workbench/api/node/*.js && echo "ExtHost patch OK"
-```
+> **Superseded. Build and contribution instructions live in [`CONTRIBUTING.md`](../CONTRIBUTING.md).**
+
+This document was written on 2026-02-10 and described the build the project expected to
+have: a code-server fork checked out as a git submodule, `yarn gulp vscode-web-min` run
+against it, patches applied as inline Python replacements inside
+`scripts/download-vscode-server.sh`, feature branches merged into a `develop` branch. None
+of that is how this repository works. There is no submodule and no `.gitmodules`, no
+`develop` branch, no `scripts/download-vscode-server.sh`, no `server/lib/`, and nothing here
+uses yarn. The server is built from MIT Code - OSS source by
+`.github/workflows/build-vscode-oss.yml` with unified diffs from `patches/`, and app builds
+fetch the result with `scripts/fetch-vscode-oss.sh`.
+
+The instructions have been removed rather than rewritten. The rest of the planning suite is
+kept as written, because a plan, an ADR or a risk score records what was thought at the time
+and editing it destroys the record. This document was procedure rather than reasoning, and a
+procedure whose commands have stopped working leaves no record worth preserving, only traps
+for whoever copies one: a script that does not exist, a gulp task that was never the right
+one, a launch command that starts `MainActivity` directly and so skips the first-run
+extraction two lines after telling the reader to clear app data.
+
+`CONTRIBUTING.md` is the prose kept current alongside the code, and it has a guard this file
+could never have: `scripts/check-build-steps.py` fails the build when a shell script CI runs
+is not mentioned there. That guard covers which scripts are named, not whether every command
+in the file still runs, but it is what stops the documentation losing a build step outright,
+which is what happened here.
+
+| Looking for | Read instead |
+| ------------------------------------------- | -------------------------------------------------------------------------------------- |
+| Prerequisites, SDK and NDK versions | `CONTRIBUTING.md`, Development Setup |
+| Clone, asset downloads, the order they run in | `CONTRIBUTING.md`, Preparing Assets |
+| Debug, release and AAB builds, version bump | `CONTRIBUTING.md`, Building |
+| Deploying, on-device debugging, health probe | `CONTRIBUTING.md`, Testing on Device |
+| Writing and fingerprinting a patch | `CONTRIBUTING.md`, How to Add a New Patch, and `patches/` |
+| Bundling a new tool | `CONTRIBUTING.md`, How to Add a New Bundled Tool |
+| Kotlin, JavaScript and shell conventions | `CONTRIBUTING.md`, Code Style |
+| Branching, commits, review, PR checklist | `CONTRIBUTING.md`, Pull Request Process |
+| Repository layout | `CONTRIBUTING.md`, Project Structure |
+| Manual on-device pass | [`DEVICE_TEST_CHECKLIST.md`](./DEVICE_TEST_CHECKLIST.md), plus `scripts/device-test.sh` |
+| Release strategy and rollout | [`10-RELEASE_PLAN.md`](./10-RELEASE_PLAN.md) |
+| What the code does | The code. Start at `scripts/build-all.sh` and `android/app/src/main/kotlin/com/vscodroid/` |

--- a/docs/12-IMPLEMENTATION_PLAN.md
+++ b/docs/12-IMPLEMENTATION_PLAN.md
@@ -2195,7 +2195,7 @@ flowchart TD
 
 1. **Extension OAuth callback relay**: Chrome Custom Tabs → Android Intent → WebView (`vscodroid://callback`)
 2. **Persist extension secrets across app restarts**: patch `isEncryptionAvailable()` → `true` in workbench.js so `SecretStorageService` uses IndexedDB instead of in-memory Map
-3. **White screen on app reopen**: `isServerHealthy()` (synchronous HTTP) threw `NetworkOnMainThreadException` on main thread when reconnecting to already-running server; replaced with `isServerRunning()` (process liveness check, no I/O)
+3. **White screen on app reopen**: `isServerHealthy()` (synchronous HTTP) threw `NetworkOnMainThreadException` on the main thread when reconnecting to an already-running server. What shipped is `NodeService.isServerReady()`, which reports what the health probe already found and costs no I/O. Not a process-liveness check: `Process.isAlive` is true from the moment the process is spawned and for the whole of a post-crash restart, so navigating on it points the WebView at a port with nothing listening. The liveness wrapper has been removed from `NodeService` and `ServerReadinessCallSiteTest` fails the build if it comes back
 4. **Mobile menu CSS**: touch-friendly hamburger dropdown (44px touch targets, 14px font, 280px min-width) appended to workbench.css
 5. **Keyboard/ExtraKeyRow positioning**: fix double-compensation (adjustResize + bottomMargin). Switch to edge-to-edge (`setDecorFitsSystemWindows=false`) with manual insets padding for consistent behavior on Android 13-16
 

--- a/docs/12-IMPLEMENTATION_PLAN.md
+++ b/docs/12-IMPLEMENTATION_PLAN.md
@@ -2687,6 +2687,6 @@ Every task is "done" when:
 | Security controls       | [06-SECURITY](./06-SECURITY.md)                   | §3                         |
 | Test plans              | [07-TESTING_STRATEGY](./07-TESTING_STRATEGY.md)   | §3                         |
 | Risk mitigations        | [08-RISK_MATRIX](./08-RISK_MATRIX.md)             | §3                         |
-| Dev environment         | [09-DEVELOPMENT_GUIDE](./09-DEVELOPMENT_GUIDE.md) | §1-§3                      |
+| Dev environment         | [CONTRIBUTING](../CONTRIBUTING.md)                | Setup, Assets, Building    |
 | Release process         | [10-RELEASE_PLAN](./10-RELEASE_PLAN.md)           | §1-§6                      |
 | Milestone criteria      | [MILESTONES](../MILESTONES.md)                    | All                        |

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ They record what was planned, not what was built — see [Document Status](#docu
 | 06 | [Security Design](./06-SECURITY.md) | Threat model, security controls, data protection | Everyone |
 | 07 | [Testing Strategy](./07-TESTING_STRATEGY.md) | Test plan, types, environments, coverage | QA, Developers |
 | 08 | [Risk Assessment](./08-RISK_MATRIX.md) | Risk identification, analysis, mitigation | Project leads |
-| 09 | [Development Guide](./09-DEVELOPMENT_GUIDE.md) | Setup, conventions, workflow, contribution | Developers |
+| 09 | [Development Guide](./09-DEVELOPMENT_GUIDE.md) | Superseded by `CONTRIBUTING.md`; a pointer at where each topic lives now | Developers |
 | 10 | [Release Plan](./10-RELEASE_PLAN.md) | CI/CD, versioning, Play Store, rollout | DevOps, Project leads |
 | 11 | [Glossary](./11-GLOSSARY.md) | Terms, acronyms, technology definitions | Everyone |
 | 12 | [Implementation Plan](./12-IMPLEMENTATION_PLAN.md) | Week-by-week task breakdown, dependencies, checkpoints | Project leads, Developers |
@@ -63,11 +63,15 @@ The **planning suite** (01–12) was written before the app existed and is kept 
 as a description of the build. Where one contradicts the code, the code is right. Two forms of note
 appear in them, and they mean different things:
 
-- **A banner at the top** (01, 03, 04, 07, 08, 09, 12, and on §2 of 10, which is stale where the
+- **A banner at the top** (01, 03, 04, 07, 08, 12, and on §2 of 10, which is stale where the
   rest of that document is not) says the document is a dated record and names what has since
   overtaken it. The body below a banner is mostly left as written, on purpose: a plan, an ADR or a
   risk score is a record of what was thought at the time, and editing it would destroy the record
   rather than update it.
+- **A pointer** (09) replaces the body outright. That document was procedure rather than
+  reasoning: setup commands, gulp tasks, a branch strategy. Commands that no longer run leave no
+  record to preserve, only something to copy by mistake, so the instructions were removed and what
+  is left says where each topic lives now.
 - **A correction inside the text**, a struck-through clause with what shipped beside it (02), or a
   rewritten definition (11), is used where a document's job is to describe rather than to
   remember. 05 and 06 are corrected the same way and carry no banner, because they have been kept


### PR DESCRIPTION
Two internal documents told contributors to do things the code refuses.

**The readiness question.** `MILESTONES.md` and `docs/12-IMPLEMENTATION_PLAN.md` both recorded the white-screen-on-reopen fix as a switch to `isServerRunning()`, a process-liveness check. That is backwards. `Process.isAlive` is true from the instant the process is spawned and stays true through a restart after a crash, so navigating on it points the WebView at a port with nothing listening. What shipped is `NodeService.isServerReady()`, which returns what the HTTP probe already found. The liveness wrapper was removed from `NodeService`, and `ServerReadinessCallSiteTest` fails the build if it returns.

**The development guide.** `docs/09-DEVELOPMENT_GUIDE.md` described a build this repository has never had: a code-server fork as a git submodule, `yarn gulp vscode-web-min`, patches as inline Python replacements in `scripts/download-vscode-server.sh`, branches merged into `develop`. Several of its commands cannot succeed and several more mislead, the worst being an `am start` on `MainActivity` two lines after `pm clear`, which skips first-run extraction. It is now a pointer at `CONTRIBUTING.md`, and what `CONTRIBUTING.md` lacked moved into it:

- `./scripts/setup.sh`, as step 0 of the asset steps. `build-all.sh` runs it first, and it refuses a missing NDK before the downloads rather than twenty minutes into them. No gate covers it, because no workflow invokes it.
- Per-component logcat tags and the `/version` probe, with the two states they do not survive: an adopted server produces no `[node]` lines, and once the port line rolls out of the ring buffer, `files/server/editor-server.pid` still holds it.
- Which of `versionCode` and `versionName` each part of first-run setup reads.

The milestone header also drops its hand-written count of open boxes, and the CI device-testing box names the real blocker instead of a hosted lab.

Verified with the unit suite (990 tests, 0 failures), the seven JavaScript self-checks, and `check-build-steps.py`.