### PR TITLE
fix(toolchain): state download size, and record two attribution positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Switching to another app no longer kills your language servers. Android's window-hidden signal numerically outranks its real out-of-memory warning.
 - A script of yours whose name merely contains a language server's, such as `run-eslint.js`, is no longer classed as one and killed under memory pressure.
 - Low-memory warnings now reach the background server after the app is swiped away, so idle language servers are still reclaimed instead of holding memory and process slots.
+- The toolchain picker states download and installed size separately. It showed only the unpacked figure, so every toolchain read as three times what it costs to fetch.
 - Stopping the app from its notification no longer freezes the screen for several seconds or shows the "isn't responding" dialog.
 
 **Device folders (SAF)**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,7 @@ Thank you for your interest in contributing to VSCodroid. This guide covers ever
 - [Testing on Device](#testing-on-device)
 - [How to Add a New Bundled Tool](#how-to-add-a-new-bundled-tool)
 - [How to Add a New Patch](#how-to-add-a-new-patch)
+- [Things that break quietly](#things-that-break-quietly)
 - [Code Style](#code-style)
 - [Pull Request Process](#pull-request-process)
 - [Reporting Bugs](#reporting-bugs)
@@ -696,6 +697,34 @@ generated identifiers, broke on every version bump, and printed `SKIP` on a miss
 5. **Explain why in the patch's own commit message.** A diff shows what changed; the reason it is
    needed on Android is what the next person will not be able to reconstruct.
 
+
+## Things that break quietly
+
+Four rules that are not obvious from reading any single file, and that no test
+enforces. Breaking one costs nothing at build time and shows up on a device.
+
+**`initBridge()` runs once per WebView, not once per folder.** It returns early
+on `bridgeInitialized` (`MainActivity.kt`). Re-registering the JavaScript
+interface issues a new session token, and the page is still holding the old one,
+so every bridge call from that page starts failing. The one intended
+re-registration is after a renderer crash, where `recreateWebView()` clears the
+flag for a view that no longer has the interface.
+
+**First-run setup keys on `versionName`; migrations threshold on
+`versionCode`.** Both are written together when setup completes
+(`FirstRunSetup.kt`). Bump one without the other and either setup re-runs on
+every launch or a migration never runs at all.
+
+**Tool symlinks are rebuilt on every launch, not only on first run**
+(`SplashActivity.kt` calls `setupToolSymlinks()` unconditionally). Android
+assigns a new `nativeLibraryDir` on every reinstall, which dangles every
+absolute symlink pointing into it. `File.exists()` follows links and answers
+false for a dangling one, so staleness is detected with `Os.lstat()`.
+
+**`server.js` rewrites `product.json` on every start with a shallow
+`Object.assign`.** Nested objects are replaced whole, not merged, so
+`extensionsGallery` has to carry every field it needs. Dropping one from the
+override silently removes it from the running product.
 
 ## Code Style
 

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -13,6 +13,7 @@ Versions are deliberately not listed unless pinned in this repository: most comp
 | Node.js | MIT | Termux build of `nodejs-lts`, https://github.com/nodejs/node |
 | npm | Artistic License 2.0 | https://github.com/npm/cli |
 | Python | PSF License | Termux build, https://www.python.org |
+| pip | MIT | Shipped in Python's `site-packages`; its own `LICENSE.txt` and `AUTHORS.txt` travel with it in `pip-*.dist-info/licenses/` |
 | Git | GPL v2 | Termux build, https://git-scm.com |
 | Bash | GPL v3 | Termux build, https://www.gnu.org/software/bash |
 | ripgrep | MIT / Unlicense (dual) | Bundled by the Code - OSS build (`@vscode/ripgrep-universal`), https://github.com/BurntSushi/ripgrep |

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainPickerAdapter.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainPickerAdapter.kt
@@ -79,7 +79,15 @@ class ToolchainPickerAdapter(
 
         holder.name.text = info.shortLabel
         holder.description.text = info.description
-        holder.size.text = "~${ToolchainRegistry.formatSize(info.estimatedSize)}"
+        // Both, because they answer different questions and only one of them
+        // used to be here. The single figure was the unpacked size, so a card
+        // offered "179 MB" for a 59 MB download, and the person most likely to
+        // read it is the one deciding whether to spend mobile data.
+        holder.size.text = ctx.getString(
+            R.string.toolchain_size_download_and_installed,
+            ToolchainRegistry.formatSize(info.downloadSize),
+            ToolchainRegistry.formatSize(info.estimatedSize),
+        )
 
         when (mode) {
             Mode.PICKER -> bindPickerMode(holder, info)

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainRegistry.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainRegistry.kt
@@ -14,8 +14,27 @@ object ToolchainRegistry {
         /** Short label for the toolchain card (e.g. "Go", "Ruby", "Java 17"). */
         val shortLabel: String,
         val description: String,
-        /** Approximate asset pack size in bytes (shown to user before download) */
+        /**
+         * Approximate size on disk once unpacked, in bytes.
+         *
+         * This is the free-space figure: `downloadViaHttp` gates on it plus a
+         * buffer, because the unpacked tree is what has to fit. It is not what
+         * the user is choosing about on mobile data, which is [downloadSize],
+         * and telling them this number alone overstated every toolchain by
+         * roughly three times.
+         */
         val estimatedSize: Long,
+        /**
+         * Approximate size of the ZIP fetched over HTTP, in bytes.
+         *
+         * Measured from the release assets rather than computed: a payload is
+         * rebuilt whenever its source moves, so both figures here are
+         * hand-written and go stale the same way. `downloadFile` deliberately
+         * prefers the length the server actually sent and falls back to a
+         * constant only when there is none, so nothing depends on this being
+         * exact; it exists so the picker can say what a download will cost.
+         */
+        val downloadSize: Long,
         /** Fallback URL for sideloaded installs (no Play Store). Null = Play-only. */
         val downloadUrl: String? = null,
     )
@@ -38,6 +57,7 @@ object ToolchainRegistry {
             description = "Go programming language (CGO_ENABLED=0). Runs on device, " +
                 "but cannot compile: go build and go run are refused by Android.",
             estimatedSize = 179_000_000,
+            downloadSize = 59_800_000,
             downloadUrl = "https://github.com/rmyndharis/VSCodroid/releases/latest/download/toolchain_go.zip",
         ),
         ToolchainInfo(
@@ -46,6 +66,7 @@ object ToolchainRegistry {
             shortLabel = "Ruby",
             description = "Ruby with irb, gem, bundler",
             estimatedSize = 34_000_000,
+            downloadSize = 9_900_000,
             downloadUrl = "https://github.com/rmyndharis/VSCodroid/releases/latest/download/toolchain_ruby.zip",
         ),
         ToolchainInfo(
@@ -54,6 +75,7 @@ object ToolchainRegistry {
             shortLabel = "Java 17",
             description = "OpenJDK 17 (javac, jar, jshell)",
             estimatedSize = 146_000_000,
+            downloadSize = 55_400_000,
             downloadUrl = "https://github.com/rmyndharis/VSCodroid/releases/latest/download/toolchain_java.zip",
         ),
     )

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -107,4 +107,5 @@
          which is what the Get Started walkthrough now does. -->
     <string name="shortcut_toolchains_short">Toolchains</string>
     <string name="shortcut_toolchains_long">Manage toolchains</string>
+    <string name="toolchain_size_download_and_installed">%1$s download, %2$s installed</string>
 </resources>

--- a/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainDigestInstallTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainDigestInstallTest.kt
@@ -271,7 +271,12 @@ class ToolchainDigestInstallTest {
             displayName = "Test",
             shortLabel = "Test",
             description = "loopback fixture",
+            // The fixture serves the ZIP itself, so the two figures coincide
+            // here in a way they never do for a real toolchain: nothing unpacks
+            // it. The space gate reads estimatedSize, which is what this test
+            // drives, and downloadSize only reaches the picker.
             estimatedSize = zipBytes.size.toLong(),
+            downloadSize = zipBytes.size.toLong(),
             downloadUrl = zipUrl,
         )
 

--- a/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainRegistryTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainRegistryTest.kt
@@ -44,6 +44,28 @@ class ToolchainRegistryTest {
         }
 
         @Test
+        fun `a download is smaller than what it unpacks to`() {
+            // The two figures are hand-written and both go stale when a payload
+            // is rebuilt, so this cannot check either against reality. What it
+            // can check is the one relation that holds by construction: a
+            // compressed archive is smaller than its unpacked tree. That is
+            // enough to catch the mistake worth catching, which is the two being
+            // swapped or one being copied into the other, because the picker
+            // shows them side by side and a swap reads as plausible.
+            //
+            // The single figure was the unpacked size and the picker presented
+            // it as the download, so every toolchain was advertised at roughly
+            // three times what it costs to fetch.
+            for (tc in ToolchainRegistry.available) {
+                assert(tc.downloadSize > 0) { "downloadSize must be positive: ${tc.packName}" }
+                assert(tc.downloadSize < tc.estimatedSize) {
+                    "downloadSize (${tc.downloadSize}) must be under estimatedSize " +
+                        "(${tc.estimatedSize}); the ZIP cannot exceed what it unpacks to: ${tc.packName}"
+                }
+            }
+        }
+
+        @Test
         fun `all toolchains have HTTPS download URLs`() {
             for (tc in ToolchainRegistry.available) {
                 assertNotNull(tc.downloadUrl, "downloadUrl must not be null: ${tc.packName}")

--- a/docs/LEGAL_NOTICES.md
+++ b/docs/LEGAL_NOTICES.md
@@ -311,6 +311,21 @@ licence that asks for the notice to travel with the copy.
 - **License**: Apache License 2.0 (OpenSSL 3.x)
 - **Used by**: Node.js, Python, Git, OpenSSH
 
+Git is GPL-2.0 and reaches OpenSSL through libcurl, and the two licenses are
+read as incompatible when a work combines them. The position taken here, stated
+so that it is a recorded decision rather than an oversight:
+
+- Nothing in this APK links Git against OpenSSL into one binary. They are
+  separate executables shipped side by side, each loading its own dependencies
+  at runtime, which is the same arrangement every Linux distribution ships and
+  the one Termux packages these builds as.
+- GPLv2's system-library exception is written for a system's own components and
+  is not squarely on point for a library an application bundles itself, so it is
+  not being relied on as the whole answer.
+- If a copyright holder disagreed, the remedy is to build Git against a
+  different TLS backend rather than to remove it. That is a build-time
+  substitution in `scripts/download-termux-tools.sh`, not a redesign.
+
 ---
 
 ## Complete Bundled Native Library Inventory


### PR DESCRIPTION
Three unrelated pieces of hygiene, each small on its own.

**Toolchain sizes.** The picker showed a single figure and it was the unpacked size, so Go was offered at 179 MB for a 59 MB download, Java at 146 MB for 55 MB, and Ruby at 34 MB for 9 MB. Measured from the release assets. The person most likely to read that number is deciding whether to spend mobile data, and every toolchain read as roughly three times its real cost.

One field was serving two meanings. The free-space gate wants the unpacked size and was right to use it; the picker wants the download. There are now two fields and the card states both. Neither can be checked against reality, since both are hand-written and go stale when a payload is rebuilt, so the test asserts the one relation that holds by construction: an archive is smaller than its unpacked tree.

**Attribution.** pip ships inside Python's `site-packages` and appeared in neither attribution document. Its own licence text travels with it under `pip-*.dist-info/licenses/`, so the obligation was being met by accident rather than by record. Separately, Git is GPL-2.0 and reaches OpenSSL through libcurl; both were listed and the combination was not addressed, which leaves a reader unable to tell a considered position from an oversight. The position is now stated, including what the remedy would be if a copyright holder disagreed.

**Contributing guide.** Four rules that are load-bearing, enforced by no test, and invisible from any single file: the bridge is initialised once per WebView, first-run setup and migrations key on different version fields, tool symlinks are rebuilt on every launch because a reinstall dangles them, and the product override is a shallow assign. An outside contributor had no route to any of them.

Verified with the unit suite and the attribution and build-step gates.
