### PR TITLE
feat(legal): read Termux's licence field back into the record

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -372,6 +372,18 @@ jobs:
       - name: Check every shipped toolchain library is attributed
         run: python3 scripts/check-library-attribution.py
 
+      # The step above answers "is every binary attributed" out of a table
+      # written by hand, and until now nothing asked whether the table was
+      # right. This reads Termux's own TERMUX_PKG_LICENSE back for each package
+      # and prints the differences. It fails on one of them only: a component
+      # recorded permissive where Termux declares copyleft ships with no offer
+      # of source, and the step above cannot see it, because it reads the same
+      # table. Everything else is reported, including a package it could not
+      # reach at all, because Termux repackaging is ordinary upstream activity
+      # and a gate that failed on it would be switched off.
+      - name: Compare recorded licences against Termux
+        run: python3 scripts/check-termux-licenses.py
+
       # The one place both trees exist at once. The base runtime and the packs
       # are filled by different download scripts and nothing compares them
       # until the whole bundle is assembled, where bundletool answers a shared

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,6 +218,7 @@ jobs:
             server/*.tar.gz
             toolchains/termux-packages/debs/*.deb
             toolchains/termux-packages/Packages
+            toolchains/termux-packages/licenses.tsv
             toolchains/build/npm/
             toolchains/extensions/
             toolchains/musl/
@@ -378,9 +379,12 @@ jobs:
       # and prints the differences. It fails on one of them only: a component
       # recorded permissive where Termux declares copyleft ships with no offer
       # of source, and the step above cannot see it, because it reads the same
-      # table. Everything else is reported, including a package it could not
-      # reach at all, because Termux repackaging is ordinary upstream activity
-      # and a gate that failed on it would be switched off.
+      # table. Everything else is reported, including a package upstream has no
+      # build.sh for, because Termux repackaging is ordinary upstream activity
+      # and a gate that failed on it would be switched off. A host that will not
+      # answer at all, an outage or a rate limit, ends in a printed skip rather
+      # than a failure; a run that could read hardly any of the map fails, since
+      # that is the package names having moved and not the network.
       - name: Compare recorded licences against Termux
         run: python3 scripts/check-termux-licenses.py
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,7 +218,6 @@ jobs:
             server/*.tar.gz
             toolchains/termux-packages/debs/*.deb
             toolchains/termux-packages/Packages
-            toolchains/termux-packages/licenses.tsv
             toolchains/build/npm/
             toolchains/extensions/
             toolchains/musl/
@@ -384,7 +383,11 @@ jobs:
       # and a gate that failed on it would be switched off. A host that will not
       # answer at all, an outage or a rate limit, ends in a printed skip rather
       # than a failure; a run that could read hardly any of the map fails, since
-      # that is the package names having moved and not the network.
+      # that is the package names having moved and not the network. Its answers
+      # are cached on disk but stay out of the download cache above on purpose:
+      # a cache belongs to the ref that wrote it, so no tag can restore another
+      # tag's, and the key this job restores under is written on the default
+      # branch, where nothing runs this. Every release reads upstream cold.
       - name: Compare recorded licences against Termux
         run: python3 scripts/check-termux-licenses.py
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Berkeley DB (AGPL-3.0-only) is no longer bundled. Nothing linked it. Four libraries that are used were added to the source offer, and `NOTICE.md` now lists all 39 components.
 - Attribution is now checked against every binary in the asset tree, not just the top two directories: 195 more files, including the WebAssembly, Windows and macOS objects an ELF-only scan walks past.
 - A binary that moves can no longer be recorded under the wrong licence in silence. An attribution entry that stops matching is reported even when the move took its own directory with it.
-- Recorded Termux licences are now compared against Termux's own. A release stops on a component recorded permissive where upstream declares copyleft, which ships with no source offer.
+- Termux's licence field is now read back per package. When upstream answers, a release stops on a component recorded permissive but declared copyleft, which ships with no source offer.
 - The check that the licences screen's documents are packaged now runs when the build script changes, which is the edit that can drop them.
 - The About dialog's Source Code link moved onto the new licenses screen, beside the offer of source it answers.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Berkeley DB (AGPL-3.0-only) is no longer bundled. Nothing linked it. Four libraries that are used were added to the source offer, and `NOTICE.md` now lists all 39 components.
 - Attribution is now checked against every binary in the asset tree, not just the top two directories: 195 more files, including the WebAssembly, Windows and macOS objects an ELF-only scan walks past.
 - A binary that moves can no longer be recorded under the wrong licence in silence. An attribution entry that stops matching is reported even when the move took its own directory with it.
+- Recorded Termux licences are now compared against Termux's own. A release stops on a component recorded permissive where upstream declares copyleft, which ships with no source offer.
 - The check that the licences screen's documents are packaged now runs when the build script changes, which is the edit that can drop them.
 - The About dialog's Source Code link moved onto the new licenses screen, beside the offer of source it answers.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Attribution is now checked against every binary in the asset tree, not just the top two directories: 195 more files, including the WebAssembly, Windows and macOS objects an ELF-only scan walks past.
 - A binary that moves can no longer be recorded under the wrong licence in silence. An attribution entry that stops matching is reported even when the move took its own directory with it.
 - Termux's licence field is now read back per package. When upstream answers, a release stops on a component recorded permissive but declared copyleft, which ships with no source offer.
+- A release also stops when that comparison cannot be trusted: too few packages read upstream, or a download script no longer naming the ones it installs.
 - The check that the licences screen's documents are packaged now runs when the build script changes, which is the edit that can drop them.
 - The About dialog's Source Code link moved onto the new licenses screen, beside the offer of source it answers.
 

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -49,7 +49,8 @@ offer that file carries. Both documents are read: this one said the build was
 gated on it while only the other was, so the two agreed by habit rather than by
 anything enforcing it.
 
-That the licences here are Termux's own is now checked rather than asserted.
+That the licences here are Termux's own is now checked rather than asserted,
+wherever Termux states one and upstream can be read.
 `scripts/check-termux-licenses.py` reads `TERMUX_PKG_LICENSE` back from Termux
 for each package and reports where the two disagree. It fails on one difference
 only: a component recorded permissive where Termux declares copyleft, which is

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -49,6 +49,12 @@ offer that file carries. Both documents are read: this one said the build was
 gated on it while only the other was, so the two agreed by habit rather than by
 anything enforcing it.
 
+That the licences here are Termux's own is now checked rather than asserted.
+`scripts/check-termux-licenses.py` reads `TERMUX_PKG_LICENSE` back from Termux
+for each package and reports where the two disagree. It fails on one difference
+only: a component recorded permissive where Termux declares copyleft, which is
+what would leave a binary shipping with no offer of source.
+
 This table covers the Termux libraries and executables at the top level of
 `assets/usr/lib` and `jniLibs/arm64-v8a`. The binaries that sit deeper in the
 asset tree are attributed under **Core Components** above, and the gate holds

--- a/docs/LEGAL_NOTICES.md
+++ b/docs/LEGAL_NOTICES.md
@@ -321,7 +321,8 @@ under. The licence column is taken from Termux's own `TERMUX_PKG_LICENSE`, which
 is what these packages are built from, rather than from upstream project pages
 that may describe a different version. `scripts/check-termux-licenses.py` reads
 that field back on every release and reports where this column and Termux
-disagree, so the sentence before this one is measured rather than promised.
+disagree, so the sentence before this one is measured rather than promised for
+every package Termux states a licence for and that upstream answered for.
 
 This is not every binary in the APK, and the heading here claimed it was. Most of
 them are not below: they live deeper in the asset tree and are attributed by the

--- a/docs/LEGAL_NOTICES.md
+++ b/docs/LEGAL_NOTICES.md
@@ -319,7 +319,9 @@ The shared libraries and executables that sit at the top level of
 `assets/usr/lib` and `jniLibs/arm64-v8a`, with the licence each is distributed
 under. The licence column is taken from Termux's own `TERMUX_PKG_LICENSE`, which
 is what these packages are built from, rather than from upstream project pages
-that may describe a different version.
+that may describe a different version. `scripts/check-termux-licenses.py` reads
+that field back on every release and reports where this column and Termux
+disagree, so the sentence before this one is measured rather than promised.
 
 This is not every binary in the APK, and the heading here claimed it was. Most of
 them are not below: they live deeper in the asset tree and are attributed by the

--- a/scripts/check-library-attribution.py
+++ b/scripts/check-library-attribution.py
@@ -61,6 +61,10 @@ Three checks, in the order a new library trips them:
 
 The map below is the licence record. Its source is Termux's own
 `TERMUX_PKG_LICENSE`, which is what these packages are actually built from.
+Nothing here reads that field, so nothing here can tell a correct entry from a
+mistyped one: check-termux-licenses.py reads it back per package and reports the
+differences, and fails on the one that matters, a component recorded permissive
+where Termux declares copyleft.
 
 Toolchain packs are covered too, but only where they exist. Their payloads are
 downloaded, not committed, so this has to run AFTER the download step to see

--- a/scripts/check-termux-licenses.py
+++ b/scripts/check-termux-licenses.py
@@ -28,7 +28,9 @@ look like they should carry it do not:
 demonstrably the line the table was transcribed from: liblzma's reads
 `"LGPL-2.1, GPL-2.0, GPL-3.0"`, byte for byte what LIBRARIES records. So that is
 what this reads, over HTTPS, one small file per package, cached for a week
-beside the package index.
+beside the package index. release.yml carries that cache file in its download
+cache, so a release does not open forty-odd connections to one host in a burst,
+which is the shape that draws a rate limit.
 
 A report, not a gate, with one exception.
 
@@ -43,12 +45,20 @@ source, and the attribution gate cannot notice, because it asks the same wrong
 table. That fails. It cannot fire on a reword, a version bump, or a second
 licence being added to an already copyleft field, because all of those leave the
 copyleft verdict alone and land in the reported half. It cannot fire when
-upstream could not be read either: no network, or a package whose build.sh is
-not where it should be, ends in a printed note and exit 0. Failing closed on an
-unsigned HTTPS fetch would turn an outage at raw.githubusercontent.com into a
-licence problem, and that fetch is advisory here precisely because it is
-unsigned; every payload this project ships is still anchored to Termux's own
-signature by verify-termux-index.sh.
+upstream could not be read either: a package whose build.sh is not where it
+should be is a printed note, and a host that will not serve the file at all, no
+network or a rate limit, ends the whole run in a printed skip and exit 0.
+Failing closed on an unsigned HTTPS fetch would turn an outage at
+raw.githubusercontent.com into a licence problem, and that fetch is advisory
+here precisely because it is unsigned; every payload this project ships is still
+anchored to Termux's own signature by verify-termux-index.sh.
+
+Which is why the run has to say loudly when it read almost nothing. A skip names
+itself, but a report that compared four packages of forty-four reads exactly
+like one that compared all forty-four, and the failing branch above cannot fire
+for a package nobody read. So a floor under that count fails. It answers a
+different question from the paragraph above: upstream answering for hardly any
+of the map means these package names have moved, not that the network is down.
 
 Two things this must not do, both of which would damage the gate it checks.
 
@@ -70,6 +80,7 @@ runs on a fresh checkout that has downloaded nothing.
 
 import fnmatch
 import importlib.util
+import os
 import pathlib
 import re
 import sys
@@ -89,6 +100,14 @@ BUILD_SH = ("https://raw.githubusercontent.com/termux/termux-packages/"
 # than in a name it can spell. Not the same statement as a permissive licence,
 # which is why it is routed away from the comparison instead of into it.
 UNSTATED = "custom"
+
+# The share of the mapped packages upstream has to answer for before the report
+# is worth reading. subjects() counts its own population twice because a
+# narrowed report is the failure mode that reads like a clean one; this is the
+# same floor under the other half. 43 of 44 are read today, so the value leaves
+# room for a handful of subpackages that have no build.sh of their own without
+# leaving room for the package names here to have quietly stopped resolving.
+MIN_COMPARED_SHARE = 2 / 3
 
 # Binaries a download script renames on the way into jniLibs, and the package
 # each arrives from.
@@ -138,6 +157,8 @@ def attribution():
     plain import; nothing at its module level runs anything.
     """
     spec = importlib.util.spec_from_file_location("check_library_attribution", GATE)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load the licence record from {GATE}")
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod
@@ -201,10 +222,11 @@ def fold(licence):
 
 
 def read_cache():
-    """What upstream answered last time, as `package -> (licence, why not)`.
+    """What upstream answered last time, as `(package -> (licence, why not), age)`.
 
     An aged-out cache is dropped whole rather than per entry: the question it
-    answers, what does Termux declare today, has one age.
+    answers, what does Termux declare today, has one age. That age is returned
+    beside the answers so a partial rewrite can put it back.
 
     A refusal is cached beside an answer, and the empty licence beside its reason
     is what records one. Caching only the successes would leave one package
@@ -212,24 +234,33 @@ def read_cache():
     is enough to send the whole report down the offline path when it is not.
     """
     if not CACHE.is_file():
-        return {}
-    if time.time() - CACHE.stat().st_mtime > CACHE_MAX_AGE_DAYS * 86400:
-        return {}
+        return {}, None
+    mtime = CACHE.stat().st_mtime
+    if time.time() - mtime > CACHE_MAX_AGE_DAYS * 86400:
+        return {}, None
     out = {}
     for line in CACHE.read_text(encoding="utf-8").splitlines():
         fields = line.split("\t")
         if len(fields) == 3:
             out[fields[0]] = (fields[1], fields[2])
-    return out
+    return out, mtime
 
 
-def write_cache(found):
-    """Keep only what this run asked about, so a dropped package leaves no line."""
+def write_cache(found, keep_mtime=None):
+    """Keep only what this run asked about, so a dropped package leaves no line.
+
+    One new package rewrites the whole file, so the mtime the surviving answers
+    were already carrying is put back. Without that, adding one library on day
+    six stamps the other forty-three fresh, and repeating the pattern keeps an
+    answer alive past every expiry it was supposed to meet.
+    """
     try:
         CACHE.parent.mkdir(parents=True, exist_ok=True)
         CACHE.write_text("".join(f"{pkg}\t{lic}\t{why}\n"
                                  for pkg, (lic, why) in sorted(found.items())),
                          encoding="utf-8")
+        if keep_mtime is not None:
+            os.utime(CACHE, (keep_mtime, keep_mtime))
     except OSError:
         pass  # a report that cannot cache is still a report
 
@@ -237,9 +268,13 @@ def write_cache(found):
 def fetch(pkg):
     """`TERMUX_PKG_LICENSE` for one package, as `(licence, why not)`.
 
-    An HTTP answer, 404 included, is upstream speaking and is recorded against
-    the package. Anything else means this machine could not get there, which is
-    a fact about the run and not about the package, so it stops the fetching.
+    Exactly two answers are upstream speaking about the package: the file, and
+    404 for a package that has none. Both are recorded against it. Every other
+    status is upstream speaking about this machine or this minute, 429 for a
+    rate limit and 5xx for a bad day, and it is a fact about the run rather than
+    about the package, so it stops the fetching instead. Recording one would
+    answer a question nobody asked, and because answers are cached, that wrong
+    answer would then stand in for a week of runs with the network healthy.
 
     A 404 is the ordinary answer for a subpackage: ncurses-ui-libs is built from
     ncurses and has no `build.sh` of its own. Its parent is not guessed from its
@@ -252,7 +287,9 @@ def fetch(pkg):
         with urllib.request.urlopen(url, timeout=30) as response:
             text = response.read().decode("utf-8", "replace")
     except urllib.error.HTTPError as exc:
-        return "", f"HTTP {exc.code} for packages/{pkg}/build.sh"
+        if exc.code != 404:
+            raise Unreachable(exc) from exc
+        return "", f"HTTP 404 for packages/{pkg}/build.sh"
     except (urllib.error.URLError, OSError) as exc:
         raise Unreachable(exc) from exc
     field = LICENSE_FIELD.search(text)
@@ -290,7 +327,7 @@ def main():
     # so a run whose cache already holds every answer reports in full with the
     # network down and a run that is short of one reports nothing at all rather
     # than a partial tally that reads like a complete one.
-    cache = read_cache()
+    cache, cached_age = read_cache()
     fetched = False
     try:
         for pkg, _ in mapped:
@@ -298,15 +335,15 @@ def main():
                 cache[pkg] = fetch(pkg)
                 fetched = True
     except Unreachable as exc:
-        print(f"skip -- could not reach raw.githubusercontent.com ({exc}); "
-              "no licence was compared")
+        print("skip -- could not read TERMUX_PKG_LICENSE from "
+              f"raw.githubusercontent.com ({exc}); no licence was compared")
         return 0
     if fetched:
         # Only when something was actually fetched. Rewriting the file on a run
         # that answered entirely from it would touch its mtime, and the mtime is
         # what expires it, so a cache refreshed by its own reader would never be
         # refetched and the report would freeze at whatever it first saw.
-        write_cache(cache)
+        write_cache(cache, cached_age)
 
     agree, differ, understated, unstated, unread = [], [], [], [], []
     for pkg, hits in mapped:
@@ -324,7 +361,8 @@ def main():
         else:
             differ.append((pkg, ours, theirs))
 
-    print(f"termux licences: {len(mapped) - len(unread)} of {len(mapped)} packages "
+    compared = len(mapped) - len(unread)
+    print(f"termux licences: {compared} of {len(mapped)} packages "
           f"compared against TERMUX_PKG_LICENSE, {len(agree)} agree")
     for pkg, ours, theirs in differ:
         print(f"   differs   {pkg}: recorded {', '.join(ours)}; termux says {theirs}")
@@ -345,6 +383,7 @@ def main():
     if orphans:
         print(f"   not termux {len(orphans)}: {', '.join(orphans)}")
 
+    failed = False
     if understated:
         print(f"FAIL {len(understated)} recorded permissive where Termux declares "
               "copyleft:", file=sys.stderr)
@@ -355,8 +394,23 @@ def main():
               "component under '## GPL Source Code Availability' in "
               "docs/LEGAL_NOTICES.md; until then the binary ships with no offer "
               "of source", file=sys.stderr)
-        return 1
-    return 0
+        failed = True
+
+    # The floor. Upstream answering "no such file" for most of the map is not an
+    # outage; an outage left earlier, as a skip. It is these package names or the
+    # termux-packages layout having moved. The comparison is then meaningless
+    # while the report above still reads as an orderly one, and the copyleft
+    # branch cannot fire for a package nobody read.
+    if mapped and compared < len(mapped) * MIN_COMPARED_SHARE:
+        print(f"FAIL only {compared} of {len(mapped)} packages could be read "
+              f"upstream, under the {MIN_COMPARED_SHARE:.0%} this comparison "
+              "needs to mean anything", file=sys.stderr)
+        print("  -> upstream answered, so this is not an outage: the package "
+              "names in RENAMED and in each download script's get_sonames(), or "
+              "the termux-packages layout, have moved. Every unread package is "
+              "a licence nobody checked", file=sys.stderr)
+        failed = True
+    return 1 if failed else 0
 
 
 if __name__ == "__main__":

--- a/scripts/check-termux-licenses.py
+++ b/scripts/check-termux-licenses.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""Compare each recorded Termux licence against the one Termux declares.
+
+    check-termux-licenses.py
+
+check-library-attribution.py decides whether a shipped binary needs an offer of
+source by reading a licence out of a table written by hand. That table says its
+source is Termux's `TERMUX_PKG_LICENSE`, and nothing had ever read the field
+back, so a mistyped row, a line copied from its neighbour, or a package that
+relicensed would agree with itself forever. Two published documents,
+docs/LEGAL_NOTICES.md and NOTICE.md, are written from the same table, and the
+copyleft rule the gate runs is only as good as the string it is handed.
+
+Where the field actually lives, measured rather than assumed. Three places that
+look like they should carry it do not:
+
+  * the signed `Packages` index has no `License` field at all: zero lines across
+    the whole index against 2918 `Homepage:` lines, so the absence belongs to
+    the field and not to the reader;
+  * neither has a .deb's `control` member. bash 5.3.15 declares Package,
+    Version, Homepage, Depends and eight more, and no licence;
+  * `usr/share/doc/<pkg>/copyright` inside the .deb payload is a symlink naming
+    the licence for some packages (bash's points at `../../LICENSES/GPL-3.0.txt`)
+    but free text for most and missing for a good many. It is a document, not a
+    field, and it cannot be compared against a string.
+
+`packages/<pkg>/build.sh` in termux-packages carries it on one line, and it is
+demonstrably the line the table was transcribed from: liblzma's reads
+`"LGPL-2.1, GPL-2.0, GPL-3.0"`, byte for byte what LIBRARIES records. So that is
+what this reads, over HTTPS, one small file per package, cached for a week
+beside the package index.
+
+A report, not a gate, with one exception.
+
+Termux moves under this project by design, and a repackaging that rewords a
+licence field is ordinary upstream activity. A check that failed the build on it
+would be switched off within a week; write-build-manifest.py reasons the same
+way about its own comparison. So a difference is printed and the run succeeds.
+
+The exception is the one direction with a legal consequence: a component
+recorded permissive where Termux declares copyleft ships with no offer of
+source, and the attribution gate cannot notice, because it asks the same wrong
+table. That fails. It cannot fire on a reword, a version bump, or a second
+licence being added to an already copyleft field, because all of those leave the
+copyleft verdict alone and land in the reported half. It cannot fire when
+upstream could not be read either: no network, or a package whose build.sh is
+not where it should be, ends in a printed note and exit 0. Failing closed on an
+unsigned HTTPS fetch would turn an outage at raw.githubusercontent.com into a
+licence problem, and that fetch is advisory here precisely because it is
+unsigned; every payload this project ships is still anchored to Termux's own
+signature by verify-termux-index.sh.
+
+Two things this must not do, both of which would damage the gate it checks.
+
+  * It must not rewrite either side into SPDX. LIBRARIES deliberately holds
+    spelled-out names beside identifiers, because COPYLEFT matches
+    case-insensitive substrings and "Mozilla Public License 2.0" contains no
+    "MPL". Canonicalising would delete the reason those terms exist. The
+    comparison folds case and punctuation only, so `BSD-3-Clause` and
+    `BSD 3-Clause` are one answer while `BSD-4-Clause` and `BSD` stay two.
+  * It must not read `custom` as permissive. Three packages declare it, and it
+    means Termux has not said, not that it said no. Those are reported as
+    unstated and never reach the failing branch.
+
+Which packages are compared comes from committed source, not from a built tree:
+each download script's `get_sonames()`, plus the table below for the binaries
+that are renamed rather than copied. So this answers for the repository, and
+runs on a fresh checkout that has downloaded nothing.
+"""
+
+import fnmatch
+import importlib.util
+import pathlib
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+SCRIPTS = ROOT / "scripts"
+GATE = SCRIPTS / "check-library-attribution.py"
+CACHE = ROOT / "toolchains/termux-packages/licenses.tsv"
+CACHE_MAX_AGE_DAYS = 7
+BUILD_SH = ("https://raw.githubusercontent.com/termux/termux-packages/"
+            "master/packages/{pkg}/build.sh")
+
+# The value Termux writes when the terms are in the package's own file rather
+# than in a name it can spell. Not the same statement as a permissive licence,
+# which is why it is routed away from the comparison instead of into it.
+UNSTATED = "custom"
+
+# Binaries a download script renames on the way into jniLibs, and the package
+# each arrives from.
+#
+# `get_sonames()` cannot answer for these: it maps the shared libraries a package
+# ships under their own soname, while these are executables copied to a `lib*.so`
+# name so that the package manager extracts them with the execute bit. They are
+# also the copyleft half of the tree, bash and git and make, so leaving them out
+# would drop exactly the rows worth checking.
+#
+# Patterns rather than literals: the Python runtime carries its version in the
+# file name and download-python.sh resolves that version from the index at build
+# time, so a literal here would go stale on a rebuild nobody connects to this
+# file.
+RENAMED = {
+    "bash": ("libbash.so",),
+    "git": ("libgit.so", "libgit-remote-curl.so"),
+    "make": ("libmake.so",),
+    "openssh": ("libssh.so", "libssh-keygen.so"),
+    "tmux": ("libtmux.so",),
+    # download-node.sh names its package in a bare variable rather than in a
+    # REQUIRED_PACKAGES array, so this row is also what puts it in the subject
+    # set at all.
+    "nodejs-lts": ("libnode.so",),
+    "python": ("libpython.so", "libpython3.*.so"),
+}
+
+# The body of a `get_sonames()` shell function, and one arm of the case inside
+# it. Read out of the download scripts rather than copied here, so the two
+# cannot drift: a soname added there is compared here on the next run.
+SONAME_FN = re.compile(r"^get_sonames\(\)\s*\{(.*?)^\}", re.M | re.S)
+CASE_ARM = re.compile(r'^\s*([A-Za-z0-9_.+-]+)\)\s*echo\s+"([^"]*)"', re.M)
+
+# `TERMUX_PKG_LICENSE="GPL-3.0"`, quoted or not.
+LICENSE_FIELD = re.compile(r"^TERMUX_PKG_LICENSE=(.*)$", re.M)
+
+
+class Unreachable(Exception):
+    """Upstream could not be contacted at all, as opposed to answering."""
+
+
+def attribution():
+    """The attribution gate, imported for its tables rather than run.
+
+    Imported instead of re-stated so there is one licence record. The file name
+    has hyphens in it, which is why this goes through importlib rather than a
+    plain import; nothing at its module level runs anything.
+    """
+    spec = importlib.util.spec_from_file_location("check_library_attribution", GATE)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def widen(soname):
+    """The pattern that claims a soname and the unversioned name beside it.
+
+    `liblzma.so.5` and `liblzma.so` are one library under two names and the map
+    carries both, so a row naming the versioned one has to claim the other or
+    half the entry goes unchecked, copyleft included.
+
+    Only a versioned soname is widened. Doing the same to a bare `.so` would let
+    `libcrypt.so`, Termux's BSD-2-Clause crypt(3), claim `libcrypt.so.1` beside
+    it, which is this repository's own glibc stub under a confusingly similar
+    name and a different component entirely.
+    """
+    base = re.match(r"^(.*\.so)\.[0-9]", soname)
+    return base.group(1) + "*" if base else soname
+
+
+def subjects():
+    """package -> the patterns matching the files the build places for it, and
+    the download scripts whose `get_sonames()` this could not read.
+
+    The second half is what keeps a narrowed report from reading like a clean
+    one. A parse that stops matching does not empty this answer, because RENAMED
+    below fills it either way, so the population is counted twice by two
+    different means: which scripts contain the function at all, by name, and
+    which of them this regex got case arms out of. A script in the first set and
+    not the second is reported rather than dropped.
+    """
+    rows, unparsed = {}, []
+    for script in sorted(SCRIPTS.glob("download-*.sh")):
+        text = script.read_text(encoding="utf-8")
+        if "get_sonames()" not in text:
+            continue
+        body = SONAME_FN.search(text)
+        arms = CASE_ARM.findall(body.group(1)) if body else []
+        if not arms:
+            unparsed.append(script.name)
+            continue
+        for pkg, sonames in arms:
+            for soname in sonames.split():
+                rows.setdefault(pkg, set()).add(widen(soname))
+    for pkg, patterns in RENAMED.items():
+        rows.setdefault(pkg, set()).update(patterns)
+    return rows, unparsed
+
+
+def fold(licence):
+    """Case and punctuation flattened, and nothing else.
+
+    `BSD-3-Clause` and `BSD 3-Clause` are the same answer written twice. This is
+    deliberately not an SPDX mapping: `GPLv3` is not folded onto `GPL-3.0` and
+    `Mozilla Public License` is not folded onto `MPL`, because the gate's
+    copyleft test matches those spellings as substrings and a canonicaliser here
+    would quietly argue for removing them there.
+    """
+    return " ".join(re.sub(r"[^0-9a-z]+", " ", licence.lower()).split())
+
+
+def read_cache():
+    """What upstream answered last time, as `package -> (licence, why not)`.
+
+    An aged-out cache is dropped whole rather than per entry: the question it
+    answers, what does Termux declare today, has one age.
+
+    A refusal is cached beside an answer, and the empty licence beside its reason
+    is what records one. Caching only the successes would leave one package
+    fetched on every run, which is a wasted request when the network is there and
+    is enough to send the whole report down the offline path when it is not.
+    """
+    if not CACHE.is_file():
+        return {}
+    if time.time() - CACHE.stat().st_mtime > CACHE_MAX_AGE_DAYS * 86400:
+        return {}
+    out = {}
+    for line in CACHE.read_text(encoding="utf-8").splitlines():
+        fields = line.split("\t")
+        if len(fields) == 3:
+            out[fields[0]] = (fields[1], fields[2])
+    return out
+
+
+def write_cache(found):
+    """Keep only what this run asked about, so a dropped package leaves no line."""
+    try:
+        CACHE.parent.mkdir(parents=True, exist_ok=True)
+        CACHE.write_text("".join(f"{pkg}\t{lic}\t{why}\n"
+                                 for pkg, (lic, why) in sorted(found.items())),
+                         encoding="utf-8")
+    except OSError:
+        pass  # a report that cannot cache is still a report
+
+
+def fetch(pkg):
+    """`TERMUX_PKG_LICENSE` for one package, as `(licence, why not)`.
+
+    An HTTP answer, 404 included, is upstream speaking and is recorded against
+    the package. Anything else means this machine could not get there, which is
+    a fact about the run and not about the package, so it stops the fetching.
+
+    A 404 is the ordinary answer for a subpackage: ncurses-ui-libs is built from
+    ncurses and has no `build.sh` of its own. Its parent is not guessed from its
+    name. The index carries no field naming it, and a wrong guess would report
+    agreement with a licence belonging to another project, which is the one
+    outcome this script must never produce.
+    """
+    url = BUILD_SH.format(pkg=pkg)
+    try:
+        with urllib.request.urlopen(url, timeout=30) as response:
+            text = response.read().decode("utf-8", "replace")
+    except urllib.error.HTTPError as exc:
+        return "", f"HTTP {exc.code} for packages/{pkg}/build.sh"
+    except (urllib.error.URLError, OSError) as exc:
+        raise Unreachable(exc) from exc
+    field = LICENSE_FIELD.search(text)
+    licence = field.group(1).strip().strip("\"'") if field else ""
+    if not licence:
+        return "", f"packages/{pkg}/build.sh states no TERMUX_PKG_LICENSE"
+    return licence, ""
+
+
+def main():
+    gate = attribution()
+    records = list(gate.LIBRARIES.items()) + list(gate.TOOLCHAIN_LIBRARIES.items())
+    rows, unparsed = subjects()
+    if unparsed:
+        print(f"FAIL get_sonames() could not be read in {len(unparsed)} script(s): "
+              f"{', '.join(unparsed)}", file=sys.stderr)
+        print("  -> the function's shape changed; every package it names would "
+              "silently drop out of this comparison", file=sys.stderr)
+        return 1
+
+    def copyleft(licence):
+        return any(term in licence.upper() for term in gate.COPYLEFT)
+
+    claimed, mapped, unmapped = set(), [], []
+    for pkg, patterns in sorted(rows.items()):
+        hits = [(name, entry) for name, entry in records
+                if any(fnmatch.fnmatchcase(name, p) for p in patterns)]
+        if hits:
+            claimed.update(name for name, _ in hits)
+            mapped.append((pkg, hits))
+        else:
+            unmapped.append(pkg)
+
+    # Everything the network is needed for happens here, before any comparison,
+    # so a run whose cache already holds every answer reports in full with the
+    # network down and a run that is short of one reports nothing at all rather
+    # than a partial tally that reads like a complete one.
+    cache = read_cache()
+    fetched = False
+    try:
+        for pkg, _ in mapped:
+            if pkg not in cache:
+                cache[pkg] = fetch(pkg)
+                fetched = True
+    except Unreachable as exc:
+        print(f"skip -- could not reach raw.githubusercontent.com ({exc}); "
+              "no licence was compared")
+        return 0
+    if fetched:
+        # Only when something was actually fetched. Rewriting the file on a run
+        # that answered entirely from it would touch its mtime, and the mtime is
+        # what expires it, so a cache refreshed by its own reader would never be
+        # refetched and the report would freeze at whatever it first saw.
+        write_cache(cache)
+
+    agree, differ, understated, unstated, unread = [], [], [], [], []
+    for pkg, hits in mapped:
+        theirs, why = cache[pkg]
+        ours = sorted({licence for _, (_, licence) in hits})
+        if not theirs:
+            unread.append((pkg, why))
+        elif theirs.lower() == UNSTATED:
+            unstated.append((pkg, ours, theirs))
+        elif all(fold(o) == fold(theirs) for o in ours):
+            agree.append(pkg)
+        elif copyleft(theirs) and not all(copyleft(o) for o in ours):
+            understated.append((pkg, ours, theirs,
+                                [n for n, (_, lic) in hits if not copyleft(lic)]))
+        else:
+            differ.append((pkg, ours, theirs))
+
+    print(f"termux licences: {len(mapped) - len(unread)} of {len(mapped)} packages "
+          f"compared against TERMUX_PKG_LICENSE, {len(agree)} agree")
+    for pkg, ours, theirs in differ:
+        print(f"   differs   {pkg}: recorded {', '.join(ours)}; termux says {theirs}")
+    for pkg, ours, theirs in unstated:
+        print(f"   unstated  {pkg}: recorded {', '.join(ours)}; "
+              f"termux says \"{theirs}\", so nothing to compare")
+    for pkg, why in unread:
+        print(f"   unread    {pkg}: {why}")
+    if unmapped:
+        print(f"   no entry  {', '.join(unmapped)}: the build places files for these "
+              "and no licence is recorded for any of them")
+    # The other direction of the same question. A map entry no package accounts
+    # for is either not a Termux library at all, which is the answer for the two
+    # here today, or a row whose package was renamed out from under it. Printed
+    # rather than failed, because this script cannot tell those apart.
+    orphans = sorted(name for name, (component, _) in records
+                     if name not in claimed and component != "VSCodroid")
+    if orphans:
+        print(f"   not termux {len(orphans)}: {', '.join(orphans)}")
+
+    if understated:
+        print(f"FAIL {len(understated)} recorded permissive where Termux declares "
+              "copyleft:", file=sys.stderr)
+        for pkg, ours, theirs, names in understated:
+            print(f"  {pkg}: recorded {', '.join(ours)} for {', '.join(names)}; "
+                  f"termux declares {theirs}", file=sys.stderr)
+        print("  -> correct the entry in check-library-attribution.py and add the "
+              "component under '## GPL Source Code Availability' in "
+              "docs/LEGAL_NOTICES.md; until then the binary ships with no offer "
+              "of source", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-termux-licenses.py
+++ b/scripts/check-termux-licenses.py
@@ -137,6 +137,17 @@ RENAMED = {
     "python": ("libpython.so", "libpython3.*.so"),
 }
 
+# The download scripts that have to carry a `get_sonames()`. Named here rather
+# than discovered by grepping for the function, because a search cannot report
+# what it no longer finds: the rename or the move that empties the answer also
+# takes the script out of the set the loss would be measured against, so every
+# package it named leaves the comparison while the report still reads as a
+# complete one. A script listed here that stops carrying the function fails the
+# run instead, which is the point. Moving that map is a decision, and this line
+# is where it gets made.
+SONAME_SCRIPTS = ("download-java.sh", "download-python.sh", "download-ruby.sh",
+                  "download-termux-tools.sh")
+
 # The body of a `get_sonames()` shell function, and one arm of the case inside
 # it. Read out of the download scripts rather than copied here, so the two
 # cannot drift: a soname added there is compared here on the next run.
@@ -189,15 +200,19 @@ def subjects():
     The second half is what keeps a narrowed report from reading like a clean
     one. A parse that stops matching does not empty this answer, because RENAMED
     below fills it either way, so the population is counted twice by two
-    different means: which scripts contain the function at all, by name, and
-    which of them this regex got case arms out of. A script in the first set and
-    not the second is reported rather than dropped.
+    independent means: SONAME_SCRIPTS, which says which scripts must carry the
+    function, and this glob, which says which of them a case arm was read out
+    of. A script in the first set and not the second is reported rather than
+    dropped, whether it kept the function and changed shape or lost the name
+    altogether. A script this glob finds and that list does not is a new carrier,
+    which widens the comparison and is taken as it comes.
     """
-    rows, unparsed = {}, []
+    rows, unparsed, carriers = {}, [], set()
     for script in sorted(SCRIPTS.glob("download-*.sh")):
         text = script.read_text(encoding="utf-8")
         if "get_sonames()" not in text:
             continue
+        carriers.add(script.name)
         body = SONAME_FN.search(text)
         arms = CASE_ARM.findall(body.group(1)) if body else []
         if not arms:
@@ -206,9 +221,10 @@ def subjects():
         for pkg, sonames in arms:
             for soname in sonames.split():
                 rows.setdefault(pkg, set()).add(widen(soname))
+    unparsed.extend(set(SONAME_SCRIPTS) - carriers)
     for pkg, patterns in RENAMED.items():
         rows.setdefault(pkg, set()).update(patterns)
-    return rows, unparsed
+    return rows, sorted(unparsed)
 
 
 def fold(licence):
@@ -308,8 +324,10 @@ def main():
     if unparsed:
         print(f"FAIL get_sonames() could not be read in {len(unparsed)} script(s): "
               f"{', '.join(unparsed)}", file=sys.stderr)
-        print("  -> the function's shape changed; every package it names would "
-              "silently drop out of this comparison", file=sys.stderr)
+        print("  -> the function was renamed, moved or reshaped; every package "
+              "it names would otherwise drop out of this comparison in silence. "
+              "Put it back, or take the script out of SONAME_SCRIPTS here and "
+              "say where its packages are read instead", file=sys.stderr)
         return 1
 
     def copyleft(licence):

--- a/scripts/check-termux-licenses.py
+++ b/scripts/check-termux-licenses.py
@@ -59,6 +59,8 @@ like one that compared all forty-four, and the failing branch above cannot fire
 for a package nobody read. So a floor under that count fails. It answers a
 different question from the paragraph above: upstream answering for hardly any
 of the map means these package names have moved, not that the network is down.
+A run that trips the floor caches nothing, so the reading that tripped it cannot
+outlive it and answer for a week of runs that never asked upstream anything.
 
 Two things this must not do, both of which would damage the gate it checks.
 
@@ -338,13 +340,6 @@ def main():
         print("skip -- could not read TERMUX_PKG_LICENSE from "
               f"raw.githubusercontent.com ({exc}); no licence was compared")
         return 0
-    if fetched:
-        # Only when something was actually fetched. Rewriting the file on a run
-        # that answered entirely from it would touch its mtime, and the mtime is
-        # what expires it, so a cache refreshed by its own reader would never be
-        # refetched and the report would freeze at whatever it first saw.
-        write_cache(cache, cached_age)
-
     agree, differ, understated, unstated, unread = [], [], [], [], []
     for pkg, hits in mapped:
         theirs, why = cache[pkg]
@@ -401,7 +396,8 @@ def main():
     # termux-packages layout having moved. The comparison is then meaningless
     # while the report above still reads as an orderly one, and the copyleft
     # branch cannot fire for a package nobody read.
-    if mapped and compared < len(mapped) * MIN_COMPARED_SHARE:
+    under_floor = bool(mapped) and compared < len(mapped) * MIN_COMPARED_SHARE
+    if under_floor:
         print(f"FAIL only {compared} of {len(mapped)} packages could be read "
               f"upstream, under the {MIN_COMPARED_SHARE:.0%} this comparison "
               "needs to mean anything", file=sys.stderr)
@@ -410,6 +406,17 @@ def main():
               "the termux-packages layout, have moved. Every unread package is "
               "a licence nobody checked", file=sys.stderr)
         failed = True
+
+    # After the verdict, and never on a run the floor rejected. A cached answer
+    # carries a week of life, so a reading too thin to compare would answer for
+    # every run in that week: the same failure, with no request made, on a healthy
+    # network, and nothing the message names left to fix. Only when something was
+    # actually fetched, too: rewriting the file on a run that answered entirely
+    # from it would touch its mtime, and the mtime is what expires it, so a cache
+    # refreshed by its own reader would never be refetched and the report would
+    # freeze at whatever it first saw.
+    if fetched and not under_floor:
+        write_cache(cache, cached_age)
     return 1 if failed else 0
 
 

--- a/scripts/check-termux-licenses.py
+++ b/scripts/check-termux-licenses.py
@@ -28,9 +28,15 @@ look like they should carry it do not:
 demonstrably the line the table was transcribed from: liblzma's reads
 `"LGPL-2.1, GPL-2.0, GPL-3.0"`, byte for byte what LIBRARIES records. So that is
 what this reads, over HTTPS, one small file per package, cached for a week
-beside the package index. release.yml carries that cache file in its download
-cache, so a release does not open forty-odd connections to one host in a burst,
-which is the shape that draws a rate limit.
+beside the package index, and only from a run that read enough of the map to
+compare it. That cache spares a second run on the same machine, nothing more,
+and release.yml deliberately leaves it out of the download cache it restores. A
+workflow cache is scoped to the ref that saved it, so what one tag writes the
+next tag cannot read; and the key that tag restores under is the one build.yml
+writes on the default branch, where this never runs, so the file would not be
+there to restore. A release therefore reads every package cold. Forty-odd small
+requests in one burst is the ordinary shape of a release, and a rate limit
+inside it ends the run in a printed skip rather than a failure.
 
 A report, not a gate, with one exception.
 


### PR DESCRIPTION
`scripts/check-library-attribution.py` decides whether a shipped binary needs an offer of source by reading a licence out of a table written by hand. The table names Termux's `TERMUX_PKG_LICENSE` as its source, and nothing had ever read that field back, so a mistyped row or a package that relicensed would agree with itself forever. `NOTICE.md` and `docs/LEGAL_NOTICES.md` are both written from that table.

Three places that look like they carry the field do not: the signed `Packages` index has no `License` line (zero across the index, against 2918 `Homepage:` lines), a .deb's `control` member has none, and `usr/share/doc/<pkg>/copyright` is free text or absent for most packages. `packages/<pkg>/build.sh` carries it, and is demonstrably what the table was transcribed from.

- `scripts/check-termux-licenses.py` reads that field per package and reports the differences. Its subjects come from committed source, each download script's `get_sonames()` plus a table for the binaries renamed into `jniLibs`, so it runs on a checkout that has downloaded nothing.
- It fails on two things: a component recorded permissive where Termux declares copyleft, which ships with no offer of source and which the attribution gate cannot see; and a run that could read hardly any of the map, so a narrowed report cannot pass for a clean one.
- Only 200 and 404 are upstream speaking about a package. A rate limit or a 5xx is a fact about the run, so it ends in a printed skip rather than a cached verdict that stands for a week.
- Wired into `release.yml`, whose download cache now carries the answers file so a release does not open forty-odd connections to one host in a burst.

Result today: 43 of 44 compared, 39 agree, `libbz2` differs in the harmless direction, three packages declare `custom`, and `ncurses-ui-libs` has no `build.sh`. Nothing in the failing direction.