### PR TITLE
docs(architecture): name the Logcat tags in use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The milestone log and implementation plan no longer record a process-liveness check as the fix for the white screen on reopen. A contributor could reintroduce it as precedent.
 - The milestone checklist no longer plans on-device CI as a hosted device lab. Nothing in the workflows starts the app, and arm64 runners cannot boot an emulator.
 - The bug report's documented contents match what it emits, and the logging table no longer names a server or extension-host log file that nothing in the app writes.
+- The logging table names the Logcat tags in use. It named a tag nothing logs under, and called WebView output debug-only when errors and warnings ship in release.
 - The requirements table's heap limit is no longer a flat 512 MB; the ceiling has been derived from device RAM since a fixed limit left 3-4 GB phones nothing to work with.
 - `CONTRIBUTING.md` no longer describes a URL allow-list the app does not have. VSCodroid is a development environment and reaches LAN hosts on purpose; the session token is what is checked.
 - `CONTRIBUTING.md` describes both toolchain delivery paths. It named only Play Asset Delivery, while every non-Play install takes the HTTP path that developers themselves run on.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The milestone checklist no longer plans on-device CI as a hosted device lab. Nothing in the workflows starts the app, and arm64 runners cannot boot an emulator.
 - The bug report's documented contents match what it emits, and the logging table no longer names a server or extension-host log file that nothing in the app writes.
 - The logging table names the Logcat tags in use. It named a tag nothing logs under, and called WebView output debug-only when errors and warnings ship in release.
-- The requirements table's heap limit is no longer a flat 512 MB; the ceiling has been derived from device RAM since a fixed limit left 3-4 GB phones nothing to work with.
+- The logging table says where Extension Host output lands: the server's log service writes it to `remoteagent.log` and echoes it on the server console.- The requirements table's heap limit is no longer a flat 512 MB; the ceiling has been derived from device RAM since a fixed limit left 3-4 GB phones nothing to work with.
 - `CONTRIBUTING.md` no longer describes a URL allow-list the app does not have. VSCodroid is a development environment and reaches LAN hosts on purpose; the session token is what is checked.
 - `CONTRIBUTING.md` describes both toolchain delivery paths. It named only Play Asset Delivery, while every non-Play install takes the HTTP path that developers themselves run on.
 - The contributing guide's repository map matches the shipped binaries: Python never lived in `jniLibs`, while git's HTTPS helper and the musl loader do.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The milestone checklist no longer plans on-device CI as a hosted device lab. Nothing in the workflows starts the app, and arm64 runners cannot boot an emulator.
 - The bug report's documented contents match what it emits, and the logging table no longer names a server or extension-host log file that nothing in the app writes.
 - The logging table names the Logcat tags in use. It named a tag nothing logs under, and called WebView output debug-only when errors and warnings ship in release.
-- The logging table says where Extension Host output lands: the server's log service writes it to `remoteagent.log` and echoes it on the server console.- The requirements table's heap limit is no longer a flat 512 MB; the ceiling has been derived from device RAM since a fixed limit left 3-4 GB phones nothing to work with.
+- The logging table says where Extension Host output lands: the server's log service writes it to `remoteagent.log` and echoes it on the server console.
+- The deploy script's closing hint prints a Logcat filter that matches. It named the bare tag, which nothing logs under, so the command returned nothing.
+- The requirements table's heap limit is no longer a flat 512 MB; the ceiling has been derived from device RAM since a fixed limit left 3-4 GB phones nothing to work with.
 - `CONTRIBUTING.md` no longer describes a URL allow-list the app does not have. VSCodroid is a development environment and reaches LAN hosts on purpose; the session token is what is checked.
 - `CONTRIBUTING.md` describes both toolchain delivery paths. It named only Play Asset Delivery, while every non-Play install takes the HTTP path that developers themselves run on.
 - The contributing guide's repository map matches the shipped binaries: Python never lived in `jniLibs`, while git's HTTPS helper and the musl loader do.

--- a/docs/03-ARCHITECTURE.md
+++ b/docs/03-ARCHITECTURE.md
@@ -485,16 +485,22 @@ flowchart TD
 
 ### 8.2 Logging
 
+Everything ends up in Logcat, and every tag is `VSCodroid.<class>`: `Logger` prepends that
+prefix to the per-class tag it is handed, so nothing is ever logged under the bare
+`VSCodroid`. Filter on a full tag, for example `adb logcat -s VSCodroid.ProcessManager`.
+
 | Component | Log Destination | Level |
 |-----------|----------------|-------|
-| Kotlin | Android Logcat (tag: VSCodroid) | INFO (release), DEBUG (debug) |
-| Node.js server | stdout/stderr, read by `ProcessManager.startOutputReader` and written to Logcat | DEBUG (debug builds only) |
-| Extension Host | worker_thread inside the server process (patch `0004`), not a file this app writes | as above |
-| WebView | Chrome DevTools (debug builds only) | ALL |
+| Kotlin | Logcat, tag `VSCodroid.<class>` (`VSCodroid.MainActivity`, `VSCodroid.ProcessManager`, and so on) | INFO (release), DEBUG (debug) |
+| Node.js server | stdout with stderr merged into it, read by `ProcessManager.startOutputReader` and re-logged line by line as `[node] ...` under `VSCodroid.ProcessManager` | DEBUG, so debug builds only |
+| Extension Host | worker_thread inside the server process (patch `0004`), not a file this app writes; `ExtensionHostConnection` pipes the worker's stdout and stderr into the server's log service, which prints them on the server console | as above, arriving as `[node]` lines |
+| WebView | `VSCodroidWebChromeClient.onConsoleMessage` mirrors every console message into Logcat under `VSCodroid.WebChromeClient`; Chrome DevTools additionally attaches on debug builds | ERROR and WARNING in every build, everything else DEBUG |
 
 Nothing writes `server.log` or `exthost.log`. `CrashReporter.generateBugReport` looks for
 the first under `Environment.getLogsDir` (`filesDir/home/.vscodroid/data/logs`) and never
