### PR TITLE
feat(keyboard): add function and navigation keys to the key row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The privacy policy no longer claims Microsoft's telemetry code was removed. It is disabled and given nowhere to report to, which is the accurate and stronger statement.
 - The published privacy page carries the project's trademark notice, and the store listing no longer opens with a Microsoft trademark and carries the disclaimer in full.
 - The key row guide now matches the app. It listed a plus key that has never existed and covered none of the trackpad, the extra pages or the long-press alternates.
+- The guide, README and PRD no longer promise first-run extraction in 5-10 seconds. It unpacks roughly 875 MB, and nothing had ever measured it.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Every release carries a manifest of what it was built from: editor version and commit, plus the version and checksum of each bundled tool.
 - The privacy policy describes Android backup, which copies `~/.vscodroid/data/Machine` to your Google account. SSH keys, tokens, projects and toolchains are excluded by an allowlist.
 - Two checks hold the bridge API documentation to the code: one reads the compiled class for method existence, the other reads source for parameter names, order, nullability and return types.
+- A fourth key row page carrying F1 to F12, Home, End, PgUp and PgDn. None were reachable by touch before, so any shortcut bound to one needed a hardware keyboard.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The privacy policy describes that opening a device folder makes a copy in app storage, which the old text omitted entirely.
 - The privacy policy no longer claims Microsoft's telemetry code was removed. It is disabled and given nowhere to report to, which is the accurate and stronger statement.
 - The published privacy page carries the project's trademark notice, and the store listing no longer opens with a Microsoft trademark and carries the disclaimer in full.
+- The key row guide now matches the app. It listed a plus key that has never existed and covered none of the trackpad, the extra pages or the long-press alternates.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The privacy policy no longer claims Microsoft's telemetry code was removed. It is disabled and given nowhere to report to, which is the accurate and stronger statement.
 - The published privacy page carries the project's trademark notice, and the store listing no longer opens with a Microsoft trademark and carries the disclaimer in full.
 - The key row guide now matches the app. It listed a plus key that has never existed and covered none of the trackpad, the extra pages or the long-press alternates.
-- The guide, README and PRD no longer promise first-run extraction in 5-10 seconds. It unpacks roughly 875 MB, and nothing had ever measured it.
+- The guide, README and PRD no longer promise first-run extraction in 5-10 seconds. It unpacks about 810 MB, and nothing had ever measured how long that takes.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The privacy policy describes that opening a device folder makes a copy in app storage, which the old text omitted entirely.
 - The privacy policy no longer claims Microsoft's telemetry code was removed. It is disabled and given nowhere to report to, which is the accurate and stronger statement.
 - The published privacy page carries the project's trademark notice, and the store listing no longer opens with a Microsoft trademark and carries the disclaimer in full.
-- The key row guide now matches the app. It listed a plus key that has never existed and covered none of the trackpad, the extra pages or the long-press alternates.
+- The key row guide now matches the app: the plus key it listed never existed, and the trackpad, extra pages, long-press alternates and Shift's reach were missing or wrong.
 - The guide, README and PRD no longer promise first-run extraction in 5-10 seconds. It unpacks about 810 MB, and nothing had ever measured how long that takes.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Every release carries a manifest of what it was built from: editor version and commit, plus the version and checksum of each bundled tool.
 - The privacy policy describes Android backup, which copies `~/.vscodroid/data/Machine` to your Google account. SSH keys, tokens, projects and toolchains are excluded by an allowlist.
 - Two checks hold the bridge API documentation to the code: one reads the compiled class for method existence, the other reads source for parameter names, order, nullability and return types.
