### PR TITLE
test(keyboard): guard the two properties hardware keyboards rely on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The on-device suite states when it is meant to run, checks that what shipped actually runs, and reads versions from the build rather than from literals two releases stale.
 - The on-device suite now checks toolchain installs and the terminal's shell configuration, and reports skipped rather than passed where adb cannot reach, instead of leaving both to a human checklist.
 - The extra key row's trackpad now has tests covering its speed gears and arrow output. It is the only way a touch user moves the cursor, and nothing guarded it.
-- Hardware keyboard support is now pinned by tests: no key event is intercepted, and attaching a keyboard cannot recreate the window and reload the open workspace.
+- Hardware keyboard support is now pinned by tests: no key event is intercepted, and the manifest still keeps a keyboard or a rotation from rebuilding the window.
 - Removed twenty-six tracked files that nothing built, ran or opened, including the cross-compilation scripts replaced when binaries began coming from Termux.
 - Six releases that shipped without a changelog entry now have one, reconstructed from commit history and marked as such. Two footer links named a tag that never existed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The on-device suite states when it is meant to run, checks that what shipped actually runs, and reads versions from the build rather than from literals two releases stale.
 - The on-device suite now checks toolchain installs and the terminal's shell configuration, and reports skipped rather than passed where adb cannot reach, instead of leaving both to a human checklist.
 - The extra key row's trackpad now has tests covering its speed gears and arrow output. It is the only way a touch user moves the cursor, and nothing guarded it.
+- Hardware keyboard support is now pinned by tests: no key event is intercepted, and attaching a keyboard cannot recreate the window and reload the open workspace.
 - Removed twenty-six tracked files that nothing built, ran or opened, including the cross-compilation scripts replaced when binaries began coming from Termux.
 - Six releases that shipped without a changelog entry now have one, reconstructed from commit history and marked as such. Two footer links named a tag that never existed.
 