-finds it, so a bug report carries no server-log section.
+finds it, so a bug report carries no server-log section. That directory is not empty,
+though: `ProcessManager.startServer` points the server's `--logsPath` at it, and the
+server's own log service writes `remoteagent.log` there.
 
 ### 8.3 Configuration
 

--- a/docs/03-ARCHITECTURE.md
+++ b/docs/03-ARCHITECTURE.md
@@ -485,22 +485,23 @@ flowchart TD
 
 ### 8.2 Logging
 
-Everything ends up in Logcat, and every tag is `VSCodroid.<class>`: `Logger` prepends that
-prefix to the per-class tag it is handed, so nothing is ever logged under the bare
-`VSCodroid`. Filter on a full tag, for example `adb logcat -s VSCodroid.ProcessManager`.
+Everything the Kotlin side logs ends up in Logcat, and every tag is `VSCodroid.<class>`:
+`Logger` prepends that prefix to the per-class tag it is handed, so nothing is ever logged
+under the bare `VSCodroid`. Filter on a full tag, for example
+`adb logcat -s VSCodroid.ProcessManager`.
 
 | Component | Log Destination | Level |
 |-----------|----------------|-------|
 | Kotlin | Logcat, tag `VSCodroid.<class>` (`VSCodroid.MainActivity`, `VSCodroid.ProcessManager`, and so on) | INFO (release), DEBUG (debug) |
 | Node.js server | stdout with stderr merged into it, read by `ProcessManager.startOutputReader` and re-logged line by line as `[node] ...` under `VSCodroid.ProcessManager` | DEBUG, so debug builds only |
-| Extension Host | worker_thread inside the server process (patch `0004`), not a file this app writes; `ExtensionHostConnection` pipes the worker's stdout and stderr into the server's log service, which prints them on the server console | as above, arriving as `[node]` lines |
+| Extension Host | worker_thread inside the server process (patch `0004`); `ExtensionHostConnection` pipes the worker's stdout and stderr into the server's log service, which writes them to `remoteagent.log` and prints them on the server console, from where the row above carries them into Logcat | INFO into `remoteagent.log` in every build; the Logcat copy is DEBUG, arriving as `[node]` lines |
 | WebView | `VSCodroidWebChromeClient.onConsoleMessage` mirrors every console message into Logcat under `VSCodroid.WebChromeClient`; Chrome DevTools additionally attaches on debug builds | ERROR and WARNING in every build, everything else DEBUG |
 
 Nothing writes `server.log` or `exthost.log`. `CrashReporter.generateBugReport` looks for
 the first under `Environment.getLogsDir` (`filesDir/home/.vscodroid/data/logs`) and never
 finds it, so a bug report carries no server-log section. That directory is not empty,
 though: `ProcessManager.startServer` points the server's `--logsPath` at it, and the
-server's own log service writes `remoteagent.log` there.
+server's own log service writes `remoteagent.log` there, Extension Host output included.
 
 ### 8.3 Configuration
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -46,4 +46,6 @@ echo "  ✓ Launched"
 
 echo ""
 echo "=== Deploy complete ==="
-echo "View logs: adb logcat -s VSCodroid"
+# Every tag is VSCodroid.<class>, so the bare tag matches nothing as a filterspec,
+# and logcat filterspecs take no wildcard.
+echo "View logs: adb logcat | grep VSCodroid"


### PR DESCRIPTION
The architecture document's logging table pointed readers at destinations that do not exist. Two rows named `~/.vscodroid/logs/server.log` and `~/.vscodroid/logs/exthost.log`; that path is missing the `data/` segment `Environment.getLogsDir` resolves, and nothing writes either file. Those two rows were corrected earlier. Two of the remaining rows were wrong in the same way, so the table still could not be used.

The Kotlin row named a bare `VSCodroid` tag. `Logger` prepends `VSCodroid.` to the per-class tag it is handed, so no line is ever logged under the bare prefix, and filtering on it returns an empty log. The WebView row named Chrome DevTools on debug builds as the only destination, while `VSCodroidWebChromeClient.onConsoleMessage` mirrors every console message into Logcat, with its ERROR and WARNING branches ungated by build type, so they ship in release. Its level was recorded as `ALL`, which holds for neither build.

Changes:

- Each row names its destination and the Logcat tag to filter on, with an example command above the table.
- The Node.js server row records the merged stdout/stderr, the `[node]` prefix `startOutputReader` adds, and that the line is dropped in release builds.
- The Extension Host row records that the server pipes the worker's output into its own log service, so it surfaces on the server console rather than anywhere separate.
- The WebView row's level is split into what survives a release build and what does not.
- The paragraph below notes that the logs directory does hold the server's `remoteagent.log`, so the section no longer reads as though nothing is written there.

Verified by reading each emitter and by running the unit and self-check suites.

Closes #235.