### PR TITLE
test(coverage): make three cases fail on what they name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The extra key row's trackpad now has tests covering its speed gears and arrow output. It is the only way a touch user moves the cursor, and nothing guarded it.
 - Hardware keyboard support is now pinned by tests: no key event is intercepted, and the manifest still keeps a keyboard or a rotation from rebuilding the window.
 - A test now pins that the port scan steps over a bound port rather than abandoning the range for an ephemeral one, which costs the workbench origin its stability.
+- The extensions and server-log directories the server is launched with are now pinned by name. Moving the extensions one empties the workbench's extension list silently.
 - Removed twenty-six tracked files that nothing built, ran or opened, including the cross-compilation scripts replaced when binaries began coming from Termux.
 - Six releases that shipped without a changelog entry now have one, reconstructed from commit history and marked as such. Two footer links named a tag that never existed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The on-device suite now checks toolchain installs and the terminal's shell configuration, and reports skipped rather than passed where adb cannot reach, instead of leaving both to a human checklist.
 - The extra key row's trackpad now has tests covering its speed gears and arrow output. It is the only way a touch user moves the cursor, and nothing guarded it.
 - Hardware keyboard support is now pinned by tests: no key event is intercepted, and the manifest still keeps a keyboard or a rotation from rebuilding the window.
+- A test now pins that the port scan steps over a bound port rather than abandoning the range for an ephemeral one, which costs the workbench origin its stability.
 - Removed twenty-six tracked files that nothing built, ran or opened, including the cross-compilation scripts replaced when binaries began coming from Termux.
 - Six releases that shipped without a changelog entry now have one, reconstructed from commit history and marked as such. Two footer links named a tag that never existed.
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -310,7 +310,6 @@ tasks.withType<Test> {
     //   grep -rn 'File("src/main/AndroidManifest.xml")' android/app/src/test/kotlin
     inputs.file(layout.projectDirectory.file("src/main/AndroidManifest.xml"))
         .withPropertyName("appManifest")
-    // Two suites read files no Kotlin compiles against, because the things they
     // Seven suites read files no Kotlin compiles against, because the things they
     // check cross a language boundary that has no compiler: the bootstrap's
     // adoption note (assets/server.js), the shutdown the worker hosts get

--- a/android/app/src/test/kotlin/com/vscodroid/setup/SupersededExtensionsTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/SupersededExtensionsTest.kt
@@ -65,7 +65,10 @@ class SupersededExtensionsTest {
     }
 
     @Test
-    fun `leaves alone anything whose version is not numeric`() {
+    fun `leaves alone a name that does not split into a bundled id`() {
+        // None of these three splits into an id the bundled set knows, so what
+        // they guard is that lookup and not the version comparison below it,
+        // which they never reach. The case after this one covers that.
         val present = bundled + listOf(
             "ms-python.python-2026.4.0-rc1",
             "extensions.json",

--- a/android/app/src/test/kotlin/com/vscodroid/util/EnvironmentTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/util/EnvironmentTest.kt
@@ -108,7 +108,10 @@ class EnvironmentTest {
         }
 
         @Test
-        fun `each bundled binary getter names its own file`() {
+        fun `each path getter names its own destination`() {
+            // Renamed from `each bundled binary getter names its own file`, which
+            // stopped describing the case once the filesDir-relative getters were
+            // added below: only the first two assertions name a binary.
             // The nine per-getter cases that used to sit above restated the string
             // concatenation each getter performs: change the implementation and the
             // test is edited to match, which is a restatement rather than a verdict.
@@ -132,6 +135,21 @@ class EnvironmentTest {
             assertEquals("server", under(Environment.getServerDir(context)))
             assertEquals("home", under(Environment.getHomeDir(context)))
             assertEquals("home/.vscodroid", under(Environment.getUserDataDir(context)))
+
+            // These two were still missing, and they are the ones the server is
+            // handed on its command line: --extensions-dir and --logsPath, both
+            // in ProcessManager.startServer. Measured: shortening getLogsDir's
+            // tail from data/logs to data/log left every case in this class
+            // green, because "under userDataDir" and "starts with /" are true of
+            // any tail at all.
+            //
+            // The destination is not a detail either getter is free to move. The
+            // extensions directory already holds whatever the user installed, so
+            // pointing the server at a different one empties the workbench's
+            // extension list with nothing to explain it, and the logs directory
+            // is the only place the server's own logs can be looked for.
+            assertEquals("home/.vscodroid/extensions", under(Environment.getExtensionsDir(context)))
+            assertEquals("home/.vscodroid/data/logs", under(Environment.getLogsDir(context)))
         }
     }
 }

--- a/android/app/src/test/kotlin/com/vscodroid/util/PortFinderTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/util/PortFinderTest.kt
@@ -148,9 +148,28 @@ class PortFinderTest {
             // environmental failure, not a verdict on PortFinder -- on any machine
             // already using that port.
             val taken = PortFinder.findAvailablePort()
+            assertTrue(taken < EPHEMERAL_BASE, "precondition failed: the scan range was already full")
+
             hold(taken).use {
                 val port = PortFinder.findAvailablePort()
                 assertNotEquals(taken, port, "the scan must step over a bound port")
+                // Stepping over the bound port and giving up on the range both
+                // return something that is neither `taken` nor bound, so the two
+                // assertions around this one cannot tell them apart. Measured:
+                // with the scan range shrunk to a single port, every bound port
+                // falls straight through to the ServerSocket(0) fallback and both
+                // stay green.
+                //
+                // The fallback is not a harmless second answer. It hands back a
+                // port from the kernel's ephemeral range, which getOrAllocatePort
+                // deliberately refuses to remember, so the workbench origin stops
+                // being stable across cold starts and the IndexedDB behind it is
+                // dropped on every launch.
+                assertTrue(
+                    port < EPHEMERAL_BASE,
+                    "the scan must step over $taken, not abandon the range for the " +
+                        "ephemeral fallback; got $port",
+                )
                 assertTrue(PortFinder.isPortAvailable(port))
             }
         }


### PR DESCRIPTION
Three unit cases named a behaviour they could not detect. Each is fixed on its own terms rather than by adding a parallel case beside it.

`PortFinderTest.skips a port that is already bound` asserted only that the returned port differed from the bound one and was itself free. Both hold when the scan abandons its range and falls through to the `ServerSocket(0)` fallback, which returns a port from the kernel's ephemeral range. `getOrAllocatePort` deliberately refuses to remember such a port, so the workbench origin stops being stable across cold starts and the IndexedDB behind it is dropped on every launch. The case now also asserts the returned port is still inside the scan range.

`SupersededExtensionsTest.leaves alone anything whose version is not numeric` never reached the version comparison: two of its three names split at their last dash into an id the bundled set does not contain, and one has no dash at all, so the id lookup drops them first. It is renamed to describe the lookup it does reach. The numeric guard is covered by the case below it.

`EnvironmentTest` pinned six path getters by destination and not the two that reach the server's command line. Shortening `getLogsDir`'s tail from `data/logs` to `data/log` left all eight cases in the class green, because every other assertion there only checks that a path is absolute or sits under the user-data dir. `--extensions-dir` and `--logsPath` are now asserted by name.

Verification: for each strengthened assertion the corresponding production change was applied, the named case observed failing, then reverted. `./gradlew testDebugUnitTest` passes with 1039 tests and 0 failures.

This addresses three of the twenty-one cases listed in issue #239, so that issue stays open. The remaining eighteen are named there and each still needs its own reading: a mutation caught by a sibling is sometimes correct and sometimes a test whose name promises more than it asserts, and only reading decides which.
