### PR TITLE
fix(monitor): classify language servers by program name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - When the system kills the editor server for memory or the background-process limit, the log says so instead of reporting a clean exit.
 - The editor's memory ceiling is sized from the device. A fixed limit left 3-4 GB phones being killed repeatedly while larger devices never used what they had.
 - Switching to another app no longer kills your language servers. Android's window-hidden signal numerically outranks its real out-of-memory warning.
+- A script of yours whose name merely contains a language server's, such as `run-eslint.js`, is no longer classed as one and killed under memory pressure.
 - Stopping the app from its notification no longer freezes the screen for several seconds or shows the "isn't responding" dialog.
 
 **Device folders (SAF)**

--- a/android/app/src/main/assets/process-monitor.js
+++ b/android/app/src/main/assets/process-monitor.js
@@ -37,11 +37,32 @@ const PRESSURE_FILENAME = 'vscodroid-memory-pressure';
 // .cjs extension), while an entry carrying a separator is distinctive enough to
 // be found anywhere in the name. So 'gopls' matches gopls and gopls.js and
 // nothing else, while 'rust-analyzer' still matches rust-analyzer-wrapper.
+//
+// The extension list the bare-word arm allows is Node's, so a bare word can only
+// ever name a Node entry point. A server that launches as anything else, a .py
+// file or a versioned binary, needs an entry carrying a separator so that it
+// takes the substring arm instead. That is why run-jedi-language-server.py has
+// an entry of its own below rather than being left to the bare word inside it.
 const LANG_SERVER_PATTERNS = [
     'tsserver', 'typescript-language-server',
-    'pylsp', 'pyright', 'python-language-server', 'jedi',
+    'pylsp', 'python-language-server',
+    // Both of these launch as a name with the bare pattern on the front, so
+    // neither is reachable from 'pyright' or 'jedi' alone. ms-python runs
+    // python_files/run-jedi-language-server.py through the interpreter, and it
+    // is the default Python server this app writes into settings.json, so it is
+    // the one most likely to be holding a process slot on a stock install;
+    // pyright ships dist/pyright-langserver.js. Hyphens put both on the
+    // substring arm, which is what a .py entry point requires.
+    'pyright', 'pyright-langserver',
+    'jedi', 'jedi-language-server',
     'gopls', 'rust-analyzer', 'clangd',
-    'eslint', 'vscode-eslint',
+    // 'eslintServer' for the server the bundled ESLint extension forks, which
+    // its client names as server/out/eslintServer.js. A bare 'eslint' reaches
+    // the eslint CLI and nothing else now that a bare word has to be the whole
+    // basename, and 'vscode-eslint' reaches nothing at all: that string only
+    // ever appeared in the extension's directory name, which stopped being
+    // compared when classification moved to argument basenames.
+    'eslint', 'eslintServer', 'vscode-eslint',
     // The three bundled with VS Code, named as they actually launch. They were
     // 'css-languageserver', 'html-languageserver' and 'json-languageserver',
     // which match nothing: the processes are cssServerMain.js, htmlServerMain.js

--- a/android/app/src/main/assets/process-monitor.js
+++ b/android/app/src/main/assets/process-monitor.js
@@ -32,6 +32,11 @@ const KILL_ON_PRESSURE = new Set(['critical']);
 // literals and refuses a disagreement in either direction.
 const PRESSURE_FILENAME = 'vscodroid-memory-pressure';
 
+// How an entry matches depends on its shape, which namesProgram() below reads:
+// a bare word has to name the program exactly (optionally with a .js, .mjs or
+// .cjs extension), while an entry carrying a separator is distinctive enough to
+// be found anywhere in the name. So 'gopls' matches gopls and gopls.js and
+// nothing else, while 'rust-analyzer' still matches rust-analyzer-wrapper.
 const LANG_SERVER_PATTERNS = [
     'tsserver', 'typescript-language-server',
     'pylsp', 'pyright', 'python-language-server', 'jedi',
@@ -59,14 +64,14 @@ const LANG_SERVER_PATTERNS = [
     // un-classified the server it names.
     //
     // Both program names in full, rather than the 'tailwind' they share. A bare
-    // 'tailwind' also matches a user's own tailwind.config.js, build-tailwind.js,
-    // or an npx tailwindcss run, and being classified 'langserver' is not cosmetic:
-    // it puts a process into lsCpuTracker and makes it eligible for the idle kill
-    // under memory pressure. Killing a build someone is waiting on is a worse
-    // outcome than failing to reclaim a language server.
+    // 'tailwind' also names a user's own tailwind.js build script, and being
+    // classified 'langserver' is not cosmetic: it puts a process into
+    // lsCpuTracker and makes it eligible for the idle kill under memory
+    // pressure. Killing a build someone is waiting on is a worse outcome than
+    // failing to reclaim a language server.
     //
-    // Two entries because neither contains the other: 'tailwindmodeserver.js' does
-    // not contain 'tailwindserver'.
+    // Two entries because neither names the other: tailwindModeServer.js is not
+    // 'tailwindServer' with an extension on the end.
     //
     // check-langserver-patterns.py cannot see this one: it globs *ServerMain.js
     // under vscode-reh/extensions, and Tailwind is a marketplace extension living
@@ -171,6 +176,27 @@ function readCpuTime(pid) {
 }
 
 /**
+ * Does this argument's basename name the program a pattern describes?
+ *
+ * A bare word does not name a program wherever it appears: 'eslint' is inside
+ * run-eslint.js and eslint.config.js, and 'tsserver' is inside tsserver-log.js,
+ * which reaches this via `--out=/tmp/tsserver-log.js` because every argument is
+ * tested and not only the one the launcher runs. Being classified 'langserver'
+ * is not cosmetic: it puts the process into lsCpuTracker, and five minutes with
+ * no CPU movement then make it a SIGTERM the next time Android reports critical
+ * memory pressure. So a bare word has to be the whole name, give or take the
+ * extension a Node entry point carries.
+ *
+ * Patterns carrying a separator, 'rust-analyzer' and 'cssServerMain.js', are
+ * specific enough that finding one inside a name means what it says, and they
+ * keep the substring test they need.
+ */
+function namesProgram(name, needle) {
+    if (!/^\w+$/.test(needle)) return name.includes(needle);
+    return ['', '.js', '.mjs', '.cjs'].some((ext) => name === needle + ext);
+}
+
+/**
  * Classify a process by its cmdline.
  */
 function classify(cmdline) {
@@ -208,7 +234,7 @@ function classify(cmdline) {
 
     for (const pattern of LANG_SERVER_PATTERNS) {
         const needle = pattern.toLowerCase();
-        if (names.some((name) => name.includes(needle))) return 'langserver';
+        if (names.some((name) => namesProgram(name, needle))) return 'langserver';
     }
 
     // Generic node bootstrap-fork (extension host, search, etc.)

--- a/scripts/check-langserver-patterns.py
+++ b/scripts/check-langserver-patterns.py
@@ -3,12 +3,12 @@
 
     check-langserver-patterns.py <extensions-dir>
 
-process-monitor.js labels a process as a language server by substring-matching
-its command line against a list of patterns, and that list is what decides which
-processes the idle-kill can reclaim. A pattern that matches nothing is invisible
-twice over: the server keeps running, it keeps counting against Android's
-phantom-process budget, and the feature built to manage exactly that never sees
-it.
+process-monitor.js labels a process as a language server by matching the
+basename of each command-line argument against a list of patterns, and that list
+is what decides which processes the idle-kill can reclaim. A pattern that
+matches nothing is invisible twice over: the server keeps running, it keeps
+counting against Android's phantom-process budget, and the feature built to
+manage exactly that never sees it.
 
 That already happened. The list carried 'css-languageserver',
 'html-languageserver' and 'json-languageserver' while the processes VS Code
@@ -29,7 +29,10 @@ lower-cased the command line first and matched against that, so a pattern with a
 capital in it could not match there while matching perfectly here. Every run of
 this script said the three bundled servers were covered, and none of them was.
 Both sides now fold case and both look at the basename, which is the part that
-names the program rather than the directory somebody put it in.
+names the program rather than the directory somebody put it in. Both also split
+the list the same way: a pattern that is a single word has to be the whole
+basename, give or take the extension a Node entry point carries, while a pattern
+carrying a separator is still found anywhere inside it.
 """
 
 import pathlib
@@ -61,6 +64,19 @@ def patterns():
     return re.findall(r"'([^']+)'", src[start:end])
 
 
+def matches(name, pattern):
+    """classify()'s comparison, against one already-lower-cased basename.
+
+    The character class is spelled out rather than written \\w: Python's is
+    unicode-aware and JavaScript's is not, and a helper that accepts a pattern
+    the monitor would reject is this script's whole failure mode.
+    """
+    needle = pattern.lower()
+    if not re.fullmatch(r"[A-Za-z0-9_]+", needle):
+        return needle in name
+    return any(name == needle + ext for ext in ("", ".js", ".mjs", ".cjs"))
+
+
 def main(extensions):
     pats = patterns()
     # An empty list would make every assertion below vacuously true, and this
@@ -82,7 +98,7 @@ def main(extensions):
         # each argument, case-folded. The argument that carries a server is its
         # path, so its basename is what has to match here.
         name = server.name.lower()
-        hit = next((p for p in pats if p.lower() in name), None)
+        hit = next((p for p in pats if matches(name, p)), None)
         if hit:
             print(f"  ok      {server.name} matched by {hit!r}")
         else:

--- a/scripts/check-langserver-patterns.py
+++ b/scripts/check-langserver-patterns.py
@@ -53,6 +53,14 @@ def patterns():
     it looked for. A traceback exits non-zero too, but it tells whoever hits it
     that this script broke rather than that the list moved, which sends them to
     the wrong file.
+
+    Each line is cut at its first `//` before any quoted string is taken from
+    it. The list is heavily commented, and those comments quote the names of
+    patterns that were tried and removed for matching nothing. Reading them as
+    entries turned this script into the thing it exists to prevent: a server
+    could be reported covered by a 'pattern' that lives only in prose, while the
+    monitor classified the same process 'unknown'. No pattern contains `//`, so
+    the cut can only ever remove commentary.
     """
     src = MONITOR.read_text()
     start = src.find("const LANG_SERVER_PATTERNS")
@@ -61,7 +69,18 @@ def patterns():
     end = src.find("];", start)
     if end < 0:
         return []
-    return re.findall(r"'([^']+)'", src[start:end])
+    code = "\n".join(line.split("//", 1)[0] for line in src[start:end].splitlines())
+    found = re.findall(r"'([^']*)'", code)
+    # A pattern is compared against one basename, so whitespace in one means the
+    # cut above stopped working and prose is being read as code again. An empty
+    # one is worse than wrong: the monitor's substring arm accepts '' inside
+    # every name, so one would classify every process a language server. Refuse
+    # the whole list rather than the offending entry, because a partial list
+    # silently narrows what this script checks, which is the failure it is here
+    # to catch.
+    if any(not p or re.search(r"\s", p) for p in found):
+        return []
+    return found
 
 
 def matches(name, pattern):

--- a/scripts/test-process-monitor.js
+++ b/scripts/test-process-monitor.js
@@ -44,6 +44,10 @@ function writeProc(root, pid, argv, { uid = UID, ppid = 1 } = {}) {
 }
 
 const NODE = '/data/data/com.vscodroid/lib/arm64/libnode.so';
+// The interpreter FirstRunSetup writes into settings.json as
+// python.defaultInterpreterPath, which is what ms-python launches its server
+// with. Not every language server is a Node one, and the two rules differ there.
+const PY = '/data/user/0/com.vscodroid/files/usr/bin/python3';
 const REH = '/data/user/0/com.vscodroid/files/server/vscode-reh';
 // Marketplace and bundled-by-us extensions are extracted here, which is a
 // different tree from the editor's own extensions under REH.
@@ -244,6 +248,33 @@ function main() {
         [1015, ['/data/user/0/com.vscodroid/files/usr/bin/gopls', '-mode=stdio'], 'langserver'],
         [1016, [NODE, `${REH}/extensions/node_modules/typescript/lib/tsserver.js`,
             '--useInferredProjectPerProjectRoot'], 'langserver'],
+        // The three servers whose program name carries a bare pattern on the
+        // front rather than being one. They are here because the bare-word rule
+        // above cannot reach them and nothing else would say so: a server that
+        // stops being classified keeps running, keeps its slot against the
+        // 32-process budget, and reads exactly like no server running.
+        //
+        // The first two ship in this APK. The ESLint extension's client forks
+        // server/out/eslintServer.js, and ms-python runs
+        // python_files/run-jedi-language-server.py through the interpreter --
+        // that one on every stock install, because settings.json is written with
+        // python.languageServer set to Jedi.
+        [1017, [NODE, `${EXT}/dbaeumer.vscode-eslint-3.0.34/server/out/eslintServer.js`,
+            '--node-ipc', '--clientProcessId=1'], 'langserver'],
+        [1018, [PY, `${EXT}/ms-python.python-2026.4.0/python_files/run-jedi-language-server.py`],
+            'langserver'],
+        // Not bundled, and the reason the entry for it carries hyphens: pyright
+        // arrives with an extension the user installs.
+        [1019, [NODE, '/data/user/0/com.vscodroid/files/home/projects/node_modules/pyright/dist/pyright-langserver.js',
+            '--stdio'], 'langserver'],
+        // The other direction for two of those entries, so that neither is
+        // satisfied by a rule that matches everything: a user's own script whose
+        // name merely contains the server's, one of them under the very
+        // interpreter that runs the real one.
+        [1020, [PY, '/data/user/0/com.vscodroid/files/home/projects/tools/jedi-scraper.py'],
+            'unknown'],
+        [1021, [NODE, '/data/user/0/com.vscodroid/files/home/projects/site/eslintServer.config.js'],
+            'unknown'],
     ];
     for (const [pid, argv] of cases) {
         writeProc(proc, pid, argv);

--- a/scripts/test-process-monitor.js
+++ b/scripts/test-process-monitor.js
@@ -227,6 +227,23 @@ function main() {
             'unknown'],
         [1012, [NODE, '/data/user/0/com.vscodroid/files/home/projects/build-tailwind.js'],
             'unknown'],
+        // The same specificity question for the patterns that are single words.
+        // These four are one rule read in both directions, and either half alone
+        // passes on the wrong one: a rule that only has to classify gopls is
+        // satisfied by matching every basename containing it, and a rule that
+        // only has to spare run-eslint.js is satisfied by matching nothing.
+        [1013, [NODE, '/data/user/0/com.vscodroid/files/home/projects/site/run-eslint.js'],
+            'unknown'],
+        // The pattern reaches this one through a flag's value, not through the
+        // script being run: every argument is tested, and the basename of
+        // --out=/tmp/tsserver-log.js is tsserver-log.js.
+        [1014, [NODE, '/data/user/0/com.vscodroid/files/home/projects/site/build.js',
+            '--out=/tmp/tsserver-log.js'], 'unknown'],
+        // A server whose program name is the pattern with nothing around it, and
+        // one that is the pattern plus the extension its entry point carries.
+        [1015, ['/data/user/0/com.vscodroid/files/usr/bin/gopls', '-mode=stdio'], 'langserver'],
+        [1016, [NODE, `${REH}/extensions/node_modules/typescript/lib/tsserver.js`,
+            '--useInferredProjectPerProjectRoot'], 'langserver'],
     ];
     for (const [pid, argv] of cases) {
         writeProc(proc, pid, argv);


### PR DESCRIPTION
The process monitor decides what is a language server by testing patterns against the basename of each command-line argument. Half the patterns are ordinary words matched anywhere inside it, so a user's own `run-eslint.js`, and even a path handed to a flag such as `--out=/tmp/tsserver-log.js`, came out `langserver`. That label is not cosmetic: `classify()` returning `langserver` puts the pid into `lsCpuTracker`, and `killIdleLangServers()` SIGTERMs anything there that has moved no CPU for five minutes the next time Android reports critical memory pressure.

- `process-monitor.js`: `namesProgram()` splits the list by pattern shape. A single word must be the whole basename, optionally with `.js`, `.mjs` or `.cjs`; a pattern carrying a separator keeps the substring test that `rust-analyzer` and `cssServerMain.js` need.
- Three entries added for servers whose program name only begins with a bare word: `eslintServer` for the server the bundled ESLint extension forks, `jedi-language-server` for the ms-python server that first-run `settings.json` makes the default, and `pyright-langserver`. The Python one requires a separator rather than preferring one, since the extensions the bare-word arm allows are Node's.
- `scripts/check-langserver-patterns.py`: mirrors that comparison, and now reads array elements instead of every quoted string between the declaration and the closing bracket, so a name appearing only in a comment is no longer reported as coverage.
- `scripts/test-process-monitor.js`: nine fixtures pin the rule in both directions, three of them servers that must stay classified.

The direction of error is what matters: a rule that stops matching is silent, and the server keeps one of Android's 32 process slots. So the true-positive fixtures carry as much weight as the false-positive ones, and the two that ship in this APK are among them.

Verified with all seven JavaScript self-checks, the Python gate against fixture trees in three directions, and the 990-test unit suite.