--- a/android/app/src/test/kotlin/com/vscodroid/keyboard/HardwareKeyboardTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/keyboard/HardwareKeyboardTest.kt
@@ -33,14 +33,24 @@ import javax.xml.parsers.DocumentBuilderFactory
  */
 class HardwareKeyboardTest {
 
-    private val kotlinSources = File("src/main/kotlin")
+    /**
+     * Both source roots the build compiles Kotlin from, not just the populated
+     * one. Every file lives under src/main/kotlin today, but src/main/java is
+     * the other default root and is the location an IDE offers first when a new
+     * class is added to an Android module. A `.kt` file landing there is
+     * compiled into the app identically, so a scan of one root reports a clean
+     * tree while the override is in the APK. The control below cannot reveal
+     * that, because it looks for a file in the root that is read either way.
+     */
+    private val kotlinSources = listOf(File("src/main/kotlin"), File("src/main/java"))
 
     private val manifest = File("src/main/AndroidManifest.xml")
 
-    /** Every override of [names] under src/main/kotlin, as `path:line: text`. */
+    /** Every override of [names] under [kotlinSources], as `path:line: text`. */
     private fun overridesOf(vararg names: String): List<String> {
         val declaration = Regex("""\boverride\s+fun\s+(${names.joinToString("|")})\s*\(""")
-        return kotlinSources.walkTopDown()
+        return kotlinSources.asSequence()
+            .flatMap { it.walkTopDown() }
             .filter { it.isFile && it.extension == "kt" }
             .flatMap { file ->
                 file.readLines().withIndex()
@@ -59,9 +69,9 @@ class HardwareKeyboardTest {
 
     @Test
     fun `no key event is intercepted before the WebView sees it`() {
-        check(kotlinSources.isDirectory) {
-            "no Kotlin sources at ${kotlinSources.absolutePath}: this test would " +
-                "otherwise pass by looking at nothing"
+        check(kotlinSources.any { it.isDirectory }) {
+            "no Kotlin sources at ${kotlinSources.map { it.absolutePath }}: this test " +
+                "would otherwise pass by looking at nothing"
         }
 
         // The control, and it has to come first, because this guard is the kind
@@ -86,6 +96,11 @@ class HardwareKeyboardTest {
             "onKeyMultiple",
             "onKeyPreIme",
             "onKeyShortcut",
+            // Not a View callback like the rest, and the one that would be easy
+            // to miss for that reason. WebViewClient.shouldOverrideKeyEvent is
+            // asked before the page is given the key, and returning true keeps
+            // it, so it swallows a keystroke exactly as the others do.
+            "shouldOverrideKeyEvent",
         )
 
         assertEquals(

--- a/android/app/src/test/kotlin/com/vscodroid/keyboard/HardwareKeyboardTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/keyboard/HardwareKeyboardTest.kt
@@ -151,20 +151,23 @@ class HardwareKeyboardTest {
                 "activity declarations. It found: ${declared.keys}",
         )
 
+        // Rotation is included rather than left to the message. It is the same
+        // attribute, it costs the same teardown, and a message that says to keep
+        // the rest of the string while checking none of it is an invitation to
+        // trim the attribute down to what this test reads.
+        val required = listOf("keyboard", "keyboardHidden", "orientation", "screenSize")
         val unguarded = guarded.filterNot { name ->
-            val qualifiers = declared[name].orEmpty().split("|")
-            "keyboard" in qualifiers && "keyboardHidden" in qualifiers
+            declared[name].orEmpty().split("|").containsAll(required)
         }
 
         assertEquals(
             emptyList<String>(), unguarded,
-            "Plugging in or unplugging a keyboard is a configuration change. Without " +
-                "`keyboard` and `keyboardHidden` in android:configChanges, Android " +
-                "answers it by destroying the activity and creating a new one, which " +
+            "Plugging in or unplugging a keyboard is a configuration change, and so is " +
+                "turning the phone. Without $required in android:configChanges, Android " +
+                "answers one by destroying the activity and creating a new one, which " +
                 "takes the WebView with it: the open workspace, its editors and " +
                 "whatever was not yet saved all reload the moment a Bluetooth " +
-                "keyboard connects. Keep the rest of the attribute too; the same " +
-                "string is what stops a rotation doing the same thing.",
+                "keyboard connects or the screen rotates. Declared: $declared.",
         )
     }
 }

--- a/android/app/src/test/kotlin/com/vscodroid/keyboard/HardwareKeyboardTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/keyboard/HardwareKeyboardTest.kt
@@ -1,0 +1,155 @@
+package com.vscodroid.keyboard
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.w3c.dom.Element
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+
+/**
+ * The two properties a physical keyboard's support rests on.
+ *
+ * Neither one is a feature anybody wrote, and that is the problem. Keys work
+ * because nothing in this app touches a key event: the system dispatches it,
+ * the WebView receives it unchanged, and the workbench binds it. The window
+ * survives a keyboard being plugged in because the manifest claims the keyboard
+ * configuration qualifiers, so Android hands the activity a configuration
+ * change instead of destroying it and building a new one.
+ *
+ * A property with no code to point at has nothing to break when it stops
+ * holding. The user guide recommends a Bluetooth keyboard for the best
+ * experience with complex editing, and until these two tests there was nothing
+ * anywhere that would have noticed that stopping being true.
+ *
+ * Both read files rather than behaviour, which is the weaker kind of test, so
+ * each says below how it fails when the reading itself has stopped working: a
+ * scan that has gone blind must go red, never green.
+ *
+ * What neither covers: a key swallowed some other way than an override, e.g.
+ * `View.setOnKeyListener` on the WebView, and anything a real HID device does
+ * that the dispatch path does not (pairing, layout mapping, its own modifier
+ * reporting). Those stay with checklist KB-4, which needs hardware.
+ */
+class HardwareKeyboardTest {
+
+    private val kotlinSources = File("src/main/kotlin")
+
+    private val manifest = File("src/main/AndroidManifest.xml")
+
+    /** Every override of [names] under src/main/kotlin, as `path:line: text`. */
+    private fun overridesOf(vararg names: String): List<String> {
+        val declaration = Regex("""\boverride\s+fun\s+(${names.joinToString("|")})\s*\(""")
+        return kotlinSources.walkTopDown()
+            .filter { it.isFile && it.extension == "kt" }
+            .flatMap { file ->
+                file.readLines().withIndex()
+                    .filterNot { (_, line) ->
+                        // Prose naming a callback is not an override of it, and
+                        // the reason this app has none is worth writing down
+                        // somewhere without tripping the guard that keeps it so.
+                        val start = line.trimStart()
+                        start.startsWith("//") || start.startsWith("*") || start.startsWith("/*")
+                    }
+                    .filter { (_, line) -> declaration.containsMatchIn(line) }
+                    .map { (i, line) -> "${file.path}:${i + 1}: ${line.trim()}" }
+            }
+            .toList()
+    }
+
+    @Test
+    fun `no key event is intercepted before the WebView sees it`() {
+        check(kotlinSources.isDirectory) {
+            "no Kotlin sources at ${kotlinSources.absolutePath}: this test would " +
+                "otherwise pass by looking at nothing"
+        }
+
+        // The control, and it has to come first, because this guard is the kind
+        // that passes by finding nothing. A clean tree and a scan that has
+        // stopped recognising `override fun` produce the identical empty list.
+        // What separates them is the one input callback this app does override:
+        // if the same scan cannot find GestureTrackpad's onTouchEvent, its
+        // verdict on key events below is worth nothing.
+        val touch = overridesOf("onTouchEvent")
+        assertTrue(
+            touch.any { it.contains("GestureTrackpad.kt") },
+            "the scan found no override of onTouchEvent, so it is not reading these " +
+                "sources and cannot be trusted to have found a key-event override " +
+                "either. It returned: $touch",
+        )
+
+        val interceptors = overridesOf(
+            "dispatchKeyEvent",
+            "onKeyDown",
+            "onKeyUp",
+            "onKeyLongPress",
+            "onKeyMultiple",
+            "onKeyPreIme",
+            "onKeyShortcut",
+        )
+
+        assertEquals(
+            emptyList<String>(), interceptors,
+            "Hardware keyboard support here IS the absence of these overrides. Every " +
+                "keystroke reaches the WebView exactly as the system dispatched it, " +
+                "and the workbench binds it; an override is a chance to swallow one " +
+                "before the editor sees it. Modifier state added here would also be " +
+                "applied twice for anyone typing on a physical keyboard while the " +
+                "extra key row's Ctrl or Alt is latched, since the row's modifiers " +
+                "are already applied in the page by KeyInjector.setupModifierInterceptor. " +
+                "Handling a key in Kotlin is a deliberate decision to be re-tested " +
+                "against a real keyboard (checklist KB-4), not something to arrive at " +
+                "by adding an override.",
+        )
+    }
+
+    /** `android:name` to `android:configChanges` for every activity in the manifest. */
+    private fun activityConfigChanges(): Map<String, String> {
+        val document = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(manifest)
+        val activities = document.getElementsByTagName("activity")
+        return (0 until activities.length)
+            .map { activities.item(it) as Element }
+            .associate { it.getAttribute("android:name") to it.getAttribute("android:configChanges") }
+    }
+
+    @Test
+    fun `attaching a keyboard does not tear the window down`() {
+        check(manifest.isFile) {
+            "AndroidManifest.xml not found at ${manifest.absolutePath}: this test " +
+                "would otherwise pass by looking at nothing"
+        }
+
+        // The two that claim the qualifiers today, and the two where being
+        // rebuilt costs something: the editor's WebView lives in one, first-run
+        // extraction runs in the other.
+        val guarded = listOf(".SplashActivity", ".MainActivity")
+        val declared = activityConfigChanges()
+
+        // The control. Unlike the scan above, this guard fails closed on its own
+        // instrument: an attribute it cannot read comes back empty and is
+        // reported as a missing qualifier. The one way it could still pass by
+        // reading nothing is if the parse found no activities at all, so that is
+        // what this asserts.
+        assertTrue(
+            declared.keys.containsAll(guarded),
+            "the manifest parse did not find $guarded, so it is not reading the " +
+                "activity declarations. It found: ${declared.keys}",
+        )
+
+        val unguarded = guarded.filterNot { name ->
+            val qualifiers = declared[name].orEmpty().split("|")
+            "keyboard" in qualifiers && "keyboardHidden" in qualifiers
+        }
+
+        assertEquals(
+            emptyList<String>(), unguarded,
+            "Plugging in or unplugging a keyboard is a configuration change. Without " +
+                "`keyboard` and `keyboardHidden` in android:configChanges, Android " +
+                "answers it by destroying the activity and creating a new one, which " +
+                "takes the WebView with it: the open workspace, its editors and " +
+                "whatever was not yet saved all reload the moment a Bluetooth " +
+                "keyboard connects. Keep the rest of the attribute too; the same " +
+                "string is what stops a rotation doing the same thing.",
+        )
+    }
+}

--- a/docs/DEVICE_TEST_CHECKLIST.md
+++ b/docs/DEVICE_TEST_CHECKLIST.md
@@ -41,7 +41,7 @@
 | KB-1 | GBoard typing | Open file, type code with GBoard | Characters appear correctly, no duplication | | |
 | KB-2 | Samsung keyboard | Open file, type code with Samsung KB | Characters appear correctly | | |
 | KB-3 | SwiftKey | Open file, type with SwiftKey | Characters appear correctly | | |
-| KB-4 | Hardware keyboard | Connect BT/USB keyboard, type | All keys work including modifiers | | |
+| KB-4 | Hardware keyboard | Connect BT/USB keyboard, type | All keys work including modifiers. Only hardware answers this row: the automated suite's `hardware_key_chord_reaches_workbench` injects a virtual device, which exercises dispatch but not pairing, layout mapping or how a real HID keyboard reports its modifiers | | |
 | KB-5 | Extra Key Row — Tab | Press Tab in editor | Indentation inserted | | |
 | KB-6 | Extra Key Row — Esc | Press Esc with menu open | Menu/dialog closes | | |
 | KB-7 | Extra Key Row — Ctrl+S | Press Ctrl on EKR then S on keyboard | File saves (no error) | | |

--- a/scripts/device-test.sh
+++ b/scripts/device-test.sh
@@ -1313,6 +1313,9 @@ bash_process_count() {
 # in Phase 2, so its Node process is there to be found -- if that is not visible
 # either, the reading is about `ps`, not about the terminal.
 APP_PROCS=$(app_process_lines)
+# Set only where a chord is actually injected, so that Test 34 below can tell
+# "the chord went nowhere" from "no chord was sent", which most runs are.
+CHORD_VERDICT=""
 if [ -z "$APP_UID" ] || ! echo "$APP_PROCS" | grep -q "node"; then
     skip "terminal_opens" \
         "could not read this app's processes out of ps (uid='$APP_UID'), so an empty result would prove nothing"
@@ -1339,14 +1342,47 @@ else
                 BASH_AFTER=$(bash_process_count)
                 if [ "$BASH_AFTER" -gt "$BASH_BEFORE" ]; then
                     pass "terminal_opens (bash spawned in the app's own domain)"
+                    CHORD_VERDICT="delivered"
                 else
                     skip "terminal_opens" \
                         "no bash appeared after Ctrl+backtick; the workbench may not have had keyboard focus. Not evidence of a broken terminal -- open one by hand (checklist TT-1)"
+                    CHORD_VERDICT="silent"
                 fi
             fi
         fi
     fi
 fi
+
+# Test 34: a hardware-style chord is delivered to the workbench.
+#
+# The same injection Test 33 uses, read for the other thing it proves. `input
+# keycombination` goes through InputDispatcher, which is the path a physical
+# keyboard's keys take, so a terminal appearing after Ctrl+backtick is evidence
+# that a chord crossed the whole stack -- system, activity, WebView, workbench --
+# with nothing swallowing it on the way. That property, that no key event is
+# intercepted, is the entirety of this app's hardware keyboard support, and this
+# is the only automated reading of it on a device. It gets its own name because
+# nobody looking for keyboard coverage looks under terminal_opens.
+#
+# It does not satisfy checklist KB-4. `input` injects a virtual device: it
+# exercises dispatch and says nothing about pairing, layout mapping, or how a
+# real HID device reports its modifiers.
+#
+# PASS or SKIP only, never FAIL, for the reason Test 33 gives above: a workbench
+# that never had focus and a keystroke that was eaten look identical from here.
+case "$CHORD_VERDICT" in
+    delivered)
+        pass "hardware_key_chord_reaches_workbench (Ctrl+backtick was acted on)"
+        ;;
+    silent)
+        skip "hardware_key_chord_reaches_workbench" \
+            "the chord was injected and nothing acted on it, which is what a lost keystroke and an unfocused workbench both look like. Type on a real keyboard instead (checklist KB-4)"
+        ;;
+    *)
+        skip "hardware_key_chord_reaches_workbench" \
+            "no chord was injected, so nothing was measured; the terminal_opens result above says why"
+        ;;
+esac
 
 # ═══════════════════════════════════════════════════════════════════
 # Summary

--- a/scripts/device-test.sh
+++ b/scripts/device-test.sh
@@ -1313,8 +1313,9 @@ bash_process_count() {
 # in Phase 2, so its Node process is there to be found -- if that is not visible
 # either, the reading is about `ps`, not about the terminal.
 APP_PROCS=$(app_process_lines)
-# Set only where a chord is actually injected, so that Test 34 below can tell
-# "the chord went nowhere" from "no chord was sent", which most runs are.
+# Set on every path Test 33 can leave by, so that Test 34 below reports the
+# reason itself rather than pointing at a line that may be a pass about process
+# counts. Empty is the one case Test 33 explains: it gave up before injecting.
 CHORD_VERDICT=""
 if [ -z "$APP_UID" ] || ! echo "$APP_PROCS" | grep -q "node"; then
     skip "terminal_opens" \
@@ -1323,6 +1324,7 @@ else
     BASH_BEFORE=$(bash_process_count)
     if [ "$BASH_BEFORE" -gt 0 ]; then
         pass "terminal_opens ($BASH_BEFORE bash process(es) running under $PKG)"
+        CHORD_VERDICT="not-needed"
     else
         FOCUS=$($ADB shell "dumpsys window 2>/dev/null | grep -E 'mCurrentFocus|mFocusedApp'" 2>/dev/null | tr -d '\r')
         if [ -z "$FOCUS" ]; then
@@ -1378,9 +1380,13 @@ case "$CHORD_VERDICT" in
         skip "hardware_key_chord_reaches_workbench" \
             "the chord was injected and nothing acted on it, which is what a lost keystroke and an unfocused workbench both look like. Type on a real keyboard instead (checklist KB-4)"
         ;;
+    not-needed)
+        skip "hardware_key_chord_reaches_workbench" \
+            "a terminal was already open, so Test 33 had nothing to inject and no chord was sent. Re-run with no terminal open, or type on a real keyboard (checklist KB-4)"
+        ;;
     *)
         skip "hardware_key_chord_reaches_workbench" \
-            "no chord was injected, so nothing was measured; the terminal_opens result above says why"
+            "the run stopped before a chord could be injected: this app's processes, the focused window or the input command itself could not be read. The terminal_opens skip above names which"
         ;;
 esac
 


### PR DESCRIPTION
The user guide recommends a Bluetooth keyboard for complex editing. That promise rests on two properties nobody wrote code for, and nothing would have failed when either stopped holding.

- `HardwareKeyboardTest` asserts that no Kotlin source overrides `dispatchKeyEvent`, `onKeyDown`, `onKeyUp`, `onKeyPreIme`, `onKeyShortcut` or `WebViewClient.shouldOverrideKeyEvent`. Every keystroke reaching the WebView exactly as the system dispatched it is the support; an override is a chance to swallow one. It scans `src/main/kotlin` and `src/main/java`, because the build compiles Kotlin from either and only the first is populated today.
- The same class parses `AndroidManifest.xml` and requires `keyboard`, `keyboardHidden`, `orientation` and `screenSize` in `android:configChanges` for `MainActivity` and `SplashActivity`. Those qualifiers keep Android handing the activity a configuration change instead of destroying it and taking the WebView, the open workspace and its unsaved editors with it. They are necessary rather than proven sufficient: a keyboard Android also classifies as a DPad moves `Configuration.navigation`, which no activity claims.
- `app/build.gradle.kts` declares the manifest as an input to the test task. Without it, editing only the manifest leaves `testDebugUnitTest` UP-TO-DATE, so the guard could not run on the edit it exists to catch.
- Both guards read files, so each carries a control that goes red when the reading itself breaks: the scan must still find `GestureTrackpad.onTouchEvent`, and the parse must still find both activities by name.
- `scripts/device-test.sh` reports the Ctrl+backtick it already injects under `hardware_key_chord_reaches_workbench` as well as `terminal_opens`, with a distinct reason on each path that sends no chord. Checklist KB-4 stays manual: `adb shell input` injects a virtual device, exercising dispatch but not pairing or a real HID keyboard's modifier reporting.

No production code changed. Verified with the full unit suite (992 tests), `lintDebug`, the JavaScript self-checks, and the device script's syntax and self-check.