### PR TITLE
feat(webview): open the device file picker for Explorer uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The Explorer's **Upload...** now opens the device file picker. It was on every folder's menu and hung silently, the only route to import a single file from device storage.
 - **Open Source Licenses**, on the About dialog: the notices now ship inside the app and read offline, so the GPL written offer of source reaches every device holding those binaries.
 - VSCodroid warns when the installed Android System WebView is older than Chrome 105, the version it is tested against. It warns and continues rather than refusing to start, and a version it cannot read is not treated as an old one.
 - **Serve on Network**: lists the ports your dev servers are listening on, shows the address other devices can reach them at, and copies it. Loopback-only servers are called out.

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -621,17 +621,21 @@ class MainActivity : AppCompatActivity() {
      * "Canceled" errors on gallery requests and IndexedDB connections closing.
      *
      * Strategy:
+     * - a device file picker still waiting to be answered: nothing at all,
+     *   whatever the absence
      * - >5 min background with a sign-in in flight: health check instead of the
      *   forced reload
      * - >5 min background: force reload (stale state almost certain)
      * - >1 min background: run JS health check, reload only if broken
      * - <1 min: no action needed (WebSocket survives short pauses)
      *
-     * The first line is the one that is not about staleness at all. Five minutes
-     * in the background is the ordinary shape of a sign-in that needed a second
-     * factor or an organisation's consent screen, so the reload written for a
-     * stale WebSocket was firing precisely when the user came back from one, and
-     * it discards the page the callback has to land in.
+     * Neither of the first two lines is about staleness. Five minutes in the
+     * background is the ordinary shape of a sign-in that needed a second factor
+     * or an organisation's consent screen, so the reload written for a stale
+     * WebSocket was firing precisely when the user came back from one, and it
+     * discards the page the callback has to land in. Browsing device storage for
+     * a file is the same trip through another app, and it ends the same way, with
+     * a result being handed to this page.
      */
     private fun handleResumeFromBackground() {
         val ts = backgroundedAt
@@ -652,7 +656,7 @@ class MainActivity : AppCompatActivity() {
         if (!shouldActOnResume(nodeService?.isServerReady(), ts, serverPort)) return
 
         val bgMs = SystemClock.elapsedRealtime() - ts
-        when (resumeAction(bgMs, signInIsPending())) {
+        when (resumeAction(bgMs, signInIsPending(), fileChooserIsPending())) {
             ResumeAction.RELOAD -> {
                 Logger.i(tag, "Reloading after ${bgMs / 1000}s in background")
                 // reload(), not a rebuilt URL. The WebView URL is the only
@@ -699,6 +703,18 @@ class MainActivity : AppCompatActivity() {
             authCallbackIsExpected(it, now, AUTH_TAB_WINDOW_MILLIS)
         }
     }
+
+    /**
+     * Whether an `<input type=file>` is still waiting for the device picker.
+     *
+     * Asked of the chrome client on the current WebView, which is where
+     * [deliverFileChooserResult] takes the answer, so the two cannot disagree
+     * about which document is owed one. A client that was replaced with its page
+     * reports nothing pending, which is right: there is no selection left to
+     * protect.
+     */
+    private fun fileChooserIsPending(): Boolean =
+        (webView?.webChromeClient as? VSCodroidWebChromeClient)?.hasPendingFileChooser == true
 
     /**
      * Probes the WebView for an IndexedDB connection that did not survive being
@@ -1974,13 +1990,31 @@ internal enum class ResumeAction {
  * safe here: it only reloads when IndexedDB is already unusable, and a page in
  * that state has nothing left to collect a callback with.
  *
+ * [fileChooserPending] outranks both, and gets the stronger answer rather than
+ * the probe. The difference from a sign-in is that the answer is already
+ * arriving: the picker is another app, so the browse *is* the absence, and the
+ * chosen file is handed to this same document moments after this decision. The
+ * probe would not be enough, on two counts. It reloads the page from JS when
+ * IndexedDB is unusable, which discards the selection just as the forced reload
+ * does; and it starts at one minute, where browsing storage for longer than that
+ * is the ordinary case rather than the exotic one.
+ *
+ * The cost is a page left possibly stale, and it is bounded: the answer is being
+ * delivered now, and the next trip through the background judges the page afresh
+ * on its own absence.
+ *
  * An earlier shape of this held the reload for later by putting the caller's
  * backgrounded reading back. That reading is written afresh by `onStop`, which
  * Android always delivers before the next `onStart`, so the restored value was
  * overwritten before its only consumer could read it and the reload was dropped
  * rather than deferred.
  */
-internal fun resumeAction(bgMs: Long, signInPending: Boolean): ResumeAction = when {
+internal fun resumeAction(
+    bgMs: Long,
+    signInPending: Boolean,
+    fileChooserPending: Boolean,
+): ResumeAction = when {
+    fileChooserPending -> ResumeAction.NOTHING
     bgMs > FORCE_RELOAD_THRESHOLD_MS && signInPending -> ResumeAction.PROBE_CONNECTION
     bgMs > FORCE_RELOAD_THRESHOLD_MS -> ResumeAction.RELOAD
     bgMs > HEALTH_CHECK_THRESHOLD_MS -> ResumeAction.PROBE_CONNECTION

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.vscodroid
 
 import android.Manifest
+import android.content.ActivityNotFoundException
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
@@ -174,6 +175,39 @@ class MainActivity : AppCompatActivity() {
         ActivityResultContracts.OpenDocumentTree()
     ) { uri ->
         uri?.let { handleSafFolderSelected(it) }
+    }
+
+    /**
+     * The device file picker behind `<input type=file>`, which is what the
+     * Explorer's `Upload...` command opens.
+     *
+     * Two contracts and not one, because the contract is what decides the
+     * picker's selection mode: offering multi-select to an input that asked for
+     * a single file lets the user choose five and lose four without being told.
+     *
+     * Registered as fields, like every launcher above: `registerForActivityResult`
+     * throws once the Activity is past its own `onCreate`.
+     */
+    private val fileChooserLauncher = registerForActivityResult(
+        ActivityResultContracts.OpenDocument()
+    ) { uri -> deliverFileChooserResult(listOfNotNull(uri)) }
+
+    private val multiFileChooserLauncher = registerForActivityResult(
+        ActivityResultContracts.OpenMultipleDocuments()
+    ) { uris -> deliverFileChooserResult(uris) }
+
+    /**
+     * Routes the picker's answer to the client that asked for it.
+     *
+     * Read back off the WebView rather than held in a field of its own: the
+     * chrome client is replaced together with the view on a renderer crash, and
+     * a result belonging to the page that died must not be handed to the one
+     * that replaced it. A result arriving after the process was recreated finds
+     * no client and is dropped, which is right, because the element waiting for
+     * it went with the old process.
+     */
+    private fun deliverFileChooserResult(uris: List<Uri>) {
+        (webView?.webChromeClient as? VSCodroidWebChromeClient)?.onFileChooserResult(uris)
     }
 
     private val serviceConnection = object : ServiceConnection {
@@ -1103,7 +1137,22 @@ class MainActivity : AppCompatActivity() {
                 injectBridgeToken()
             },
         )
-        wv.webChromeClient = VSCodroidWebChromeClient()
+        wv.webChromeClient = VSCodroidWebChromeClient { allowMultiple ->
+            // "*/*" rather than the input's accept types: the Upload command's
+            // input declares none, and a filter derived from one could only ever
+            // narrow what the user is allowed to import.
+            try {
+                if (allowMultiple) {
+                    multiFileChooserLauncher.launch(arrayOf("*/*"))
+                } else {
+                    fileChooserLauncher.launch(arrayOf("*/*"))
+                }
+                true
+            } catch (e: ActivityNotFoundException) {
+                Logger.w(tag, "No document picker on this device", e)
+                false
+            }
+        }
 
         val keyInjector = KeyInjector(wv)
         extraKeyRow?.keyInjector = keyInjector

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -207,7 +207,15 @@ class MainActivity : AppCompatActivity() {
      * it went with the old process.
      */
     private fun deliverFileChooserResult(uris: List<Uri>) {
-        (webView?.webChromeClient as? VSCodroidWebChromeClient)?.onFileChooserResult(uris)
+        val client = webView?.webChromeClient as? VSCodroidWebChromeClient
+        if (client == null) {
+            // Logged because a selection that goes nowhere looks from the outside
+            // exactly like a picker that never opened, and the two need different
+            // answers from whoever reads the report.
+            Logger.w(tag, "No client left to answer; dropping ${uris.size} selection(s)")
+            return
+        }
+        client.onFileChooserResult(uris)
     }
 
     private val serviceConnection = object : ServiceConnection {

--- a/android/app/src/main/kotlin/com/vscodroid/webview/VSCodroidWebChromeClient.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/webview/VSCodroidWebChromeClient.kt
@@ -72,12 +72,17 @@ class VSCodroidWebChromeClient(
      * Without this override the default client declines, no chooser opens, and
      * the command waits forever with nothing said.
      *
-     * Returning true takes ownership of [filePathCallback], and the platform
-     * requires it to be invoked exactly once. Any path that returns without
-     * invoking it wedges the element for good: the page keeps one request
-     * outstanding, so every later Upload on that document does nothing at all,
-     * and only a reload clears it. That is why the failure paths here answer
-     * with an empty array rather than returning false and walking away.
+     * Returning true takes ownership of [filePathCallback], which must then be
+     * invoked exactly once. Returning true and never invoking it wedges the
+     * element for good: the page keeps one request outstanding, so every later
+     * Upload on that document does nothing at all, and only a reload clears it.
+     * Every path below therefore answers, the failing ones included.
+     *
+     * The pairing to avoid is answering *and* declining: a callback invoked here
+     * on a path that also returns false hands a request back to the framework
+     * that has already been answered. What the framework does with a request
+     * declined without an answer was not measured here, so nothing below leans
+     * on it either way.
      */
     override fun onShowFileChooser(
         webView: WebView,

--- a/android/app/src/main/kotlin/com/vscodroid/webview/VSCodroidWebChromeClient.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/webview/VSCodroidWebChromeClient.kt
@@ -1,12 +1,31 @@
 package com.vscodroid.webview
 
+import android.net.Uri
 import android.webkit.ConsoleMessage
+import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
+import android.webkit.WebView
 import com.vscodroid.util.Logger
 
-class VSCodroidWebChromeClient : WebChromeClient() {
+/**
+ * @param openFileChooser starts the device file picker and reports whether it
+ *   actually got dispatched. `allowMultiple` carries what the page asked for.
+ */
+class VSCodroidWebChromeClient(
+    private val openFileChooser: (allowMultiple: Boolean) -> Boolean
+) : WebChromeClient() {
 
     private val tag = "WebChromeClient"
+
+    /**
+     * The one `<input type=file>` still waiting for an answer, or null.
+     *
+     * Kept per client rather than per Activity because that is the lifetime the
+     * waiting element has: a renderer crash replaces this client along with the
+     * page, and the replacement must not inherit a callback belonging to a
+     * document that no longer exists.
+     */
+    private var pendingFileChooser: ValueCallback<Array<Uri>>? = null
 
     override fun onConsoleMessage(consoleMessage: ConsoleMessage): Boolean {
         // Redacted as one string, which covers both halves that can carry the
@@ -31,5 +50,53 @@ class VSCodroidWebChromeClient : WebChromeClient() {
             else -> Logger.d(tag, message)
         }
         return true
+    }
+
+    /**
+     * Opens the device file picker for an `<input type=file>`.
+     *
+     * The Explorer's `Upload...` command is the caller that matters: it appends
+     * a multiple-selection input to the document and waits on its `input` event.
+     * Without this override the default client declines, no chooser opens, and
+     * the command waits forever with nothing said.
+     *
+     * Returning true takes ownership of [filePathCallback], and the platform
+     * requires it to be invoked exactly once. Any path that returns without
+     * invoking it wedges the element for good: the page keeps one request
+     * outstanding, so every later Upload on that document does nothing at all,
+     * and only a reload clears it. That is why the failure paths here answer
+     * with an empty array rather than returning false and walking away.
+     */
+    override fun onShowFileChooser(
+        webView: WebView,
+        filePathCallback: ValueCallback<Array<Uri>>,
+        fileChooserParams: FileChooserParams
+    ): Boolean {
+        // Only one request can be tracked, so anything still outstanding is
+        // answered before it is displaced rather than dropped. A displaced
+        // callback nobody answers is the permanent wedge described above, and
+        // the likeliest way to reach one is a result that never came back.
+        answerFileChooser(emptyArray())
+        pendingFileChooser = filePathCallback
+        if (!openFileChooser(fileChooserParams.mode == FileChooserParams.MODE_OPEN_MULTIPLE)) {
+            Logger.w(tag, "No file picker started; answering the page with nothing")
+            answerFileChooser(emptyArray())
+        }
+        return true
+    }
+
+    /**
+     * Hands the picker's answer back to the page.
+     *
+     * An empty list is a cancellation, which the page still has to be told
+     * about. Safe to call with nothing outstanding: a result can arrive for a
+     * page that has since been replaced, and there is then nobody to answer.
+     */
+    fun onFileChooserResult(uris: List<Uri>) = answerFileChooser(uris.toTypedArray())
+
+    private fun answerFileChooser(uris: Array<Uri>) {
+        val callback = pendingFileChooser ?: return
+        pendingFileChooser = null
+        callback.onReceiveValue(uris)
     }
 }

--- a/android/app/src/main/kotlin/com/vscodroid/webview/VSCodroidWebChromeClient.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/webview/VSCodroidWebChromeClient.kt
@@ -27,6 +27,18 @@ class VSCodroidWebChromeClient(
      */
     private var pendingFileChooser: ValueCallback<Array<Uri>>? = null
 
+    /**
+     * Whether an `<input type=file>` is still waiting for the picker.
+     *
+     * Read by the Activity on the way back from the background. The picker runs
+     * in another app, so browsing storage backgrounds this one exactly as a
+     * sign-in does, and the resume rule reloads the page after five minutes: a
+     * file chosen at the end of a long browse would arrive at a document that is
+     * being torn down, and be lost with nothing said.
+     */
+    val hasPendingFileChooser: Boolean
+        get() = pendingFileChooser != null
+
     override fun onConsoleMessage(consoleMessage: ConsoleMessage): Boolean {
         // Redacted as one string, which covers both halves that can carry the
         // connection token: `sourceId` is a script URL and `message` is arbitrary

--- a/android/app/src/test/kotlin/com/vscodroid/ExtensionCallbackTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/ExtensionCallbackTest.kt
@@ -1452,6 +1452,10 @@ class ConnectionHealthProbeTest {
  * and the callback is delivered on the way back, into the same moment this
  * decision is made. The workbench keeps the requests it is waiting on in memory,
  * so a reload here throws away a sign-in that had already succeeded, silently.
+ *
+ * Picking a file from device storage is the second such trip, and the one a user
+ * makes far more often. The picker is another app, browsing it takes as long as
+ * finding the file takes, and the selection comes back through this same moment.
  */
 class ResumeActionTest {
 
@@ -1466,7 +1470,10 @@ class ResumeActionTest {
         // here is an action never taken. The probe is what can be answered safely
         // -- it reloads only when IndexedDB is already unusable, and such a page
         // has nothing left to collect a callback with.
-        assertEquals(ResumeAction.PROBE_CONNECTION, resumeAction(long, signInPending = true))
+        assertEquals(
+            ResumeAction.PROBE_CONNECTION,
+            resumeAction(long, signInPending = true, fileChooserPending = false),
+        )
     }
 
     @Test
@@ -1475,7 +1482,10 @@ class ResumeActionTest {
         // long absence to the probe would leave a page stale for the rest of the
         // session, which is the failure the reload was added for in the first
         // place.
-        assertEquals(ResumeAction.RELOAD, resumeAction(long, signInPending = false))
+        assertEquals(
+            ResumeAction.RELOAD,
+            resumeAction(long, signInPending = false, fileChooserPending = false),
+        )
     }
 
     @Test
@@ -1484,14 +1494,54 @@ class ResumeActionTest {
         // only reloads when IndexedDB is already unusable, and a page in that
         // state has nothing left to collect a callback with, so suppressing it
         // would trade a real recovery for a callback that cannot be delivered.
-        assertEquals(ResumeAction.PROBE_CONNECTION, resumeAction(middling, signInPending = true))
-        assertEquals(ResumeAction.PROBE_CONNECTION, resumeAction(middling, signInPending = false))
+        assertEquals(
+            ResumeAction.PROBE_CONNECTION,
+            resumeAction(middling, signInPending = true, fileChooserPending = false),
+        )
+        assertEquals(
+            ResumeAction.PROBE_CONNECTION,
+            resumeAction(middling, signInPending = false, fileChooserPending = false),
+        )
+    }
+
+    @Test
+    fun `a file picker still waiting for an answer stops the reload`() {
+        // Browsing device storage is a trip through another app, so the browse is
+        // the absence: a file chosen after ten minutes in Downloads comes back
+        // through this decision, and the reload discards the document the URI is
+        // about to be handed to. The selection is lost with no message and no
+        // log line, which is the failure this outranks.
+        assertEquals(
+            ResumeAction.NOTHING,
+            resumeAction(long, signInPending = false, fileChooserPending = true),
+        )
+    }
+
+    @Test
+    fun `a file picker stops the probe as well as the reload`() {
+        // Not the downgrade a sign-in gets. The probe reloads the page from JS
+        // when IndexedDB is unusable, which loses the selection the same way, and
+        // it starts at one minute, where a browse of that length is ordinary.
+        assertEquals(
+            ResumeAction.NOTHING,
+            resumeAction(middling, signInPending = false, fileChooserPending = true),
+        )
+        assertEquals(
+            ResumeAction.NOTHING,
+            resumeAction(long, signInPending = true, fileChooserPending = true),
+        )
     }
 
     @Test
     fun `a short absence does nothing, with or without a sign-in`() {
-        assertEquals(ResumeAction.NOTHING, resumeAction(1_000L, signInPending = true))
-        assertEquals(ResumeAction.NOTHING, resumeAction(1_000L, signInPending = false))
+        assertEquals(
+            ResumeAction.NOTHING,
+            resumeAction(1_000L, signInPending = true, fileChooserPending = false),
+        )
+        assertEquals(
+            ResumeAction.NOTHING,
+            resumeAction(1_000L, signInPending = false, fileChooserPending = false),
+        )
     }
 
     @Test
@@ -1500,11 +1550,37 @@ class ResumeActionTest {
         // fine, and makes the sign-in branch unreachable -- so a return from a
         // second factor reloads the page the callback has to land in. At exactly
         // the threshold neither fires, which is the boundary worth stating too.
-        assertEquals(ResumeAction.PROBE_CONNECTION, resumeAction(long, signInPending = true))
         assertEquals(
             ResumeAction.PROBE_CONNECTION,
-            resumeAction(FORCE_RELOAD_THRESHOLD_MS, signInPending = true),
+            resumeAction(long, signInPending = true, fileChooserPending = false),
+        )
+        assertEquals(
+            ResumeAction.PROBE_CONNECTION,
+            resumeAction(FORCE_RELOAD_THRESHOLD_MS, signInPending = true, fileChooserPending = false),
             "the reload threshold is exclusive; at the boundary there is no reload to spare",
+        )
+    }
+
+    @Test
+    fun `the resume decision is told about the picker, not only the sign-in`() {
+        // Source reading, for the reason AuthCallbackCallSiteTest gives for the
+        // sign-in half: resumeAction can be exactly right and never told. Passing
+        // a literal false here, or dropping the argument on a later edit, leaves
+        // every case above green while the reload goes back to discarding the
+        // file the user just picked.
+        val mainActivity = File("src/main/kotlin/com/vscodroid/MainActivity.kt")
+        check(mainActivity.isFile) { "MainActivity.kt not found at ${mainActivity.absolutePath}" }
+
+        val decisions = mainActivity.readLines()
+            .filterNot { val t = it.trimStart(); t.startsWith("//") || t.startsWith("*") }
+            .filter { it.contains("resumeAction(") }
+            .filterNot { it.contains("fun resumeAction") }
+
+        assertEquals(1, decisions.size, "expected one resume decision, found: $decisions")
+        assertTrue(
+            decisions.single().contains("fileChooserIsPending()"),
+            "the resume decision must be told whether a file picker is still out; found: " +
+                decisions.single(),
         )
     }
 }

--- a/android/app/src/test/kotlin/com/vscodroid/webview/ConnectionTokenLoggingTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/ConnectionTokenLoggingTest.kt
@@ -240,7 +240,7 @@ class ConnectionTokenLoggingTest {
      */
     @Test
     fun `a console message carrying the token is not logged with it`() {
-        val client = VSCodroidWebChromeClient()
+        val client = VSCodroidWebChromeClient { _ -> false }
 
         listOf(
             ConsoleMessage.MessageLevel.ERROR,

--- a/android/app/src/test/kotlin/com/vscodroid/webview/FileChooserCallbackTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/FileChooserCallbackTest.kt
@@ -1,0 +1,179 @@
+package com.vscodroid.webview
+
+import android.net.Uri
+import android.webkit.ValueCallback
+import android.webkit.WebChromeClient.FileChooserParams
+import android.webkit.WebView
+import com.vscodroid.util.Logger
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * That every `<input type=file>` gets exactly one answer.
+ *
+ * The platform contract has teeth. Returning true from `onShowFileChooser`
+ * takes ownership of the callback, and a callback that is never invoked leaves
+ * the element with a request outstanding for as long as the document lives: no
+ * later chooser opens on that page, so the Explorer's `Upload...` silently does
+ * nothing from then on and reopening the folder does not clear it. That is a
+ * worse failure than declining the request outright, because it survives the
+ * retry the user will make.
+ *
+ * So these drive the answer, not the request. Each case asserts what the page
+ * received and how many times, which is the only thing the contract is about.
+ */
+class FileChooserCallbackTest {
+
+    /** What the launcher was asked for, one entry per dispatch. */
+    private val dispatched = mutableListOf<Boolean>()
+
+    /** Whether the fake launcher reports that it started something. */
+    private var launcherStarts = true
+
+    private lateinit var client: VSCodroidWebChromeClient
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(Logger)
+        every { Logger.w(any(), any(), any()) } just Runs
+        every { Logger.w(any(), any()) } just Runs
+        dispatched.clear()
+        launcherStarts = true
+        client = VSCodroidWebChromeClient { allowMultiple ->
+            dispatched += allowMultiple
+            launcherStarts
+        }
+    }
+
+    @AfterEach
+    fun tearDown() = unmockkAll()
+
+    /** Records every answer handed to one `<input type=file>`. */
+    private class Element {
+        val answers = mutableListOf<List<Uri>>()
+        val callback = ValueCallback<Array<Uri>> { answers += it?.toList() ?: emptyList() }
+    }
+
+    private fun show(element: Element, mode: Int = FileChooserParams.MODE_OPEN): Boolean {
+        val params = mockk<FileChooserParams>(relaxed = true)
+        every { params.mode } returns mode
+        return client.onShowFileChooser(mockk<WebView>(relaxed = true), element.callback, params)
+    }
+
+    /**
+     * Cancelling is the common case, and it is the one that wedges the page if
+     * it goes unanswered: the picker returns nothing and there is no event on
+     * the way to say so.
+     */
+    @Test
+    fun `a cancelled picker still answers the page`() {
+        val element = Element()
+        assertTrue(show(element), "the chooser was handled, so the callback is ours to invoke")
+
+        client.onFileChooserResult(emptyList())
+
+        assertEquals(listOf(emptyList<Uri>()), element.answers,
+            "cancellation has to reach the page as an empty selection, exactly once")
+    }
+
+    /** The picked files reach the page, in the order the picker gave them. */
+    @Test
+    fun `the picked files reach the page`() {
+        val element = Element()
+        show(element, FileChooserParams.MODE_OPEN_MULTIPLE)
+        val first = mockk<Uri>(relaxed = true)
+        val second = mockk<Uri>(relaxed = true)
+
+        client.onFileChooserResult(listOf(first, second))
+
+        assertEquals(1, element.answers.size, "one request, one answer")
+        assertEquals(2, element.answers[0].size, "both files were selected")
+        assertSame(first, element.answers[0][0])
+        assertSame(second, element.answers[0][1])
+    }
+
+    /**
+     * Only one request can be tracked at a time, so the one being displaced has
+     * to be answered on the way out. Dropping it is how a page ends up with a
+     * request that can never be satisfied.
+     */
+    @Test
+    fun `a second request answers the one it displaces`() {
+        val first = Element()
+        val second = Element()
+        show(first)
+        show(second)
+
+        assertEquals(listOf(emptyList<Uri>()), first.answers,
+            "the displaced request must be released, not dropped")
+        assertEquals(emptyList<List<Uri>>(), second.answers,
+            "the request that is still outstanding must not be answered early")
+
+        val picked = mockk<Uri>(relaxed = true)
+        client.onFileChooserResult(listOf(picked))
+
+        assertEquals(1, second.answers.size, "the result belongs to the live request")
+        assertSame(picked, second.answers[0].single())
+        assertEquals(1, first.answers.size, "the displaced request is answered once, not twice")
+    }
+
+    /**
+     * Exactly once, in the other direction. A launcher result can arrive for a
+     * page that has already been replaced, and a second answer to the same
+     * element is as much a contract breach as none.
+     */
+    @Test
+    fun `a result arriving twice is delivered once`() {
+        val element = Element()
+        show(element)
+
+        client.onFileChooserResult(listOf(mockk<Uri>(relaxed = true)))
+        client.onFileChooserResult(listOf(mockk<Uri>(relaxed = true)))
+
+        assertEquals(1, element.answers.size, "the second result has nobody left to answer")
+    }
+
+    /** Nothing outstanding, nothing to answer, and nothing to crash on. */
+    @Test
+    fun `a result with nothing outstanding is harmless`() {
+        client.onFileChooserResult(listOf(mockk<Uri>(relaxed = true)))
+    }
+
+    /**
+     * A device with no document picker at all. The dispatch fails, and the page
+     * has to hear about it now, because nothing else ever will.
+     */
+    @Test
+    fun `a picker that cannot start answers immediately`() {
+        launcherStarts = false
+        val element = Element()
+
+        assertTrue(show(element), "the request was still handled here, not declined")
+
+        assertEquals(listOf(emptyList<Uri>()), element.answers,
+            "a chooser that never opened has to release the element straight away")
+    }
+
+    /**
+     * Multi-select is offered only when the page asked for it. An input for one
+     * file that is shown a multi-select picker lets the user choose several and
+     * silently keeps one.
+     */
+    @Test
+    fun `selection mode follows what the page asked for`() {
+        show(Element(), FileChooserParams.MODE_OPEN)
+        show(Element(), FileChooserParams.MODE_OPEN_MULTIPLE)
+
+        assertEquals(listOf(false, true), dispatched)
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/webview/FileChooserCallbackTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/FileChooserCallbackTest.kt
@@ -181,7 +181,7 @@ class FileChooserCallbackTest {
         launcherStarts = false
         val element = Element()
 
-        assertTrue(show(element), "the request was still handled here, not declined")
+        assertTrue(show(element), "a path that answers the callback must claim the request too")
 
         assertEquals(listOf(emptyList<Uri>()), element.answers,
             "a chooser that never opened has to release the element straight away")

--- a/android/app/src/test/kotlin/com/vscodroid/webview/FileChooserCallbackTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/FileChooserCallbackTest.kt
@@ -13,6 +13,7 @@ import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -141,6 +142,28 @@ class FileChooserCallbackTest {
         client.onFileChooserResult(listOf(mockk<Uri>(relaxed = true)))
 
         assertEquals(1, element.answers.size, "the second result has nobody left to answer")
+    }
+
+    /**
+     * What the Activity reads to keep the resume reload off a page that is about
+     * to be handed a file.
+     *
+     * The picker is another app, so the browse backgrounds this one, and coming
+     * back from a long browse is the shape the forced reload was written for.
+     * Reporting nothing outstanding there loses the selection with no message
+     * anywhere, so the flag has to be true for exactly as long as the answer is
+     * still owed.
+     */
+    @Test
+    fun `an outstanding request is visible until it is answered`() {
+        val element = Element()
+        assertFalse(client.hasPendingFileChooser, "nothing is waiting before a request")
+
+        show(element)
+        assertTrue(client.hasPendingFileChooser, "the request is out while the picker is up")
+
+        client.onFileChooserResult(emptyList())
+        assertFalse(client.hasPendingFileChooser, "answering releases the element")
     }
 
     /** Nothing outstanding, nothing to answer, and nothing to crash on. */


### PR DESCRIPTION
The Explorer context menu offers `Upload...` on every writable folder, and tapping it does nothing. The command appends an `<input type=file>` to the document and waits on its `input` event; with no `onShowFileChooser` override the default chrome client declines the request, so no chooser opens and the promise never settles. Nothing is logged and no error reaches the user. It is also the only route to import a single file from device storage, since the bridge only ever offered a whole SAF tree.

- `VSCodroidWebChromeClient` implements `onShowFileChooser` and now takes the launch as a constructor parameter; it was previously built with no arguments.
- `MainActivity` registers two activity-result launchers as fields, `OpenDocument` and `OpenMultipleDocuments`, chosen by whether the page asked for `MODE_OPEN_MULTIPLE`, and routes the answer back through the chrome client installed on the WebView.
- The resume rule no longer touches the page while a chooser is outstanding. The picker is another app, so the browse is the absence `onStop` records, and a browse over five minutes returned to a forced reload on the same trip that carried the selection.
- `FileChooserCallbackTest` covers the callback contract, `ResumeActionTest` the new resume case and the call site feeding it.

The risk is concentrated in that callback. Once the override returns true it must be invoked exactly once, or the element keeps a request outstanding and every later Upload on that page silently does nothing. Cancellation, a picker that cannot start, and a request that displaces one still waiting are therefore all answered rather than dropped.

Verified with the unit suite (1001 tests) and `lintDebug`, both green. Opening the picker itself needs a device.