### PR TITLE
test(coverage): make four cases fail on what they name

### DIFF
--- a/android/app/src/test/kotlin/com/vscodroid/bridge/SecurityManagerTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/bridge/SecurityManagerTest.kt
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -46,8 +45,21 @@ class SecurityManagerTest {
     inner class TokenGenerationTest {
 
         @Test
-        fun `generates non-null token`() {
-            assertNotNull(manager.getSessionToken())
+        fun `generates a token with more than one distinct character`() {
+            // `assertNotNull` stood here and could not fail. getSessionToken()
+            // returns a non-null Kotlin type, so the only production change it
+            // refused was one that threw before any test ran, and a generator
+            // emitting one character 64 times satisfied it exactly as readily as
+            // a random one. Length and alphabet are pinned next door and accept
+            // that value too, since "aaaa..." is 64 lowercase hex characters.
+            //
+            // The floor, then, is that the value varies within itself at all.
+            // How far it varies is SessionTokenEntropyTest's question.
+            val token = manager.getSessionToken()
+            assertTrue(
+                token.toSet().size > 1,
+                "the token is one character repeated, so it is a constant: $token",
+            )
         }
 
         @Test

--- a/android/app/src/test/kotlin/com/vscodroid/keyboard/KeyMappingTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/keyboard/KeyMappingTest.kt
@@ -15,6 +15,22 @@ import org.junit.jupiter.params.provider.ValueSource
  */
 class KeyMappingTest {
 
+    /**
+     * Every key the table holds. The table is private, so covering all of it
+     * means naming the keys, and a named list is only as good as its last
+     * update: `carries one entry per mapping` counts the entries the table
+     * emits and fails when this list is not all of them, so an added mapping
+     * cannot slip past the tests that walk it.
+     */
+    private val allMappedKeys = listOf(
+        "Tab", "Escape", "ArrowLeft", "ArrowUp", "ArrowRight", "ArrowDown",
+        "Home", "End", "PageUp", "PageDown",
+        "F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8", "F9", "F10", "F11", "F12",
+        "{", "}", "(", ")", ";", ":", "\"", "/", "[", "]", "|", "\\", "~", "`",
+        "'", "=", "!", "#", "@", "&", "_", "<", ">", ",", ".", "-", "+", "*",
+        "%", "?", "^", "$", "Enter", "Backspace", " "
+    )
+
     @Nested
     inner class GetKeyDefTest {
 
@@ -95,13 +111,13 @@ class KeyMappingTest {
 
         @Test
         fun `all mappings have non-empty key and code`() {
-            // Test via known keys that should exist
-            val expectedKeys = listOf(
-                "Tab", "Escape", "Enter", "Backspace", " ",
-                "{", "}", "(", ")", ";", ":", "/", "[", "]",
-                "|", "\\", "~", "`", "'", "=", "!", "#", "@", "&", "_"
-            )
-            for (key in expectedKeys) {
+            // The whole table, which is what the name says. The hand-written 25
+            // this walked instead left out 32 of the 57 entries, among them all
+            // four arrows, whose code and keyCode are pinned by nothing else
+            // here: giving ArrowUp an empty code left the entire suite green,
+            // and that value goes straight into the KeyboardEvent's `code` at
+            // KeyInjector.injectKey.
+            for (key in allMappedKeys) {
                 val keyDef = KeyMapping.getKeyDef(key)
                 assertNotNull(keyDef, "KeyDef for '$key' should exist")
                 assertTrue(keyDef!!.key.isNotEmpty(), "key should not be empty for '$key'")
@@ -279,16 +295,8 @@ class KeyMappingTest {
             // Every entry contributes exactly one `:[`, so this counts entries without
             // needing to parse, and moves when the table does.
             val entries = Regex(":\\[").findAll(lookup).count()
-            val known = listOf(
-                "Tab", "Escape", "ArrowLeft", "ArrowUp", "ArrowRight", "ArrowDown",
-                "Home", "End", "PageUp", "PageDown",
-                "F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8", "F9", "F10", "F11", "F12",
-                "{", "}", "(", ")", ";", ":", "\"", "/", "[", "]", "|", "\\", "~", "`",
-                "'", "=", "!", "#", "@", "&", "_", "<", ">", ",", ".", "-", "+", "*",
-                "%", "?", "^", "$", "Enter", "Backspace", " "
-            )
-            assertEquals(known.size, entries, "one entry per mapping")
-            for (key in known) {
+            assertEquals(allMappedKeys.size, entries, "one entry per mapping")
+            for (key in allMappedKeys) {
                 assertNotNull(KeyMapping.getKeyDef(key), "'$key' should be in the table")
             }
         }

--- a/android/app/src/test/kotlin/com/vscodroid/service/ProcessManagerTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/service/ProcessManagerTest.kt
@@ -1698,9 +1698,13 @@ class HeapCeilingTest {
     }
 
     @Test
-    fun `a device the manufacturer flagged as low-RAM gets the floor`() {
-        // Whatever totalMem says: the flag is the OEM stating the device is
-        // constrained in ways the number does not show.
+    fun `the low-RAM flag takes the floor whatever the total says`() {
+        // The flag as an argument, not as a device. Nothing here reads
+        // ActivityManager.isLowRamDevice, so this says nothing about whether the
+        // OEM's flag ever reaches the derivation: passing a constant false at the
+        // call site leaves it green while every low-RAM phone gets the ceiling its
+        // total earns. `a low-RAM device gets the floor on the command line` is
+        // what covers that wire.
         assertEquals(HEAP_CEILING_MIN_MB, heapCeilingMb(8L * 1024, isLowRam = true))
     }
 

--- a/android/app/src/test/kotlin/com/vscodroid/util/PortFinderTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/util/PortFinderTest.kt
@@ -230,15 +230,37 @@ class PortFinderTest {
             // The workbench keys IndexedDB by origin, and the port is part of the
             // origin: a different port here empties secret storage and every
             // extension's globalState, with nothing in any log to explain it.
-            val first = PortFinder.getOrAllocatePort(context)
-            val second = PortFinder.getOrAllocatePort(context)
-            assertEquals(first, second)
+            //
+            // A cold start begins from what the previous process left in prefs, so
+            // the remembered port is seeded rather than allocated here, and it has
+            // to be one a fresh scan would not hand back on its own. Allocating
+            // twice in a row cannot tell the two apart: findAvailablePort() scans
+            // upward from a fixed base, so while that base is free the scan returns
+            // the same number the remembered branch would, and the assertion holds
+            // with the reuse branch deleted.
+            val base = PortFinder.findAvailablePort()
+            assertTrue(base < EPHEMERAL_BASE, "precondition failed: the scan range was already full")
+            val remembered = hold(base).use { PortFinder.findAvailablePort() }
+            assertNotEquals(base, remembered, "precondition failed: the scan did not step over $base")
+            assertTrue(
+                remembered < EPHEMERAL_BASE,
+                "precondition failed: the scan abandoned the range for an ephemeral port",
+            )
+
+            stored = remembered
+
+            assertEquals(
+                remembered, PortFinder.getOrAllocatePort(context),
+                "the port the previous process left behind must come back while it is " +
+                    "free; rediscovering $base puts the workbench on a new origin and " +
+                    "drops the storage keyed to $remembered",
+            )
         }
 
         @Test
         fun `does not drift back to a lower port once it has moved`() {
-            // `returns the same port on the next cold start` cannot see whether
-            // the port was remembered. findAvailablePort() scans upward from a
+            // Allocating twice over a free scan base cannot see whether the
+            // port was remembered. findAvailablePort() scans upward from a
             // fixed default, so while that default is free -- the ordinary case --
             // a fresh scan returns the same number the remembered branch would
             // have. Both calls move together, and the assertion holds with the


### PR DESCRIPTION
Four unit cases named a behaviour they could not detect, each fixed on its own terms rather than by adding a parallel case beside it. Part of #239.

**`KeyMappingTest.all mappings have non-empty key and code`** walked a hand-written list of 25 keys while `KeyMapping.mappings` holds 57. The 32 it never reached include all four arrows, whose `code` and `keyCode` nothing else in the file pins: giving `ArrowUp` an empty `code` left all 1088 unit tests green, and that value goes verbatim into the `KeyboardEvent` that `KeyInjector.injectKey` dispatches, so the extra key row would send an event naming no physical key. The case now walks the full list that `carries one entry per mapping` already held, and that case asserts the list size against the entries the table emits, so an added mapping turns it red until the list follows.

**`PortFinderTest.returns the same port on the next cold start`** allocated twice and compared. `findAvailablePort()` scans upward from a fixed base, so while that base is free both calls return the same number whether or not the remembered-port branch runs; the case held with that branch deleted. It now seeds prefs with a port the scan would not reach on its own and requires that value back.

**`SecurityManagerTest.generates non-null token`** called `assertNotNull` on a non-null Kotlin type built in the constructor, so no production change could fail it alone. A generator returning one character 64 times passed it and the length and alphabet case beside it. It now requires the value to vary within itself, renamed to match.

**`ProcessManagerTest.a device the manufacturer flagged as low-RAM gets the floor`** passes the flag itself, so a call site reading a constant `false` leaves it green. Renamed to what it reaches; the wire is covered by `a low-RAM device gets the floor on the command line`.

Test-only. `./gradlew testDebugUnitTest`: 1088 tests, 0 failures.
