### PR TITLE
fix(auth): record the sign-in a link hand-off carries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -231,6 +231,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A link opened from inside the editor no longer disappears when the bridge declines it; the click falls through to the WebView's own handling.
 - A browser launch that failed left the sign-in callback window open for ten minutes, during which any `vscodroid://callback` on the device was accepted.
 - A sign-in page on plain http now completes. Only the Custom Tabs hand-off was recording itself, so a self-hosted provider reached through the system browser had its return refused.
+- A sign-in opened by a link navigation rather than by the editor's own route now completes. That hand-off recorded nothing, so its return was refused with nothing said.
 - Signing in when Android has closed the app mid-browser now tells you what happened instead of silently doing nothing.
 - A sign-in that outlasts its window now says so instead of failing silently, and coming back after five minutes no longer discards a callback the editor was collecting.
 - The **Browse Extensions** step on Get Started could never complete, so the walkthrough stayed permanently unfinished. It waited on a view identifier the workbench does not register.

--- a/android/app/src/main/kotlin/com/vscodroid/bridge/AndroidBridge.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/bridge/AndroidBridge.kt
@@ -87,9 +87,12 @@ private const val MAX_TRACKED_SIGN_INS = 32
  * arms nothing, so the callback that comes back for it is refused in the log and
  * nowhere else: the message for a late arrival sits on the other side of that
  * branch, and `openExternalUrl` still reports the launch as made, so the sign-in
- * fails quietly. An id it invents is not reachable: the value has to come out of
- * a URL the workbench asked this app to open, which already requires the session
- * token.
+ * fails quietly. An id it invents has to have come out of a URL this app was
+ * asked to open, and there are two askers rather than one. [openExternalUrl]
+ * refuses a caller without the session token. `VSCodroidWebViewClient`'s
+ * `shouldOverrideUrlLoading` has no token to check, so it arms only for a
+ * main-frame navigation: the main frame is our own page, while the other frames
+ * carry content this app does not vouch for. Widening this pattern widens both.
  */
 private val AUTH_REQUEST_ID = Regex("""vscode-reqid(?:=|%(?:25)*3[Dd])(\d+)""")
 

--- a/android/app/src/main/kotlin/com/vscodroid/webview/VSCodroidWebViewClient.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/webview/VSCodroidWebViewClient.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
 import android.net.Uri
+import android.os.SystemClock
 import android.webkit.RenderProcessGoneDetail
 import android.webkit.ServiceWorkerClient
 import android.webkit.ServiceWorkerController
@@ -12,6 +13,8 @@ import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import com.vscodroid.bridge.AuthTabWindow
+import com.vscodroid.bridge.authRequestIdsIn
 import com.vscodroid.util.Environment
 import com.vscodroid.util.Logger
 import java.io.ByteArrayInputStream
