### PR TITLE
fix(monitor): classify the language servers the editor forks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -266,7 +266,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Every folder opened in Restricted Mode**, and the setting meant to turn that off has never worked on this platform. The server's own switch is now used.
 - **None of the app's own settings ever took effect**; they were written to a file the editor does not read.
 - The Tailwind CSS language server is visible to the process monitor again, so it can be reclaimed and appears under its own name.
-- The HTML, CSS and JSON language servers are visible to the process monitor. Their names had never matched the processes VS Code starts.
+- The HTML, CSS, JSON and Markdown language servers can now be reclaimed under memory pressure. All four launch without a file extension, so no name had ever matched them.
 - Language server processes are identified correctly. The guard reported them fine throughout because it compared a different form of the name, and the same matching could shut down your own script whose path contained `eslint`.
 - The process count in the status bar includes the server's bootstrap process, which the system counts against the same limit. Every threshold had fired one process late.
 

--- a/android/app/src/main/assets/process-monitor.js
+++ b/android/app/src/main/assets/process-monitor.js
@@ -59,26 +59,47 @@ const LANG_SERVER_PATTERNS = [
     // 'eslintServer' for the server the bundled ESLint extension forks, which
     // its client names as server/out/eslintServer.js. A bare 'eslint' reaches
     // the eslint CLI and nothing else now that a bare word has to be the whole
-    // basename, and 'vscode-eslint' reaches nothing at all: that string only
+    // basename.
+    //
+    // 'vscode-eslint' was here and is gone. It reached nothing: that string only
     // ever appeared in the extension's directory name, which stopped being
-    // compared when classification moved to argument basenames.
-    'eslint', 'eslintServer', 'vscode-eslint',
-    // The three bundled with VS Code, named as they actually launch. They were
+    // compared when classification moved to argument basenames. Left in place it
+    // was worse than inert, because a hyphen puts it on the substring arm, where
+    // the only names it can still reach are a user's own: `node
+    // vscode-eslint-shim.js` was classified langserver, tracked, and eligible
+    // for the idle kill.
+    'eslint', 'eslintServer',
+    // The four bundled with the editor, named as they actually launch. They were
     // 'css-languageserver', 'html-languageserver' and 'json-languageserver',
-    // which match nothing: the processes are cssServerMain.js, htmlServerMain.js
+    // which match nothing: the files are cssServerMain.js, htmlServerMain.js
     // and jsonServerMain.js. So the servers most likely to be running were the
     // ones the monitor could not see, and the idle-kill never reclaimed them
     // while they counted against the phantom-process budget.
     //
     // Renaming them was not enough on its own, and the second half took another
     // release to find: classify() lower-cases the command line, so a pattern
-    // carrying a capital could never match it and these three stayed invisible
-    // under their correct names too. Matching is case-insensitive on both sides
-    // now, which is why they are still spelled the way the files are.
-    // scripts/check-langserver-patterns.py fails the build if these stop matching
-    // what ships; scripts/test-process-monitor.js fails it if the matching
-    // itself regresses.
-    'cssServerMain.js', 'htmlServerMain.js', 'jsonServerMain.js',
+    // carrying a capital could never match it and these stayed invisible under
+    // their correct names too. Matching is case-insensitive on both sides now,
+    // which is why they are still spelled the way the files are.
+    //
+    // No extension, and that is the third half. Each client passes an
+    // extensionless module path to `fork` -- cssClientMain.js builds
+    // `./server/.../node/cssServerMain` and the markdown client builds
+    // `./dist/serverWorkerMain` -- and Node puts that path in argv[1] verbatim.
+    // Measured: `fork("/tmp/x/child")` gives the child argv[1] "/tmp/x/child",
+    // so the basename classify() compares is "cssservermain", with nothing after
+    // it. A pattern spelled with .js carries a dot, which takes it to the
+    // substring arm, and "cssservermain".includes("cssservermain.js") is false.
+    // As bare words they take the extension arm instead, which accepts the name
+    // with no extension and with .js, so both spellings are covered whichever
+    // way a future client launches them.
+    //
+    // scripts/test-process-monitor.js is what fails the build if this regresses.
+    // check-langserver-patterns.py compares against the file name on disk, so it
+    // certified all three as covered for as long as they were wrong; it now
+    // requires the extensionless spelling too, which is the one that reaches
+    // argv.
+    'cssServerMain', 'htmlServerMain', 'jsonServerMain', 'serverWorkerMain',
     // 'tailwindcss' until the matching moved from the whole command line to the
     // basename of each argument. That string only ever appeared in the extension's
     // *directory* -- bradlc.vscode-tailwindcss-0.16.0 -- so the change quietly

--- a/scripts/check-langserver-patterns.py
+++ b/scripts/check-langserver-patterns.py
@@ -42,8 +42,11 @@ import sys
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 MONITOR = ROOT / "android/app/src/main/assets/process-monitor.js"
 
-# VS Code's built-in language servers are all named <lang>ServerMain.js.
-SERVER_ENTRY = "*ServerMain.js"
+# The editor's built-in language servers are named <lang>ServerMain.js, except
+# markdown's, which is serverWorkerMain.js. Globbing only the first shape meant
+# this script reported three servers on a tree that ships four, and said nothing
+# about the fourth in either direction.
+SERVER_ENTRIES = ("*ServerMain.js", "*WorkerMain.js")
 
 
 def patterns():
@@ -105,9 +108,9 @@ def main(extensions):
         print(f"  FAIL   no patterns parsed from {MONITOR.name}; the list moved or changed shape")
         return 1
 
-    servers = sorted(extensions.rglob(SERVER_ENTRY))
+    servers = sorted({p for glob in SERVER_ENTRIES for p in extensions.rglob(glob)})
     if not servers:
-        print(f"  FAIL   no {SERVER_ENTRY} under {extensions}; "
+        print(f"  FAIL   nothing matching {' or '.join(SERVER_ENTRIES)} under {extensions}; "
               "either nothing ships them or the naming convention changed")
         return 1
 
@@ -116,12 +119,24 @@ def main(extensions):
         # classify() splits the command line on spaces and tests the basename of
         # each argument, case-folded. The argument that carries a server is its
         # path, so its basename is what has to match here.
-        name = server.name.lower()
-        hit = next((p for p in pats if matches(name, p)), None)
+        #
+        # Both spellings, and requiring both is the point. Every one of these
+        # clients passes an extensionless module path to `fork`, so the basename
+        # that reaches argv has no `.js` on it, while the file on disk does. This
+        # script compared only the file name, so a pattern spelled with .js was
+        # reported as covering a server the monitor could not see, for three
+        # servers at once. A bare-word pattern satisfies both; one carrying a dot
+        # satisfies only the file name, and now fails here instead of passing.
+        spellings = (server.name.lower(), server.stem.lower())
+        hit = next((p for p in pats if all(matches(s, p) for s in spellings)), None)
         if hit:
-            print(f"  ok      {server.name} matched by {hit!r}")
+            print(f"  ok      {server.stem} matched by {hit!r}, with and without .js")
         else:
-            print(f"  FAIL    {server.name} is matched by no pattern")
+            partial = next((p for p in pats if any(matches(s, p) for s in spellings)), None)
+            print(f"  FAIL    {server.name} is matched by no pattern that covers both spellings")
+            if partial:
+                print(f"            {partial!r} matches the file name but not {server.stem},"
+                      " which is what `fork` puts in argv")
             print(f"            {server.relative_to(extensions)}")
             failed = True
 

--- a/scripts/test-process-monitor.js
+++ b/scripts/test-process-monitor.js
@@ -304,6 +304,37 @@ function main() {
             'unknown'],
         [1021, [NODE, '/data/user/0/com.vscodroid/files/home/projects/site/eslintServer.config.js'],
             'unknown'],
+        // The editor's own servers as they actually launch, which is the spelling
+        // that was missing. Every one of these clients passes an extensionless
+        // module path to `fork`, and Node puts it in argv[1] verbatim, so the
+        // basename carries no `.js`. The fixtures above at 1002 and 1003 named
+        // the file on disk instead, which is why they passed for years while the
+        // real processes were classified 'unknown'. Both spellings are covered
+        // now, since a client is free to change which it passes.
+        [1022, [NODE, `${REH}/extensions/css-language-features/server/dist/node/cssServerMain`,
+            '--node-ipc'], 'langserver'],
+        [1023, [NODE, `${REH}/extensions/html-language-features/server/dist/node/htmlServerMain`,
+            '--node-ipc'], 'langserver'],
+        [1024, [NODE, `${REH}/extensions/json-language-features/server/dist/node/jsonServerMain`,
+            '--node-ipc'], 'langserver'],
+        // Markdown's, which no pattern reached at all before and which the gate
+        // could not even see: it globbed *ServerMain.js and this is
+        // serverWorkerMain.js. Its client builds `./dist/serverWorkerMain` and
+        // forks it over IPC, so it is a real process holding a slot.
+        [1025, [NODE, `${REH}/extensions/markdown-language-features/dist/serverWorkerMain`,
+            '--node-ipc'], 'langserver'],
+        // And the other direction, so none of the four is satisfied by a rule
+        // that matches too much. A bare word has to be the whole basename, so a
+        // user's own file merely starting with one of these names stays theirs.
+        [1026, [NODE, '/data/user/0/com.vscodroid/files/home/projects/site/cssServerMain.helper.js'],
+            'unknown'],
+        [1027, [NODE, '/data/user/0/com.vscodroid/files/home/projects/serverWorkerMain-shim.js'],
+            'unknown'],
+        // 'vscode-eslint' used to be a pattern, and a hyphen put it on the
+        // substring arm where the only names it could still reach were the
+        // user's. It is gone, and this is what its absence has to keep true.
+        [1028, [NODE, '/data/user/0/com.vscodroid/files/home/projects/vscode-eslint-shim.js'],
+            'unknown'],
     ];
     for (const [pid, argv] of cases) {
         writeProc(proc, pid, argv);


### PR DESCRIPTION
Four of the language servers the editor bundles were never classified as language servers at runtime. The idle kill walks only the processes it has classified, so none of the four could ever be reclaimed under memory pressure, and each held one of the 32 process slots Android allows for the life of the session. The process report told the user there were none active.

Each of these clients passes an extensionless module path to `fork`, and Node puts that path in `argv[1]` verbatim, so the basename the monitor compares carries no `.js`. Measured with a probe rather than assumed: `fork("/tmp/x/child")` gives the child `argv[1] == "/tmp/x/child"`. The patterns were spelled `cssServerMain.js` and so on; a dot takes a pattern to the substring arm, and `"cssservermain"` does not contain `"cssservermain.js"`.

- `process-monitor.js`: the three become bare words, which take the extension arm and match with and without `.js`, so either spelling holds if a client changes. Markdown's `serverWorkerMain` is added; it had no pattern at all. `vscode-eslint` is removed, having only ever matched a directory name, and on the substring arm the only names left to reach were a user's own.
- `check-langserver-patterns.py`: it compared the file name on disk, which is why it certified all three as covered. It now requires a pattern to match the extensionless stem too, and globs `*WorkerMain.js`, without which it saw three servers on a tree shipping four.
- `test-process-monitor.js`: seven cases, covering all four as they launch and three user scripts that must stay unclassified.

Verified by reverting each half: the old spelling makes the gate fail with the reason named, and makes the runtime label the real server `unknown`; restoring `vscode-eslint` labels a user's `vscode-eslint-shim.js` a language server.
