### PR TITLE
fix(webview): save a downloaded file where the user chooses

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -169,6 +169,7 @@ jobs:
           node scripts/test-server-bootstrap.js
           node scripts/test-process-monitor-extension.js
           node scripts/test-bridge-relay.js
+          node scripts/test-download-capture.js
           node scripts/test-serve-network.js
 
       - name: Run lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,6 +207,7 @@ jobs:
           node scripts/test-server-bootstrap.js
           node scripts/test-process-monitor-extension.js
           node scripts/test-bridge-relay.js
+          node scripts/test-download-capture.js
           node scripts/test-serve-network.js
 
       - name: Install system dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,7 +94,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - The Explorer's **Upload...** now opens the device file picker. It was on every folder's menu and hung silently, the only route to import a single file from device storage.
-- The Explorer's **Download** now asks where to save and writes the file there. It did nothing at all, and a failure now says so instead of leaving a partial file.
+- The Explorer's **Download** now asks where to save each file and writes it there. It did nothing at all, and a failure says so instead of leaving a partial file.
 - **Open Source Licenses**, on the About dialog: the notices now ship inside the app and read offline, so the GPL written offer of source reaches every device holding those binaries.
 - VSCodroid warns when the installed Android System WebView is older than Chrome 105, the version it is tested against. It warns and continues rather than refusing to start, and a version it cannot read is not treated as an old one.
 - **Serve on Network**: lists the ports your dev servers are listening on, shows the address other devices can reach them at, and copies it. Loopback-only servers are called out.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - The Explorer's **Upload...** now opens the device file picker. It was on every folder's menu and hung silently, the only route to import a single file from device storage.