@@ -264,13 +267,37 @@ class VSCodroidWebViewClient(
         if (isLocalhost(url) || isCdnRedirect(url)) {
             return false
         }
+        // Empty until this launch arms something, and then the ids to take back
+        // if the launch throws. Same shape as `AndroidBridge.openExternalUrl`,
+        // and for the same reason: arming precedes the launch, so a launch
+        // nothing accepted would otherwise leave the relay open with no sign-in
+        // in flight.
+        var armed: List<String> = emptyList()
         // Fix #7: Open external URLs in system browser instead of blocking silently
         try {
             val intent = Intent(Intent.ACTION_VIEW, url)
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            // The app's second way out to a browser, and the one that recorded
+            // nothing. The bridge is the route the workbench normally takes, but
+            // `MainActivity.injectWindowOpenOverride` falls through to a plain
+            // navigation whenever the page holds no session token yet or the
+            // bridge reports no launch, and a subframe's `window.open` becomes
+            // one too because this WebView does not support multiple windows. A
+            // sign-in leaving this way returns by the same `vscodroid://callback`
+            // and was judged against a window nobody had opened, so it was
+            // refused in the log and the sign-in hung with nothing said.
+            //
+            // What is armed is the request ids the address carries, never the
+            // fact that a browser opened: a documentation link carries none and
+            // so opens nothing, which is what keeps this from widening the
+            // window every external link is followed.
+            armed = AuthTabWindow.arm(
+                authRequestIdsIn(url.toString()), SystemClock.elapsedRealtime()
+            )
             view.context.startActivity(intent)
             Logger.i(tag, "Opened external URL: ${redactToken(url.toString())}")
         } catch (e: Exception) {
+            AuthTabWindow.disarm(armed)
             Logger.e(tag, "Failed to open external URL: ${redactToken(url.toString())}", e)
         }
         return true  // Don't navigate WebView to external URL

--- a/android/app/src/main/kotlin/com/vscodroid/webview/VSCodroidWebViewClient.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/webview/VSCodroidWebViewClient.kt
@@ -281,19 +281,35 @@ class VSCodroidWebViewClient(
             // nothing. The bridge is the route the workbench normally takes, but
             // `MainActivity.injectWindowOpenOverride` falls through to a plain
             // navigation whenever the page holds no session token yet or the
-            // bridge reports no launch, and a subframe's `window.open` becomes
-            // one too because this WebView does not support multiple windows. A
-            // sign-in leaving this way returns by the same `vscodroid://callback`
-            // and was judged against a window nobody had opened, so it was
-            // refused in the log and the sign-in hung with nothing said.
+            // bridge reports no launch, and the workbench's own opener assigns
+            // `location.href` for every scheme that is not http or https. A
+            // sign-in leaving either way returns by the same
+            // `vscodroid://callback` and was judged against a window nobody had
+            // opened, so it was refused in the log and the sign-in hung with
+            // nothing said.
+            //
+            // Main frame only, and that is the boundary rather than a detail.
+            // Both routes above navigate the top-level frame: the injected
+            // override patches the main window's `window.open`, and the opener
+            // assigns the main window's `location`. Nothing else here is our
+            // own page. Every other frame renders content this app does not
+            // vouch for, including the remote site the bundled simple browser
+            // puts in an iframe, and a frame may always navigate itself whatever
+            // its sandbox says. Arming on those would let a page the user merely
+            // opened choose which callback ids this app accepts, and evict the
+            // sign-in actually in flight from a record that keeps the most
+            // recent few. The bridge route is gated by the session token; this
+            // one has no token to check, so the frame is what stands in for it.
             //
             // What is armed is the request ids the address carries, never the
             // fact that a browser opened: a documentation link carries none and
             // so opens nothing, which is what keeps this from widening the
             // window every external link is followed.
-            armed = AuthTabWindow.arm(
-                authRequestIdsIn(url.toString()), SystemClock.elapsedRealtime()
-            )
+            if (request.isForMainFrame) {
+                armed = AuthTabWindow.arm(
+                    authRequestIdsIn(url.toString()), SystemClock.elapsedRealtime()
+                )
+            }
             view.context.startActivity(intent)
             Logger.i(tag, "Opened external URL: ${redactToken(url.toString())}")
         } catch (e: Exception) {

--- a/android/app/src/test/kotlin/com/vscodroid/ExtensionCallbackTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/ExtensionCallbackTest.kt
@@ -535,15 +535,24 @@ class AuthCallbackCallSiteTest {
 
     @Test
     fun `the launch arms the ids the address carries, not the fact that it launched`() {
-        // The narrowing, at the one place it can be undone in a line. Passing
-        // anything other than the ids read out of the address puts the old
-        // behaviour back: every browser launch opening the callback window,
-        // whether or not a sign-in was involved.
+        // The narrowing, at the bridge's arming site. Passing anything other
+        // than the ids read out of the address puts the old behaviour back:
+        // every browser launch opening the callback window, whether or not a
+        // sign-in was involved.
+        //
+        // Not the only arming site any more. `VSCodroidWebViewClient` arms the
+        // link-navigation hand-off as well, and this reads AndroidBridge.kt
+        // only; `ExternalUrlHandoffTest` holds that site to the same rule from
+        // the other end, by driving it with an address whose only number is not
+        // a request id.
         check(bridge.isFile) { "AndroidBridge.kt not found" }
 
         val arming = code(bridge).filter { it.contains("AuthTabWindow.arm(") }
 
-        assertEquals(1, arming.size, "expected exactly one arming site, found: $arming")
+        assertEquals(
+            1, arming.size,
+            "expected exactly one arming site in AndroidBridge.kt, found: $arming",
+        )
         assertTrue(
             arming.single().contains("authRequestIdsIn("),
             "the arming must be keyed on the request ids in the address; found: ${arming.single()}",

--- a/android/app/src/test/kotlin/com/vscodroid/webview/ExternalUrlHandoffTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/ExternalUrlHandoffTest.kt
@@ -87,8 +87,19 @@ class ExternalUrlHandoffTest {
         /** A neighbouring id nothing here launched, and the one that must stay refused. */
         const val UNSOLICITED_REQUEST_ID = "910"
 
-        /** A link with no sign-in in it, which must open no window at all. */
-        const val DOCS = "https://code.visualstudio.com/docs"
+        /**
+         * A link with no sign-in in it, which must open no window at all.
+         *
+         * It carries a number on purpose. A hand-off that armed every digit run
+         * in the address rather than the ids `vscode-reqid` names would still
+         * satisfy the two cases above, since the id [SIGN_IN] carries is also a
+         * digit run of its own; only a control that carries an unrelated number
+         * tells the two apart.
+         */
+        const val DOCS = "https://code.visualstudio.com/docs/1234"
+
+        /** The number [DOCS] carries, which nothing may read as a request id. */
+        const val DOCS_NUMBER = "1234"
 
         /**
          * The clock reading every launch below is armed with. Distinctive so that
@@ -135,7 +146,9 @@ class ExternalUrlHandoffTest {
      */
     @AfterEach
     fun handBackArmedRequests() {
-        AuthTabWindow.disarm(listOf(SIGN_IN_REQUEST_ID, UNSOLICITED_REQUEST_ID))
+        AuthTabWindow.disarm(
+            listOf(SIGN_IN_REQUEST_ID, UNSOLICITED_REQUEST_ID, DOCS_NUMBER)
+        )
     }
 
     @BeforeEach

--- a/android/app/src/test/kotlin/com/vscodroid/webview/ExternalUrlHandoffTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/ExternalUrlHandoffTest.kt
@@ -99,7 +99,8 @@ class ExternalUrlHandoffTest {
     }
 
     private fun request(
-        scheme: String, host: String, port: Int, address: String = ""
+        scheme: String, host: String, port: Int, address: String = "",
+        fromMainFrame: Boolean = true
     ): WebResourceRequest {
         val uri = mockk<Uri>(relaxed = true)
         every { uri.scheme } returns scheme
@@ -111,6 +112,9 @@ class ExternalUrlHandoffTest {
         every { uri.toString() } returns address
         val req = mockk<WebResourceRequest>(relaxed = true)
         every { req.url } returns uri
+        // Stated rather than left to the relaxed mock, which would answer false
+        // and quietly make every case below a subframe case.
+        every { req.isForMainFrame } returns fromMainFrame
         return req
     }
 
@@ -210,12 +214,11 @@ class ExternalUrlHandoffTest {
      *
      * The bridge is the route the workbench normally takes, and it records the
      * launch. This one is the fallback underneath it, reached when the page
-     * holds no session token yet, when the bridge reports no launch, and when a
-     * subframe calls `window.open`, which this WebView turns into a navigation
-     * because it does not support multiple windows. It recorded nothing, so the
-     * `vscodroid://callback` that came back was judged against a window nobody
-     * had opened and refused in the log, with no message anywhere: the sign-in
-     * simply never completed.
+     * holds no session token yet, when the bridge reports no launch, and when
+     * the workbench's own opener assigns `location.href` for a scheme that is
+     * not http or https. It recorded nothing, so the `vscodroid://callback` that
+     * came back was judged against a window nobody had opened and refused in the
+     * log, with no message anywhere: the sign-in simply never completed.
      *
      * Asserted on the acceptance decision itself rather than on the arming call,
      * because the arming is only interesting for what it lets back in.
@@ -261,6 +264,45 @@ class ExternalUrlHandoffTest {
             callbackWouldBeTaken(SIGN_IN_REQUEST_ID),
             "a launch that failed left the callback window armed for a sign-in that never " +
                 "started, and nothing on the way back can tell the difference",
+        )
+    }
+
+    /**
+     * A frame that is not our own page may leave for a browser, but may not
+     * decide which callbacks come back.
+     *
+     * This callback receives subframe navigations as well as top-level ones, and
+     * a frame may always navigate itself whatever its sandbox permits. The frames
+     * here render content this app does not vouch for: the bundled simple browser
+     * puts an arbitrary remote site in an iframe, and previews and notebook
+     * output are built from whatever the workspace holds. The other route to
+     * arming, `AndroidBridge.openExternalUrl`, refuses a caller without the
+     * session token; there is no token to check here, so the frame is what
+     * carries that weight.
+     *
+     * Both routes this hand-off exists to serve navigate the top-level frame, so
+     * nothing real is lost: `MainActivity.injectWindowOpenOverride` patches the
+     * main window's `window.open`, and the workbench opener assigns the main
+     * window's `location`.
+     *
+     * The cost of getting this wrong is not only a forged callback. The record
+     * keeps the most recent 32 launches, one address can carry many ids, and the
+     * oldest goes when it overflows, so a page able to arm at will can push out
+     * the sign-in the user has open in the browser right now.
+     */
+    @Test
+    fun `a sign-in address in a subframe opens no callback window`() {
+        val handled = client.shouldOverrideUrlLoading(
+            view, request("https", "github.com", -1, SIGN_IN, fromMainFrame = false)
+        )
+
+        assertTrue(handled, "a subframe's external link still leaves for a browser")
+        verify(exactly = 1) { context.startActivity(any()) }
+        assertFalse(
+            callbackWouldBeTaken(SIGN_IN_REQUEST_ID),
+            "a frame this app does not vouch for chose which vscodroid://callback the app " +
+                "will accept. The filter is exported and BROWSABLE, so that is a sign-in " +
+                "the user never started being taken from whatever is on the device.",
         )
     }
 

--- a/android/app/src/test/kotlin/com/vscodroid/webview/ExternalUrlHandoffTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/ExternalUrlHandoffTest.kt
@@ -3,8 +3,12 @@ package com.vscodroid.webview
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.os.SystemClock
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
+import com.vscodroid.authCallbackIsExpected
+import com.vscodroid.bridge.AUTH_TAB_WINDOW_MILLIS
+import com.vscodroid.bridge.AuthTabWindow
 import com.vscodroid.util.Logger
 import io.mockk.Runs
 import io.mockk.every
@@ -12,7 +16,9 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkConstructor
 import io.mockk.mockkObject
+import io.mockk.mockkStatic
 import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -64,14 +70,68 @@ class ExternalUrlHandoffTest {
     private lateinit var view: WebView
     private lateinit var client: VSCodroidWebViewClient
 
-    private fun request(scheme: String, host: String, port: Int): WebResourceRequest {
+    private companion object {
+        /**
+         * An https sign-in address carrying the request id the workbench minted
+         * for the callback it is waiting on. The id travels inside `state`,
+         * percent-encoded twice, which is the ordinary shape: the callback
+         * address is a parameter of the authorisation address.
+         */
+        const val SIGN_IN =
+            "https://github.com/login/oauth/authorize?client_id=abc" +
+                "&state=http%253A%252F%252F127.0.0.1%253A13337%252Fcallback%253Fvscode-reqid%253D909"
+
+        /** The id [SIGN_IN] carries. */
+        const val SIGN_IN_REQUEST_ID = "909"
+
+        /** A neighbouring id nothing here launched, and the one that must stay refused. */
+        const val UNSOLICITED_REQUEST_ID = "910"
+
+        /** A link with no sign-in in it, which must open no window at all. */
+        const val DOCS = "https://code.visualstudio.com/docs"
+
+        /**
+         * The clock reading every launch below is armed with. Distinctive so that
+         * [AuthTabWindow.armedReadings] can be asked whether a launch recorded
+         * anything at all, whatever key it might have chosen.
+         */
+        const val LAUNCHED_AT = 1_700_111L
+    }
+
+    private fun request(
+        scheme: String, host: String, port: Int, address: String = ""
+    ): WebResourceRequest {
         val uri = mockk<Uri>(relaxed = true)
         every { uri.scheme } returns scheme
         every { uri.host } returns host
         every { uri.port } returns port
+        // Read by `authRequestIdsIn`, and a relaxed mock's own `toString` names
+        // the mock rather than an address, so a case about request ids has to
+        // say what the address is. Empty elsewhere: no id, nothing armed.
+        every { uri.toString() } returns address
         val req = mockk<WebResourceRequest>(relaxed = true)
         every { req.url } returns uri
         return req
+    }
+
+    /**
+     * The decision `MainActivity.receiveCallbackIntent` makes about an arriving
+     * `vscodroid://callback`, in the two steps it makes it in: a request this app
+     * never launched has no reading, and a reading has to be inside the window.
+     */
+    private fun callbackWouldBeTaken(requestId: String): Boolean {
+        val armedAt = AuthTabWindow.armedAt(requestId) ?: return false
+        return authCallbackIsExpected(armedAt, LAUNCHED_AT, AUTH_TAB_WINDOW_MILLIS)
+    }
+
+    /**
+     * [AuthTabWindow] is an object and this suite runs in one JVM, so what these
+     * cases write through the real API outlives them. mockk's cleanup covers
+     * mocks, not that.
+     */
+    @AfterEach
+    fun handBackArmedRequests() {
+        AuthTabWindow.disarm(listOf(SIGN_IN_REQUEST_ID, UNSOLICITED_REQUEST_ID))
     }
 
     @BeforeEach
@@ -83,6 +143,12 @@ class ExternalUrlHandoffTest {
 
         mockkConstructor(Intent::class)
         every { anyConstructed<Intent>().addFlags(any()) } returns mockk(relaxed = true)
+
+        // The hand-off records the sign-in it is carrying, and reads the clock to
+        // do it. android.jar's stub throws, which the catch below would turn into
+        // a launch that never happened, so every case here needs it answered.
+        mockkStatic(SystemClock::class)
+        every { SystemClock.elapsedRealtime() } returns LAUNCHED_AT
 
         context = mockk(relaxed = true)
         view = mockk(relaxed = true)
@@ -137,5 +203,85 @@ class ExternalUrlHandoffTest {
         val handled = client.shouldOverrideUrlLoading(view, request("intent", "scan", -1))
         verify(exactly = 1) { context.startActivity(any()) }
         assertTrue(handled)
+    }
+
+    /**
+     * A sign-in that leaves through this route can come back.
+     *
+     * The bridge is the route the workbench normally takes, and it records the
+     * launch. This one is the fallback underneath it, reached when the page
+     * holds no session token yet, when the bridge reports no launch, and when a
+     * subframe calls `window.open`, which this WebView turns into a navigation
+     * because it does not support multiple windows. It recorded nothing, so the
+     * `vscodroid://callback` that came back was judged against a window nobody
+     * had opened and refused in the log, with no message anywhere: the sign-in
+     * simply never completed.
+     *
+     * Asserted on the acceptance decision itself rather than on the arming call,
+     * because the arming is only interesting for what it lets back in.
+     */
+    @Test
+    fun `a sign-in handed over here is a callback this app then accepts`() {
+        val handled = client.shouldOverrideUrlLoading(
+            view, request("https", "github.com", -1, SIGN_IN)
+        )
+
+        assertTrue(handled, "the address has to leave the WebView for a browser at all")
+        verify(exactly = 1) { context.startActivity(any()) }
+
+        assertTrue(
+            callbackWouldBeTaken(SIGN_IN_REQUEST_ID),
+            "the callback for the sign-in this hand-off carried must be accepted when it " +
+                "returns; refusing it is a sign-in that hangs with nothing said",
+        )
+        assertFalse(
+            callbackWouldBeTaken(UNSOLICITED_REQUEST_ID),
+            "only the request the address carried may be accepted. The callback filter is " +
+                "exported and BROWSABLE and the id is a small integer, so a hand-off that " +
+                "opened the relay to anything else opens it to whatever is on the device.",
+        )
+    }
+
+    /**
+     * A hand-off that no activity took must not leave the relay open behind it.
+     *
+     * The record is written before the launch, because the launch hands off to
+     * another process. So a launch that then threw has already opened the window
+     * for the ids it named, and for the next ten minutes any app on the device
+     * can post a `vscodroid://callback` naming one of them, through an exported
+     * BROWSABLE filter, for a sign-in that never started.
+     */
+    @Test
+    fun `a hand-off that no activity took leaves nothing armed`() {
+        every { context.startActivity(any()) } throws IllegalStateException("no activity took it")
+
+        client.shouldOverrideUrlLoading(view, request("https", "github.com", -1, SIGN_IN))
+
+        assertFalse(
+            callbackWouldBeTaken(SIGN_IN_REQUEST_ID),
+            "a launch that failed left the callback window armed for a sign-in that never " +
+                "started, and nothing on the way back can tell the difference",
+        )
+    }
+
+    /**
+     * The other half, and the one that keeps this from being a widening: every
+     * external link goes through here, and a link to documentation must not put
+     * the callback relay within reach of an id nobody asked for.
+     *
+     * Measured on the readings rather than on a key, so a hand-off that recorded
+     * the fact of a launch under any name at all is caught.
+     */
+    @Test
+    fun `a link carrying no sign-in opens no callback window`() {
+        client.shouldOverrideUrlLoading(view, request("https", "code.visualstudio.com", -1, DOCS))
+
+        verify(exactly = 1) { context.startActivity(any()) }
+        assertFalse(
+            AuthTabWindow.armedReadings().contains(LAUNCHED_AT),
+            "following a documentation link recorded a launch. Every external link in the " +
+                "editor arrives here, so recording them all reopens the window an unsolicited " +
+                "vscodroid://callback is taken in.",
+        )
     }
 }


### PR DESCRIPTION
A browser launch records the request ids the address carries, so the `vscodroid://callback` coming back can be matched against the sign-in that asked for it (`AndroidBridge.openExternalUrl`, `AuthTabWindow.arm`). Only one of the app's two ways out to a browser did that.

`VSCodroidWebViewClient.shouldOverrideUrlLoading` launches a browser as well, and it is the route a sign-in takes when the page holds no session token yet, when the bridge reports no launch, and when the workbench's own opener assigns `location.href` for a scheme that is not http or https. A sign-in leaving that way was refused on return in the log and nowhere else, so it hung with no message.

Changes:

- `shouldOverrideUrlLoading` arms the callback window on the request ids read out of the address, before the launch, and takes them back when the launch throws. A link carrying no request arms nothing.
- The arming is restricted to main-frame navigations. This callback also receives subframe navigations, and those frames render content the app does not vouch for, including the remote site the bundled simple browser displays. Both routes above navigate the top-level frame, so nothing a sign-in needs is lost.
- `ExternalUrlHandoffTest` gains four cases asserting the acceptance decision rather than the call: the solicited callback is accepted while a neighbouring id is refused, a failed launch leaves nothing armed, a subframe carrying a sign-in address arms nothing, and a link whose only number is not a request id records no launch.

Who can cause an arming is worth stating plainly: the bridge route requires the session token, this route requires a navigation of our own top-level page, and neither accepts a callback for an id no launch named.

Verified with the full unit suite (994 tests) and `lintDebug`, and by reverting each behaviour and confirming the matching case goes red.