### PR TITLE
fix(python): keep environment discovery off the native locator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -273,6 +273,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The web walkthrough greets users with VSCodroid branding again, and the hamburger menu returned to touch-friendly sizing.
 - **Every folder opened in Restricted Mode**, and the setting meant to turn that off has never worked on this platform. The server's own switch is now used.
 - **None of the app's own settings ever took effect**; they were written to a file the editor does not read.
+- Python discovery no longer runs through a native locator that is missing from the extension build available here, which found no interpreters and warned on every Python command.
 - The Tailwind CSS language server is visible to the process monitor again, so it can be reclaimed and appears under its own name.
 - The HTML, CSS, JSON and Markdown language servers can now be reclaimed under memory pressure. All four launch without a file extension, so no name had ever matched them.
 - Language server processes are identified correctly. The guard reported them fine throughout because it compared a different form of the name, and the same matching could shut down your own script whose path contained `eslint`.

--- a/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
@@ -1550,6 +1550,13 @@ claude() {
             // that `exists()` accepts forever. The workbench reads a short file
             // as the settings rather than as an error, so the user would come
             // up with an arbitrary subset of the defaults and no way to tell.
+            //
+            // The two Python discovery keys are pinned here as well as in
+            // [refreshManagedPaths], and the duplication is load-bearing:
+            // SplashActivity runs that refresh BEFORE runSetup(), so on a clean
+            // install it returns at its own `!exists()` guard and a first
+            // session would otherwise run unpinned. See PYTHON_LOCATOR for why
+            // neither value is a preference.
             val defaults = """
                 {
                     "workbench.startupEditor": "none",
@@ -1577,6 +1584,8 @@ claude() {
                     "security.workspace.trust.enabled": false,
                     "python.languageServer": "Jedi",
                     "python.defaultInterpreterPath": "${context.filesDir.absolutePath}/usr/bin/python3",
+                    "python.locator": "js",
+                    "python.useEnvironmentsExtension": false,
                     "claudeCode.claudeProcessWrapper": "${Environment.getMuslLoaderPath(context)}",
                     "launch": {
                         "version": "0.2.0",
@@ -2434,6 +2443,72 @@ private val CLAUDE_WRAPPER_KEY = Regex(""""claudeCode\.claudeProcessWrapper"\s*:
 private val VERIFY_SIGNATURE = Regex(""""extensions\.verifySignature"\s*:""")
 
 /**
+ * The two settings that route Python environment discovery through `pet`, the
+ * Python extension's native locator.
+ *
+ * Pinned rather than defaulted, and not as a preference: `pet` is a Rust binary
+ * the extension spawns from `<extension>/python-env-tools/bin/pet`, and it is
+ * not in the artefact this app can obtain. Open VSX serves `ms-python.python`
+ * only as a `universal` VSIX, packaged without a target, and that recipe never
+ * compiles the locator. Measured on the bundled 2026.4.0 tree, which is also
+ * the newest the registry serves: no `python-env-tools` directory, and no ELF
+ * file of any kind. Nothing chosen at download time can change that.
+ *
+ * With `python.locator` on `native` the extension therefore spawns a path that
+ * does not exist, warns "Python Locator failed to start" with a Do Not Show
+ * Again button, and lists no interpreters (issue #241). Silencing that button
+ * is what must not be mistaken for a fix.
+ *
+ * `python.useEnvironmentsExtension` is the second key because the extension
+ * tests it FIRST, in `initialize`, and a true value hands discovery to
+ * `ms-python.vscode-python-envs` before the locator gate is ever read. That
+ * extension is installable from Open VSX (it is in this one's extension pack)
+ * and walks into the same wall: its 1.36.0 universal VSIX names
+ * `python-env-tools/bin/pet` in its bundle, ships no such file, and falls back
+ * to looking for it inside the Python extension. Pinning only the locator would
+ * leave that branch reaching the same missing binary.
+ *
+ * Both default to the safe value already, so what this covers is a document
+ * where something else has moved them: both carry the `onExP` tag, so the value
+ * in force is not only the user's to set. A hand edit back is undone at the
+ * next launch, and that is the intent rather than a side effect, since there is
+ * nothing on the device for either path to spawn.
+ *
+ * Shipping a per-platform VSIX would not lift this either. The extension tree
+ * lives under `filesDir`, which SELinux refuses to `execve`, the same wall that
+ * makes the Claude Code CLI run through musl's loader.
+ */
+private val PYTHON_LOCATOR = SettingPin("python.locator", """"[^"]*"""", "\"js\"")
+private val PYTHON_ENV_EXTENSION =
+    SettingPin("python.useEnvironmentsExtension", """(?:true|false)""", "false")
+
+/**
+ * A setting this app holds at [value] whatever the document says.
+ *
+ * [valuePattern] is the value shape that can be rewritten in place. A key
+ * carrying anything else is left exactly as it stands rather than gaining a
+ * second copy of itself further up, which is the distinction
+ * [CLAUDE_WRAPPER_KEY] draws for the same reason.
+ *
+ * Held rather than merely inserted when absent, which is where this parts
+ * company with [VERIFY_SIGNATURE]. Signature verification back on is a working
+ * configuration and so a decision worth keeping; a locator pointed at a binary
+ * that is not in the artefact has no working configuration to keep.
+ */
+private class SettingPin(val key: String, valuePattern: String, val value: String) {
+    private val quotedKey = "\"" + key.replace(".", "\\.") + "\""
+    private val managed = Regex("""($quotedKey\s*:\s*)$valuePattern""")
+    private val present = Regex("""$quotedKey\s*:""")
+
+    fun applyTo(content: String): String = when {
+        managed.containsMatchIn(content) ->
+            managed.replace(content) { "${it.groupValues[1]}$value" }
+        present.containsMatchIn(content) -> content
+        else -> insertSetting(content, key, value)
+    }
+}
+
+/**
  * The first property in the document, with the indentation it sits at.
  *
  * Anchored to the opening brace so it cannot match a property nested inside some
@@ -2934,6 +3009,12 @@ internal fun refreshManagedPaths(
     if (!VERIFY_SIGNATURE.containsMatchIn(updated)) {
         updated = insertSetting(updated, "extensions.verifySignature", "false")
     }
+
+    // Reaches installs that already have a settings.json, which is every device
+    // the failure was reported from: createDefaultSettings() writes only when
+    // the file is absent, so on its own it would fix nobody who already has one.
+    updated = PYTHON_LOCATOR.applyTo(updated)
+    updated = PYTHON_ENV_EXTENSION.applyTo(updated)
 
     return updated.takeIf { it != content }
 }

--- a/android/app/src/test/kotlin/com/vscodroid/setup/PythonLocatorDefaultTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/PythonLocatorDefaultTest.kt
@@ -1,0 +1,106 @@
+package com.vscodroid.setup
+
+import android.content.Context
+import android.content.pm.ApplicationInfo
+import com.google.android.play.core.assetpacks.AssetPackManagerFactory
+import com.vscodroid.util.Environment
+import com.vscodroid.util.Logger
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+/**
+ * The settings a clean install starts on already keep Python discovery off the
+ * native locator.
+ *
+ * [refreshManagedPaths] pins the same two keys and is covered by
+ * `SettingsPathsTest`, so this looks redundant until the order is read:
+ * `SplashActivity` runs `updateSettingsNativeLibPaths()` before `runSetup()`,
+ * and that refresh returns at its own `!exists()` guard when there is no
+ * settings.json yet. On a clean install the refresh therefore cannot be what
+ * writes these, and a first session would run on the unpinned document, spawn
+ * a `pet` that is not in the artefact Open VSX publishes, and put "Python
+ * Locator failed to start" in front of a user who has not opened a file yet.
+ *
+ * Runs the real writer rather than asserting on the string it embeds, the same
+ * way `TerminalShellPathTest` does and for the same reason: the point is the
+ * value reaching the file the workbench reads.
+ */
+class PythonLocatorDefaultTest {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    private lateinit var context: Context
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(Logger)
+        every { Logger.i(any(), any()) } just Runs
+        every { Logger.w(any(), any()) } just Runs
+        every { Logger.d(any(), any()) } just Runs
+
+        val nativeLibDir = File(tempDir, "nativeLibs").apply { mkdirs() }
+        context = mockk(relaxed = true)
+        every { context.applicationInfo } returns
+            ApplicationInfo().apply { nativeLibraryDir = nativeLibDir.absolutePath }
+        every { context.filesDir } returns tempDir
+        every { context.cacheDir } returns tempDir
+        every { context.getExternalFilesDir(any()) } returns File(tempDir, "external")
+
+        // Constructing ToolchainManager runs Play Core's static setup, which
+        // cannot complete off-device; stubbing the factory is enough.
+        mockkStatic(AssetPackManagerFactory::class)
+        every { AssetPackManagerFactory.getInstance(any()) } returns mockk(relaxed = true)
+    }
+
+    @AfterEach
+    fun tearDown() = unmockkAll()
+
+    @Test
+    fun `a clean install starts with the native locator unreachable`() {
+        createDefaultSettings()
+
+        val written = settingsText()
+        assertTrue(
+            written.contains(""""python.locator": "js""""),
+            "the first-run defaults leave the locator unpinned:\n$written",
+        )
+    }
+
+    @Test
+    fun `a clean install does not hand discovery to the environments extension`() {
+        // Checked before the locator in the extension's own initialize(), so a
+        // true value would bypass the pin above entirely.
+        createDefaultSettings()
+
+        val written = settingsText()
+        assertTrue(
+            written.contains(""""python.useEnvironmentsExtension": false"""),
+            "the first-run defaults leave delegation unpinned:\n$written",
+        )
+    }
+
+    private fun createDefaultSettings() {
+        FirstRunSetup::class.java
+            .getDeclaredMethod("createDefaultSettings")
+            .apply { isAccessible = true }
+            .invoke(FirstRunSetup(context))
+    }
+
+    private fun settingsText(): String {
+        val settings = File(Environment.getMachineSettingsPath(context))
+        assertTrue(settings.isFile, "no settings file was written at $settings")
+        return settings.readText()
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/setup/SettingsPathsTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/SettingsPathsTest.kt
@@ -42,9 +42,11 @@ class SettingsPathsTest {
         preamble: String = "",
         claudeWrapper: String? = wrapper,
         verifySignature: Boolean = true,
+        pythonLocator: String? = "js",
+        envExtension: String? = "false",
     ) = """
         {
-        $preamble    "editor.fontSize": 14,${claudeWrapper?.let { "\n    \"claudeCode.claudeProcessWrapper\": \"$it\"," } ?: ""}${if (verifySignature) "\n        \"extensions.verifySignature\": false," else ""}
+        $preamble    "editor.fontSize": 14,${claudeWrapper?.let { "\n    \"claudeCode.claudeProcessWrapper\": \"$it\"," } ?: ""}${if (verifySignature) "\n        \"extensions.verifySignature\": false," else ""}${pythonLocator?.let { "\n        \"python.locator\": \"$it\"," } ?: ""}${envExtension?.let { "\n        \"python.useEnvironmentsExtension\": $it," } ?: ""}
             "terminal.integrated.profiles.linux": {
                 "bash": {
                     "path": "$bashPath",
@@ -177,6 +179,8 @@ class SettingsPathsTest {
             {
                 "claudeCode.claudeProcessWrapper": "$wrapper",
                 "extensions.verifySignature": false,
+                "python.locator": "js",
+                "python.useEnvironmentsExtension": false,
                 "terminal.integrated.profiles.linux": {
                     "bash": {
                         "icon": "terminal-bash"
@@ -222,6 +226,8 @@ class SettingsPathsTest {
             {
                 "claudeCode.claudeProcessWrapper": "$wrapper",
                 "extensions.verifySignature": false,
+                "python.locator": "js",
+                "python.useEnvironmentsExtension": false,
                 "terminal.integrated.profiles.linux": {
                     "bash": {
                         "path": "$oldDir/libbash.so",
@@ -300,7 +306,8 @@ class SettingsPathsTest {
         @Test
         fun `returns null when git path is absent rather than inventing one`() {
             val noGit = """{ "claudeCode.claudeProcessWrapper": "$wrapper", """ +
-                """"extensions.verifySignature": false, "editor.fontSize": 14 }"""
+                """"extensions.verifySignature": false, "python.locator": "js", """ +
+                """"python.useEnvironmentsExtension": false, "editor.fontSize": 14 }"""
 
             assertNull(refreshManagedPaths(noGit, shell, git, wrapper))
         }
@@ -312,6 +319,8 @@ class SettingsPathsTest {
                 {
                     "claudeCode.claudeProcessWrapper": "$wrapper",
                     "extensions.verifySignature": false,
+                    "python.locator": "js",
+                    "python.useEnvironmentsExtension": false,
                     "terminal.integrated.profiles.linux": {
                         "zsh": { "path": "$oldDir/libzsh.so" }
                     }
@@ -453,6 +462,113 @@ class SettingsPathsTest {
 
             assertNull(refreshManagedPaths(once, shell, git, wrapper),
                 "a second pass rewrote a settled document")
+        }
+    }
+
+    /**
+     * Python discovery must stay off the native locator.
+     *
+     * `pet` is a Rust binary the Python extension spawns from its own tree, and
+     * Open VSX publishes only the `universal` VSIX, which is packaged without a
+     * target and never compiles it. The bundled 2026.4.0 tree carries no
+     * `python-env-tools` directory and no ELF file at all, so `python.locator`
+     * on `native` spawns a path that cannot exist: "Python Locator failed to
+     * start", then no interpreters (issue #241).
+     *
+     * Held rather than only inserted, unlike `extensions.verifySignature`. That
+     * one has a working configuration in either state; this one does not, and
+     * the device the failure was reported from had the value already moved.
+     */
+    @Nested
+    inner class PythonDiscovery {
+
+        @Test
+        fun `pins the locator for installs that predate the key`() {
+            // Every install made before this shipped, which is the population
+            // the notification was reported from. createDefaultSettings() only
+            // writes a settings.json that is absent, so nothing else reaches them.
+            val before = settings(shell, git, args = "[]", pythonLocator = null)
+            val result = requireNotNull(refreshManagedPaths(before, shell, git, wrapper)) {
+                "a missing python.locator must be added"
+            }
+
+            assertTrue(
+                result.contains(""""python.locator": "js""""),
+                "locator not pinned:\n$result",
+            )
+        }
+
+        @Test
+        fun `moves the locator back off native`() {
+            // The reported state, whatever put it there. Insert-when-absent
+            // would leave this device exactly as it is.
+            val before = settings(shell, git, args = "[]", pythonLocator = "native")
+            val result = requireNotNull(refreshManagedPaths(before, shell, git, wrapper)) {
+                "a native locator must be moved back to js"
+            }
+
+            assertTrue(
+                result.contains(""""python.locator": "js""""),
+                "locator left on the native path:\n$result",
+            )
+            // The key, not the bare word. A real nativeLibraryDir is in this
+            // document, and so is anything else a future managed value spells
+            // with it, so a document-wide search fails on unrelated text while
+            // reporting that the locator survived.
+            assertTrue(
+                !result.contains(""""python.locator": "native""""),
+                "the native value survived:\n$result",
+            )
+        }
+
+        @Test
+        fun `pins the environments extension away for installs that predate the key`() {
+            val before = settings(shell, git, args = "[]", envExtension = null)
+            val result = requireNotNull(refreshManagedPaths(before, shell, git, wrapper)) {
+                "a missing python.useEnvironmentsExtension must be added"
+            }
+
+            assertTrue(
+                result.contains(""""python.useEnvironmentsExtension": false"""),
+                "setting not inserted:\n$result",
+            )
+        }
+
+        @Test
+        fun `turns the environments extension back off`() {
+            // The extension tests this key BEFORE the locator, so a true value
+            // hands discovery to ms-python.vscode-python-envs and never reaches
+            // the locator pin. Its own Open VSX build looks for the same binary.
+            val before = settings(shell, git, args = "[]", envExtension = "true")
+            val result = requireNotNull(refreshManagedPaths(before, shell, git, wrapper)) {
+                "delegation to an extension without pet must be turned off"
+            }
+
+            assertTrue(
+                result.contains(""""python.useEnvironmentsExtension": false"""),
+                "delegation left on:\n$result",
+            )
+        }
+
+        @Test
+        fun `does not add a second key beside a value it cannot rewrite`() {
+            // The trap anchoring always brings: a shape the pattern does not
+            // match is not the same as a key that is absent. Writing the key
+            // twice would leave the last one winning at random.
+            val before = settings(shell, git, args = "[]")
+                .replace(""""python.locator": "js"""", """"python.locator": null""")
+            val result = refreshManagedPaths(before, shell, git, wrapper) ?: before
+
+            val occurrences = Regex(""""python\.locator"""").findAll(result).count()
+            assertEquals(1, occurrences, "the key appears $occurrences times:\n$result")
+        }
+
+        @Test
+        fun `leaves a document that already carries both pins alone`() {
+            assertNull(
+                refreshManagedPaths(settings(shell, git, args = "[]"), shell, git, wrapper),
+                "a settled document was rewritten on every launch",
+            )
         }
     }
 }


### PR DESCRIPTION
Python environment discovery fails on device: the extension warns "Python Locator failed to start. Python environment discovery may not work correctly." and then lists no interpreters, so creating a virtual environment or running any Python command has nothing to run against (#241).

The cause is a binary that cannot be present. When `python.locator` is `native`, the Python extension spawns `pet` from `<extension>/python-env-tools/bin/pet`. Open VSX publishes `ms-python.python` only as a `universal` VSIX, packaged without a target, and that recipe never compiles the Rust locator. The bundled 2026.4.0 tree, which is also the newest the registry serves, contains no `python-env-tools` directory and no ELF file of any kind. No download-time choice changes that, and a per-platform VSIX would not help either: it would land under `filesDir`, which SELinux refuses to `execve`.

Changes:

- `createDefaultSettings()` pins `python.locator` to `js` and `python.useEnvironmentsExtension` to `false`, beside the existing machine-scoped Python defaults.
- `refreshManagedPaths()` holds both at those values on every launch. That is the only path reaching an install which already has a settings.json, and it is what corrects affected devices on update.
- Both are needed: `SplashActivity` runs the refresh before `runSetup()`, so on a clean install the refresh returns at its own `!exists()` guard.

The pin rewrites rather than inserts when absent, unlike `extensions.verifySignature` in the same function. The reported device already had the value moved, and `native` has no working configuration here, so there is no user opinion to preserve.

The second key is included because the extension tests it first and delegates to `ms-python.vscode-python-envs`, whose Open VSX build looks for the same missing binary. The notification itself is not suppressed.

Verified: 1088 unit tests green. Reducing the pin to insert-when-absent, the plausible wrong answer, fails exactly the two cases covering an install that already carries the key.