+- The Explorer's **Download** now asks where to save and writes the file there. It did nothing at all, and a failure now says so instead of leaving a partial file.
 - **Open Source Licenses**, on the About dialog: the notices now ship inside the app and read offline, so the GPL written offer of source reaches every device holding those binaries.
 - VSCodroid warns when the installed Android System WebView is older than Chrome 105, the version it is tested against. It warns and continues rather than refusing to start, and a version it cannot read is not treated as an old one.
 - **Serve on Network**: lists the ports your dev servers are listening on, shows the address other devices can reach them at, and copies it. Loopback-only servers are called out.

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -239,7 +239,27 @@ class MainActivity : AppCompatActivity() {
      */
     private val downloadDestinationLauncher = registerForActivityResult(
         ActivityResultContracts.CreateDocument("*/*")
-    ) { uri -> downloads.onDestinationChosen(uri) }
+    ) { uri ->
+        val requestId = pickerRequestId
+        pickerRequestId = null
+        downloads.onDestinationChosen(requestId, uri)
+    }
+
+    /**
+     * The download the picker on screen was opened for.
+     *
+     * The contract answers with a `Uri` and nothing else, so the request has to
+     * be carried across the launch by hand. Without it the coordinator would
+     * have to take whatever it is holding as the owner of the answer, and a
+     * result belonging to a download that has since been dropped would be
+     * adopted by the one that replaced it: bytes written into a document
+     * created under the wrong file's name.
+     *
+     * Main thread only, which is what makes a plain field enough: it is set
+     * inside the post below and read in the callback above, and
+     * [DownloadCoordinator] launches one picker at a time.
+     */
+    private var pickerRequestId: String? = null
 
     /**
      * Saving a file the editor asked to download.
@@ -253,12 +273,23 @@ class MainActivity : AppCompatActivity() {
      * name each other, and inference cannot start from either end.
      */
     private val downloads: DownloadCoordinator = DownloadCoordinator(object : DownloadHost {
-        override fun askDestination(fileName: String): Boolean = try {
-            downloadDestinationLauncher.launch(fileName)
-            true
-        } catch (e: ActivityNotFoundException) {
-            Logger.w(tag, "No document creator on this device", e)
-            false
+        /**
+         * Posted rather than launched here. A download that waited its turn is
+         * started from whatever thread finished the one before it, which is the
+         * WebView's bridge thread, and the activity result registry is main
+         * thread state.
+         */
+        override fun askDestination(requestId: String, fileName: String) {
+            runOnUiThread {
+                pickerRequestId = requestId
+                try {
+                    downloadDestinationLauncher.launch(fileName)
+                } catch (e: ActivityNotFoundException) {
+                    Logger.w(tag, "No document creator on this device", e)
+                    pickerRequestId = null
+                    downloads.onDestinationUnavailable(requestId)
+                }
+            }
         }
 
         override fun openDestination(destination: Uri): OutputStream? =

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -18,6 +18,7 @@ import android.os.Bundle
 import android.net.Uri
 import android.os.IBinder
 import android.os.SystemClock
+import android.provider.DocumentsContract
 import android.text.util.Linkify
 import android.view.View
 import android.webkit.RenderProcessGoneDetail
@@ -28,6 +29,7 @@ import android.widget.ScrollView
 import android.widget.TextView
 import android.widget.Toast
 import java.io.File
+import java.io.OutputStream
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.SystemBarStyle
 import androidx.activity.enableEdgeToEdge
@@ -54,6 +56,9 @@ import com.vscodroid.setup.FirstRunSetup
 import com.vscodroid.storage.SafStorageManager
 import com.vscodroid.util.Logger
 import com.vscodroid.util.Notices
+import com.vscodroid.webview.DownloadCoordinator
+import com.vscodroid.webview.DownloadHost
+import com.vscodroid.webview.DownloadOutcome
 import com.vscodroid.webview.VSCodroidWebChromeClient
 import com.vscodroid.webview.VSCodroidWebView
 import com.vscodroid.webview.VSCodroidWebViewClient
@@ -217,6 +222,98 @@ class MainActivity : AppCompatActivity() {
         }
         client.onFileChooserResult(uris)
     }
+
+    /**
+     * Where a downloaded file is written, chosen by the user.
+     *
+     * `CreateDocument` and not `OpenDocument`: saving needs a grant to write a
+     * document that does not exist yet, and the read grant the file picker
+     * returns cannot create one.
+     *
+     * The type is the wildcard because the name already carries the extension.
+     * That name comes from the anchor the editor clicked, so it is `App.kt`
+     * rather than a guess, and a picker told `text/plain` would offer to save
+     * it as `App.kt.txt`. Naming a concrete type buys nothing here either: this
+     * is the device's own storage picker, and it is being asked to create a
+     * file, not to filter a list.
+     */
+    private val downloadDestinationLauncher = registerForActivityResult(
+        ActivityResultContracts.CreateDocument("*/*")
+    ) { uri -> downloads.onDestinationChosen(uri) }
+
+    /**
+     * Saving a file the editor asked to download.
+     *
+     * The Activity supplies the four things the coordinator cannot do itself:
+     * the picker, the document behind the picker's answer, the page that holds
+     * the bytes, and the user. Everything about *when* each of those happens is
+     * in [DownloadCoordinator].
+     *
+     * The type is spelled out because this and [downloadDestinationLauncher]
+     * name each other, and inference cannot start from either end.
+     */
+    private val downloads: DownloadCoordinator = DownloadCoordinator(object : DownloadHost {
+        override fun askDestination(fileName: String): Boolean = try {
+            downloadDestinationLauncher.launch(fileName)
+            true
+        } catch (e: ActivityNotFoundException) {
+            Logger.w(tag, "No document creator on this device", e)
+            false
+        }
+
+        override fun openDestination(destination: Uri): OutputStream? =
+            contentResolver.openOutputStream(destination)
+
+        /**
+         * Deletes a document a failed download created.
+         *
+         * The picker creates the file when the user confirms the name, so by
+         * the time anything can go wrong there is already a file in their
+         * folder wearing the name of the one they wanted. Left alone it is a
+         * download that looks finished until it is opened.
+         */
+        override fun discardDestination(destination: Uri) {
+            try {
+                DocumentsContract.deleteDocument(contentResolver, destination)
+            } catch (e: Exception) {
+                // Reported and not raised: this only ever runs on a path that has
+                // already failed, and a delete that fails leaves a file the user
+                // can delete themselves, which is not worth a second message.
+                Logger.w(tag, "Could not remove the unfinished download", e)
+            }
+        }
+
+        override fun requestBytes(requestId: String, url: String) {
+            // The answer is used, and only for the one case the page cannot
+            // report itself: the capture script not being there at all. Its own
+            // failures come back through finishDownload; a missing script has
+            // nothing to send one with, and without this the download would sit
+            // on a created file forever with nothing said.
+            val script = "(function() {" +
+                "  if (!window.__vscodroidDownload) return false;" +
+                "  return window.__vscodroidDownload.send(" +
+                "${JSONObject.quote(url)}, ${JSONObject.quote(requestId)});" +
+                "})()"
+            webView?.evaluateJavascript(script) { answer ->
+                if (answer == "false") {
+                    downloads.onComplete(requestId, "the page cannot read this download")
+                }
+            } ?: downloads.onComplete(requestId, "there is no page to read this download")
+        }
+
+        override fun report(outcome: DownloadOutcome, fileName: String, detail: String?) {
+            if (detail != null) Logger.w(tag, "Download of $fileName: $detail")
+            val message = when (outcome) {
+                DownloadOutcome.SAVED -> "Saved $fileName"
+                DownloadOutcome.CANCELLED -> "Download cancelled"
+                DownloadOutcome.FAILED -> "Could not save $fileName"
+            }
+            // Hopped because the bytes arrive on the WebView's bridge thread, so
+            // the end of a download is reported from a thread that cannot touch
+            // a Toast.
+            runOnUiThread { Toast.makeText(this@MainActivity, message, Toast.LENGTH_SHORT).show() }
+        }
+    })
 
     private val serviceConnection = object : ServiceConnection {
         override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
@@ -765,6 +862,14 @@ class MainActivity : AppCompatActivity() {
         webView?.let { wv ->
             VSCodroidWebView.configure(wv)
             applyWindowInsetsPadding(wv)
+            // Here and not in initBridge, which runs once per server lifecycle
+            // behind a guard: a WebView with no download listener drops every
+            // download on the floor without a word, which is exactly the state
+            // this fixes, and a replacement view created for a renderer crash
+            // has to come back with one.
+            wv.setDownloadListener { url, _, contentDisposition, _, _ ->
+                downloads.onDownloadStart(url, contentDisposition)
+            }
             wv.webViewClient = bootstrapClient()
             // Show a loading placeholder while Node.js starts
             // viewport-fit=cover enables rendering into display cutout area
@@ -1131,7 +1236,15 @@ class MainActivity : AppCompatActivity() {
             onOpenFolderPicker = { runOnUiThread { openFolderPicker() } },
             onOpenRecentFolder = { uri -> runOnUiThread { openRecentSafFolder(uri) } },
             onShowAbout = { runOnUiThread { showAboutDialog() } },
-            safManager = safManager
+            safManager = safManager,
+            // Not hopped to the UI thread, unlike the five above. These three
+            // carry a download's bytes, and the coordinator guards its own
+            // state precisely so they can be answered on the thread they
+            // arrive on: posting them would reorder chunks against each other
+            // and turn the write into an unbounded queue on the main thread.
+            onDownloadNamed = { url, fileName -> downloads.onDownloadNamed(url, fileName) },
+            onDownloadChunk = { requestId, base64 -> downloads.onBytes(requestId, base64) },
+            onDownloadComplete = { requestId, error -> downloads.onComplete(requestId, error) },
         )
         wv.addJavascriptInterface(bridge, "AndroidBridge")
 
@@ -1255,6 +1368,8 @@ class MainActivity : AppCompatActivity() {
         injectTouchTargetCSS()
         // Fix #7: Override window.open() to route through AndroidBridge
         injectWindowOpenOverride()
+        // Keeps a downloaded blob readable long enough to be saved, and names it
+        injectDownloadCapture()
         // Open in Browser, SSH keys and About are contributed by the bundled bridge
         // extension, which registers them through the extension API and reaches Android
         // over the relay below. They cannot be injected from here: the workbench is an
@@ -1406,6 +1521,126 @@ class MainActivity : AppCompatActivity() {
                         if (t && AndroidBridge.openExternalUrl(url, t)) { return null; }
                     }
                     return orig.apply(window, arguments);
+                };
+            })();
+            """.trimIndent(),
+            null
+        )
+    }
+
+    /**
+     * Lets a file the editor downloads be saved to the device.
+     *
+     * Two jobs, both of which have to happen inside the page because both are
+     * about objects that only exist there.
+     *
+     * The first is keeping the bytes reachable. The editor reads a file into
+     * memory, wraps it in a blob, hands the platform a `blob:` URL for it and
+     * revokes that URL on the very next task. Saving needs the user to choose a
+     * destination first, which takes seconds, so by the time there is anywhere
+     * to write the URL names nothing at all and the download would fail every
+     * time. Revocation is therefore deferred, and only for URLs a download is
+     * actually using, so nothing else in the workbench is kept alive by this.
+     *
+     * The second is the name. A blob has none, and the platform's download hook
+     * is given the URL rather than the anchor, so `App.kt` would arrive as a
+     * UUID. The anchor knows, at the moment it is clicked, and a bridge call
+     * blocks the page until it returns, so reporting the name here puts it on
+     * the Android side before the download hook can ask for it.
+     *
+     * Both hooks call through unconditionally. Nothing here decides whether a
+     * click downloads, and a page that stopped downloading because our
+     * bookkeeping threw would be a worse failure than the one being fixed.
+     */
+    private fun injectDownloadCapture() {
+        webView?.evaluateJavascript(
+            """
+            (function() {
+                if (window.__vscodroidDownload) return;
+
+                var HOLD_MS = 120000;
+                var held = new Set();
+
+                function token() { return (window.__vscodroid || {}).authToken; }
+
+                var revoke = URL.revokeObjectURL.bind(URL);
+                URL.revokeObjectURL = function(url) {
+                    if (held.has(url)) return;
+                    revoke(url);
+                };
+
+                // Each hold releases itself, so a download nobody completes
+                // costs one blob for two minutes rather than for the life of
+                // the page.
+                function hold(url) {
+                    if (held.has(url)) return;
+                    held.add(url);
+                    setTimeout(function() { held.delete(url); revoke(url); }, HOLD_MS);
+                }
+
+                var click = HTMLAnchorElement.prototype.click;
+                HTMLAnchorElement.prototype.click = function() {
+                    try {
+                        var name = this.getAttribute('download');
+                        var url = this.href;
+                        if (name !== null && url) {
+                            if (url.lastIndexOf('blob:', 0) === 0) hold(url);
+                            var t = token();
+                            if (t && window.AndroidBridge) {
+                                AndroidBridge.noteDownloadName(t, url, name);
+                            }
+                        }
+                    } catch (e) { /* the click matters more than the record of it */ }
+                    return click.apply(this, arguments);
+                };
+
+                function encode(bytes) {
+                    var text = '';
+                    for (var i = 0; i < bytes.length; i += 0x8000) {
+                        text += String.fromCharCode.apply(null, bytes.subarray(i, i + 0x8000));
+                    }
+                    return btoa(text);
+                }
+
+                window.__vscodroidDownload = {
+                    // Reads url and pushes it back in pieces under id. Answers
+                    // whether it started, which is the one failure Android
+                    // cannot be told about any other way.
+                    send: function(url, id) {
+                        var t = token();
+                        var bridge = window.AndroidBridge;
+                        if (!t || !bridge) return false;
+                        fetch(url).then(function(response) {
+                            if (!response.ok) throw new Error('status ' + response.status);
+                            var reader = response.body.getReader();
+                            return (function pump() {
+                                return reader.read().then(function(step) {
+                                    if (step.done) {
+                                        bridge.finishDownload(t, id, '');
+                                        return;
+                                    }
+                                    // A refused chunk has already been explained
+                                    // on the Android side. Reporting it again
+                                    // here would replace that reason with this
+                                    // one, which says nothing.
+                                    if (!bridge.writeDownloadChunk(t, id, encode(step.value))) {
+                                        reader.cancel();
+                                        return;
+                                    }
+                                    // Yield between pieces: every bridge call
+                                    // blocks this thread, so a large file would
+                                    // otherwise freeze the editor for the whole
+                                    // transfer.
+                                    return new Promise(function(go) {
+                                        setTimeout(go, 0);
+                                    }).then(pump);
+                                });
+                            })();
+                        }).catch(function(e) {
+                            bridge.finishDownload(t, id, String((e && e.message) || e) || 'failed');
+                        });
+                        return true;
+                    }
                 };
             })();
             """.trimIndent(),
@@ -1620,6 +1855,12 @@ class MainActivity : AppCompatActivity() {
 
         // Reset bridge so initBridge() re-registers on the new WebView
         bridgeInitialized = false
+        // The page that owed the bytes for a download in flight is gone, so
+        // nothing will ever arrive for it. Dropped here rather than left to be
+        // displaced by the next download, which may never come: the document
+        // the picker created would sit in the user's folder as an empty file
+        // with the name of the one they wanted.
+        downloads.onPageGone()
         // The replacement has loaded nothing yet, so a callback arriving now has
         // to be held again rather than injected into a page that is not there.
         workbenchLoaded = false

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -1541,6 +1541,10 @@ class MainActivity : AppCompatActivity() {
      * to write the URL names nothing at all and the download would fail every
      * time. Revocation is therefore deferred, and only for URLs a download is
      * actually using, so nothing else in the workbench is kept alive by this.
+     * The Blob itself is kept alongside, because the bytes have to be read off
+     * the object: the page is served under `connect-src 'self' ws: wss: https:`,
+     * so a request for a `blob:` URL is refused before it starts, and that is
+     * every download of a file the editor could hold in memory.
      *
      * The second is the name. A blob has none, and the platform's download hook
      * is given the URL rather than the anchor, so `App.kt` would arrive as a
@@ -1559,9 +1563,30 @@ class MainActivity : AppCompatActivity() {
                 if (window.__vscodroidDownload) return;
 
                 var HOLD_MS = 120000;
-                var held = new Set();
+                var MAX_TRACKED = 8;
+
+                // url -> the object behind it. The page is asked for the bytes
+                // of a download by URL, and the bytes have to come off this
+                // object rather than off the URL: see readerFor below.
+                var made = new Map();
+                var held = new Map();
 
                 function token() { return (window.__vscodroid || {}).authToken; }
+
+                var create = URL.createObjectURL.bind(URL);
+                URL.createObjectURL = function(source) {
+                    var url = create(source);
+                    try {
+                        made.set(url, source);
+                        // Bounded, because the workbench mints object URLs for
+                        // all sorts of things and remembering every one of them
+                        // would pin its bytes for the life of the page. A
+                        // download claims its own entry on the click, which is
+                        // the task straight after this one.
+                        if (made.size > MAX_TRACKED) made.delete(made.keys().next().value);
+                    } catch (e) { /* the URL matters more than the record of it */ }
+                    return url;
+                };
 
                 var revoke = URL.revokeObjectURL.bind(URL);
                 URL.revokeObjectURL = function(url) {
@@ -1574,8 +1599,28 @@ class MainActivity : AppCompatActivity() {
                 // the page.
                 function hold(url) {
                     if (held.has(url)) return;
-                    held.add(url);
+                    held.set(url, made.get(url));
+                    made.delete(url);
                     setTimeout(function() { held.delete(url); revoke(url); }, HOLD_MS);
+                }
+
+                // The bytes of url, as a reader.
+                //
+                // A blob is read off the object and never off its URL. The
+                // workbench page is served under
+                // connect-src 'self' ws: wss: https:, which does not list
+                // blob:, so fetching a blob: URL is refused before it leaves
+                // the page: "Connecting to 'blob:...' violates the following
+                // Content Security Policy directive". Reading a Blob is not a
+                // request and no directive governs it. Anything else is a real
+                // URL the policy already allows.
+                function readerFor(url) {
+                    var blob = held.get(url);
+                    if (blob && blob.stream) return Promise.resolve(blob.stream().getReader());
+                    return fetch(url).then(function(response) {
+                        if (!response.ok) throw new Error('status ' + response.status);
+                        return response.body.getReader();
+                    });
                 }
 
                 var click = HTMLAnchorElement.prototype.click;
@@ -1610,9 +1655,13 @@ class MainActivity : AppCompatActivity() {
                         var t = token();
                         var bridge = window.AndroidBridge;
                         if (!t || !bridge) return false;
-                        fetch(url).then(function(response) {
-                            if (!response.ok) throw new Error('status ' + response.status);
-                            var reader = response.body.getReader();
+                        // Started on a promise so that a reader this page
+                        // cannot open at all is reported like any other failed
+                        // read, rather than thrown back at the caller that has
+                        // already been told the read began.
+                        Promise.resolve().then(function() {
+                            return readerFor(url);
+                        }).then(function(reader) {
                             return (function pump() {
                                 return reader.read().then(function(step) {
                                     if (step.done) {

--- a/android/app/src/main/kotlin/com/vscodroid/bridge/AndroidBridge.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/bridge/AndroidBridge.kt
@@ -219,7 +219,10 @@ class AndroidBridge(
     private val onOpenFolderPicker: () -> Unit = {},
     private val onOpenRecentFolder: (Uri) -> Unit = {},
     private val onShowAbout: () -> Unit = {},
-    private val safManager: SafStorageManager? = null
+    private val safManager: SafStorageManager? = null,
+    private val onDownloadNamed: (url: String, fileName: String) -> Unit = { _, _ -> },
+    private val onDownloadChunk: (requestId: String, base64: String) -> Boolean = { _, _ -> false },
+    private val onDownloadComplete: (requestId: String, error: String?) -> Unit = { _, _ -> },
 ) {
     private val tag = "AndroidBridge"
 
@@ -432,6 +435,52 @@ class AndroidBridge(
         val uri = Uri.parse(uriString)
         Logger.i(tag, "Opening recent SAF folder: $uri")
         onOpenRecentFolder(uri)
+    }
+
+    // -- Saving a download to the device --
+
+    /**
+     * Reports the name the page is about to download [url] under.
+     *
+     * Called from the anchor click, before the platform has decided the click
+     * is a download at all, and that is the point: a bridge call blocks the
+     * page until it returns, so the name is on this side before the download
+     * hook fires and the hook does not have to ask for it. A blob carries no
+     * name, so without this every file the editor downloads would be offered
+     * under a placeholder.
+     */
+    @JavascriptInterface
+    fun noteDownloadName(authToken: String, url: String, fileName: String) {
+        if (!security.validateToken(authToken)) return
+        onDownloadNamed(url, fileName)
+    }
+
+    /**
+     * Hands over one piece of a download the page is reading, base64 encoded
+     * because the bridge carries text.
+     *
+     * @return true when it was written. The page stops reading on false, which
+     *   is what keeps a failed write from being followed by the rest of a file
+     *   and a report of success.
+     */
+    @JavascriptInterface
+    fun writeDownloadChunk(authToken: String, requestId: String, base64: String): Boolean {
+        if (!security.validateToken(authToken)) return false
+        return onDownloadChunk(requestId, base64)
+    }
+
+    /**
+     * Ends a download the page was reading. [error] is empty on success and
+     * carries a reason otherwise.
+     *
+     * Empty rather than null because the value is written by JavaScript, where
+     * the absent case is easy to send by accident; an empty string is the one
+     * spelling both sides agree means "nothing went wrong".
+     */
+    @JavascriptInterface
+    fun finishDownload(authToken: String, requestId: String, error: String) {
+        if (!security.validateToken(authToken)) return
+        onDownloadComplete(requestId, error.ifEmpty { null })
     }
 
     // -- Storage Management --

--- a/android/app/src/main/kotlin/com/vscodroid/webview/DownloadCoordinator.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/webview/DownloadCoordinator.kt
@@ -20,6 +20,16 @@ enum class DownloadOutcome { SAVED, CANCELLED, FAILED }
 private const val MAX_NAMES = 8
 
 /**
+ * How many downloads may wait for their turn at the picker.
+ *
+ * There is one picker and it takes the user seconds to answer, so downloads
+ * started while it is open queue behind it. A bound rather than a capacity:
+ * every waiting download is holding a file's bytes in the page, and the page
+ * decides how many downloads to start.
+ */
+private const val MAX_QUEUED = 8
+
+/**
  * Everything [DownloadCoordinator] needs from the Activity it runs inside.
  *
  * An interface rather than the pile of lambdas the chrome client uses, because
@@ -29,12 +39,16 @@ private const val MAX_NAMES = 8
  */
 interface DownloadHost {
     /**
-     * Starts the create-document picker for a file named [fileName]. Answers
-     * whether anything took the request, on the same terms as the file chooser:
-     * false means no picker opened, so no result will ever arrive and whoever
-     * is waiting has to be told now.
+     * Starts the create-document picker for [requestId], offering [fileName].
+     *
+     * The answer comes back at [DownloadCoordinator.onDestinationChosen]
+     * carrying the same [requestId], or at
+     * [DownloadCoordinator.onDestinationUnavailable] when no picker opened at
+     * all. Nothing is returned from here because a download that waited its
+     * turn is started from whatever thread finished the one before it, while a
+     * picker can only be launched from the main thread.
      */
-    fun askDestination(fileName: String): Boolean
+    fun askDestination(requestId: String, fileName: String)
 
     /** Opens the document the user chose for writing, or null when it will not open. */
     fun openDestination(destination: Uri): OutputStream?
@@ -71,6 +85,13 @@ interface DownloadHost {
  * was a menu entry that did nothing and said nothing, and a fix that fails
  * quietly is the same defect wearing more code.
  *
+ * One at a time is a rule about the picker, not a simplification. Downloading a
+ * multi-select starts one download per file at once, and only one picker can be
+ * open and answerable: a second one launched over the first produces two
+ * results that nothing can tell apart, and the file the user named for one gets
+ * the bytes of the other. So the rest queue, keep their own names, and get
+ * their own picker in turn.
+ *
  * Thread confinement is not available. [onDownloadStart] and
  * [onDestinationChosen] arrive on the UI thread, while [onBytes] and
  * [onComplete] arrive on the WebView's bridge thread, so the state is guarded
@@ -83,15 +104,37 @@ class DownloadCoordinator(private val host: DownloadHost) {
     /**
      * The download being worked on, or null.
      *
-     * One at a time, and the id is what makes that safe rather than a
-     * simplification that leaks. The page is told which request it is answering
-     * and every answer is checked against the live one, so bytes belonging to a
-     * download that has already been displaced are dropped instead of being
-     * written into the file the user is currently waiting for. Without the
-     * check, cancelling one download and starting another would silently
-     * interleave two files.
+     * The page is told which request it is answering and every answer is
+     * checked against this one, so bytes belonging to a download that is
+     * already over are dropped instead of being written into the file the user
+     * is waiting for now. Without the check, a download that failed while the
+     * page was still reading it would spill the rest of its file into the next
+     * one.
      */
     private var pending: Pending? = null
+
+    /**
+     * Downloads started while the picker was busy, in the order they arrived.
+     *
+     * Multi-select download starts one download per file, and there is one
+     * picker: two of them open at once produce two results that cannot be told
+     * apart from one another, and the file the user named for one is filled
+     * with the bytes of the other. So the later ones wait here and are offered
+     * their own picker, under their own name, when their turn comes.
+     */
+    private val waiting = ArrayDeque<Pending>()
+
+    /**
+     * The request the picker on screen belongs to, or null when none is open.
+     *
+     * Kept apart from [pending] because the two stop agreeing exactly when it
+     * matters. A picker outlives the download that opened it: the renderer can
+     * die under it, and the request is then dropped while the picker is still
+     * on screen. Its result still arrives, having already created a document,
+     * and the id is what says that document belongs to nobody and has to go.
+     * It is also what keeps a second picker from being opened over the first.
+     */
+    private var awaitingPicker: String? = null
 
     private var requestCounter = 0L
 
@@ -139,37 +182,80 @@ class DownloadCoordinator(private val host: DownloadHost) {
 
     /**
      * A download has started in the page. Works out what to call it and asks
-     * the user where to put it.
+     * the user where to put it, or queues it when the picker is busy.
      */
     @Synchronized
     fun onDownloadStart(url: String, contentDisposition: String?) {
-        // Anything still in flight loses, and loses loudly. It cannot be kept:
-        // there is one create-document result callback and it is about to be
-        // claimed by this download, so the previous one would wait for an
-        // answer that now belongs to somebody else.
-        abandon("replaced by a later download")
-
         // Consumed, not read. The page reports a name per click, so leaving it
         // behind would let a later download of the same URL that the page did
         // not name inherit this one's filename.
         val fileName = downloadFileName(url, contentDisposition, reportedNames.remove(url))
         requestCounter += 1
         val request = Pending("dl-$requestCounter", url, fileName)
-        pending = request
 
-        if (!host.askDestination(fileName)) {
-            // No picker opened, so no result will arrive to close this out. The
-            // user asked for a file and has to hear that they are not getting
-            // one, here, because nothing downstream will ever run.
-            Logger.w(tag, "No create-document picker started for $fileName")
-            pending = null
-            host.report(DownloadOutcome.FAILED, fileName, "no picker")
+        if (pending != null || awaitingPicker != null) {
+            if (waiting.size >= MAX_QUEUED) {
+                // Refused rather than dropped from the other end: the downloads
+                // already waiting were asked for first, and a queue that
+                // silently forgets its tail is the failure this class exists to
+                // rule out.
+                Logger.w(tag, "Refusing $fileName; ${waiting.size} downloads already waiting")
+                host.report(DownloadOutcome.FAILED, fileName, "too many downloads at once")
+                return
+            }
+            waiting.addLast(request)
+            return
         }
+        start(request)
+    }
+
+    /** Hands [request] the picker. Only ever called with nothing else holding it. */
+    private fun start(request: Pending) {
+        pending = request
+        awaitingPicker = request.id
+        host.askDestination(request.id, request.fileName)
     }
 
     /**
-     * The create-document picker answered. [destination] is null when the user
-     * backed out.
+     * Gives the picker to the next download waiting for it, if it is free.
+     *
+     * Called from every path that ends a download, including the ones that end
+     * it badly. A download that fails must not take the queue behind it down,
+     * and a queue that stops being drained is a page waiting on files that will
+     * never be asked for.
+     */
+    private fun startNextIfIdle() {
+        if (pending != null || awaitingPicker != null) return
+        start(waiting.removeFirstOrNull() ?: return)
+    }
+
+    /**
+     * No picker opened for [requestId], so no result will ever arrive for it.
+     *
+     * The user asked for a file and has to hear that they are not getting one,
+     * from here, because nothing downstream will run.
+     */
+    @Synchronized
+    fun onDestinationUnavailable(requestId: String) {
+        if (awaitingPicker == requestId) awaitingPicker = null
+        val request = live(requestId)
+        if (request == null) {
+            startNextIfIdle()
+            return
+        }
+        Logger.w(tag, "No create-document picker started for ${request.fileName}")
+        fail(request, "no picker")
+    }
+
+    /**
+     * The create-document picker answered [requestId]. [destination] is null
+     * when the user backed out.
+     *
+     * The id is checked rather than assumed, and a result that does not match
+     * the download waiting for one loses its document. The picker creates the
+     * file the moment the user confirms a name, so a result nobody is waiting
+     * on has already put an empty file in their folder wearing the name of a
+     * file they will not get.
      *
      * Cancelling is the ordinary case and it is deliberately not silent. It is
      * also the cheapest to get right: the picker creates nothing until the user
@@ -177,11 +263,19 @@ class DownloadCoordinator(private val host: DownloadHost) {
      * go of the request.
      */
     @Synchronized
-    fun onDestinationChosen(destination: Uri?) {
-        val request = pending ?: return
+    fun onDestinationChosen(requestId: String?, destination: Uri?) {
+        if (requestId != null && requestId == awaitingPicker) awaitingPicker = null
+        val request = pending?.takeIf { it.id == requestId }
+        if (request == null) {
+            Logger.w(tag, "Destination for $requestId belongs to no download in flight")
+            destination?.let { host.discardDestination(it) }
+            startNextIfIdle()
+            return
+        }
         if (destination == null) {
             pending = null
             host.report(DownloadOutcome.CANCELLED, request.fileName, null)
+            startNextIfIdle()
             return
         }
         // Recorded before the stream is opened, so a failure to open still has
@@ -258,23 +352,28 @@ class DownloadCoordinator(private val host: DownloadHost) {
         }
         pending = null
         host.report(DownloadOutcome.SAVED, request.fileName, null)
+        startNextIfIdle()
     }
 
     /**
-     * Drops a download that can no longer be completed, without reporting.
+     * Drops every download that can no longer be completed, without reporting.
      *
      * For the WebView going away underneath one. The page that owed the bytes
-     * no longer exists, so nothing will ever arrive, and the document created
-     * for it has to go rather than stay as an empty file the user did not ask
-     * for. Silent because the user is watching a renderer crash recover, and a
+     * no longer exists, so nothing will ever arrive for the download in flight
+     * or for any of the ones queued behind it, and the document created for it
+     * has to go rather than stay as an empty file the user did not ask for.
+     * Silent because the user is watching a renderer crash recover, and a
      * download failure toast on top of that explains nothing.
+     *
+     * A picker still on screen is left alone, because it belongs to the user
+     * rather than to the page. Its result arrives naming a download that is
+     * gone, and [onDestinationChosen] removes the document it created.
      */
     @Synchronized
-    fun onPageGone() = abandon("the page went away")
-
-    private fun abandon(reason: String) {
+    fun onPageGone() {
+        waiting.clear()
         val request = pending ?: return
-        Logger.w(tag, "Abandoning the download of ${request.fileName}: $reason")
+        Logger.w(tag, "Abandoning the download of ${request.fileName}: the page went away")
         pending = null
         closeAndDiscard(request)
     }
@@ -283,6 +382,7 @@ class DownloadCoordinator(private val host: DownloadHost) {
         pending = null
         closeAndDiscard(request)
         host.report(DownloadOutcome.FAILED, request.fileName, detail)
+        startNextIfIdle()
     }
 
     /**
@@ -309,7 +409,7 @@ class DownloadCoordinator(private val host: DownloadHost) {
     private fun live(requestId: String): Pending? {
         val request = pending
         if (request == null || request.id != requestId) {
-            Logger.d(tag, "Ignoring bytes for $requestId; it is not the live download")
+            Logger.d(tag, "Ignoring an answer for $requestId; it is not the live download")
             return null
         }
         return request

--- a/android/app/src/main/kotlin/com/vscodroid/webview/DownloadCoordinator.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/webview/DownloadCoordinator.kt
@@ -1,0 +1,317 @@
+package com.vscodroid.webview
+
+import android.net.Uri
+import com.vscodroid.util.Logger
+import java.io.IOException
+import java.io.OutputStream
+import java.util.Base64
+
+/** How a download ended, which is the one thing the user has to be told. */
+enum class DownloadOutcome { SAVED, CANCELLED, FAILED }
+
+/**
+ * How many download names the page may have outstanding.
+ *
+ * A bound rather than a capacity. One click names one URL and the name is taken
+ * back out the moment the download for it starts, so the steady state is zero
+ * or one; anything above that is a click the platform decided not to turn into
+ * a download, and those must not accumulate.
+ */
+private const val MAX_NAMES = 8
+
+/**
+ * Everything [DownloadCoordinator] needs from the Activity it runs inside.
+ *
+ * An interface rather than the pile of lambdas the chrome client uses, because
+ * these five are one collaborator seen from five sides and a test wants to
+ * watch them together: the ordering between opening a document, writing to it
+ * and discarding it is most of what can go wrong here.
+ */
+interface DownloadHost {
+    /**
+     * Starts the create-document picker for a file named [fileName]. Answers
+     * whether anything took the request, on the same terms as the file chooser:
+     * false means no picker opened, so no result will ever arrive and whoever
+     * is waiting has to be told now.
+     */
+    fun askDestination(fileName: String): Boolean
+
+    /** Opens the document the user chose for writing, or null when it will not open. */
+    fun openDestination(destination: Uri): OutputStream?
+
+    /** Removes a document this download created and did not fill. */
+    fun discardDestination(destination: Uri)
+
+    /** Asks the page to read [url] and push its bytes back under [requestId]. */
+    fun requestBytes(requestId: String, url: String)
+
+    /** Tells the user how a download ended. [detail] is for the log, not the screen. */
+    fun report(outcome: DownloadOutcome, fileName: String, detail: String?)
+}
+
+/**
+ * Runs one download at a time, from the platform's download hook to a file the
+ * user chose.
+ *
+ * Every download the editor starts arrives here, and the shape of the job is
+ * fixed by two things that cannot be changed from this side. The first is that
+ * the destination is a SAF document the user picks *after* the download has
+ * already begun, so there is a gap between "a download started" and "there is
+ * somewhere to put it" that has to be held open. The second is that the bytes
+ * do not come from this process: the editor hands the platform a `blob:` URL
+ * for anything it could read into memory, and a blob belongs to the page. So
+ * the page is asked for the bytes and pushes them back in pieces, which is why
+ * this is a state machine and not a copy loop.
+ *
+ * The rule the whole class exists to keep is that **a download that did not
+ * happen never looks like one that did**. A partial file left behind with the
+ * name the user chose is indistinguishable from a complete one until they open
+ * it, so every path that ends badly removes the document it created and says
+ * so. Reporting is not optional on any path either: the defect this replaces
+ * was a menu entry that did nothing and said nothing, and a fix that fails
+ * quietly is the same defect wearing more code.
+ *
+ * Thread confinement is not available. [onDownloadStart] and
+ * [onDestinationChosen] arrive on the UI thread, while [onBytes] and
+ * [onComplete] arrive on the WebView's bridge thread, so the state is guarded
+ * outright rather than by a convention that has no way to hold.
+ */
+class DownloadCoordinator(private val host: DownloadHost) {
+
+    private val tag = "DownloadCoordinator"
+
+    /**
+     * The download being worked on, or null.
+     *
+     * One at a time, and the id is what makes that safe rather than a
+     * simplification that leaks. The page is told which request it is answering
+     * and every answer is checked against the live one, so bytes belonging to a
+     * download that has already been displaced are dropped instead of being
+     * written into the file the user is currently waiting for. Without the
+     * check, cancelling one download and starting another would silently
+     * interleave two files.
+     */
+    private var pending: Pending? = null
+
+    private var requestCounter = 0L
+
+    /**
+     * Names the page has reported for URLs it is about to download.
+     *
+     * Filled by [onDownloadNamed], which the page calls from the anchor click
+     * itself, before the platform has been asked for anything. That ordering is
+     * the whole reason this is a map rather than a question asked when the
+     * download arrives: a bridge call blocks the page until it returns, so by
+     * the time the click reaches the platform the name is already here, and
+     * [onDownloadStart] stays synchronous. Asking the page afterwards would put
+     * a callback between a download starting and the picker opening, and a
+     * callback that does not arrive is a download that does nothing, which is
+     * the failure being fixed.
+     *
+     * Bounded and insertion-ordered, so a page that names downloads nobody ever
+     * starts loses its oldest entries instead of growing for the life of the
+     * document. Ordinary use holds one.
+     */
+    private val reportedNames = object : LinkedHashMap<String, String>() {
+        override fun removeEldestEntry(eldest: Map.Entry<String, String>?) = size > MAX_NAMES
+    }
+
+    private class Pending(
+        val id: String,
+        val url: String,
+        val fileName: String,
+        var destination: Uri? = null,
+        var stream: OutputStream? = null,
+    )
+
+    /**
+     * The page is about to download [url] under [fileName], which is the
+     * `download` attribute of the anchor it is clicking.
+     *
+     * Recorded rather than acted on. The platform decides whether a click
+     * becomes a download, and this runs before it has, so the name is put
+     * somewhere [onDownloadStart] can find it and nothing else happens.
+     */
+    @Synchronized
+    fun onDownloadNamed(url: String, fileName: String) {
+        reportedNames[url] = fileName
+    }
+
+    /**
+     * A download has started in the page. Works out what to call it and asks
+     * the user where to put it.
+     */
+    @Synchronized
+    fun onDownloadStart(url: String, contentDisposition: String?) {
+        // Anything still in flight loses, and loses loudly. It cannot be kept:
+        // there is one create-document result callback and it is about to be
+        // claimed by this download, so the previous one would wait for an
+        // answer that now belongs to somebody else.
+        abandon("replaced by a later download")
+
+        // Consumed, not read. The page reports a name per click, so leaving it
+        // behind would let a later download of the same URL that the page did
+        // not name inherit this one's filename.
+        val fileName = downloadFileName(url, contentDisposition, reportedNames.remove(url))
+        requestCounter += 1
+        val request = Pending("dl-$requestCounter", url, fileName)
+        pending = request
+
+        if (!host.askDestination(fileName)) {
+            // No picker opened, so no result will arrive to close this out. The
+            // user asked for a file and has to hear that they are not getting
+            // one, here, because nothing downstream will ever run.
+            Logger.w(tag, "No create-document picker started for $fileName")
+            pending = null
+            host.report(DownloadOutcome.FAILED, fileName, "no picker")
+        }
+    }
+
+    /**
+     * The create-document picker answered. [destination] is null when the user
+     * backed out.
+     *
+     * Cancelling is the ordinary case and it is deliberately not silent. It is
+     * also the cheapest to get right: the picker creates nothing until the user
+     * confirms, so there is no document to remove and the only work is letting
+     * go of the request.
+     */
+    @Synchronized
+    fun onDestinationChosen(destination: Uri?) {
+        val request = pending ?: return
+        if (destination == null) {
+            pending = null
+            host.report(DownloadOutcome.CANCELLED, request.fileName, null)
+            return
+        }
+        // Recorded before the stream is opened, so a failure to open still has
+        // somewhere to point. The picker has already created the document by
+        // the time it answers, so an unopenable one is an empty file sitting in
+        // the user's chosen folder wearing the name of the file they wanted.
+        request.destination = destination
+        val stream = try {
+            host.openDestination(destination)
+        } catch (e: IOException) {
+            Logger.w(tag, "Could not open the chosen document", e)
+            null
+        }
+        if (stream == null) {
+            fail(request, "the chosen document could not be opened")
+            return
+        }
+        request.stream = stream
+        host.requestBytes(request.id, request.url)
+    }
+
+    /**
+     * Bytes for [requestId], base64 as the bridge can only carry text.
+     *
+     * @return true when they were written, false on anything else. The page
+     *   stops reading when this says false, which is the only backpressure in
+     *   the design and also how a failed write stops a transfer that would
+     *   otherwise run to completion and report success over a file with a hole
+     *   in it.
+     */
+    @Synchronized
+    fun onBytes(requestId: String, base64: String): Boolean {
+        val request = live(requestId) ?: return false
+        val stream = request.stream ?: return false
+        val bytes = try {
+            Base64.getDecoder().decode(base64)
+        } catch (e: IllegalArgumentException) {
+            fail(request, "the page sent bytes that are not base64")
+            return false
+        }
+        return try {
+            stream.write(bytes)
+            true
+        } catch (e: IOException) {
+            Logger.w(tag, "Write to the chosen document failed", e)
+            fail(request, "writing to the chosen document failed")
+            false
+        }
+    }
+
+    /**
+     * The page has no more bytes. [error] is null on success and a reason
+     * otherwise.
+     *
+     * Closing is part of the success test rather than cleanup after it. A
+     * `content://` stream can buffer, so the write that actually reaches
+     * storage may be the one `close` performs, and reporting success before it
+     * returns would report on a file that had not been written yet.
+     */
+    @Synchronized
+    fun onComplete(requestId: String, error: String?) {
+        val request = live(requestId) ?: return
+        if (error != null) {
+            fail(request, error)
+            return
+        }
+        try {
+            request.stream?.close()
+        } catch (e: IOException) {
+            Logger.w(tag, "Closing the chosen document failed", e)
+            request.stream = null
+            fail(request, "the file could not be finished")
+            return
+        }
+        pending = null
+        host.report(DownloadOutcome.SAVED, request.fileName, null)
+    }
+
+    /**
+     * Drops a download that can no longer be completed, without reporting.
+     *
+     * For the WebView going away underneath one. The page that owed the bytes
+     * no longer exists, so nothing will ever arrive, and the document created
+     * for it has to go rather than stay as an empty file the user did not ask
+     * for. Silent because the user is watching a renderer crash recover, and a
+     * download failure toast on top of that explains nothing.
+     */
+    @Synchronized
+    fun onPageGone() = abandon("the page went away")
+
+    private fun abandon(reason: String) {
+        val request = pending ?: return
+        Logger.w(tag, "Abandoning the download of ${request.fileName}: $reason")
+        pending = null
+        closeAndDiscard(request)
+    }
+
+    private fun fail(request: Pending, detail: String) {
+        pending = null
+        closeAndDiscard(request)
+        host.report(DownloadOutcome.FAILED, request.fileName, detail)
+    }
+
+    /**
+     * Closes the stream and removes the document behind it.
+     *
+     * The close comes first and its failure is swallowed on purpose: this runs
+     * only on paths that have already decided the download failed, so there is
+     * no verdict left for it to change, and a throw here would skip the discard
+     * and leave behind exactly the half-written file the discard exists to
+     * prevent.
+     */
+    private fun closeAndDiscard(request: Pending) {
+        try {
+            request.stream?.close()
+        } catch (e: IOException) {
+            Logger.d(tag, "Ignoring a close failure on a download already lost: ${e.message}")
+        }
+        request.stream = null
+        request.destination?.let { host.discardDestination(it) }
+        request.destination = null
+    }
+
+    /** The pending download when [requestId] names it, or null when it names a stale one. */
+    private fun live(requestId: String): Pending? {
+        val request = pending
+        if (request == null || request.id != requestId) {
+            Logger.d(tag, "Ignoring bytes for $requestId; it is not the live download")
+            return null
+        }
+        return request
+    }
+}

--- a/android/app/src/main/kotlin/com/vscodroid/webview/DownloadNaming.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/webview/DownloadNaming.kt
@@ -1,0 +1,144 @@
+package com.vscodroid.webview
+
+import java.net.URLDecoder
+
+/**
+ * The name offered when nothing usable can be read off the download.
+ *
+ * Extension-less, because reaching here means nothing knew one. The picker
+ * creates the file under exactly the name it is given, so an extension invented
+ * from the MIME type would be a guess the user cannot see is a guess, while a
+ * bare name is visibly incomplete in a field they are already looking at.
+ */
+internal const val FALLBACK_DOWNLOAD_NAME = "download"
+
+/**
+ * Longest name offered to the picker, chosen against the 255-byte limit most
+ * filesystems impose rather than against anything Android checks.
+ */
+private const val MAX_NAME_LENGTH = 200
+
+/** Space is the first printable character; DEL is the one that follows them. */
+private const val FIRST_PRINTABLE = 0x20
+private const val DELETE_CHAR = 0x7F
+
+private val CONTENT_DISPOSITION_EXTENDED =
+    Regex("""filename\*\s*=\s*[^']*'[^']*'([^;]+)""", RegexOption.IGNORE_CASE)
+
+private val CONTENT_DISPOSITION_PLAIN =
+    Regex("""filename\s*=\s*"([^"]*)"|filename\s*=\s*([^;"]+)""", RegexOption.IGNORE_CASE)
+
+/**
+ * Picks the name a downloaded file is offered to the user under.
+ *
+ * Four sources, tried in the order of how much each one knows, because on this
+ * platform the richest of them is also the one most likely to be absent.
+ *
+ * [suggested] is the `download` attribute of the anchor the editor clicked,
+ * read back out of the page. It is the only source that carries the name the
+ * user is expecting, and every other source below is a consolation prize: the
+ * editor builds its anchor over a `blob:` URL whose text is a UUID, and a blob
+ * has no name to ask for. Whether the attribute reaches the platform download
+ * listener at all is not something this code can decide, which is why it is
+ * passed in rather than read from [contentDisposition].
+ *
+ * [contentDisposition] is a real header and is honoured when present, extended
+ * form first: `filename*` carries the encoding and survives non-ASCII names,
+ * while `filename` is defined over a byte range that does not.
+ *
+ * The URL is asked twice and the two questions are not the same one. A resource
+ * served by the editor's remote-resource endpoint carries the file's POSIX path
+ * in a `path` query parameter, so the basename of *that* is the real name;
+ * looking at the URL's own last segment there would answer
+ * `vscode-remote-resource` for every file in the workspace. Only when there is
+ * no `path` parameter does the last path segment get asked, and then only if it
+ * looks like a filename, which is what keeps a `blob:` UUID out.
+ *
+ * Every candidate goes through [safeFileName] and a candidate that does not
+ * survive it falls through to the next, rather than being handed on empty. That
+ * is the difference between a bad name and no name: the picker shows this in an
+ * editable field, so a wrong guess costs the user a retype, while an empty one
+ * offers a file that cannot be created.
+ */
+internal fun downloadFileName(
+    url: String,
+    contentDisposition: String?,
+    suggested: String?,
+): String =
+    safeFileName(suggested)
+        ?: safeFileName(fileNameFromContentDisposition(contentDisposition))
+        ?: safeFileName(pathParameterBaseName(url))
+        ?: safeFileName(lastPathSegment(url)?.takeIf { it.contains('.') })
+        ?: FALLBACK_DOWNLOAD_NAME
+
+/**
+ * Reduces a candidate to a name that names one file, or null when nothing is
+ * left of it.
+ *
+ * The separator strip is the part that matters and it runs on every candidate,
+ * including the `download` attribute, which is page-controlled text. A name
+ * that survived with a separator in it would be handed to the create-document
+ * picker as a path, and what a documents provider does with one is the
+ * provider's decision rather than this app's. Taking the last segment is also
+ * exactly right for the candidates that legitimately arrive as paths, so the
+ * defensive reading and the useful one are the same operation.
+ *
+ * `.` and `..` are refused rather than trimmed, because they survive every
+ * character-level rule here and name a directory rather than a file.
+ */
+internal fun safeFileName(candidate: String?): String? {
+    val raw = candidate?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+    val basename = raw.substringAfterLast('/').substringAfterLast('\\')
+    val cleaned = basename
+        .filter { it.code >= FIRST_PRINTABLE && it.code != DELETE_CHAR }
+        .trim()
+        .take(MAX_NAME_LENGTH)
+        .trim()
+    if (cleaned.isEmpty() || cleaned == "." || cleaned == "..") return null
+    return cleaned
+}
+
+private fun fileNameFromContentDisposition(header: String?): String? {
+    if (header.isNullOrEmpty()) return null
+    CONTENT_DISPOSITION_EXTENDED.find(header)?.groupValues?.get(1)?.let {
+        return percentDecode(it.trim())
+    }
+    val plain = CONTENT_DISPOSITION_PLAIN.find(header) ?: return null
+    return plain.groupValues.drop(1).firstOrNull { it.isNotEmpty() }?.trim()
+}
+
+/**
+ * The basename of the `path` query parameter, which is how the editor's
+ * remote-resource endpoint names the file it is serving.
+ */
+private fun pathParameterBaseName(url: String): String? {
+    val query = url.substringBefore('#').substringAfter('?', "")
+    if (query.isEmpty()) return null
+    val value = query.split('&')
+        .firstOrNull { it.startsWith("path=") }
+        ?.removePrefix("path=")
+        ?: return null
+    return percentDecode(value.replace('+', ' '))
+}
+
+private fun lastPathSegment(url: String): String? =
+    url.substringBefore('#')
+        .substringBefore('?')
+        .substringAfterLast('/')
+        .takeIf { it.isNotEmpty() }
+        ?.let { percentDecode(it) }
+
+/**
+ * Percent-decoding that answers the input when the input is not valid encoding.
+ *
+ * A name is a display string rather than a protocol field, so a stray `%` in
+ * one is a character and not a syntax error. The decoder throws on it, and the
+ * throw would travel out of a naming helper and cancel a download over a
+ * filename.
+ */
+private fun percentDecode(value: String): String =
+    try {
+        URLDecoder.decode(value, "UTF-8")
+    } catch (e: IllegalArgumentException) {
+        value
+    }

--- a/android/app/src/main/kotlin/com/vscodroid/webview/DownloadNaming.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/webview/DownloadNaming.kt
@@ -138,7 +138,13 @@ private fun lastPathSegment(url: String): String? =
  */
 private fun percentDecode(value: String): String =
     try {
-        URLDecoder.decode(value, "UTF-8")
+        // Percent-escapes only. `URLDecoder` also turns `+` into a space, which
+        // is the rule for a query parameter and wrong everywhere else: a path
+        // segment and a Content-Disposition filename both carry `+` as itself,
+        // so `c++notes.txt` would arrive as `c  notes.txt`. Escaping it first
+        // makes the decoder hand it back unchanged, and the one caller that
+        // does want the query rule applies it before calling here.
+        URLDecoder.decode(value.replace("+", "%2B"), "UTF-8")
     } catch (e: IllegalArgumentException) {
         value
     }

--- a/android/app/src/test/kotlin/com/vscodroid/BridgeCallbackThreadHopTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/BridgeCallbackThreadHopTest.kt
@@ -36,12 +36,17 @@ import java.io.File
  * executor satisfies this test and is just as broken. It also only reads this
  * one construction site; a second bridge built elsewhere is invisible to it.
  *
- * The exempt entry is deliberate rather than an oversight. `onBackPressed`
- * returns a `Boolean` the caller consumes immediately, and `runOnUiThread`
- * returns `Unit`, posting it would mean answering before the answer exists.
- * Its body must therefore stay free of UI calls, which is not something this
- * test can check; it is recorded here so the exemption is a decision on the
- * record rather than a gap someone finds later.
+ * The exempt entries are deliberate rather than oversights, and they share one
+ * shape: each is a callback whose answer or whose ordering is consumed before a
+ * posted body could run. `onBackPressed` and `onDownloadChunk` return a
+ * `Boolean` the caller consumes immediately, and `runOnUiThread` returns `Unit`,
+ * so posting them would mean answering before the answer exists. The two
+ * download callbacks beside them are ordered against calls that cannot be
+ * posted for that reason, and posting only some of a sequence reorders it.
+ *
+ * Every exempt body must therefore stay free of UI calls, which is not something
+ * this test can check; the reasons are recorded here so each exemption is a
+ * decision on the record rather than a gap someone finds later.
  */
 class BridgeCallbackThreadHopTest {
 
@@ -54,6 +59,13 @@ class BridgeCallbackThreadHopTest {
      */
     private val exempt = mapOf(
         "onBackPressed" to "returns a Boolean the caller reads synchronously",
+        "onDownloadChunk" to "returns a Boolean the caller reads synchronously",
+        "onDownloadNamed" to
+            "the platform's download hook runs immediately after the click that calls this, " +
+            "so a posted name would arrive after the download that needs it",
+        "onDownloadComplete" to
+            "ordered against onDownloadChunk, which cannot be posted; posting only this one " +
+            "would end the download before its last pieces were written",
     )
 
     /**

--- a/android/app/src/test/kotlin/com/vscodroid/bridge/BridgeTokenUniformityTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/bridge/BridgeTokenUniformityTest.kt
@@ -52,6 +52,16 @@ class BridgeTokenUniformityTest {
         val onOpenRecentFolder: (Uri) -> Unit = mockk(relaxed = true)
         val onShowAbout: () -> Unit = mockk(relaxed = true)
         val safManager: SafStorageManager = mockk(relaxed = true)
+        // Passed rather than left to default, and that is the whole point of
+        // this fixture. Every one of these has a no-op default, so a collaborator
+        // omitted here is not merely untested: it is absent from [collaborators],
+        // and the half of the guard that checks a method OBEYS the token rather
+        // than merely consulting it has nothing to watch. A new bridge method
+        // reaching an omitted callback would pass this suite while ignoring the
+        // token entirely.
+        val onDownloadNamed: (String, String) -> Unit = mockk(relaxed = true)
+        val onDownloadChunk: (String, String) -> Boolean = mockk(relaxed = true)
+        val onDownloadComplete: (String, String?) -> Unit = mockk(relaxed = true)
 
         val bridge = AndroidBridge(
             context = context,
@@ -63,12 +73,16 @@ class BridgeTokenUniformityTest {
             onOpenRecentFolder = onOpenRecentFolder,
             onShowAbout = onShowAbout,
             safManager = safManager,
+            onDownloadNamed = onDownloadNamed,
+            onDownloadChunk = onDownloadChunk,
+            onDownloadComplete = onDownloadComplete,
         )
 
         /** Everything the bridge can reach except the validator it is allowed to consult. */
         val collaborators = listOf(
             context, clipboard, onBackPressed, onMinimize,
             onOpenFolderPicker, onOpenRecentFolder, onShowAbout, safManager,
+            onDownloadNamed, onDownloadChunk, onDownloadComplete,
         )
 
         init {

--- a/android/app/src/test/kotlin/com/vscodroid/webview/DownloadCoordinatorTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/DownloadCoordinatorTest.kt
@@ -41,6 +41,9 @@ class DownloadCoordinatorTest {
     /** What the fake picker was asked to create, one entry per request. */
     private val asked = mutableListOf<String>()
 
+    /** The request each of those pickers was opened for, in the same order. */
+    private val pickerIds = mutableListOf<String>()
+
     /** Documents the fake picker created and did not delete. */
     private val documents = mutableMapOf<Uri, RecordingStream>()
 
@@ -97,9 +100,10 @@ class DownloadCoordinatorTest {
     }
 
     private val host = object : DownloadHost {
-        override fun askDestination(fileName: String): Boolean {
+        override fun askDestination(requestId: String, fileName: String) {
             asked += fileName
-            return pickerOpens
+            pickerIds += requestId
+            if (!pickerOpens) coordinator.onDestinationUnavailable(requestId)
         }
 
         override fun openDestination(destination: Uri): OutputStream? {
@@ -130,6 +134,7 @@ class DownloadCoordinatorTest {
         every { Logger.w(any(), any()) } just Runs
         every { Logger.w(any(), any(), any()) } just Runs
         asked.clear()
+        pickerIds.clear()
         documents.clear()
         discarded.clear()
         reported.clear()
@@ -152,10 +157,14 @@ class DownloadCoordinatorTest {
     /** The id the page is told to answer under, for the request just started. */
     private fun liveRequestId(): String = readRequests.last().first
 
+    /** Answers the picker on screen the way the Activity does, naming its request. */
+    private fun chooseDestination(target: Uri?) =
+        coordinator.onDestinationChosen(pickerIds.last(), target)
+
     /** Drives one whole download to the point where the page is reading it. */
     private fun startAndChoose(url: String = "blob:x", target: Uri = destination()): String {
         coordinator.onDownloadStart(url, null)
-        coordinator.onDestinationChosen(target)
+        chooseDestination(target)
         return liveRequestId()
     }
 
@@ -192,7 +201,7 @@ class DownloadCoordinatorTest {
     fun `cancelling says so and leaves nothing behind`() {
         coordinator.onDownloadStart("blob:x", null)
 
-        coordinator.onDestinationChosen(null)
+        chooseDestination(null)
 
         assertEquals(listOf(DownloadOutcome.CANCELLED to FALLBACK_DOWNLOAD_NAME), reported,
             "a cancellation the user cannot see is the failure this replaces")
@@ -265,7 +274,7 @@ class DownloadCoordinatorTest {
         destinationOpens = false
         coordinator.onDownloadStart("blob:x", null)
 
-        coordinator.onDestinationChosen(target)
+        chooseDestination(target)
 
         assertEquals(listOf(DownloadOutcome.FAILED to FALLBACK_DOWNLOAD_NAME), reported)
         assertEquals(listOf(target), discarded,
@@ -286,27 +295,161 @@ class DownloadCoordinatorTest {
         assertEquals(listOf(DownloadOutcome.FAILED to FALLBACK_DOWNLOAD_NAME), reported)
         // Nothing is left waiting: a later result would otherwise be taken as
         // this request's answer and write into a file nobody asked for.
-        coordinator.onDestinationChosen(destination())
+        val stray = destination("stray")
+        chooseDestination(stray)
         assertEquals(1, reported.size, "the abandoned request must not be revived by a stray result")
+        assertEquals(listOf(stray), discarded, "and the document it created does not stay behind")
     }
 
     /**
-     * Bytes belonging to a download that has already been displaced.
+     * Multi-select download: one download per file, arriving before the user has
+     * answered anything.
+     *
+     * The measured failure was two pickers open at once, whose results are two
+     * `Uri`s and nothing else. Matched by arrival they cross over, and the file
+     * created under the first name is filled with the second file's bytes while
+     * an empty one keeps the other name. So each file has to reach the
+     * destination chosen for it, and that is what is asserted here, not the
+     * order the pickers happened to open in.
+     */
+    @Test
+    fun `two downloads at once each land in the destination chosen for them`() {
+        coordinator.onDownloadNamed("blob:one", "first.txt")
+        coordinator.onDownloadNamed("blob:two", "second.txt")
+        coordinator.onDownloadStart("blob:one", null)
+        coordinator.onDownloadStart("blob:two", null)
+
+        assertEquals(listOf("first.txt"), asked,
+            "a second picker cannot be told apart from the first, so it must not be opened")
+
+        val first = destination("first")
+        chooseDestination(first)
+        val firstId = liveRequestId()
+        coordinator.onBytes(firstId, encode("one"))
+        coordinator.onComplete(firstId, null)
+
+        assertEquals(listOf("first.txt", "second.txt"), asked,
+            "the download that waited gets its turn, under its own name")
+        val second = destination("second")
+        chooseDestination(second)
+        val secondId = liveRequestId()
+        coordinator.onBytes(secondId, encode("two"))
+        coordinator.onComplete(secondId, null)
+
+        assertEquals("one", documents[first]!!.written.toString())
+        assertEquals("two", documents[second]!!.written.toString())
+        assertEquals(
+            listOf(DownloadOutcome.SAVED to "first.txt", DownloadOutcome.SAVED to "second.txt"),
+            reported,
+        )
+        assertEquals(emptyList<Uri>(), discarded, "neither file was left empty or removed")
+    }
+
+    /**
+     * A queued download still gets a picker after the one ahead of it failed.
+     *
+     * The queue is drained from the paths that end a download, and the ones that
+     * end badly are the easy half to forget. Forgetting them leaves the page
+     * waiting on a file it will never be asked to read, with nothing said.
+     */
+    @Test
+    fun `a download waiting behind a failed one still gets its turn`() {
+        coordinator.onDownloadNamed("blob:two", "second.txt")
+        val firstId = startAndChoose("blob:one", destination("first"))
+        coordinator.onDownloadStart("blob:two", null)
+
+        coordinator.onComplete(firstId, "the page could not read it")
+
+        assertEquals(listOf(FALLBACK_DOWNLOAD_NAME, "second.txt"), asked)
+        val second = destination("second")
+        chooseDestination(second)
+        coordinator.onBytes(liveRequestId(), encode("two"))
+        coordinator.onComplete(liveRequestId(), null)
+        assertEquals("two", documents[second]!!.written.toString())
+    }
+
+    /**
+     * The picker outlives the download that opened it. A renderer crash drops
+     * the request while the user is still choosing a folder, and their answer
+     * arrives afterwards having already created the file.
+     *
+     * Taking it would fill a document named for a file the page can no longer
+     * read; leaving it would leave that document empty in the user's folder.
+     */
+    @Test
+    fun `a destination chosen for a download that is gone is not adopted`() {
+        coordinator.onDownloadStart("blob:one", null)
+        coordinator.onPageGone()
+
+        val orphan = destination("orphan")
+        chooseDestination(orphan)
+
+        assertEquals(listOf(orphan), discarded)
+        assertEquals(emptyList<Pair<String, String>>(), readRequests,
+            "there is no page left to read anything")
+        // And the next download is not locked out by the picker that answered
+        // too late.
+        coordinator.onDownloadStart("blob:two", null)
+        assertEquals(2, asked.size)
+    }
+
+    /**
+     * A result carrying an id that is not the one the picker was opened for.
+     *
+     * The download in flight is left exactly as it was, because its own answer
+     * is still coming, and the document the stray result created is removed.
+     */
+    @Test
+    fun `a destination that names another request never displaces the live one`() {
+        coordinator.onDownloadStart("blob:one", null)
+        val stray = destination("stray")
+
+        coordinator.onDestinationChosen("dl-not-this-one", stray)
+
+        assertEquals(listOf(stray), discarded)
+        assertEquals(emptyList<Pair<DownloadOutcome, String>>(), reported)
+        val target = destination("target")
+        chooseDestination(target)
+        val id = liveRequestId()
+        coordinator.onBytes(id, encode("mine"))
+        coordinator.onComplete(id, null)
+        assertEquals("mine", documents[target]!!.written.toString(),
+            "the download that was waiting still gets the destination it was promised")
+    }
+
+    /**
+     * The queue is bounded, and the refusal is reported. What it protects is not
+     * a size: every waiting download is a file the page is holding in memory for
+     * it, so an unbounded queue is unbounded memory driven by page clicks.
+     */
+    @Test
+    fun `downloads beyond what the queue holds are refused out loud`() {
+        coordinator.onDownloadStart("blob:live", null)
+        repeat(8) { coordinator.onDownloadStart("blob:queued$it", null) }
+
+        coordinator.onDownloadStart("blob:overflow", null)
+
+        assertEquals(listOf(DownloadOutcome.FAILED to FALLBACK_DOWNLOAD_NAME), reported,
+            "a download that will never be started has to say so")
+        assertEquals(1, asked.size, "and nothing ahead of it in the queue was disturbed")
+    }
+
+    /**
+     * Bytes belonging to a download that is already over.
      *
      * The page is told which request it is answering precisely so this can be
-     * refused. Without the check, a slow first download and a second one started
-     * over it would interleave into the file the user is currently waiting for,
-     * and the result would be a corrupt file reported as saved.
+     * refused. The page reads on its own schedule and is only asked to stop
+     * between pieces, so a download that failed here can still have pieces in
+     * flight when the next one opens its file. Without the check they would
+     * land in it, and the result would be a corrupt file reported as saved.
      */
     @Test
     fun `bytes from a stale request never reach the live file`() {
-        val first = destination("first")
-        val firstId = startAndChoose("blob:one", first)
+        val firstId = startAndChoose("blob:one", destination("first"))
+        coordinator.onComplete(firstId, "the read failed")
 
         val second = destination("second")
-        coordinator.onDownloadStart("blob:two", null)
-        coordinator.onDestinationChosen(second)
-        val secondId = liveRequestId()
+        val secondId = startAndChoose("blob:two", second)
 
         assertEquals(false, coordinator.onBytes(firstId, encode("stale")),
             "an answer for a request that is over is refused")
@@ -318,21 +461,25 @@ class DownloadCoordinatorTest {
     }
 
     /**
-     * Starting a second download over one still in flight. The first cannot be
-     * kept: there is one picker result to claim and the second has just claimed
-     * it. So its file has to go, and it must not be reported as saved.
+     * A second download started over one still being written.
+     *
+     * The first is not displaced. It has a document open and a page reading into
+     * it, and the second has nothing yet, so the second waits: displacing here
+     * was what left a file behind under the wrong name.
      */
     @Test
-    fun `a second download removes the file the first was filling`() {
+    fun `a second download waits rather than taking the first one's place`() {
         val first = destination("first")
         val firstId = startAndChoose("blob:one", first)
         coordinator.onBytes(firstId, encode("partial"))
 
         coordinator.onDownloadStart("blob:two", null)
 
-        assertEquals(listOf(first), discarded, "the displaced download's file must not survive")
-        assertTrue(reported.none { it.first == DownloadOutcome.SAVED },
-            "a download that was cut short is not a saved one")
+        assertEquals(1, asked.size, "the second download has no picker yet")
+        assertEquals(emptyList<Uri>(), discarded, "and the first one keeps the file it is filling")
+        coordinator.onComplete(firstId, null)
+        assertEquals("partial", documents[first]!!.written.toString())
+        assertTrue(reported.contains(DownloadOutcome.SAVED to FALLBACK_DOWNLOAD_NAME))
     }
 
     /**
@@ -368,7 +515,7 @@ class DownloadCoordinatorTest {
         coordinator.onDownloadNamed("blob:x", "report.pdf")
 
         coordinator.onDownloadStart("blob:x", null)
-        coordinator.onDestinationChosen(null)
+        chooseDestination(null)
         coordinator.onDownloadStart("blob:x", null)
 
         assertEquals(listOf("report.pdf", FALLBACK_DOWNLOAD_NAME), asked,
@@ -403,7 +550,7 @@ class DownloadCoordinatorTest {
         repeat(64) { coordinator.onDownloadNamed("blob:$it", "file$it.txt") }
 
         coordinator.onDownloadStart("blob:0", null)
-        coordinator.onDestinationChosen(null)
+        chooseDestination(null)
         coordinator.onDownloadStart("blob:63", null)
 
         assertEquals(listOf(FALLBACK_DOWNLOAD_NAME, "file63.txt"), asked,

--- a/android/app/src/test/kotlin/com/vscodroid/webview/DownloadCoordinatorTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/DownloadCoordinatorTest.kt
@@ -1,0 +1,438 @@
+package com.vscodroid.webview
+
+import android.net.Uri
+import com.vscodroid.util.Logger
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.io.OutputStream
+import java.util.Base64
+
+/**
+ * That a download either arrives complete or is visibly not there.
+ *
+ * The failure this replaces was a menu entry that did nothing and reported
+ * nothing, so silence is the defect and every case below asserts what the user
+ * was told as well as what was written. The second half is the one with teeth:
+ * the picker creates the file as soon as the user confirms a name, so every
+ * path that ends badly starts from a real file already sitting in their folder
+ * wearing the name of the one they wanted. Left behind, that file is a download
+ * that looks finished until it is opened, which is worse than the original bug
+ * because the user has no reason to retry.
+ *
+ * So these drive outcomes, not calls. Each case asserts three things together:
+ * what reached the file, whether the file survived, and what was reported. Any
+ * one of them alone is satisfiable by an implementation that is wrong about the
+ * other two.
+ */
+class DownloadCoordinatorTest {
+
+    /** What the fake picker was asked to create, one entry per request. */
+    private val asked = mutableListOf<String>()
+
+    /** Documents the fake picker created and did not delete. */
+    private val documents = mutableMapOf<Uri, RecordingStream>()
+
+    /** Documents removed through [DownloadHost.discardDestination]. */
+    private val discarded = mutableListOf<Uri>()
+
+    /** Every outcome reported, in order. */
+    private val reported = mutableListOf<Pair<DownloadOutcome, String>>()
+
+    /** URLs the page was asked to read, paired with the request id. */
+    private val readRequests = mutableListOf<Pair<String, String>>()
+
+    /** Whether the fake picker reports that it opened. */
+    private var pickerOpens = true
+
+    /** Set to make the next [DownloadHost.openDestination] answer null. */
+    private var destinationOpens = true
+
+    /** Set to make writes to the next opened document throw. */
+    private var writesFail = false
+
+    /** Set to make closing the next opened document throw. */
+    private var closeFails = false
+
+    private lateinit var coordinator: DownloadCoordinator
+
+    /**
+     * A document that remembers its bytes and whether it was closed, and can be
+     * told to fail on either.
+     *
+     * `closed` is tracked because a stream left open is a file the provider may
+     * never flush, and nothing else in the suite would notice: the bytes are
+     * already in this object by then, so an assertion on content alone passes
+     * over a coordinator that never closes anything.
+     */
+    private inner class RecordingStream : OutputStream() {
+        val written = ByteArrayOutputStream()
+        var closed = false
+
+        override fun write(b: Int) {
+            if (writesFail) throw IOException("no space")
+            written.write(b)
+        }
+
+        override fun write(b: ByteArray, off: Int, len: Int) {
+            if (writesFail) throw IOException("no space")
+            written.write(b, off, len)
+        }
+
+        override fun close() {
+            closed = true
+            if (closeFails) throw IOException("commit failed")
+        }
+    }
+
+    private val host = object : DownloadHost {
+        override fun askDestination(fileName: String): Boolean {
+            asked += fileName
+            return pickerOpens
+        }
+
+        override fun openDestination(destination: Uri): OutputStream? {
+            if (!destinationOpens) return null
+            val stream = RecordingStream()
+            documents[destination] = stream
+            return stream
+        }
+
+        override fun discardDestination(destination: Uri) {
+            discarded += destination
+            documents.remove(destination)
+        }
+
+        override fun requestBytes(requestId: String, url: String) {
+            readRequests += requestId to url
+        }
+
+        override fun report(outcome: DownloadOutcome, fileName: String, detail: String?) {
+            reported += outcome to fileName
+        }
+    }
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(Logger)
+        every { Logger.d(any(), any()) } just Runs
+        every { Logger.w(any(), any()) } just Runs
+        every { Logger.w(any(), any(), any()) } just Runs
+        asked.clear()
+        documents.clear()
+        discarded.clear()
+        reported.clear()
+        readRequests.clear()
+        pickerOpens = true
+        destinationOpens = true
+        writesFail = false
+        closeFails = false
+        coordinator = DownloadCoordinator(host)
+    }
+
+    @AfterEach
+    fun tearDown() = unmockkAll()
+
+    private fun destination(name: String = "doc"): Uri = mockk<Uri>(relaxed = true, name = name)
+
+    private fun encode(text: String): String =
+        Base64.getEncoder().encodeToString(text.toByteArray())
+
+    /** The id the page is told to answer under, for the request just started. */
+    private fun liveRequestId(): String = readRequests.last().first
+
+    /** Drives one whole download to the point where the page is reading it. */
+    private fun startAndChoose(url: String = "blob:x", target: Uri = destination()): String {
+        coordinator.onDownloadStart(url, null)
+        coordinator.onDestinationChosen(target)
+        return liveRequestId()
+    }
+
+    /**
+     * The ordinary success, asserted end to end because it is the baseline every
+     * failure case is measured against.
+     */
+    @Test
+    fun `a completed download writes its bytes and says so`() {
+        val target = destination()
+        coordinator.onDownloadNamed("blob:x", "App.kt")
+        val id = startAndChoose("blob:x", target)
+
+        assertEquals(listOf("App.kt"), asked, "the picker is offered the name the page reported")
+        coordinator.onBytes(id, encode("fun main"))
+        coordinator.onBytes(id, encode("() {}"))
+        coordinator.onComplete(id, null)
+
+        val document = documents[target]!!
+        assertEquals("fun main() {}", document.written.toString(),
+            "every piece reaches the file, in the order the page sent them")
+        assertTrue(document.closed, "the document is closed, which is what commits it")
+        assertEquals(listOf(DownloadOutcome.SAVED to "App.kt"), reported)
+        assertEquals(emptyList<Uri>(), discarded, "a completed download keeps its file")
+    }
+
+    /**
+     * Backing out of the picker. The common case, and the one where doing
+     * nothing looks most like working correctly: there is no file to clean up,
+     * so an implementation that simply forgets the request passes every
+     * assertion except the report.
+     */
+    @Test
+    fun `cancelling says so and leaves nothing behind`() {
+        coordinator.onDownloadStart("blob:x", null)
+
+        coordinator.onDestinationChosen(null)
+
+        assertEquals(listOf(DownloadOutcome.CANCELLED to FALLBACK_DOWNLOAD_NAME), reported,
+            "a cancellation the user cannot see is the failure this replaces")
+        assertEquals(emptyList<Pair<String, String>>(), readRequests,
+            "nothing is read for a download with nowhere to go")
+        assertEquals(emptyList<Uri>(), discarded,
+            "the picker creates nothing until the user confirms, so there is nothing to remove")
+    }
+
+    /**
+     * A write that fails midway. The partial file is the whole point: it exists,
+     * it has the right name, and it is short. Anything that leaves it there has
+     * turned a failed download into one the user will not know to repeat.
+     */
+    @Test
+    fun `a write that fails removes the half-written file`() {
+        val target = destination()
+        coordinator.onDownloadNamed("blob:x", "notes.md")
+        val id = startAndChoose("blob:x", target)
+        coordinator.onBytes(id, encode("first half"))
+
+        writesFail = true
+        val accepted = coordinator.onBytes(id, encode("second half"))
+
+        assertEquals(false, accepted, "the page has to be told to stop reading")
+        assertEquals(listOf(target), discarded, "the partial file must not survive")
+        assertEquals(listOf(DownloadOutcome.FAILED to "notes.md"), reported)
+    }
+
+    /**
+     * The same shape reported from the page's end rather than found here: the
+     * fetch failed, so the bytes already written are all there will ever be.
+     */
+    @Test
+    fun `an error from the page removes the file it was filling`() {
+        val target = destination()
+        val id = startAndChoose(target = target)
+        coordinator.onBytes(id, encode("partial"))
+
+        coordinator.onComplete(id, "status 404")
+
+        assertEquals(listOf(target), discarded)
+        assertEquals(listOf(DownloadOutcome.FAILED to FALLBACK_DOWNLOAD_NAME), reported)
+    }
+
+    /**
+     * Closing is part of the write, not cleanup after it. A `content://` stream
+     * can hold everything until close, so a close that throws means the file was
+     * never written, and reporting success there is the one failure the user has
+     * no way at all to detect.
+     */
+    @Test
+    fun `a file that will not close is a failure, not a save`() {
+        val target = destination()
+        val id = startAndChoose(target = target)
+        coordinator.onBytes(id, encode("everything"))
+
+        closeFails = true
+        coordinator.onComplete(id, null)
+
+        assertEquals(listOf(DownloadOutcome.FAILED to FALLBACK_DOWNLOAD_NAME), reported,
+            "bytes that never reached storage are not a saved file")
+        assertEquals(listOf(target), discarded)
+    }
+
+    /** A document the picker created but nothing can write to. */
+    @Test
+    fun `a destination that will not open is reported and removed`() {
+        val target = destination()
+        destinationOpens = false
+        coordinator.onDownloadStart("blob:x", null)
+
+        coordinator.onDestinationChosen(target)
+
+        assertEquals(listOf(DownloadOutcome.FAILED to FALLBACK_DOWNLOAD_NAME), reported)
+        assertEquals(listOf(target), discarded,
+            "an empty file wearing the wanted name is the failure being avoided")
+        assertEquals(emptyList<Pair<String, String>>(), readRequests)
+    }
+
+    /**
+     * A device with no document creator. Nothing downstream will ever run, so
+     * the refusal has to be reported from here or not at all.
+     */
+    @Test
+    fun `a picker that cannot open reports immediately`() {
+        pickerOpens = false
+
+        coordinator.onDownloadStart("blob:x", null)
+
+        assertEquals(listOf(DownloadOutcome.FAILED to FALLBACK_DOWNLOAD_NAME), reported)
+        // Nothing is left waiting: a later result would otherwise be taken as
+        // this request's answer and write into a file nobody asked for.
+        coordinator.onDestinationChosen(destination())
+        assertEquals(1, reported.size, "the abandoned request must not be revived by a stray result")
+    }
+
+    /**
+     * Bytes belonging to a download that has already been displaced.
+     *
+     * The page is told which request it is answering precisely so this can be
+     * refused. Without the check, a slow first download and a second one started
+     * over it would interleave into the file the user is currently waiting for,
+     * and the result would be a corrupt file reported as saved.
+     */
+    @Test
+    fun `bytes from a stale request never reach the live file`() {
+        val first = destination("first")
+        val firstId = startAndChoose("blob:one", first)
+
+        val second = destination("second")
+        coordinator.onDownloadStart("blob:two", null)
+        coordinator.onDestinationChosen(second)
+        val secondId = liveRequestId()
+
+        assertEquals(false, coordinator.onBytes(firstId, encode("stale")),
+            "an answer for a request that is over is refused")
+        coordinator.onBytes(secondId, encode("fresh"))
+        coordinator.onComplete(secondId, null)
+
+        assertEquals("fresh", documents[second]!!.written.toString(),
+            "only the live download's bytes reach its file")
+    }
+
+    /**
+     * Starting a second download over one still in flight. The first cannot be
+     * kept: there is one picker result to claim and the second has just claimed
+     * it. So its file has to go, and it must not be reported as saved.
+     */
+    @Test
+    fun `a second download removes the file the first was filling`() {
+        val first = destination("first")
+        val firstId = startAndChoose("blob:one", first)
+        coordinator.onBytes(firstId, encode("partial"))
+
+        coordinator.onDownloadStart("blob:two", null)
+
+        assertEquals(listOf(first), discarded, "the displaced download's file must not survive")
+        assertTrue(reported.none { it.first == DownloadOutcome.SAVED },
+            "a download that was cut short is not a saved one")
+    }
+
+    /**
+     * The renderer died under a download. The page that owed the bytes is gone,
+     * so nothing will ever arrive, and the file has to go with it.
+     *
+     * Silent on purpose, and that is asserted rather than assumed: the user is
+     * watching a crash recover, and a download toast on top of it explains
+     * nothing about either event.
+     */
+    @Test
+    fun `a page that goes away takes its unfinished file with it`() {
+        val target = destination()
+        val id = startAndChoose(target = target)
+        coordinator.onBytes(id, encode("partial"))
+
+        coordinator.onPageGone()
+
+        assertEquals(listOf(target), discarded)
+        assertEquals(emptyList<Pair<DownloadOutcome, String>>(), reported)
+    }
+
+    /**
+     * A name reported by the page belongs to the one download that follows it.
+     *
+     * Held in a map keyed by URL, so leaving it there would let a later download
+     * of the same URL that the page never named inherit this name. The editor
+     * mints a fresh blob URL per download, so that reuse is not what the editor
+     * does; it is what any other page in the WebView could do.
+     */
+    @Test
+    fun `a reported name is used once and not inherited`() {
+        coordinator.onDownloadNamed("blob:x", "report.pdf")
+
+        coordinator.onDownloadStart("blob:x", null)
+        coordinator.onDestinationChosen(null)
+        coordinator.onDownloadStart("blob:x", null)
+
+        assertEquals(listOf("report.pdf", FALLBACK_DOWNLOAD_NAME), asked,
+            "the second download of the same URL was never named by the page")
+    }
+
+    /**
+     * The page reports a name; a real `Content-Disposition` header is the next
+     * source down. Both arriving at once has to resolve to the page's, because
+     * it is the only one that saw the anchor the user clicked.
+     */
+    @Test
+    fun `the name the page reported outranks the header`() {
+        coordinator.onDownloadNamed("blob:x", "chosen.txt")
+
+        coordinator.onDownloadStart("blob:x", "attachment; filename=\"other.txt\"")
+
+        assertEquals(listOf("chosen.txt"), asked)
+    }
+
+    /** Exactly once, in the other direction: a repeated completion has nobody left to answer. */
+    @Test
+    fun `a download that completes twice is reported once`() {
+        val id = startAndChoose()
+
+        coordinator.onComplete(id, null)
+        coordinator.onComplete(id, null)
+
+        assertEquals(1, reported.size)
+    }
+
+    /** Bytes with nothing outstanding are refused rather than thrown on. */
+    @Test
+    fun `bytes with no download in flight are harmless`() {
+        assertEquals(false, coordinator.onBytes("dl-1", encode("stray")))
+        assertEquals(emptyList<Pair<DownloadOutcome, String>>(), reported)
+    }
+
+    /**
+     * Text the page sends that is not base64 at all. It reaches the decoder
+     * before anything else can judge it, and an unhandled throw there would
+     * escape into the bridge thread with the document still open.
+     */
+    @Test
+    fun `bytes that are not base64 fail the download rather than escaping`() {
+        val target = destination()
+        val id = startAndChoose(target = target)
+
+        assertEquals(false, coordinator.onBytes(id, "not base64 at all!!"))
+
+        assertEquals(listOf(target), discarded)
+        assertEquals(listOf(DownloadOutcome.FAILED to FALLBACK_DOWNLOAD_NAME), reported)
+    }
+
+    /** Binary content survives the encode and decode unchanged, byte for byte. */
+    @Test
+    fun `bytes outside the printable range arrive unchanged`() {
+        val target = destination()
+        val payload = ByteArray(256) { it.toByte() }
+        val id = startAndChoose(target = target)
+
+        coordinator.onBytes(id, Base64.getEncoder().encodeToString(payload))
+        coordinator.onComplete(id, null)
+
+        assertArrayEquals(payload, documents[target]!!.written.toByteArray())
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/webview/DownloadCoordinatorTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/DownloadCoordinatorTest.kt
@@ -389,6 +389,27 @@ class DownloadCoordinatorTest {
         assertEquals(listOf("chosen.txt"), asked)
     }
 
+    /**
+     * The page fills the name map and the platform empties it, so a page that
+     * names clicks the platform never turns into downloads fills it alone.
+     *
+     * Asserted from the outside, because what the bound protects is not a size
+     * but the absence of unbounded growth driven by page-controlled input. The
+     * newest name still works, which is what stops a bound from being satisfied
+     * by a map that forgets everything.
+     */
+    @Test
+    fun `names the page reports for downloads that never start do not accumulate`() {
+        repeat(64) { coordinator.onDownloadNamed("blob:$it", "file$it.txt") }
+
+        coordinator.onDownloadStart("blob:0", null)
+        coordinator.onDestinationChosen(null)
+        coordinator.onDownloadStart("blob:63", null)
+
+        assertEquals(listOf(FALLBACK_DOWNLOAD_NAME, "file63.txt"), asked,
+            "the oldest names are dropped while the newest one is still usable")
+    }
+
     /** Exactly once, in the other direction: a repeated completion has nobody left to answer. */
     @Test
     fun `a download that completes twice is reported once`() {

--- a/android/app/src/test/kotlin/com/vscodroid/webview/DownloadListenerWiringTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/DownloadListenerWiringTest.kt
@@ -92,4 +92,19 @@ class DownloadListenerWiringTest {
                 "user's folder, empty, under the name of the file they asked for."
         }
     }
+
+    @Test
+    fun `the page that answers the listener is given the script that answers it`() {
+        val inject = withoutComments(body("injectBridgeToken"))
+
+        assertTrue(inject.contains("injectDownloadCapture(")) {
+            "injectBridgeToken no longer injects the capture script, so no page has the " +
+                "shadowed createObjectURL or the sender the listener hands off to. The " +
+                "listener still installs, the picker still opens, and every download then " +
+                "fails with nothing to read the bytes. Nothing else notices: the script's " +
+                "own check reads the function's text out of this file rather than asking " +
+                "whether anyone calls it, and the two cases above only prove the listener " +
+                "is installed. Inject it wherever the page is prepared now."
+        }
+    }
 }

--- a/android/app/src/test/kotlin/com/vscodroid/webview/DownloadListenerWiringTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/DownloadListenerWiringTest.kt
@@ -1,0 +1,95 @@
+package com.vscodroid.webview
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * That every WebView this app puts on screen can receive a download.
+ *
+ * `DownloadCoordinator` decides what happens to a download and is tested
+ * directly. None of that runs unless a `DownloadListener` is installed, and
+ * nothing else in the suite would notice its absence: the coordinator's tests
+ * call it themselves, so they stay green over a WebView the platform never
+ * speaks to. That is precisely the state this replaced, where Download was on
+ * the menu, did nothing, and reported nothing.
+ *
+ * Reading the source is the weaker kind of test in this suite and is used for
+ * the same reason `BridgeCallbackThreadHopTest` uses it: there is no seam.
+ * `setDownloadListener` is a final method on a framework class, the listener is
+ * built inline, and a unit test has no WebView to install one on.
+ *
+ * The placement is asserted, not just the presence, and that is the part worth
+ * explaining. A renderer crash destroys the WebView and builds another, and the
+ * replacement is configured by `setupWebView`. A listener installed anywhere
+ * that runs once per Activity would leave every post-crash WebView silently
+ * back at the original defect. So the link is checked rather than assumed:
+ * `recreateWebView` must call the function the listener lives in.
+ */
+class DownloadListenerWiringTest {
+
+    private val source = File("src/main/kotlin/com/vscodroid/MainActivity.kt").readText()
+
+    /** The body of a `private fun name(` declaration, to its closing brace. */
+    private fun body(name: String): String {
+        val start = source.indexOf("private fun $name(")
+        assertTrue(start >= 0) {
+            "$name is gone from MainActivity.kt, so this test is measuring nothing. " +
+                "If it moved or was renamed, point this at the new site rather than deleting it."
+        }
+        val open = source.indexOf('{', start)
+        var depth = 0
+        var i = open
+        while (i < source.length) {
+            if (source[i] == '{') depth += 1
+            if (source[i] == '}') {
+                depth -= 1
+                if (depth == 0) return source.substring(open, i + 1)
+            }
+            i += 1
+        }
+        throw AssertionError("Could not find the end of $name in MainActivity.kt")
+    }
+
+    /**
+     * Comments removed, so prose about the rule cannot satisfy a search for the
+     * rule. This file's subject is discussed at length in the comments around
+     * the very lines it checks.
+     */
+    private fun withoutComments(text: String): String =
+        text.lines().joinToString("\n") { line ->
+            val marker = line.indexOf("//")
+            if (marker >= 0) line.substring(0, marker) else line
+        }
+
+    @Test
+    fun `every WebView gets a download listener that reaches the coordinator`() {
+        val setup = withoutComments(body("setupWebView"))
+
+        assertTrue(setup.contains("setDownloadListener")) {
+            "No download listener is installed in setupWebView. Without one, Android drops " +
+                "every download the editor starts and says nothing, which is the defect " +
+                "issue #234 recorded."
+        }
+        assertTrue(setup.contains("downloads.onDownloadStart")) {
+            "The download listener does not reach DownloadCoordinator. A listener that is " +
+                "installed and does nothing fails exactly as invisibly as no listener at all."
+        }
+    }
+
+    @Test
+    fun `a WebView rebuilt after a renderer crash is configured the same way`() {
+        val recreate = withoutComments(body("recreateWebView"))
+
+        assertTrue(recreate.contains("setupWebView(")) {
+            "recreateWebView no longer routes through setupWebView, so the replacement " +
+                "WebView does not get whatever setupWebView installs, the download listener " +
+                "included. Install it wherever the replacement is configured now."
+        }
+        assertTrue(recreate.contains("downloads.onPageGone")) {
+            "A download in flight when the renderer died is left holding the document the " +
+                "picker created. The page owing its bytes is gone, so that file stays in the " +
+                "user's folder, empty, under the name of the file they asked for."
+        }
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/webview/DownloadNamingTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/DownloadNamingTest.kt
@@ -1,0 +1,206 @@
+package com.vscodroid.webview
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+/**
+ * What a downloaded file is called.
+ *
+ * Not cosmetic. The name is offered to the create-document picker and the file
+ * is created under it, so a wrong one costs the user a retype and an empty one
+ * offers a file that cannot be created at all. Four sources feed it and they
+ * disagree often, which is why the order between them is asserted here rather
+ * than left to whichever branch happens to run first.
+ *
+ * The sanitising half is the part with a security shape: the best source is the
+ * page's own `download` attribute, which is text the page chose. A candidate
+ * carrying a path separator would be handed to the picker as a path, and what a
+ * documents provider does with one is the provider's decision and not this
+ * app's.
+ */
+class DownloadNamingTest {
+
+    /**
+     * The page's own report wins, because it is the only source that saw the
+     * anchor the user clicked. Every case below is a URL and a header that would
+     * each give a different answer.
+     */
+    @Test
+    fun `the name the page reported outranks every other source`() {
+        val name = downloadFileName(
+            url = "http://127.0.0.1:5000/vscode-remote-resource?path=%2Fhome%2Fu%2Ffrom-url.txt",
+            contentDisposition = "attachment; filename=\"from-header.txt\"",
+            suggested = "from-page.txt",
+        )
+
+        assertEquals("from-page.txt", name)
+    }
+
+    /** With no report from the page, a real header is the next thing that knows. */
+    @Test
+    fun `a content-disposition header is used when the page said nothing`() {
+        val name = downloadFileName(
+            url = "http://127.0.0.1:5000/vscode-remote-resource?path=%2Fhome%2Fu%2Ffrom-url.txt",
+            contentDisposition = "attachment; filename=\"from-header.txt\"",
+            suggested = null,
+        )
+
+        assertEquals("from-header.txt", name)
+    }
+
+    /**
+     * The extended form carries its encoding, so it is the one that survives a
+     * non-ASCII name. Both forms are usually present together and the plain one
+     * is the lossy copy, so reading it first would discard the good name in
+     * exactly the case the two differ.
+     */
+    @Test
+    fun `the encoded filename form is preferred over the plain one`() {
+        val name = downloadFileName(
+            url = "http://host/x",
+            contentDisposition =
+                "attachment; filename=\"ascii-fallback.txt\"; filename*=UTF-8''caf%C3%A9%20menu.txt",
+            suggested = null,
+        )
+
+        assertEquals("café menu.txt", name)
+    }
+
+    /** An unquoted `filename` is legal and is read. */
+    @Test
+    fun `an unquoted filename is read`() {
+        val name = downloadFileName(
+            url = "http://host/x",
+            contentDisposition = "attachment; filename=plain.txt; size=10",
+            suggested = null,
+        )
+
+        assertEquals("plain.txt", name)
+    }
+
+    /**
+     * The editor's remote-resource endpoint carries the file's POSIX path in a
+     * query parameter, and the URL's own last segment is the endpoint's name.
+     * Reading the segment instead would call every file in the workspace
+     * `vscode-remote-resource`, which is a plausible-looking name and therefore
+     * the worst kind of wrong.
+     */
+    @Test
+    fun `the path parameter is read rather than the endpoint name`() {
+        val name = downloadFileName(
+            url = "http://127.0.0.1:5000/vscode-remote-resource" +
+                "?path=%2Fdata%2Fprojects%2Fapp%2Fbuild.gradle.kts&tkn=secret",
+            contentDisposition = null,
+            suggested = null,
+        )
+
+        assertEquals("build.gradle.kts", name)
+    }
+
+    /** An ordinary file URL still answers with its last segment. */
+    @Test
+    fun `a plain url falls back to its last segment`() {
+        val name = downloadFileName("https://host/a/b/archive.tar.gz", null, null)
+
+        assertEquals("archive.tar.gz", name)
+    }
+
+    /**
+     * A blob URL is a UUID with no extension and names nothing. Offering it
+     * would put an unopenable name in front of the user while looking like a
+     * real answer, so the last-segment rule requires a dot and this falls
+     * through to the placeholder instead.
+     */
+    @Test
+    fun `a blob url gives the placeholder rather than its uuid`() {
+        val name = downloadFileName(
+            "blob:http://127.0.0.1:5000/6f1d2c30-9a4b-4c1e-8f77-2b0a5d3e91cc", null, null,
+        )
+
+        assertEquals(FALLBACK_DOWNLOAD_NAME, name)
+    }
+
+    /**
+     * Every candidate is reduced to one path segment, including the page's own
+     * report, which is the one an attacker controls.
+     */
+    @Test
+    fun `a name carrying a path is reduced to its last segment`() {
+        assertEquals("passwd", safeFileName("../../../etc/passwd"))
+        assertEquals("evil.sh", safeFileName("""C:\Windows\evil.sh"""))
+        assertEquals("file.txt", safeFileName("/absolute/file.txt"))
+    }
+
+    /**
+     * Candidates that survive every character rule and still name no file. They
+     * have to be refused rather than trimmed, so the next source gets its turn.
+     */
+    @Test
+    fun `names that point at a directory are refused`() {
+        assertNull(safeFileName("."))
+        assertNull(safeFileName(".."))
+        assertNull(safeFileName("some/dir/"))
+        assertNull(safeFileName("   "))
+        assertNull(safeFileName(""))
+        assertNull(safeFileName(null))
+    }
+
+    /** Control characters are dropped, and a name that was only those is refused. */
+    @Test
+    fun `control characters are removed`() {
+        assertEquals("report.txt", safeFileName("re\u0000port\u0007.txt"))
+        assertNull(safeFileName("\u0001\u0002\u007F"))
+    }
+
+    /**
+     * A refused candidate hands over to the next source rather than emptying the
+     * name. Falling through is the whole reason [safeFileName] answers null.
+     */
+    @Test
+    fun `a refused candidate falls through to the next source`() {
+        val name = downloadFileName(
+            url = "https://host/a/real-name.txt",
+            contentDisposition = "attachment; filename=\"..\"",
+            suggested = "   ",
+        )
+
+        assertEquals("real-name.txt", name)
+    }
+
+    /** Nothing knows anything. The placeholder is the answer, never an empty string. */
+    @Test
+    fun `a url with nothing to read still gives a usable name`() {
+        assertEquals(FALLBACK_DOWNLOAD_NAME, downloadFileName("https://host/", null, null))
+        assertEquals(FALLBACK_DOWNLOAD_NAME, downloadFileName("", null, ""))
+    }
+
+    /**
+     * Long names are cut rather than passed on. The limit is about the
+     * filesystem, so it has to apply to the page's report too, which is the
+     * source with no length rule of its own.
+     */
+    @Test
+    fun `an overlong name is cut to something a filesystem accepts`() {
+        val name = downloadFileName("https://host/x", null, "a".repeat(500) + ".txt")
+
+        assertEquals(200, name.length)
+    }
+
+    /**
+     * Percent-encoding is undone so the user sees the name rather than its
+     * transport form, and a stray percent is a character rather than a syntax
+     * error: a decoder that throws would cancel a download over a filename.
+     */
+    @Test
+    fun `encoded segments are decoded and a bad escape is left alone`() {
+        assertEquals("my file.txt", downloadFileName("https://host/my%20file.txt", null, null))
+        assertEquals("100%.csv", downloadFileName("https://host/100%.csv", null, null))
+    }
+
+    /** A fragment is not part of any name. */
+    @Test
+    fun `a fragment is not read as part of the name`() {
+        assertEquals("page.html", downloadFileName("https://host/page.html#section", null, null))
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/webview/DownloadNamingTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/DownloadNamingTest.kt
@@ -203,4 +203,23 @@ class DownloadNamingTest {
     fun `a fragment is not read as part of the name`() {
         assertEquals("page.html", downloadFileName("https://host/page.html#section", null, null))
     }
+
+    /**
+     * `+` means a space in a query parameter and means itself everywhere else,
+     * and one decoder serves both. Reading a path segment under the query rule
+     * turns a C++ file into one with two spaces in the middle of its name.
+     */
+    @Test
+    fun `a plus in a path segment is a plus, not a space`() {
+        assertEquals("c++notes.txt", downloadFileName("https://host/a/c++notes.txt", null, null))
+        assertEquals(
+            "a+b.txt",
+            downloadFileName("https://host/x", "attachment; filename*=UTF-8''a%2Bb.txt", null),
+        )
+        // And the one place the query rule is right still gets it.
+        assertEquals(
+            "my file.txt",
+            downloadFileName("https://host/r?path=/w/my+file.txt", null, null),
+        )
+    }
 }

--- a/docs/05-API_SPEC.md
+++ b/docs/05-API_SPEC.md
@@ -135,7 +135,7 @@ Exposed via `@JavascriptInterface`:
 
 Every method takes the session token and validates it before doing anything; a call
 with a token that does not match is refused before the method acts. Thirty of
-the thirty-one then return an empty value — `false`, `null`, `""`, `"{}"`, `"[]"`,
+the thirty-one then return an empty value: `false`, `null`, `""`, `"{}"`, `"[]"`,
 `0`, or nothing. **`generateSshKey` is the exception**: it returns
 `{"success":false,"error":"unauthorized"}`, a truthy string, so a caller testing
 `if (!result)` reads a refusal as success. Test its `success` field. Read the token from

--- a/docs/05-API_SPEC.md
+++ b/docs/05-API_SPEC.md
@@ -64,7 +64,7 @@ compare.
    (`SecurityManager.generateToken`, in `bridge/`, not a `security/` package).
    `MainActivity.injectBridgeToken()` writes it to `window.__vscodroid.authToken`
    after the page loads.
-2. **Every method, not a chosen subset**: all 28 `@JavascriptInterface` methods take the
+2. **Every method, not a chosen subset**: all 31 `@JavascriptInterface` methods take the
    token and validate it before doing anything, returning without acting on refusal
    (§2.4 records the one method whose refusal value is not an empty one).
    `BridgeTokenUniformityTest` enumerates them by reflection and fails the build
@@ -134,8 +134,8 @@ The OAuth pair described a flow this app does not implement — see §2.5.
 Exposed via `@JavascriptInterface`:
 
 Every method takes the session token and validates it before doing anything; a call
-with a token that does not match is refused before the method acts. Twenty-seven of
-the twenty-eight then return an empty value — `false`, `null`, `""`, `"{}"`, `"[]"`,
+with a token that does not match is refused before the method acts. Thirty of
+the thirty-one then return an empty value — `false`, `null`, `""`, `"{}"`, `"[]"`,
 `0`, or nothing. **`generateSshKey` is the exception**: it returns
 `{"success":false,"error":"unauthorized"}`, a truthy string, so a caller testing
 `if (!result)` reads a refusal as success. Test its `success` field. Read the token from
@@ -144,7 +144,7 @@ the twenty-eight then return an empty value — `false`, `null`, `""`, `"{}"`, `
 added without the check, so this holds for the class rather than for the list below.
 
 **Registered is not the same as reachable, and the difference decides what an extension
-can do.** All 28 methods below live on the `AndroidBridge` object injected into the
+can do.** All 31 methods below live on the `AndroidBridge` object injected into the
 workbench page, so anything running in that page's own realm can call them directly. An
 extension cannot: it runs in the web extension host, which does not see objects added by
 `addJavascriptInterface`. Extensions reach the bridge over the BroadcastChannel relay
@@ -230,6 +230,47 @@ not opened through a picker at all — a `content://` URI has no POSIX path and 
 server only ever sees POSIX paths. And there is no `MANAGE_EXTERNAL_STORAGE` in the
 manifest to request: external storage is reached through SAF, one user-granted folder
 at a time.
+
+#### Saving a Download
+
+These three are not called by extensions. They are called by the capture script
+`MainActivity.injectDownloadCapture()` injects into the workbench page, and they exist
+because the bytes of a download live in the page and cannot be reached from Kotlin.
+The editor hands the platform a `blob:` URL for any file it could read into memory,
+revokes that URL on the next task, and a blob has no name. So the page reports the
+name at click time and streams the bytes back afterwards.
+
+```kotlin
+@JavascriptInterface
+fun noteDownloadName(authToken: String, url: String, fileName: String)
+// Reports the name the page is about to download `url` under, taken from the
+// anchor's `download` attribute.
+// Returns NOTHING. Called before the platform has decided the click is a
+// download at all; a bridge call blocks the page until it returns, so the name
+// is on the Android side before the download hook fires.
+
+@JavascriptInterface
+fun writeDownloadChunk(authToken: String, requestId: String, base64: String): Boolean
+// One piece of the download named by `requestId`, base64 because the bridge
+// carries text. Each piece is decoded on its own, so each must be encoded on
+// its own.
+// Returns: true when it was written. On false the page must STOP reading -- the
+// write failed, the user has already been told why, and the rest of the file
+// has nowhere to go.
+
+@JavascriptInterface
+fun finishDownload(authToken: String, requestId: String, error: String)
+// Ends the download named by `requestId`.
+// `error` is the EMPTY STRING on success and a reason otherwise. Empty rather
+// than null because the value is written by JavaScript, where the absent case
+// is easy to send by accident.
+// Returns NOTHING. Whether the file survived is reported to the user by the
+// Android side, not back to the page.
+```
+
+A `requestId` that is not the download currently in flight is ignored, in both methods.
+Chunks belonging to a download that has since been cancelled or displaced would otherwise
+be written into the file the user is waiting for now.
 
 #### Storage Management
 

--- a/scripts/test-download-capture.js
+++ b/scripts/test-download-capture.js
@@ -1,0 +1,441 @@
+/**
+ * Self-check for the download capture script, which is what makes saving a
+ * file from the Explorer possible at all.
+ *
+ *   node scripts/test-download-capture.js
+ *
+ * The script is JavaScript written inside a Kotlin raw string and handed to
+ * `WebView.evaluateJavascript`. Nothing compiles it, nothing lints it, and no
+ * Kotlin test can reach it: the unit tests stop at the bridge methods it calls.
+ * So the half that decides whether a download has any bytes to save had no
+ * cover at all.
+ *
+ * What it is protecting is not obvious from reading it, so it is worth stating
+ * once. The editor reads a file into memory, wraps it in a blob, hands the
+ * platform a `blob:` URL and then revokes that URL on the very next task:
+ *
+ *     e = URL.createObjectURL(n), setTimeout(() => URL.revokeObjectURL(e))
+ *
+ * (`workbench.web.main.internal.js`, the body of `triggerDownload`.) Saving
+ * needs the user to choose a destination first, which takes seconds. So by the
+ * time there is anywhere to write, an untouched `blob:` URL names nothing and
+ * every download fails. Deferring that revocation is the whole reason this
+ * script exists, and it is a one-line behaviour that no other check would
+ * notice losing: remove the deferral and this file goes red, while the Kotlin
+ * suite, lint and the build all stay green and every download fails on device.
+ *
+ * Extraction is deliberately strict. If the raw string moves or changes shape
+ * this fails saying so, rather than quietly checking an empty string, which is
+ * the failure mode that makes a scan of nothing look like a pass.
+ */
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const ROOT = path.join(__dirname, '..');
+const MAIN_ACTIVITY = path.join(
+    ROOT, 'android/app/src/main/kotlin/com/vscodroid/MainActivity.kt',
+);
+
+/** How a literal dollar is written inside a Kotlin raw string. */
+const DOLLAR_ESCAPE = "${'$'}";
+
+/**
+ * The body of the raw string in `injectDownloadCapture()`, with the indentation
+ * `trimIndent()` removes taken off, which is the text the WebView is given.
+ */
+function extractCapture() {
+    const lines = fs.readFileSync(MAIN_ACTIVITY, 'utf8').split('\n');
+    const fn = lines.findIndex((l) => l.includes('private fun injectDownloadCapture()'));
+    assert.notStrictEqual(
+        fn, -1,
+        'injectDownloadCapture() is gone from MainActivity.kt, so this check has nothing to ' +
+        'run. If the script moved, point this at its new home rather than deleting the check.',
+    );
+
+    const open = lines.findIndex((l, i) => i > fn && l.trim() === '"""');
+    const close = lines.findIndex((l, i) => i > open && l.trim().startsWith('"""'));
+    assert.ok(open !== -1 && close !== -1 && close > open + 1,
+        'could not find the raw string in injectDownloadCapture(); its shape changed');
+
+    const body = lines.slice(open + 1, close);
+    const indent = Math.min(
+        ...body.filter((l) => l.trim()).map((l) => l.length - l.trimStart().length),
+    );
+    const js = body.map((l) => (l.trim() ? l.slice(indent) : '')).join('\n');
+
+    // A bare $ is interpolated by Kotlin before the WebView ever sees the
+    // string, so the injected script would not be the one written here.
+    const withoutEscapes = js.split(DOLLAR_ESCAPE).join('');
+    assert.ok(
+        !withoutEscapes.includes('$'),
+        'the capture script contains a bare $, which Kotlin interpolates into the raw string ' +
+        'before the WebView sees it. Escape it, or the injected script is not what is written.',
+    );
+    assert.ok(js.includes('revokeObjectURL'),
+        'the extracted text does not mention revokeObjectURL, so the wrong block was extracted');
+    assert.ok(js.includes('writeDownloadChunk'),
+        'the extracted text does not mention writeDownloadChunk, so the wrong block was extracted');
+
+    return js.split(DOLLAR_ESCAPE).join('$');
+}
+
+const SCRIPT = extractCapture();
+
+// ---- the page, stubbed ----------------------------------------------------
+
+/**
+ * One run of the capture script against a fresh fake page.
+ *
+ * Rebuilt per case rather than shared. The script installs itself once per
+ * document and refuses to install twice, so a shared page would leave every
+ * case after the first testing the previous case's hooks.
+ */
+function newPage(options) {
+    const opts = options || {};
+    const state = {
+        revoked: [],          // urls that reached the real revokeObjectURL
+        clicked: [],          // urls whose click was passed through
+        named: [],            // {token, url, fileName} reported to the bridge
+        chunks: [],           // base64 pieces handed to the bridge
+        finished: [],         // {id, error} reported to the bridge
+        cancelled: false,     // whether the reader was cancelled
+        timers: [],
+    };
+
+    const URLStub = {
+        revokeObjectURL(url) { state.revoked.push(url); },
+    };
+
+    function HTMLAnchorElement() {}
+    HTMLAnchorElement.prototype.click = function () { state.clicked.push(this.href); };
+    HTMLAnchorElement.prototype.getAttribute = function (name) {
+        return Object.prototype.hasOwnProperty.call(this.attrs, name) ? this.attrs[name] : null;
+    };
+
+    const AndroidBridge = {
+        noteDownloadName(token, url, fileName) {
+            if (opts.bridgeThrows) throw new Error('bridge is unhappy');
+            state.named.push({ token, url, fileName });
+        },
+        writeDownloadChunk(token, id, base64) {
+            state.chunks.push({ token, id, base64 });
+            return opts.refuseChunkAt === undefined
+                || state.chunks.length <= opts.refuseChunkAt;
+        },
+        finishDownload(token, id, error) {
+            state.finished.push({ token, id, error });
+        },
+    };
+
+    // A reader over fixed pieces, which is the shape fetch gives for both a
+    // blob and an http response.
+    function responseFor(url) {
+        if (opts.fetchRejects) return Promise.reject(new Error('network is down'));
+        if (opts.status && opts.status !== 200) {
+            return Promise.resolve({ ok: false, status: opts.status });
+        }
+        let next = 0;
+        const pieces = opts.pieces || [];
+        return Promise.resolve({
+            ok: true,
+            status: 200,
+            body: {
+                getReader() {
+                    return {
+                        read() {
+                            if (next >= pieces.length) return Promise.resolve({ done: true });
+                            const value = pieces[next];
+                            next += 1;
+                            return Promise.resolve({ done: false, value });
+                        },
+                        cancel() { state.cancelled = true; },
+                    };
+                },
+            },
+        });
+    }
+
+    // Zero-delay timers are the pump yielding between pieces and have to run
+    // for real. The hold expiry is two minutes away, so it is captured instead
+    // and fired on demand: waiting for it would make this check take longer
+    // than the whole suite, and stubbing the clock away would leave the release
+    // untested, which is how a hold that never expires ships as a memory leak.
+    state.pendingHolds = [];
+    const timer = (fn, ms) => {
+        if (ms >= 1000) {
+            state.pendingHolds.push(fn);
+            return 0;
+        }
+        return setTimeout(fn, ms);
+    };
+
+    const sandbox = {
+        console,
+        setTimeout: timer,
+        clearTimeout,
+        Promise,
+        Set,
+        Map,
+        String,
+        Error,
+        Object,
+        Uint8Array,
+        URL: URLStub,
+        HTMLAnchorElement,
+        btoa: (binary) => Buffer.from(binary, 'binary').toString('base64'),
+        fetch: responseFor,
+    };
+    sandbox.window = sandbox;
+    sandbox.AndroidBridge = AndroidBridge;
+    if (opts.token !== null) sandbox.__vscodroid = { authToken: opts.token || 'session-token' };
+    if (opts.noBridge) delete sandbox.AndroidBridge;
+
+    const context = vm.createContext(sandbox);
+    vm.runInContext(SCRIPT, context);
+
+    state.context = context;
+    state.sandbox = sandbox;
+    state.anchor = (href, attrs) => {
+        const a = new HTMLAnchorElement();
+        a.href = href;
+        a.attrs = attrs || {};
+        return a;
+    };
+    state.revoke = (url) => sandbox.URL.revokeObjectURL(url);
+    state.send = (url, id) => sandbox.window.__vscodroidDownload.send(url, id);
+    state.runScriptAgain = () => vm.runInContext(SCRIPT, context);
+    return state;
+}
+
+/** Lets every queued microtask and zero-delay timer run. */
+function settle() {
+    return new Promise((done) => setTimeout(done, 5));
+}
+
+const BLOB = 'blob:http://127.0.0.1:5000/6f1d2c30-9a4b-4c1e-8f77-2b0a5d3e91cc';
+
+// ---- the cases ------------------------------------------------------------
+
+const cases = [];
+function test(name, fn) { cases.push({ name, fn }); }
+
+/**
+ * The one that matters. The editor revokes the blob URL on the next task, and
+ * the user has not even seen the destination picker by then.
+ */
+test('a blob a download used stays resolvable after the editor revokes it', () => {
+    const page = newPage();
+    const anchor = page.anchor(BLOB, { download: 'App.kt' });
+
+    anchor.click();
+    page.revoke(BLOB);
+
+    assert.deepStrictEqual(page.revoked, [],
+        'the editor revoked the blob one task after clicking; letting that through leaves ' +
+        'nothing to save by the time the user has picked a destination');
+});
+
+/** Nothing else is held. A blanket deferral would keep every blob the workbench makes. */
+test('a blob no download used is revoked as the page asked', () => {
+    const page = newPage();
+    const other = 'blob:http://127.0.0.1:5000/unrelated';
+
+    page.anchor(BLOB, { download: 'App.kt' }).click();
+    page.revoke(other);
+
+    assert.deepStrictEqual(page.revoked, [other],
+        'only the URL a download is using may be held back');
+});
+
+/**
+ * A held URL releases itself rather than living as long as the page does.
+ *
+ * The hold pins the file's bytes in memory, so a hold that never expires is a
+ * download-shaped leak: click download, back out of the picker, repeat, and the
+ * page keeps every one of those files. Both halves are asserted, because a hold
+ * that expires immediately passes the release test and breaks the deferral, and
+ * one that never expires passes the deferral test and leaks.
+ */
+test('a held blob is revoked once its hold expires', () => {
+    const page = newPage();
+    page.anchor(BLOB, { download: 'App.kt' }).click();
+    page.revoke(BLOB);
+    assert.deepStrictEqual(page.revoked, [], 'still held while the download could be running');
+
+    assert.strictEqual(page.pendingHolds.length, 1, 'the hold has to have an expiry queued');
+    page.pendingHolds.forEach((fire) => fire());
+
+    assert.deepStrictEqual(page.revoked, [BLOB],
+        'an expired hold has to release the blob it was keeping alive');
+
+    // And the release is complete: the URL is no longer special, so a later
+    // revoke passes straight through rather than being swallowed forever.
+    page.revoke(BLOB);
+    assert.deepStrictEqual(page.revoked, [BLOB, BLOB]);
+});
+
+/** The name is the only thing that knows what the file is called. */
+test('a download click reports its name and token to Android', () => {
+    const page = newPage();
+
+    page.anchor(BLOB, { download: 'App.kt' }).click();
+
+    assert.deepStrictEqual(page.named, [
+        { token: 'session-token', url: BLOB, fileName: 'App.kt' },
+    ]);
+});
+
+/** An ordinary link is not a download and must not be touched. */
+test('a link with no download attribute is left entirely alone', () => {
+    const page = newPage();
+
+    page.anchor('https://example.com/page', {}).click();
+    page.revoke(BLOB);
+
+    assert.deepStrictEqual(page.named, [], 'a plain link is not a download');
+    assert.deepStrictEqual(page.revoked, [BLOB], 'and it holds nothing back');
+    assert.deepStrictEqual(page.clicked, ['https://example.com/page'],
+        'the click still happens');
+});
+
+/**
+ * Bookkeeping must never cost the page a click. A throw here is the difference
+ * between a download that does not save and a workbench where links stop
+ * working.
+ */
+test('a bridge that throws does not swallow the click', () => {
+    const page = newPage({ bridgeThrows: true });
+
+    page.anchor(BLOB, { download: 'App.kt' }).click();
+
+    assert.deepStrictEqual(page.clicked, [BLOB],
+        'the original click has to run whatever the recording did');
+});
+
+/** The whole transfer, asserted on the bytes rather than on the call count. */
+test('send streams the exact bytes and reports a clean finish', async () => {
+    const page = newPage({
+        pieces: [Uint8Array.from([0, 1, 2, 250]), Uint8Array.from([255, 65, 66])],
+    });
+
+    assert.strictEqual(page.send(BLOB, 'dl-1'), true, 'a started read reports that it started');
+    await settle();
+
+    const bytes = Buffer.concat(page.chunks.map((c) => Buffer.from(c.base64, 'base64')));
+    assert.deepStrictEqual(
+        Array.from(bytes), [0, 1, 2, 250, 255, 65, 66],
+        'the file that reaches Android must be the file the page read, byte for byte',
+    );
+    assert.deepStrictEqual(page.finished, [{ token: 'session-token', id: 'dl-1', error: '' }],
+        'an empty error is how success is spelled across the bridge');
+});
+
+/** Every piece is decodable on its own, because Android decodes them one at a time. */
+test('each piece decodes on its own', async () => {
+    const page = newPage({
+        pieces: [Uint8Array.from([1, 2]), Uint8Array.from([3]), Uint8Array.from([4, 5, 6])],
+    });
+
+    page.send(BLOB, 'dl-1');
+    await settle();
+
+    assert.strictEqual(page.chunks.length, 3, 'one bridge call per piece read');
+    const perPiece = page.chunks.map((c) => Array.from(Buffer.from(c.base64, 'base64')));
+    assert.deepStrictEqual(perPiece, [[1, 2], [3], [4, 5, 6]],
+        'a piece that only decodes when joined to its neighbours would corrupt the file');
+});
+
+/** A read that fails has to say so, or the download waits on a file forever. */
+test('a failed read is reported as an error', async () => {
+    const page = newPage({ fetchRejects: true });
+
+    page.send(BLOB, 'dl-1');
+    await settle();
+
+    assert.strictEqual(page.finished.length, 1, 'a failure still ends the download');
+    assert.strictEqual(page.finished[0].id, 'dl-1');
+    assert.ok(page.finished[0].error, 'an empty error would be read as success');
+});
+
+/** A URL that resolves but answers an error status is a failure too. */
+test('a non-ok response is reported as an error', async () => {
+    const page = newPage({ status: 404 });
+
+    page.send(BLOB, 'dl-1');
+    await settle();
+
+    assert.strictEqual(page.finished.length, 1);
+    assert.ok(/404/.test(page.finished[0].error),
+        `the status belongs in the reason; got ${page.finished[0].error}`);
+});
+
+/**
+ * Android refuses a piece when the write failed, and it has already told the
+ * user why. Reading on would send the rest of a file into a stream that is
+ * gone; finishing again would replace a real reason with a generic one.
+ */
+test('a refused piece stops the read without reporting a second reason', async () => {
+    const page = newPage({
+        pieces: [Uint8Array.from([1]), Uint8Array.from([2]), Uint8Array.from([3])],
+        refuseChunkAt: 1,
+    });
+
+    page.send(BLOB, 'dl-1');
+    await settle();
+
+    assert.strictEqual(page.chunks.length, 2, 'reading stops at the piece that was refused');
+    assert.strictEqual(page.cancelled, true, 'the reader is released rather than left open');
+    assert.deepStrictEqual(page.finished, [],
+        'Android already reported this failure; a second report would overwrite the reason');
+});
+
+/**
+ * Without a token or a bridge nothing can be sent, and Android has to hear that
+ * from the return value: there is no other channel left to say it on.
+ */
+test('send refuses when it has no way to answer', () => {
+    assert.strictEqual(newPage({ noBridge: true }).send(BLOB, 'dl-1'), false,
+        'no bridge means no route for the bytes or for the failure');
+    assert.strictEqual(newPage({ token: null }).send(BLOB, 'dl-1'), false,
+        'an unauthenticated call would be refused on the other side with nothing said');
+});
+
+/**
+ * The script is injected on every page load. Installing twice would wrap the
+ * revoke hook around itself, and a held URL would then be released by the inner
+ * copy while the outer one still refuses it.
+ */
+test('injecting the script twice changes nothing', () => {
+    const page = newPage();
+    page.runScriptAgain();
+
+    page.anchor(BLOB, { download: 'App.kt' }).click();
+    page.revoke(BLOB);
+
+    assert.deepStrictEqual(page.revoked, [], 'the hold still holds after a second injection');
+    assert.deepStrictEqual(page.named, [
+        { token: 'session-token', url: BLOB, fileName: 'App.kt' },
+    ], 'one click still reports one name');
+});
+
+// ---- run ------------------------------------------------------------------
+
+(async () => {
+    let failed = 0;
+    for (const c of cases) {
+        try {
+            await c.fn();
+            console.log(`ok   ${c.name}`);
+        } catch (e) {
+            failed += 1;
+            console.error(`FAIL ${c.name}`);
+            console.error(`     ${e.message}`);
+        }
+    }
+    console.log(`\n${cases.length - failed}/${cases.length} passed`);
+    process.exit(failed ? 1 : 0);
+})();

