### PR TITLE
ci: bound the package index refresh

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,8 +111,23 @@ jobs:
         # The runner image ships a baked apt index. Ubuntu keeps only the current
         # version of a package in the pool, so once the indexed one is superseded
         # the download 404s. Refresh the index before installing.
+        #
+        # Bounded, because an unbounded refresh is not a slow step, it is a lost
+        # job: when the Azure mirror stops answering apt falls through to the
+        # public archive and can sit there without output until the job's whole
+        # 30 minute budget is gone, and every later step is reported as skipped
+        # rather than as never reached. Measured twice on the same commit. Three
+        # short attempts clear a transient stall; a real outage now fails in
+        # minutes with the mirror named, and still fails, because installing off
+        # a stale index is what the refresh above exists to prevent.
+        timeout-minutes: 8
         run: |
-          sudo apt-get update
+          for attempt in 1 2 3; do
+            if sudo timeout 120 apt-get update; then
+              break
+            fi
+            echo "  apt-get update stalled or failed (attempt $attempt of 3)"
+          done
           # gnupg is on the runner image today, but the Termux index check is a
           # gate: naming it here keeps it from depending on what the image
           # happens to bake in.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,8 +216,17 @@ jobs:
       - name: Install system dependencies
         # See build.yml: the runner's baked apt index goes stale as Ubuntu drops
         # superseded versions from the pool, so refresh it before installing.
+        # Bounded and retried for the reason given there, which applies harder
+        # here: this job's budget is 90 minutes, so an unbounded stall costs an
+        # hour and a half of a release before anything says why.
+        timeout-minutes: 8
         run: |
-          sudo apt-get update
+          for attempt in 1 2 3; do
+            if sudo timeout 120 apt-get update; then
+              break
+            fi
+            echo "  apt-get update stalled or failed (attempt $attempt of 3)"
+          done
           # gnupg named explicitly: verify-termux-index.sh refuses to run without
           # it, and a release is the worst place to discover a runner image
           # changed what it bakes in.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -305,6 +305,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Build and release**
 
+- A stalled package mirror no longer eats a whole build. Refreshing the index was unbounded, so it could consume the job's entire budget and report every later step as skipped.
 - Unit tests re-run when a patch, the bootstrap script, a bundled extension manifest or a documented requirement changes. None was a declared input, so incremental runs served stale verdicts.
 - A server tree built before the current terminal-host shutdown is refused rather than packaged; the patch check matched text an earlier version of that patch had already added.
 - A server build release could take over the `latest` release pointer, which breaks toolchain downloads for every non-Play install. It is now kept out of that pointer permanently.


### PR DESCRIPTION
`Install system dependencies` runs `sudo apt-get update` with no bound. That is fine while the mirror answers and costs about six seconds. When it does not, the step sits without output until the job's `timeout-minutes` runs out, and the run reports every later step as `skipped` rather than as never reached, so the log reads like a build that chose not to do anything.

Measured twice on the same commit this morning: the step ran from 02:29:40 to 02:58:54, printed its last line at 02:30:18 and produced nothing for the following 28 minutes. Its own output shows why: `Ign:` against `azure.archive.ubuntu.com` for every suite, then a fallthrough to `archive.ubuntu.com` that stalled midway through the package indexes. The job died at its 30 minute cap with `Fetch Code - OSS server` onwards untouched.

Changes:

- The refresh in `build.yml` and `release.yml` is wrapped in `timeout 120` and retried up to three times, with the step capped at `timeout-minutes: 8` as a backstop.
- A failed refresh does not skip the install. Installing off a stale index is exactly what the refresh exists to prevent, so the install runs and fails on the 404 the original comment describes, which is a legible failure rather than a silent one.

`timeout` is `/usr/bin/timeout` from `coreutils` on the runner image, verified rather than assumed.

This only changes how a stall is reported and how long it takes. The successful path is unchanged: the first attempt returns and the loop breaks. `release.yml` matters more here than `build.yml`, since its budget is 90 minutes.
