### PR TITLE
test(device): record the instrumented run, and what v1.0.0 traces cost

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -350,6 +350,16 @@ shipped, `--instrumented` runs the app:
 The last one is new because it was missing: the instrumented suite had a command
 in the block below and no moment at which anyone owed it a run.
 
+`--instrumented` writes what it did to
+`android/app/build/reports/device-run.txt`: the time, the commit, the device
+fingerprint, Gradle's exit status and the counts read out of the XML that run
+wrote. **Before tagging a release, put that record in the release notes or the
+pull request that prepares the tag.** No check enforces it, and none can while
+no runner this project has measured is able to start the suite. What the record
+changes is that "was it run, on what, and when" has an answer that is a file
+rather than a recollection, and that a suite which never started says so instead
+of reporting zero failures.
+
 ```bash
 bash scripts/device-test.sh                 # build, install, and test
 bash scripts/device-test.sh --skip-build    # test an APK you already built

--- a/docs/10-RELEASE_PLAN.md
+++ b/docs/10-RELEASE_PLAN.md
@@ -349,6 +349,20 @@ Notes:
 - **Play Console**: Android Vitals for crash clusters and ANR analysis
 - **User-initiated reports**: "Report a Bug" option in app settings → generates log bundle
 
+**A stack trace from v1.0.0 cannot be read back.** That build ran R8, and its
+`mapping.txt` was never published or archived; the only copy would have been in a
+local build directory, which holds one build at a time and has since been
+overwritten. Measured: the published v1.0.0 APK carries `pg-map-id 7e59ec8`,
+while the map still on disk is `bd8a693`, so they do not correspond. A trace from
+that build can be triaged by its message and its unobfuscated frames and no
+further.
+
+Later releases do not have this problem. `release.yml` attaches `mapping.txt` to
+the release it builds, and `r8.yml` keeps it as a workflow artifact, so the map
+travels with the build that produced it. When triaging, take the map from the
+release the reporter installed rather than from a local build directory, which
+holds whatever was compiled last.
+
 ### 7.3 Feedback Channels
 
 | Channel | Purpose |

--- a/scripts/device-test.sh
+++ b/scripts/device-test.sh
@@ -561,9 +561,65 @@ if $INSTRUMENTED; then
     printf "\n  ${GREEN}%d passed${RESET} — handing off to Gradle%s\n\n" \
         "$PASS" "${DEVICE:+ (ANDROID_SERIAL=$DEVICE)}"
     cd "$ROOT_DIR/android" || exit 1
-    # exec so the suite's own exit status is this script's, with no wrapper
-    # between a failing test and whoever is reading.
-    exec ./gradlew connectedDebugAndroidTest
+
+    # This used to `exec`, so that the suite's exit status was this script's with
+    # no wrapper between a failing test and whoever is reading. That property is
+    # kept below by exiting with the captured status; what `exec` also did was
+    # make it impossible to write anything afterwards, and a run that leaves no
+    # trace is a run nobody can be asked to have done.
+    #
+    # Nothing runs this suite automatically and no runner measured here can, so
+    # the only thing between a release and an unrun suite is a person
+    # remembering. A record does not make anyone run it. It makes the answer to
+    # "was it run, on what, and when" a file rather than a recollection.
+    ./gradlew connectedDebugAndroidTest
+    GRADLE_STATUS=$?
+
+    RECORD="$ROOT_DIR/android/app/build/reports/device-run.txt"
+    mkdir -p "$(dirname "$RECORD")"
+    # Counts come from the XML the run just wrote, not from Gradle's log. A
+    # stale report from an earlier run says "0 failures" and is
+    # indistinguishable from success, which is the trap the mutation harness
+    # documents for the same reason.
+    RESULT_DIR="$ROOT_DIR/android/app/build/outputs/androidTest-results/connected"
+    COUNTS=$(python3 - "$RESULT_DIR" <<'PY' 2>/dev/null || echo "counts unavailable"
+import glob, os, re, sys
+t = f = e = s = n = 0
+for p in glob.glob(os.path.join(sys.argv[1], "**", "*.xml"), recursive=True):
+    with open(p, encoding="utf-8", errors="replace") as fh:
+        head = fh.read(800)
+    m = re.search(r'tests="(\d+)".*?failures="(\d+)".*?errors="(\d+)"', head, re.S)
+    if m:
+        n += 1
+        t += int(m.group(1)); f += int(m.group(2)); e += int(m.group(3))
+    m = re.search(r'skipped="(\d+)"', head)
+    if m:
+        s += int(m.group(1))
+# Zeros are the answer both to "nothing failed" and to "nothing ran", and only
+# one of those is good news. Say which, rather than printing a clean-looking
+# line for a suite that never started.
+if n == 0:
+    print("no result files: the suite wrote nothing, so it did not run")
+elif t == 0:
+    print(f"{n} result file(s) but 0 tests: the suite ran nothing")
+else:
+    print(f"tests={t} failures={f} errors={e} skipped={s}")
+PY
+)
+    FINGERPRINT=$($ADB ${DEVICE:+-s "$DEVICE"} shell getprop ro.build.fingerprint 2>/dev/null | tr -d '\r')
+    {
+        printf 'instrumented suite\n'
+        printf '  when        %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+        printf '  commit      %s\n' "$(git -C "$ROOT_DIR" rev-parse --short HEAD 2>/dev/null)"
+        printf '  device      %s\n' "${FINGERPRINT:-unknown}"
+        printf '  gradle exit %s\n' "$GRADLE_STATUS"
+        printf '  %s\n' "$COUNTS"
+    } > "$RECORD"
+
+    printf '\n'
+    cat "$RECORD"
+    printf '\n  recorded in %s\n\n' "${RECORD#"$ROOT_DIR"/}"
+    exit "$GRADLE_STATUS"
 fi
 
 # ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Two pieces of record-keeping, both about being able to answer a question after the fact rather than from recollection.

**The instrumented suite leaves a trace.** Nothing runs it automatically and no runner this project has measured is able to, so the only thing standing between a release and an unrun suite is a person remembering. There was no way to tell afterwards either: `--instrumented` exec'd straight into Gradle and wrote nothing.

It now records the time, the commit, the device fingerprint, Gradle's exit status and the test counts to `android/app/build/reports/device-run.txt`, and the contributing guide asks for that record when a tag is prepared. The suite's own exit status is still this script's, which is what the `exec` was there for.

The counts come from the XML that run wrote, not from Gradle's log, and a run that produced no XML says so rather than reporting zeros. Zero failures and zero tests are otherwise the same line, and only one of them is good news. Verified against fixtures covering all three states: real results, no result files, and a file reporting no tests.

**A v1.0.0 stack trace cannot be read back.** That build ran R8 and its map was never published or archived. The only copy would have been a local build directory, which holds one build at a time and has since been overwritten. Measured rather than assumed: the published v1.0.0 APK carries `pg-map-id 7e59ec8` and the map still on disk is `bd8a693`, so they do not correspond.

Later releases are unaffected, since `release.yml` attaches the map to the release and `r8.yml` keeps it as an artifact. The note says so, and says to take the map from the release the reporter installed.