--- a/scripts/test-download-capture.js
+++ b/scripts/test-download-capture.js
@@ -24,6 +24,18 @@
  * notice losing: remove the deferral and this file goes red, while the Kotlin
  * suite, lint and the build all stay green and every download fails on device.
  *
+ * The second such behaviour is where the bytes are read from. A live `blob:`
+ * URL is still not fetchable here: the server sends the workbench page
+ *
+ *     connect-src 'self' ws: wss: https:;
+ *
+ * (`out/server-main.js`, the `Content-Security-Policy` response header), and
+ * `blob:` is not in that list, so Blink refuses the request with "Connecting to
+ * 'blob:...' violates the following Content Security Policy directive" before
+ * it leaves the page. Measured under that exact header. So the bytes come off
+ * the Blob object, which is not a request and which no directive governs, and
+ * the script keeps the object beside the URL to have one to read.
+ *
  * Extraction is deliberately strict. If the raw string moves or changes shape
  * this fails saying so, rather than quietly checking an empty string, which is
  * the failure mode that makes a scan of nothing look like a pass.
@@ -102,11 +114,17 @@ function newPage(options) {
         named: [],            // {token, url, fileName} reported to the bridge
         chunks: [],           // base64 pieces handed to the bridge
         finished: [],         // {id, error} reported to the bridge
+        fetched: [],          // urls a network request was attempted for
         cancelled: false,     // whether the reader was cancelled
+        minted: 0,            // how many object URLs the page asked for
         timers: [],
     };
 
     const URLStub = {
+        createObjectURL() {
+            state.minted += 1;
+            return `blob:http://127.0.0.1:5000/object-${state.minted}`;
+        },
         revokeObjectURL(url) { state.revoked.push(url); },
     };
 