-- A fourth key row page carrying F1 to F12, Home, End, PgUp and PgDn. None were reachable by touch before, so any shortcut bound to one needed a hardware keyboard.
+- Two more key row pages carry F1 to F12, Home, End, PgUp and PgDn. None were reachable by touch, so a shortcut bound to one needed a hardware keyboard.
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ flowchart TD
 ### Install from Google Play
 
 1. **Install** from [Google Play](https://play.google.com/store/apps/details?id=com.vscodroid).
-2. Open the app. Core binaries extract automatically (~5-10 seconds).
+2. Open the app. Core binaries extract automatically the first time, behind a progress bar.
 3. Pick your languages (Go, Ruby, Java). They install automatically.
 4. Start coding. Editor, terminal, and tools are ready.
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ If you are **ready to learn**, you should be able to **start today**.
 - **Integrated Terminal** — Full bash terminal with real PTY support (vim, tmux, readline all work).
 - **Batteries Included** — Node.js, Python 3, Git, npm, SSH, and essential tools bundled out of the box.
 - **Offline-First** — Code without an internet connection. Everything runs locally on your device.
-- **Mobile-Optimized** — Extra Key Row (Ctrl, Alt, Tab, Esc, F1-F12, symbols, cursor trackpad), touch-friendly UI, clipboard bridge.
+- **Mobile-Optimized**: Extra Key Row (Ctrl, Alt, Tab, Esc, F1-F12, symbols, cursor trackpad), touch-friendly UI, clipboard bridge.
 - **SSH Out of the Box** — Bundled OpenSSH client and `ssh-keygen`, preconfigured with sane defaults (ed25519, keepalive, `accept-new`).
 - **Language Picker** — Select your languages; Go/Ruby/Java install on demand — via Play Asset Delivery on Play installs, or direct download on sideloaded installs.
 - **Dev Server Preview** — Preview a running dev server in an editor tab beside your code, or hand it to the device's browser.

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ If you are **ready to learn**, you should be able to **start today**.
 - **Integrated Terminal** — Full bash terminal with real PTY support (vim, tmux, readline all work).
 - **Batteries Included** — Node.js, Python 3, Git, npm, SSH, and essential tools bundled out of the box.
 - **Offline-First** — Code without an internet connection. Everything runs locally on your device.
-- **Mobile-Optimized** — Extra Key Row (Ctrl, Alt, Tab, Esc, arrows), touch-friendly UI, clipboard bridge.
+- **Mobile-Optimized** — Extra Key Row (Ctrl, Alt, Tab, Esc, F1-F12, symbols, cursor trackpad), touch-friendly UI, clipboard bridge.
 - **SSH Out of the Box** — Bundled OpenSSH client and `ssh-keygen`, preconfigured with sane defaults (ed25519, keepalive, `accept-new`).
 - **Language Picker** — Select your languages; Go/Ruby/Java install on demand — via Play Asset Delivery on Play installs, or direct download on sideloaded installs.
 - **Dev Server Preview** — Preview a running dev server in an editor tab beside your code, or hand it to the device's browser.
@@ -151,7 +151,7 @@ flowchart TD
   subgraph APP["Android App (Kotlin)"]
     WV["WebView"]
     WEB["VS Code Web Client (vscode-web)"]
-    KEY["Extra Key Row [Tab][Esc][Ctrl][Alt]"]
+    KEY["Extra Key Row [Tab][Esc][Ctrl][Alt][F1-F12] + cursor trackpad"]
     NODE["Node.js Process (VS Code Server, vscode-reh, ARM64)"]
     REH["VS Code Server (vscode-reh)"]
     EXT["Extension Host"]

--- a/android/app/src/main/kotlin/com/vscodroid/keyboard/KeyMapping.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/keyboard/KeyMapping.kt
@@ -18,8 +18,8 @@ object KeyMapping {
         "ArrowDown" to KeyDef("ArrowDown", "ArrowDown", 40),
         // Navigation and function keys. Each needs a row of its own here rather
         // than the [getKeyDefOrLetter] fallback, which derives the fields from
-        // the first character: "F2" would be sent as KeyF with keyCode 70 and
-        // type an F, and "Home" as KeyH.
+        // the first character: "F2" would be sent as KeyF with keyCode 70, which
+        // VS Code resolves as the letter F, and "Home" as KeyH.
         "Home" to KeyDef("Home", "Home", 36),
         "End" to KeyDef("End", "End", 35),
         "PageUp" to KeyDef("PageUp", "PageUp", 33),

--- a/android/app/src/main/kotlin/com/vscodroid/keyboard/KeyMapping.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/keyboard/KeyMapping.kt
@@ -16,6 +16,26 @@ object KeyMapping {
         "ArrowUp" to KeyDef("ArrowUp", "ArrowUp", 38),
         "ArrowRight" to KeyDef("ArrowRight", "ArrowRight", 39),
         "ArrowDown" to KeyDef("ArrowDown", "ArrowDown", 40),
+        // Navigation and function keys. Each needs a row of its own here rather
+        // than the [getKeyDefOrLetter] fallback, which derives the fields from
+        // the first character: "F2" would be sent as KeyF with keyCode 70 and
+        // type an F, and "Home" as KeyH.
+        "Home" to KeyDef("Home", "Home", 36),
+        "End" to KeyDef("End", "End", 35),
+        "PageUp" to KeyDef("PageUp", "PageUp", 33),
+        "PageDown" to KeyDef("PageDown", "PageDown", 34),
+        "F1" to KeyDef("F1", "F1", 112),
+        "F2" to KeyDef("F2", "F2", 113),
+        "F3" to KeyDef("F3", "F3", 114),
+        "F4" to KeyDef("F4", "F4", 115),
+        "F5" to KeyDef("F5", "F5", 116),
+        "F6" to KeyDef("F6", "F6", 117),
+        "F7" to KeyDef("F7", "F7", 118),
+        "F8" to KeyDef("F8", "F8", 119),
+        "F9" to KeyDef("F9", "F9", 120),
+        "F10" to KeyDef("F10", "F10", 121),
+        "F11" to KeyDef("F11", "F11", 122),
+        "F12" to KeyDef("F12", "F12", 123),
         "{" to KeyDef("{", "BracketLeft", 219, requiresShift = true),
         "}" to KeyDef("}", "BracketRight", 221, requiresShift = true),
         "(" to KeyDef("(", "Digit9", 57, requiresShift = true),

--- a/android/app/src/main/kotlin/com/vscodroid/keyboard/KeyPageAdapter.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/keyboard/KeyPageAdapter.kt
@@ -25,12 +25,16 @@ class KeyPageAdapter(
      *
      * They used to be two values, and the copy here was only ever written in one
      * direction: releasing a modifier reached it, switching one on did not, so it
-     * said "off" for the whole time a modifier was held. Nothing rebinds a page
-     * as the row stands, four pages with `offscreenPageLimit = 1` leaves at
-     * most two detached at a time, and RecyclerView returns a detached page
-     * from its two-entry view cache already bound, so the gap never
-     * surfaced. Enough pages to overflow that cache, or a different limit, turns
-     * it into a Ctrl repainted idle while the next key still arrives as Ctrl+key.
+     * said "off" for the whole time a modifier was held. That stayed invisible
+     * while the row had three pages: `offscreenPageLimit = 1` left at most one
+     * detached, and RecyclerView handed a single detached page back from its
+     * two-entry view cache still bound, so nothing was ever repainted from the
+     * stale copy. Five pages no longer fit that argument. Sitting on page 1
+     * leaves three detached, one more than the view cache holds, so a page
+     * really does go to the pool and come back through [onBindViewHolder].
+     * That is harmless only because this map is now the single answer and the
+     * bind repaints from it; splitting it in two again would show up as a Ctrl
+     * painted idle while the next key still arrives as Ctrl+key.
      */
     private val toggleState = mutableMapOf<String, Boolean>()
 

--- a/android/app/src/main/kotlin/com/vscodroid/keyboard/KeyPageAdapter.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/keyboard/KeyPageAdapter.kt
@@ -26,9 +26,9 @@ class KeyPageAdapter(
      * They used to be two values, and the copy here was only ever written in one
      * direction: releasing a modifier reached it, switching one on did not, so it
      * said "off" for the whole time a modifier was held. Nothing rebinds a page
-     * as the row stands, three pages with `offscreenPageLimit = 1` leaves at
-     * most one detached at a time, and RecyclerView returns a single detached
-     * page from its two-entry view cache already bound, so the gap never
+     * as the row stands, four pages with `offscreenPageLimit = 1` leaves at
+     * most two detached at a time, and RecyclerView returns a detached page
+     * from its two-entry view cache already bound, so the gap never
      * surfaced. Enough pages to overflow that cache, or a different limit, turns
      * it into a Ctrl repainted idle while the next key still arrives as Ctrl+key.
      */

--- a/android/app/src/main/kotlin/com/vscodroid/keyboard/KeyPageConfig.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/keyboard/KeyPageConfig.kt
@@ -58,10 +58,21 @@ object KeyPages {
             KeyItem.Button("#", "#", contentDescription = "Hash"),
             KeyItem.Button("@", "@", contentDescription = "At sign"),
         )),
-        // Page 4: Function and navigation keys. Nothing else on the row reaches
-        // them. No other page carries one, and the trackpad emits arrows only
-        // (TrackpadGesture.accumulate), so any binding on a function key or on
-        // Home, End, PageUp and PageDown wanted a hardware keyboard.
+        // Pages 4 and 5: function and navigation keys. Nothing else on the row
+        // reaches them. No other page carries one, and the trackpad emits arrows
+        // only (TrackpadGesture.accumulate), so any binding on a function key or
+        // on Home, End, PageUp and PageDown wanted a hardware keyboard.
+        //
+        // Sixteen keys are split over two pages of eight rather than crowded
+        // onto one, and eight is a ceiling rather than a preference. Every
+        // button gets LayoutParams(0, MATCH_PARENT, 1f) in KeyPageAdapter, so
+        // LinearLayout measures it with an EXACTLY spec at its share of the row
+        // and ExtraKeyButton's own 48dp minWidth cannot widen it back. Sixteen
+        // on a 360dp portrait row leaves about 18.5dp a key, well under the
+        // 48dp minimum touch target, and four-character labels like PgDn clip
+        // rather than merely shrink. Eight leaves about 41dp, which is what
+        // pages 2 and 3 already carry.
+        // Page 4: F1 to F8
         KeyPage(listOf(
             KeyItem.Button("F1", "F1", contentDescription = "Function key F1"),
             KeyItem.Button("F2", "F2", contentDescription = "Function key F2"),
@@ -71,6 +82,9 @@ object KeyPages {
             KeyItem.Button("F6", "F6", contentDescription = "Function key F6"),
             KeyItem.Button("F7", "F7", contentDescription = "Function key F7"),
             KeyItem.Button("F8", "F8", contentDescription = "Function key F8"),
+        )),
+        // Page 5: F9 to F12 and the four navigation keys
+        KeyPage(listOf(
             KeyItem.Button("F9", "F9", contentDescription = "Function key F9"),
             KeyItem.Button("F10", "F10", contentDescription = "Function key F10"),
             KeyItem.Button("F11", "F11", contentDescription = "Function key F11"),

--- a/android/app/src/main/kotlin/com/vscodroid/keyboard/KeyPageConfig.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/keyboard/KeyPageConfig.kt
@@ -58,5 +58,27 @@ object KeyPages {
             KeyItem.Button("#", "#", contentDescription = "Hash"),
             KeyItem.Button("@", "@", contentDescription = "At sign"),
         )),
+        // Page 4: Function and navigation keys. Nothing else on the row reaches
+        // them. No other page carries one, and the trackpad emits arrows only
+        // (TrackpadGesture.accumulate), so any binding on a function key or on
+        // Home, End, PageUp and PageDown wanted a hardware keyboard.
+        KeyPage(listOf(
+            KeyItem.Button("F1", "F1", contentDescription = "Function key F1"),
+            KeyItem.Button("F2", "F2", contentDescription = "Function key F2"),
+            KeyItem.Button("F3", "F3", contentDescription = "Function key F3"),
+            KeyItem.Button("F4", "F4", contentDescription = "Function key F4"),
+            KeyItem.Button("F5", "F5", contentDescription = "Function key F5"),
+            KeyItem.Button("F6", "F6", contentDescription = "Function key F6"),
+            KeyItem.Button("F7", "F7", contentDescription = "Function key F7"),
+            KeyItem.Button("F8", "F8", contentDescription = "Function key F8"),
+            KeyItem.Button("F9", "F9", contentDescription = "Function key F9"),
+            KeyItem.Button("F10", "F10", contentDescription = "Function key F10"),
+            KeyItem.Button("F11", "F11", contentDescription = "Function key F11"),
+            KeyItem.Button("F12", "F12", contentDescription = "Function key F12"),
+            KeyItem.Button("Home", "Home", contentDescription = "Home key"),
+            KeyItem.Button("End", "End", contentDescription = "End key"),
+            KeyItem.Button("PgUp", "PageUp", contentDescription = "Page up"),
+            KeyItem.Button("PgDn", "PageDown", contentDescription = "Page down"),
+        )),
     )
 }

--- a/android/app/src/test/kotlin/com/vscodroid/keyboard/KeyMappingTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/keyboard/KeyMappingTest.kt
@@ -171,6 +171,38 @@ class KeyMappingTest {
     }
 
     @Nested
+    inner class FunctionAndNavigationKeyTest {
+
+        /**
+         * An absent entry is not a dead key. [KeyMapping.getKeyDefOrLetter]
+         * derives the fields from the first character, so a missing "F2" is sent
+         * as `KeyF` with keyCode 70 and types an F into the file, and "Home" is
+         * sent as `KeyH`. Only the real code and keyCode reach a binding.
+         */
+        @ParameterizedTest(name = "F{0} carries its own code and keyCode")
+        @ValueSource(ints = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
+        fun `function keys carry the function key code and keyCode`(n: Int) {
+            val def = KeyMapping.getKeyDef("F$n")
+            assertNotNull(def, "'F$n' has no definition, so it falls back to the letter heuristic")
+            assertEquals("F$n", def!!.code, "'F$n' must carry its own physical code")
+            assertEquals(111 + n, def.keyCode, "F1 to F12 are keyCodes 112 to 123")
+            assertFalse(def.requiresShift, "'F$n' is typed without Shift")
+        }
+
+        @Test
+        fun `navigation keys carry their own code and keyCode`() {
+            val expected = mapOf("Home" to 36, "End" to 35, "PageUp" to 33, "PageDown" to 34)
+            for ((key, keyCode) in expected) {
+                val def = KeyMapping.getKeyDef(key)
+                assertNotNull(def, "'$key' has no definition, so it falls back to the letter heuristic")
+                assertEquals(key, def!!.code, "'$key' must carry its own physical code")
+                assertEquals(keyCode, def.keyCode, "'$key' has one keyCode and it is not negotiable")
+                assertFalse(def.requiresShift, "'$key' is typed without Shift")
+            }
+        }
+    }
+
+    @Nested
     inner class PunctuationCoverageTest {
 
         /**
@@ -242,6 +274,8 @@ class KeyMappingTest {
             val entries = Regex(":\\[").findAll(lookup).count()
             val known = listOf(
                 "Tab", "Escape", "ArrowLeft", "ArrowUp", "ArrowRight", "ArrowDown",
+                "Home", "End", "PageUp", "PageDown",
+                "F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8", "F9", "F10", "F11", "F12",
                 "{", "}", "(", ")", ";", ":", "\"", "/", "[", "]", "|", "\\", "~", "`",
                 "'", "=", "!", "#", "@", "&", "_", "<", ">", ",", ".", "-", "+", "*",
                 "%", "?", "^", "$", "Enter", "Backspace", " "

--- a/android/app/src/test/kotlin/com/vscodroid/keyboard/KeyMappingTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/keyboard/KeyMappingTest.kt
@@ -176,15 +176,21 @@ class KeyMappingTest {
         /**
          * An absent entry is not a dead key. [KeyMapping.getKeyDefOrLetter]
          * derives the fields from the first character, so a missing "F2" is sent
-         * as `KeyF` with keyCode 70 and types an F into the file, and "Home" is
-         * sent as `KeyH`. Only the real code and keyCode reach a binding.
+         * as `KeyF` with keyCode 70, which VS Code resolves as the letter F, and
+         * "Home" is sent as `KeyH`.
+         *
+         * All three fields are pinned. `keyCode` is what a keybinding resolves
+         * through, `code` names the physical key, and `key` is what anything
+         * reading `event.key` sees, so a typo in one of them is wrong in a way
+         * the other two cannot report.
          */
-        @ParameterizedTest(name = "F{0} carries its own code and keyCode")
+        @ParameterizedTest(name = "F{0} carries its own key, code and keyCode")
         @ValueSource(ints = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
         fun `function keys carry the function key code and keyCode`(n: Int) {
             val def = KeyMapping.getKeyDef("F$n")
             assertNotNull(def, "'F$n' has no definition, so it falls back to the letter heuristic")
-            assertEquals("F$n", def!!.code, "'F$n' must carry its own physical code")
+            assertEquals("F$n", def!!.key, "'F$n' must report itself as F$n to event.key")
+            assertEquals("F$n", def.code, "'F$n' must carry its own physical code")
             assertEquals(111 + n, def.keyCode, "F1 to F12 are keyCodes 112 to 123")
             assertFalse(def.requiresShift, "'F$n' is typed without Shift")
         }
@@ -195,7 +201,8 @@ class KeyMappingTest {
             for ((key, keyCode) in expected) {
                 val def = KeyMapping.getKeyDef(key)
                 assertNotNull(def, "'$key' has no definition, so it falls back to the letter heuristic")
-                assertEquals(key, def!!.code, "'$key' must carry its own physical code")
+                assertEquals(key, def!!.key, "'$key' must report itself as $key to event.key")
+                assertEquals(key, def.code, "'$key' must carry its own physical code")
                 assertEquals(keyCode, def.keyCode, "'$key' has one keyCode and it is not negotiable")
                 assertFalse(def.requiresShift, "'$key' is typed without Shift")
             }

--- a/android/app/src/test/kotlin/com/vscodroid/keyboard/KeyPageConfigTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/keyboard/KeyPageConfigTest.kt
@@ -100,20 +100,30 @@ class KeyPageConfigTest {
     }
 
     @Nested
-    inner class Page4Test {
+    inner class FunctionAndNavigationPageTest {
 
-        private val page = KeyPages.defaults[3]
+        // Pinned as whole ordered lists rather than searched for a few members.
+        // These two pages are the only route to any of these keys, so one
+        // dropped entry is a shortcut that cannot be typed at all on a
+        // touchscreen.
 
         @Test
-        fun `carries every function key and the four navigation keys`() {
-            val buttons = page.items.filterIsInstance<KeyItem.Button>()
-            // Pinned as a whole list rather than searched for a few members.
-            // This page is the only route to any of these keys, so one dropped
-            // entry is a shortcut that cannot be typed at all on a touchscreen.
+        fun `page 4 carries F1 to F8`() {
+            val buttons = KeyPages.defaults[3].items.filterIsInstance<KeyItem.Button>()
             assertEquals(
-                (1..12).map { "F$it" } + listOf("Home", "End", "PageUp", "PageDown"),
+                (1..8).map { "F$it" },
                 buttons.map { it.value },
-                "Page 4 carries F1 to F12 then Home, End and the two page keys"
+                "Page 4 carries F1 to F8 in order"
+            )
+        }
+
+        @Test
+        fun `page 5 carries F9 to F12 and the four navigation keys`() {
+            val buttons = KeyPages.defaults[4].items.filterIsInstance<KeyItem.Button>()
+            assertEquals(
+                (9..12).map { "F$it" } + listOf("Home", "End", "PageUp", "PageDown"),
+                buttons.map { it.value },
+                "Page 5 carries F9 to F12 then Home, End and the two page keys"
             )
         }
     }
@@ -139,6 +149,34 @@ class KeyPageConfigTest {
                     KeyMapping.getKeyDef(value),
                     "'$value' is on the key row with no KeyMapping entry, so it is sent " +
                         "as whatever letter its first character names"
+                )
+            }
+        }
+
+        @Test
+        fun `no page divides the row more finely than page 1 already does`() {
+            // KeyPageAdapter gives every button LayoutParams(0, MATCH_PARENT,
+            // 1f) and the trackpad 1.5f, so LinearLayout measures each child
+            // with an EXACTLY spec at its share of the row and
+            // ExtraKeyButton's own 48dp minWidth cannot widen it back. Page 1
+            // is the densest today at 8.5 weight units, roughly 41dp a unit on
+            // a 360dp portrait row. Sixteen keys on one page works out at
+            // 18.5dp, under Android's 48dp minimum touch target, and
+            // four-character labels such as PgDn clip rather than shrink.
+            // Weights are counted in tenths to keep the arithmetic exact.
+            for ((pageIndex, page) in KeyPages.defaults.withIndex()) {
+                val tenths = page.items.sumOf { item ->
+                    val weight: Int = when (item) {
+                        is KeyItem.Button -> 10
+                        is KeyItem.GesturePad -> 15
+                    }
+                    weight
+                }
+                assertTrue(
+                    tenths <= 85,
+                    "Page ${pageIndex + 1} claims ${tenths / 10.0} weight units. The row is " +
+                        "divided exactly, so past 8.5 every key on the page gets narrower " +
+                        "than page 1 already makes them; split the page instead"
                 )
             }
         }

--- a/android/app/src/test/kotlin/com/vscodroid/keyboard/KeyPageConfigTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/keyboard/KeyPageConfigTest.kt
@@ -136,9 +136,9 @@ class KeyPageConfigTest {
             // A key the table does not name is not a dead key. KeyInjector
             // resolves through KeyMapping.getKeyDefOrLetter, which derives the
             // event fields from the first character, so an unmapped "F2" is sent
-            // as KeyF with keyCode 70 and types an F into the file. The three
-            // modifiers never reach the injector; ExtraKeyRow.handleKeyAction
-            // consumes them itself.
+            // as KeyF with keyCode 70 and VS Code resolves it as the letter F.
+            // The three modifiers never reach the injector;
+            // ExtraKeyRow.handleKeyAction consumes them itself.
             val modifiers = setOf("Ctrl", "Alt", "Shift")
             val sent = KeyPages.defaults.flatMap { it.items }
                 .filterIsInstance<KeyItem.Button>()

--- a/android/app/src/test/kotlin/com/vscodroid/keyboard/KeyPageConfigTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/keyboard/KeyPageConfigTest.kt
@@ -100,7 +100,48 @@ class KeyPageConfigTest {
     }
 
     @Nested
+    inner class Page4Test {
+
+        private val page = KeyPages.defaults[3]
+
+        @Test
+        fun `carries every function key and the four navigation keys`() {
+            val buttons = page.items.filterIsInstance<KeyItem.Button>()
+            // Pinned as a whole list rather than searched for a few members.
+            // This page is the only route to any of these keys, so one dropped
+            // entry is a shortcut that cannot be typed at all on a touchscreen.
+            assertEquals(
+                (1..12).map { "F$it" } + listOf("Home", "End", "PageUp", "PageDown"),
+                buttons.map { it.value },
+                "Page 4 carries F1 to F12 then Home, End and the two page keys"
+            )
+        }
+    }
+
+    @Nested
     inner class ButtonIntegrityTest {
+
+        @Test
+        fun `every key the row sends has a definition of its own`() {
+            // A key the table does not name is not a dead key. KeyInjector
+            // resolves through KeyMapping.getKeyDefOrLetter, which derives the
+            // event fields from the first character, so an unmapped "F2" is sent
+            // as KeyF with keyCode 70 and types an F into the file. The three
+            // modifiers never reach the injector; ExtraKeyRow.handleKeyAction
+            // consumes them itself.
+            val modifiers = setOf("Ctrl", "Alt", "Shift")
+            val sent = KeyPages.defaults.flatMap { it.items }
+                .filterIsInstance<KeyItem.Button>()
+                .flatMap { button -> listOf(button.value) + button.alternates.map { it.value } }
+                .filterNot { it in modifiers }
+            for (value in sent) {
+                assertNotNull(
+                    KeyMapping.getKeyDef(value),
+                    "'$value' is on the key row with no KeyMapping entry, so it is sent " +
+                        "as whatever letter its first character names"
+                )
+            }
+        }
 
         @Test
         fun `every button has non-empty label and value`() {
@@ -125,7 +166,7 @@ class KeyPageConfigTest {
             //
             // What can fail is taking that default. A screen reader then reads the
             // symbol -- "{}" instead of "Curly braces" -- which is exactly the case
-            // these strings exist for. All 23 buttons name themselves today, so a
+            // these strings exist for. All 39 buttons name themselves today, so a
             // description equal to its label means one was dropped.
             for ((pageIndex, page) in KeyPages.defaults.withIndex()) {
                 for (item in page.items) {

--- a/docs/01-PRD.md
+++ b/docs/01-PRD.md
@@ -120,7 +120,7 @@ Developers increasingly work across multiple devices, yet Android — the world'
 
 | Feature | Description | Milestone |
 |---------|-------------|-----------|
-| Extra Key Row | Tab, Esc, Ctrl, Alt, arrows, brackets above soft keyboard | M2 |
+| Extra Key Row | Tab, Esc, Ctrl, Alt, F1-F12, symbols and a cursor trackpad above soft keyboard | M2 |
 | Clipboard Bridge | Copy/paste between VSCodroid and other Android apps | M2 |
 | Keyboard Handling | Proper viewport resize, cursor scroll-into-view | M2 |
 | Touch Optimization | Long-press, context menu, scroll behavior | M2 |

--- a/docs/01-PRD.md
+++ b/docs/01-PRD.md
@@ -157,7 +157,7 @@ Developers increasingly work across multiple devices, yet Android — the world'
 ```mermaid
 flowchart TD
   A["Install from Play Store"] --> B["Open App"]
-  B --> C["Splash Screen: Setting up VSCodroid<br/>Extract binaries (~5-10s)<br/>Initialize workspace directory"]
+  B --> C["Splash Screen: Setting up VSCodroid<br/>Extract binaries<br/>Initialize workspace directory"]
   C --> D["Language Picker<br/>What do you code in? [Go] [Rust] [Java] [C/C++] [Ruby] [Skip]<br/>Selected toolchains download via Play Store"]
   D --> E["Welcome Tab<br/>Quick actions: Open Folder, Clone Repo, New File<br/>Tools ready: node, python, git + selected toolchains"]
   E --> F["Start Coding"]

--- a/docs/10-RELEASE_PLAN.md
+++ b/docs/10-RELEASE_PLAN.md
@@ -236,7 +236,7 @@ Features:
 • A real editor — syntax highlighting, IntelliSense, multi-cursor
 • Extension support: install themes, linters and language support from Open VSX
 • Integrated terminal with Node.js, Python and Git pre-installed
-• Extra Key Row for Ctrl, Alt, Tab, Esc and arrow keys
+• Extra Key Row: Ctrl, Alt, Tab, Esc, F1-F12, symbols and a cursor trackpad
 • Offline-first — code without internet
 • Open folders from your device storage, including SD cards and cloud providers
 • Portrait, landscape and split-screen support

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -82,7 +82,7 @@ To edit settings as JSON, use the Command Palette: `Preferences: Open User Setti
 ### Extra Key Row
 
 When the soft keyboard is visible, a row of extra keys appears above it. The row
-holds four pages. Swipe it left or right to change page; the dots underneath show
+holds five pages. Swipe it left or right to change page; the dots underneath show
 which page you are on.
 
 **Page 1, essential coding keys:**
@@ -105,10 +105,17 @@ you and leaves the cursor between the two.
 
 **Page 3, brackets and operators:** `[` `]` `<` `>` `=` `!` `#` `@`
 
-**Page 4, function and navigation keys:** `F1` through `F12`, `Home`, `End`,
-`PgUp`, `PgDn`. This is the only place a touch user can reach them: no other page
-carries a function key, and the trackpad sends arrows only. Any shortcut the
-editor or an extension binds to one is now a tap away.
+**Page 4, function keys:** `F1` through `F8`
+
+**Page 5, the rest of the function keys and navigation:** `F9` through `F12`,
+`Home`, `End`, `PgUp`, `PgDn`
+
+Pages 4 and 5 are the only place a touch user can reach any of those keys: no
+other page carries a function key, and the trackpad sends arrows only. Any
+shortcut the editor or an extension binds to one is now a tap away. They are
+split over two pages rather than crowded onto one because the row divides its
+width evenly among whatever a page holds, and sixteen keys on one page would put
+every one of them below the size a finger can reliably hit.
 
 #### The trackpad
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -24,7 +24,7 @@ A practical guide to using VSCodroid -- the full VS Code IDE running natively on
 ### What Happens on First Open
 
 1. **Install**. Download from the [Play Store](#) or [GitHub Releases](https://github.com/rmyndharis/VSCodroid/releases). The core download is approximately 135 MB, and you need about 875 MB free for the extraction that follows.
-2. **Binary extraction** -- On first launch, VSCodroid extracts bundled tools (Node.js, Python, Git, Bash, and others) to internal storage. This takes 5-10 seconds and only happens once.
+2. **Binary extraction** -- On first launch, VSCodroid extracts bundled tools (Node.js, Python, Git, Bash, and others) to internal storage. That is the same ~875 MB named above, unpacked one file at a time behind a progress bar, so allow minutes rather than seconds on a slower device. It only happens once.
 3. **Language Picker** -- A prompt asks "What do you code in?" with options for Go, Ruby, and Java. This is the only time you are *asked*, but not your only chance to choose: touch and hold the app icon and pick **Manage toolchains** to add or remove them later. Whatever you select downloads there on the setup screen, one at a time; a download that fails is skipped and the rest continue. Skip goes straight to the editor.
 4. **Ready** -- The VS Code editor loads with terminal, file explorer, and all bundled tools available immediately.
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -93,7 +93,7 @@ which page you are on.
 | **Esc** | Close menus, cancel operations |
 | **Ctrl** | Modifier for shortcuts (Ctrl+S, Ctrl+Z, etc.) |
 | **Alt** | Modifier for shortcuts (Alt+Up/Down to move lines) |
-| **Shift** | Modifier for selections and for the row's own keys (Shift+Tab, Shift+F12) |
+| **Shift** | Modifier for selections, for the row's own keys (Shift+Tab, Shift+F12), and for Ctrl or Alt chords typed on the soft keyboard (Ctrl+Shift+P) |
 | **trackpad** | The wide pad. Drag to move the cursor; see below |
 | **{}** | Opening curly brace |
 | **()** | Opening parenthesis |
@@ -152,8 +152,9 @@ long hold, the same press a tap sends. Nothing on this row repeats.
 Three things behave differently from "the next keypress". Shift stays held for a
 whole trackpad drag, so dragging with Shift on selects text rather than moving
 the cursor once. All three clear by themselves when the soft keyboard hides. And
-Shift on this row does not reach the soft keyboard: it applies to the row's own
-keys, so for a capital letter hold the soft keyboard's own Shift instead.
+Shift on its own is not applied to what you type on the soft keyboard, so for a
+capital letter hold the soft keyboard's own Shift; latch Ctrl or Alt as well and
+the row's Shift is carried into that chord, which is how Ctrl+Shift+P is typed.
 
 The keys on each page are defined in
 `android/app/src/main/kotlin/com/vscodroid/keyboard/KeyPageConfig.kt`, and the

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -24,7 +24,7 @@ A practical guide to using VSCodroid -- the full VS Code IDE running natively on
 ### What Happens on First Open
 
 1. **Install**. Download from the [Play Store](#) or [GitHub Releases](https://github.com/rmyndharis/VSCodroid/releases). The core download is approximately 135 MB, and you need about 875 MB free for the extraction that follows.
-2. **Binary extraction** -- On first launch, VSCodroid extracts bundled tools (Node.js, Python, Git, Bash, and others) to internal storage. That is the same ~875 MB named above, unpacked one file at a time behind a progress bar, so allow minutes rather than seconds on a slower device. It only happens once.
+2. **Binary extraction** -- On first launch, VSCodroid extracts bundled tools (Node.js, Python, Git, Bash, and others) to internal storage. About 810 MB lands on disk, unpacked one file at a time behind a progress bar, so allow minutes rather than seconds on a slower device. The ~875 MB above is that payload plus the working room setup insists on before it will start. It only happens once.
 3. **Language Picker** -- A prompt asks "What do you code in?" with options for Go, Ruby, and Java. This is the only time you are *asked*, but not your only chance to choose: touch and hold the app icon and pick **Manage toolchains** to add or remove them later. Whatever you select downloads there on the setup screen, one at a time; a download that fails is skipped and the rest continue. Skip goes straight to the editor.
 4. **Ready** -- The VS Code editor loads with terminal, file explorer, and all bundled tools available immediately.
 
@@ -93,7 +93,7 @@ which page you are on.
 | **Esc** | Close menus, cancel operations |
 | **Ctrl** | Modifier for shortcuts (Ctrl+S, Ctrl+Z, etc.) |
 | **Alt** | Modifier for shortcuts (Alt+Up/Down to move lines) |
-| **Shift** | Modifier for selections and uppercase |
+| **Shift** | Modifier for selections and for the row's own keys (Shift+Tab, Shift+F12) |
 | **trackpad** | The wide pad. Drag to move the cursor; see below |
 | **{}** | Opening curly brace |
 | **()** | Opening parenthesis |
@@ -149,9 +149,11 @@ long hold, the same press a tap sends. Nothing on this row repeats.
 
 **Ctrl, Alt, and Shift are sticky** -- tap once to activate for the next keypress. Tap again to deactivate. They highlight when active.
 
-Two things behave differently from "the next keypress". Shift stays held for a
+Three things behave differently from "the next keypress". Shift stays held for a
 whole trackpad drag, so dragging with Shift on selects text rather than moving
-the cursor once. And all three clear by themselves when the soft keyboard hides.
+the cursor once. All three clear by themselves when the soft keyboard hides. And
+Shift on this row does not reach the soft keyboard: it applies to the row's own
+keys, so for a capital letter hold the soft keyboard's own Shift instead.
 
 The keys on each page are defined in
 `android/app/src/main/kotlin/com/vscodroid/keyboard/KeyPageConfig.kt`, and the

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -81,7 +81,11 @@ To edit settings as JSON, use the Command Palette: `Preferences: Open User Setti
 
 ### Extra Key Row
 
-When the soft keyboard is visible, a row of extra keys appears above it:
+When the soft keyboard is visible, a row of extra keys appears above it. The row
+holds four pages. Swipe it left or right to change page; the dots underneath show
+which page you are on.
+
+**Page 1, essential coding keys:**
 
 | Key | Purpose |
 |-----|---------|
@@ -90,11 +94,61 @@ When the soft keyboard is visible, a row of extra keys appears above it:
 | **Ctrl** | Modifier for shortcuts (Ctrl+S, Ctrl+Z, etc.) |
 | **Alt** | Modifier for shortcuts (Alt+Up/Down to move lines) |
 | **Shift** | Modifier for selections and uppercase |
-| **+** | Plus sign |
-| **{ }** | Curly braces |
-| **( )** | Parentheses |
+| **trackpad** | The wide pad. Drag to move the cursor; see below |
+| **{}** | Opening curly brace |
+| **()** | Opening parenthesis |
+
+`{}` and `()` insert only the opening character. The editor closes the pair for
+you and leaves the cursor between the two.
+
+**Page 2, common symbols:** `;` `:` `"` `/` `|` `` ` `` `&` `_`
+
+**Page 3, brackets and operators:** `[` `]` `<` `>` `=` `!` `#` `@`
+
+**Page 4, function and navigation keys:** `F1` through `F12`, `Home`, `End`,
+`PgUp`, `PgDn`. This is the only place a touch user can reach them: no other page
+carries a function key, and the trackpad sends arrows only. Any shortcut the
+editor or an extension binds to one is now a tap away.
+
+#### The trackpad
+
+The wide pad on page 1 stands in for the four arrow keys. Drag it and the cursor
+moves. It sends real arrow keys, so it works anywhere an arrow key does, the
+terminal included, and a diagonal drag moves on both axes at once.
+
+It has three gears, and which one you are in depends on how far your finger has
+travelled since the drag began, not on how fast you are moving it. A short drag
+steps character by character. Keep going in the same stroke and the same amount
+of finger travel starts buying more movement, twice over, so one long drag
+crosses lines and then whole screens. Lift your finger and the next drag starts
+in the first gear again.
+
+#### Long press
+
+Touch and hold a key that has alternates and a small popup offers them:
+
+| Key | Alternates |
+|-----|------------|
+| `{}` | `[` and `<` |
+| `()` | `]` and `>` |
+| `"` | `'` and `` ` `` |
+| `/` | `\` |
+| `` ` `` | `~` |
+
+Every other key, Tab, Esc and the three modifiers included, sends one press on a
+long hold, the same press a tap sends. Nothing on this row repeats.
+
+#### Modifiers
 
 **Ctrl, Alt, and Shift are sticky** -- tap once to activate for the next keypress. Tap again to deactivate. They highlight when active.
+
+Two things behave differently from "the next keypress". Shift stays held for a
+whole trackpad drag, so dragging with Shift on selects text rather than moving
+the cursor once. And all three clear by themselves when the soft keyboard hides.
+
+The keys on each page are defined in
+`android/app/src/main/kotlin/com/vscodroid/keyboard/KeyPageConfig.kt`, and the
+trackpad's gears in `TrackpadGesture.kt` beside it.
 
 ### Common Keyboard Shortcuts
 


### PR DESCRIPTION
The extra key row could not reach F1 to F12, Home, End, PageUp or PageDown. No page carried them, and the trackpad emits arrow keys only (`TrackpadGesture.accumulate`), so any binding on one of those keys wanted a hardware keyboard.

Two new pages carry all sixteen, eight each. Eight is a ceiling rather than a preference: `KeyPageAdapter` gives every button `LayoutParams(0, MATCH_PARENT, 1f)`, so `LinearLayout` measures it with an EXACTLY spec at its share of the row and `ExtraKeyButton`'s 48dp `minWidth` cannot widen it back. Sixteen on a 360dp portrait row is about 18.5dp a key against a 48dp minimum touch target, with `PgDn` clipping rather than shrinking. A test now refuses any page that divides the row more finely than page 1 already does.

Each key also gets a row in `KeyMapping`, which is mandatory rather than tidy: `getKeyDefOrLetter` derives the event fields from the first character for anything missing, so an unmapped `F2` would arrive as `KeyF` with keyCode 70 and VS Code would resolve it as the letter F. All three fields are pinned per key, `key` included, since that is what anything reading `event.key` sees.

The guide is corrected alongside, because it described a different row: a plus key that has never been in `KeyPageConfig`, no trackpad, no pages, no long-press alternates, and Shift as the uppercase modifier when the `beforeinput` interceptor deliberately leaves Shift to the soft keyboard. The store description draft and the PRD still promised arrow-key buttons. First-run extraction unpacks about 810 MB; the 875 MB quoted beside it is that payload plus the gate's headroom.

Verified with the full unit suite (1007 tests, zero failures) and `./gradlew lint`.