@@ -131,31 +149,38 @@ function newPage(options) {
         },
     };
 
-    // A reader over fixed pieces, which is the shape fetch gives for both a
-    // blob and an http response.
+    // A reader over fixed pieces, which is the shape both a Blob's stream and
+    // an http response body give.
+    function readerOver(pieces) {
+        let next = 0;
+        return {
+            read() {
+                if (next >= pieces.length) return Promise.resolve({ done: true });
+                const value = pieces[next];
+                next += 1;
+                return Promise.resolve({ done: false, value });
+            },
+            cancel() { state.cancelled = true; },
+        };
+    }
+
     function responseFor(url) {
+        state.fetched.push(url);
+        // The page is served under connect-src 'self' ws: wss: https:, so Blink
+        // refuses a request for a blob: URL before it starts. Modelled here
+        // rather than left out: a harness that answers one is a harness that
+        // passes over the failure the whole feature ran into.
+        if (url.lastIndexOf('blob:', 0) === 0) {
+            return Promise.reject(new TypeError('Failed to fetch'));
+        }
         if (opts.fetchRejects) return Promise.reject(new Error('network is down'));
         if (opts.status && opts.status !== 200) {
             return Promise.resolve({ ok: false, status: opts.status });
         }
-        let next = 0;
-        const pieces = opts.pieces || [];
         return Promise.resolve({
             ok: true,
             status: 200,
-            body: {
-                getReader() {
-                    return {
-                        read() {
-                            if (next >= pieces.length) return Promise.resolve({ done: true });
-                            const value = pieces[next];
-                            next += 1;
-                            return Promise.resolve({ done: false, value });
-                        },
-                        cancel() { state.cancelled = true; },
-                    };
-                },
-            },
+            body: { getReader: () => readerOver(opts.pieces || []) },
         });
     }
 
@@ -208,6 +233,14 @@ function newPage(options) {
     state.revoke = (url) => sandbox.URL.revokeObjectURL(url);
     state.send = (url, id) => sandbox.window.__vscodroidDownload.send(url, id);
     state.runScriptAgain = () => vm.runInContext(SCRIPT, context);
+    // What the editor does: wrap the file's bytes in a Blob and mint a URL for
+    // it. Through the page's own URL.createObjectURL, so the script sees it.
+    state.objectUrl = (pieces) => sandbox.URL.createObjectURL({
+        stream: () => readerOverStream(pieces),
+    });
+    function readerOverStream(pieces) {
+        return { getReader: () => readerOver(pieces) };
+    }
     return state;
 }
 
@@ -217,6 +250,9 @@ function settle() {
 }
 
 const BLOB = 'blob:http://127.0.0.1:5000/6f1d2c30-9a4b-4c1e-8f77-2b0a5d3e91cc';
+
+/** A download of something the editor did not hold in memory, served over http. */
+const REMOTE = 'http://127.0.0.1:5000/vscode-remote-resource?path=/w/App.kt';
 
 // ---- the cases ------------------------------------------------------------
 
@@ -316,15 +352,28 @@ test('a bridge that throws does not swallow the click', () => {
         'the original click has to run whatever the recording did');
 });
 
-/** The whole transfer, asserted on the bytes rather than on the call count. */
-test('send streams the exact bytes and reports a clean finish', async () => {
-    const page = newPage({
-        pieces: [Uint8Array.from([0, 1, 2, 250]), Uint8Array.from([255, 65, 66])],
-    });
+/**
+ * The one this feature turns on, and the one the shipped policy decides.
+ *
+ * Every file the editor can hold in memory is downloaded through a `blob:`
+ * URL, and the page may not fetch one: `connect-src 'self' ws: wss: https:`
+ * does not list `blob:`, so Blink blocks the request and the user gets a
+ * destination picker followed by a failure. The bytes therefore have to come
+ * off the Blob, and this asserts both halves, because reading the right bytes
+ * over a request the policy refuses is exactly what looked correct.
+ */
+test('a blob download is read off the blob, never over a request', async () => {
+    const page = newPage();
+    const url = page.objectUrl([Uint8Array.from([0, 1, 2, 250]), Uint8Array.from([255, 65, 66])]);
 
-    assert.strictEqual(page.send(BLOB, 'dl-1'), true, 'a started read reports that it started');
+    page.anchor(url, { download: 'App.kt' }).click();
+    page.revoke(url);
+    assert.strictEqual(page.send(url, 'dl-1'), true, 'a started read reports that it started');
     await settle();
 
+    assert.deepStrictEqual(page.fetched, [],
+        'fetching a blob: URL is refused by the page policy, so a download that fetches one ' +
+        'fails for every file the editor holds in memory');
     const bytes = Buffer.concat(page.chunks.map((c) => Buffer.from(c.base64, 'base64')));
     assert.deepStrictEqual(
         Array.from(bytes), [0, 1, 2, 250, 255, 65, 66],
@@ -334,13 +383,35 @@ test('send streams the exact bytes and reports a clean finish', async () => {
         'an empty error is how success is spelled across the bridge');
 });
 
+/**
+ * The record of which Blob a URL names is bounded, like every other page-fed
+ * store here. It pins the bytes, so a page that mints object URLs nobody
+ * downloads must not be able to hold the file it did download hostage.
+ */
+test('object URLs nobody downloads do not pin their bytes', async () => {
+    const page = newPage();
+    const first = page.objectUrl([Uint8Array.from([7])]);
+    for (let i = 0; i < 8; i += 1) page.objectUrl([Uint8Array.from([i])]);
+
+    page.anchor(first, { download: 'App.kt' }).click();
+    page.send(first, 'dl-1');
+    await settle();
+
+    assert.deepStrictEqual(page.fetched, [first],
+        'a blob the page stopped tracking has to fall through to a request rather than ' +
+        'be answered with the bytes of another file');
+    assert.ok(page.finished[0].error, 'and the refusal that follows is reported');
+});
+
 /** Every piece is decodable on its own, because Android decodes them one at a time. */
 test('each piece decodes on its own', async () => {
-    const page = newPage({
-        pieces: [Uint8Array.from([1, 2]), Uint8Array.from([3]), Uint8Array.from([4, 5, 6])],
-    });
+    const page = newPage();
+    const url = page.objectUrl(
+        [Uint8Array.from([1, 2]), Uint8Array.from([3]), Uint8Array.from([4, 5, 6])],
+    );
+    page.anchor(url, { download: 'App.kt' }).click();
 
-    page.send(BLOB, 'dl-1');
+    page.send(url, 'dl-1');
     await settle();
 
     assert.strictEqual(page.chunks.length, 3, 'one bridge call per piece read');
@@ -349,11 +420,28 @@ test('each piece decodes on its own', async () => {
         'a piece that only decodes when joined to its neighbours would corrupt the file');
 });
 
+/**
+ * A download the editor did not hold in memory is an ordinary URL the policy
+ * allows, and it still has to work: it is the path everything above falls back
+ * to.
+ */
+test('a download the page has no blob for is fetched', async () => {
+    const page = newPage({ pieces: [Uint8Array.from([65, 66])] });
+
+    page.send(REMOTE, 'dl-1');
+    await settle();
+
+    assert.deepStrictEqual(page.fetched, [REMOTE]);
+    const bytes = Buffer.concat(page.chunks.map((c) => Buffer.from(c.base64, 'base64')));
+    assert.deepStrictEqual(Array.from(bytes), [65, 66]);
+    assert.deepStrictEqual(page.finished, [{ token: 'session-token', id: 'dl-1', error: '' }]);
+});
+
 /** A read that fails has to say so, or the download waits on a file forever. */
 test('a failed read is reported as an error', async () => {
     const page = newPage({ fetchRejects: true });
 
-    page.send(BLOB, 'dl-1');
+    page.send(REMOTE, 'dl-1');
     await settle();
 
     assert.strictEqual(page.finished.length, 1, 'a failure still ends the download');
@@ -365,7 +453,7 @@ test('a failed read is reported as an error', async () => {
 test('a non-ok response is reported as an error', async () => {
     const page = newPage({ status: 404 });
 
-    page.send(BLOB, 'dl-1');
+    page.send(REMOTE, 'dl-1');
     await settle();
 
     assert.strictEqual(page.finished.length, 1);
@@ -379,12 +467,13 @@ test('a non-ok response is reported as an error', async () => {
  * gone; finishing again would replace a real reason with a generic one.
  */
 test('a refused piece stops the read without reporting a second reason', async () => {
-    const page = newPage({
-        pieces: [Uint8Array.from([1]), Uint8Array.from([2]), Uint8Array.from([3])],
-        refuseChunkAt: 1,
-    });
+    const page = newPage({ refuseChunkAt: 1 });
+    const url = page.objectUrl(
+        [Uint8Array.from([1]), Uint8Array.from([2]), Uint8Array.from([3])],
+    );
+    page.anchor(url, { download: 'App.kt' }).click();
 
-    page.send(BLOB, 'dl-1');
+    page.send(url, 'dl-1');
     await settle();
 
     assert.strictEqual(page.chunks.length, 2, 'reading stops at the piece that was refused');


### PR DESCRIPTION
The Explorer's Download command builds an `<a download>` element and clicks it. Android routes that through a `DownloadListener`, and the app installed none, so the menu entry did nothing and reported nothing.

Two things make this direction harder than Upload, and both are facts about the shipped editor bundle rather than guesses. The destination has to be created rather than opened, so it needs a write grant. And the URL that reaches the listener is a `blob:` URL that the editor revokes on the very next task, seconds before a person has finished choosing where to save, so re-reading it from Kotlin would fail every time.

- `DownloadCoordinator` runs one download at a time and removes the document it created on every path that ends badly. The picker creates the file as soon as the name is confirmed, so a partial one left behind reads as a finished download until it is opened, which is worse than the original bug because the user has no reason to retry.
- The injected capture script defers revocation for the URLs a download is actually using, reports the anchor's name so files are not offered under a UUID, and streams the bytes back through three new bridge methods.
- Cancelling, a refused write, a page that goes away, and a device with no document creator each report and leave nothing behind.

Downloading a folder still does nothing: that path needs the File System Access API, which Android WebView does not provide, and the editor builds no anchor without it, so nothing reaches the listener at all. Fixing it means a source patch and a server rebuild.

Verified by 34 new JVM tests and a Node self-check that runs the real injected script; the full suite is 1073 green. No device was available, so the listener firing for a `blob:` URL is not verified on hardware.

Closes #234

Closes #234.