### PR TITLE
feat(legal): ship the GPL and LGPL texts the binaries require

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The Explorer's **Upload...** now opens the device file picker. It was on every folder's menu and hung silently, the only route to import a single file from device storage.
 - The Explorer's **Download** now asks where to save each file and writes it there. It did nothing at all, and a failure says so instead of leaving a partial file.
 - **Open Source Licenses**, on the About dialog: the notices now ship inside the app and read offline, so the GPL written offer of source reaches every device holding those binaries.
+- **License Texts**, one tap from that screen: GPL-2.0, GPL-3.0 and LGPL-2.1 now ship verbatim in the app. A gnu.org link is not the copy those licenses require.
 - VSCodroid warns when the installed Android System WebView is older than Chrome 105, the version it is tested against. It warns and continues rather than refusing to start, and a version it cannot read is not treated as an old one.
 - **Serve on Network**: lists the ports your dev servers are listening on, shows the address other devices can reach them at, and copies it. Loopback-only servers are called out.
 - You can preview your own dev server at the device's network address from inside the editor, not only at `localhost`.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -69,6 +69,12 @@ anything here can run it.
 Excluded as first-party: `libglibc-shim.so` and its companion stubs, which carry
 glibc's soname but are built from this repository's own source.
 
+The copyleft rows below need more than a name. GPL-2.0, GPL-3.0 and LGPL-2.1 each
+require a copy of the licence to reach whoever receives the binary, so the three
+texts are in `licenses/` and ship in the app at **About > Licenses > License
+Texts**, verbatim; `docs/LEGAL_NOTICES.md` records which text covers which
+component.
+
 | Component | License | Linked by |
 |---|---|---|
 | Bash | GPL-3.0 | bundled tool in its own right |

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -317,20 +317,21 @@ tasks.withType<Test> {
     //   grep -rn 'File("src/main/AndroidManifest.xml")' android/app/src/test/kotlin
     inputs.file(layout.projectDirectory.file("src/main/AndroidManifest.xml"))
         .withPropertyName("appManifest")
-    // Seven suites read files no Kotlin compiles against, because the things they
+    // Eight suites read files no Kotlin compiles against, because the things they
     // check cross a language boundary that has no compiler: the bootstrap's
     // adoption note (assets/server.js), the shutdown the worker hosts get
-    // (patches/), the manifests of the bundled extensions, and the documents that
-    // restate a requirement the code owns. Gradle knew about none of them, so it
-    // answered UP-TO-DATE for a run that had to notice one of them change, and
-    // served the previous run's results. Measured on this module: a signature
-    // edited in docs/05-API_SPEC.md left the task UP-TO-DATE and the build
-    // successful, and with the file declared the same edit re-runs the suite and
-    // turns BridgeApiSpecParityTest red. Renaming a command title to a name of
-    // the same length does the same for CommandReferenceTest, and that length is
-    // the point: the only thing that already noticed an assets edit was the byte
-    // total in BuildConfig, which a size-neutral one leaves exactly where it was.
-    // A clean CI checkout was never affected; an incremental run always was.
+    // (patches/), the manifests of the bundled extensions, the verbatim licence
+    // texts, and the documents that restate a requirement the code owns. Gradle
+    // knew about none of them, so it answered UP-TO-DATE for a run that had to
+    // notice one of them change, and served the previous run's results. Measured
+    // on this module: a signature edited in docs/05-API_SPEC.md left the task
+    // UP-TO-DATE and the build successful, and with the file declared the same
+    // edit re-runs the suite and turns BridgeApiSpecParityTest red. Renaming a
+    // command title to a name of the same length does the same for
+    // CommandReferenceTest, and that length is the point: the only thing that
+    // already noticed an assets edit was the byte total in BuildConfig, which a
+    // size-neutral one leaves exactly where it was. A clean CI checkout was
+    // never affected; an incremental run always was.
     //
     // The set is the whole of what those File(...) reads reach, so check the
     // suites before narrowing any of it:
@@ -339,7 +340,9 @@ tasks.withType<Test> {
     //   assets/extensions     BundledExtensionHostTest, CommandReferenceTest,
     //                         WalkthroughCompletionEventTest
     //   patches/              WorkerHostShutdownPatchTest
-    //   README.md, docs/*.md  WebViewVersionTest, BridgeApiSpecParityTest
+    //   licenses/, NOTICE.md  NoticesTest
+    //   README.md, docs/*.md  WebViewVersionTest, BridgeApiSpecParityTest,
+    //                         NoticesTest
     //
     // Sources under src/main/kotlin are read by other suites the same way and are
     // deliberately not listed: they are compiled into the classpath this task
@@ -354,11 +357,22 @@ tasks.withType<Test> {
     inputs.files(fileTree(rootProject.projectDir.parentFile.resolve("patches")))
         .withPropertyName("serverPatches")
         .withPathSensitivity(PathSensitivity.RELATIVE)
+    // The licence texts NoticesTest pins byte for byte. That pin exists for the
+    // edit nobody means to make: a reflow, a re-wrap, an editor stripping the
+    // form feeds out of COPYING.LGPLv2.1. Undeclared, the run that has to notice
+    // such an edit is the one that answers UP-TO-DATE over the previous run's
+    // results. Measured: appending a line to licenses/COPYING.GPLv2 left the task
+    // up to date and the build successful in 679ms; declared, the same edit
+    // re-runs the suite and turns it red.
+    inputs.files(fileTree(rootProject.projectDir.parentFile.resolve("licenses")))
+        .withPropertyName("licenseTexts")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
     // Top-level markdown only. docs/ also carries a site, screenshots and a logo
     // directory, and no test reads any of them; hashing them on every run would
     // buy nothing and 2.6 MB of it is images.
     inputs.files(
         rootProject.projectDir.parentFile.resolve("README.md"),
+        rootProject.projectDir.parentFile.resolve("NOTICE.md"),
         fileTree(rootProject.projectDir.parentFile.resolve("docs")) { include("*.md") },
     )
         .withPropertyName("statedRequirements")
@@ -668,29 +682,41 @@ val verifyBundledShellPaths = tasks.register<Exec>("verifyBundledShellPaths") {
 // carried that offer and shipped nowhere; every device ran the binaries with no
 // notice of any kind on it.
 //
+// Naming a licence is not supplying it, and the three licences/ files are the
+// half that was missing. GPL-2.0 section 1, GPL-3.0 section 4 and LGPL-2.1
+// section 1 each require a copy of the licence itself to accompany the binary;
+// the documents above carried a gnu.org URL instead, which discharges nothing,
+// least of all on the offline device this app is built to be usable on. They are
+// the FSF texts as shipped in Termux's liblzma package, which is one of the
+// packages this APK redistributes, and they are verbatim: NoticesTest pins each
+// one's sha256, because a licence text that has been edited is not the licence.
+//
 // Copied from the repository root rather than committed under src/main/assets,
 // because a second copy is a copy that goes stale, and a stale licence notice is
 // worse than an absent one: it is a claim about terms that is no longer true.
-// The two files are ~44 KiB of markdown, which deflates to roughly 15 KiB in the
-// APK, about 0.01% of the base module. They grow as the tree does, since every
-// binary in it has to be named in both, so treat those as the order of magnitude
-// rather than as figures to check against.
+// The markdown is ~48 KiB and the licence texts ~78 KiB, which together deflate
+// to roughly 50 KiB in the APK, well under 0.1% of the base module. The markdown
+// grows as the tree does, since every binary in it has to be named in both, so
+// treat that as the order of magnitude rather than as a figure to check against.
 //
 // They are read out of the APK by MainActivity's licences dialog and never
 // extracted, which is why they are a separate assets source directory: it keeps
 // them out of the src/main/assets sum that sizes first-run extraction.
 val bundleNotices = tasks.register<Copy>("bundleNotices") {
     group = "build"
-    description = "Copies the attribution documents into the APK's assets."
+    description = "Copies the attribution and licence documents into the APK's assets."
 
     val repoRoot = rootProject.projectDir.parentFile
     from(File(repoRoot, "NOTICE.md"))
     from(File(repoRoot, "docs/LEGAL_NOTICES.md"))
+    from(File(repoRoot, "licenses/COPYING.GPLv2"))
+    from(File(repoRoot, "licenses/COPYING.GPLv3"))
+    from(File(repoRoot, "licenses/COPYING.LGPLv2.1"))
     into(layout.buildDirectory.dir("generated/notices"))
 
     // The names the app opens. Kept beside the copy so a rename here fails the
     // build rather than emptying the dialog on a device: com.vscodroid.util
-    // .Notices.BUNDLED lists the same two, and NoticesTest compares the lists.
+    // .Notices lists the same five, and NoticesTest compares the lists.
 }
 
 // A dependency of the merge, not of the package or the assemble: the point is

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -702,7 +702,16 @@ val verifyBundledShellPaths = tasks.register<Exec>("verifyBundledShellPaths") {
 // They are read out of the APK by MainActivity's licences dialog and never
 // extracted, which is why they are a separate assets source directory: it keeps
 // them out of the src/main/assets sum that sizes first-run extraction.
-val bundleNotices = tasks.register<Copy>("bundleNotices") {
+//
+// Sync rather than Copy, because the app opens these by basename and a Copy
+// leaves behind whatever the last run wrote. Measured: with COPYING.GPLv3
+// removed from the tree, the Copy ran, succeeded, and left the previous run's
+// COPYING.GPLv3 in the output directory, where the next incremental APK
+// packaged it. A licence text still shipping under a name the repository no
+// longer has is the stale copy this task exists to avoid, arriving by the back
+// door. Only this task writes that directory, so deleting what it did not write
+// costs nothing.
+val bundleNotices = tasks.register<Sync>("bundleNotices") {
     group = "build"
     description = "Copies the attribution and licence documents into the APK's assets."
 

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -1883,10 +1883,62 @@ class MainActivity : AppCompatActivity() {
      * a device with no network, which is the state this app is built to be
      * usable in.
      *
+     * The offer is one of the two things that have to travel with those
+     * binaries; the licence texts are the other, and they are one button away in
+     * [showLicenseTextsDialog] rather than inside this body.
+     *
      * [Notices.read] never throws and never returns empty: a document it could
      * not open is replaced in place by a line naming it.
      */
     private fun showLicensesDialog() {
+        AlertDialog.Builder(this)
+            .setTitle(getString(R.string.licenses_title))
+            .setView(scrollableNotice(Notices.read { assets.open(it) }))
+            .setPositiveButton("OK", null)
+            .setNegativeButton(getString(R.string.licenses_full_texts)) { _, _ ->
+                showLicenseTextsDialog()
+            }
+            .setNeutralButton("Source Code") { _, _ ->
+                startActivity(Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/rmyndharis/VSCodroid")))
+            }
+            .show()
+    }
+
+    /**
+     * The verbatim GPL and LGPL texts, picked from a list.
+     *
+     * Behind a chooser rather than appended to the notices above, because the
+     * three of them are 78 KiB and the notices are what someone opening that
+     * screen came for. Concatenated, the attribution and the written offer would
+     * be the first few percent of a scroll view that is otherwise licence
+     * boilerplate, which is a worse screen for every reader of it. Two taps to
+     * reach a text still puts the text on the device, and that is what the
+     * licences require.
+     *
+     * [Notices.readOne] never throws: a text that will not open is replaced by a
+     * line naming it, on screen, where it cannot be mistaken for the licence.
+     */
+    private fun showLicenseTextsDialog() {
+        val names = Notices.LICENSE_TEXTS.keys.toTypedArray()
+        AlertDialog.Builder(this)
+            .setTitle(getString(R.string.licenses_full_texts))
+            .setItems(names) { _, which ->
+                val name = names[which]
+                AlertDialog.Builder(this)
+                    .setTitle(name)
+                    .setView(
+                        scrollableNotice(
+                            Notices.readOne(Notices.LICENSE_TEXTS.getValue(name)) { assets.open(it) }
+                        )
+                    )
+                    .setPositiveButton("OK", null)
+                    .show()
+            }
+            .show()
+    }
+
+    /** A long document in a scroller, laid out the same way wherever it is shown. */
+    private fun scrollableNotice(document: String): ScrollView {
         val body = TextView(this).apply {
             // Before setText: autoLinkMask is applied when the text is set, and
             // linkifying is the point. The offer names repositories to fetch
@@ -1896,17 +1948,9 @@ class MainActivity : AppCompatActivity() {
             textSize = 11f
             val pad = (16 * resources.displayMetrics.density).toInt()
             setPadding(pad, pad, pad, pad)
-            text = Notices.read { assets.open(it) }
+            text = document
         }
-
-        AlertDialog.Builder(this)
-            .setTitle(getString(R.string.licenses_title))
-            .setView(ScrollView(this).apply { addView(body) })
-            .setPositiveButton("OK", null)
-            .setNeutralButton("Source Code") { _, _ ->
-                startActivity(Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/rmyndharis/VSCodroid")))
-            }
-            .show()
+        return ScrollView(this).apply { addView(body) }
     }
 
     private fun recreateWebView() {

--- a/android/app/src/main/kotlin/com/vscodroid/util/Notices.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/util/Notices.kt
@@ -3,7 +3,7 @@ package com.vscodroid.util
 import java.io.InputStream
 
 /**
- * The third-party attribution documents, as they are carried inside the APK.
+ * The third-party attribution documents and licence texts carried inside the APK.
  *
  * The app redistributes GPL and LGPL binaries: Bash, Git, GNU Make, readline,
  * libiconv, gdbm, liblzma and zstd, among others. The GPL's written offer of
@@ -11,6 +11,9 @@ import java.io.InputStream
  * it accompanied nothing. Both documents existed, both were complete, and both
  * lived only in the repository, which is not somewhere the holder of an installed
  * APK has any reason to look.
+ *
+ * The offer is one of two obligations, and [LICENSE_TEXTS] is the other: a copy
+ * of the licence itself has to travel with the binary as well.
  *
  * The files are packaged by the `bundleNotices` task in `app/build.gradle.kts`,
  * which copies them from the repository root rather than keeping a second copy in
@@ -31,6 +34,31 @@ object Notices {
     val BUNDLED = listOf("NOTICE.md", "LEGAL_NOTICES.md")
 
     /**
+     * The verbatim licence texts, display name to asset basename.
+     *
+     * GPL-2.0 section 1, GPL-3.0 section 4 and LGPL-2.1 section 1 each require a
+     * copy of the licence to be given to whoever receives the binary. Every one
+     * of those licences is in this APK: Git and Zstandard under GPL-2.0; Bash,
+     * GNU Make, readline and gdbm under GPL-3.0; libiconv and liblzma under
+     * LGPL-2.1. Those three texts are therefore the whole set, and the licence
+     * column of the inventory in `docs/LEGAL_NOTICES.md` is where to re-derive it
+     * when the bundled binaries change.
+     *
+     * Deliberately not in [BUNDLED]. These are 78 KiB of legalese that nobody
+     * opens the notices screen to read, and appending them to the body would
+     * bury the attribution and the source offer under a screenful-per-scroll of
+     * licence. They are one tap away from the same dialog instead, which keeps
+     * that screen as readable as it was and still hands over the texts.
+     *
+     * Order is the reading order of the chooser, so this is a `LinkedHashMap`.
+     */
+    val LICENSE_TEXTS = linkedMapOf(
+        "GNU General Public License v2.0" to "COPYING.GPLv2",
+        "GNU General Public License v3.0" to "COPYING.GPLv3",
+        "GNU Lesser General Public License v2.1" to "COPYING.LGPLv2.1"
+    )
+
+    /**
      * Every bundled document, concatenated.
      *
      * [open] is the asset reader, normally `context.assets::open`. It is a
@@ -44,12 +72,18 @@ object Notices {
      * logcat for the same reason, and it is why nothing here logs.
      */
     fun read(open: (String) -> InputStream): String =
-        BUNDLED.joinToString(SEPARATOR) { name ->
-            try {
-                open(name).bufferedReader().use { it.readText() }
-            } catch (_: Exception) {
-                missingMarker(name)
-            }
+        BUNDLED.joinToString(SEPARATOR) { readOne(it, open) }
+
+    /**
+     * One packaged document, or [missingMarker] in place of one that will not
+     * open. Never throws, for the reason [read] does not: the caller is a dialog
+     * with nowhere to put an exception except a crash.
+     */
+    fun readOne(name: String, open: (String) -> InputStream): String =
+        try {
+            open(name).bufferedReader().use { it.readText() }
+        } catch (_: Exception) {
+            missingMarker(name)
         }
 
     /** What stands in for a document this build did not package. */

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -57,6 +57,10 @@
     <string name="about_version_format">Version %s</string>
     <string name="about_licenses">Licenses</string>
     <string name="licenses_title">Open Source Licenses</string>
+    <!-- Opens the verbatim GPL and LGPL texts. Separate from the notices above
+         because the copyleft binaries in this app require the licence itself to
+         be handed over, not only named. -->
+    <string name="licenses_full_texts">License Texts</string>
 
     <!-- Toolchain picker (first-run) -->
     <string name="picker_title">What do you code in?</string>

--- a/android/app/src/test/kotlin/com/vscodroid/util/NoticesTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/util/NoticesTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.io.IOException
+import java.security.MessageDigest
 
 /**
  * The attribution documents have to reach the device, and the pieces that make
@@ -18,7 +19,9 @@ import java.io.IOException
  * them. Rename `docs/LEGAL_NOTICES.md`, or drop a `from(...)` line, and the
  * build stays green, the APK still installs, and the licences dialog quietly
  * comes up half empty on a device. There is no compiler relationship between the
- * three, which is what this test supplies.
+ * three, which is what this test supplies. Nor is there one behind the buttons
+ * that open those dialogs, so the calls are held here as well: a document nothing
+ * on screen reaches is packaged and undelivered.
  *
  * It supplies it only because the build script is declared an input to the test
  * task. These tests read `build.gradle.kts` through the file system, which Gradle
@@ -28,13 +31,17 @@ import java.io.IOException
  * deleting it makes them silent rather than wrong.
  *
  * The stake is not cosmetic. The GPL requires its written offer of source to
- * accompany the binary, and this screen is the only place it does.
+ * accompany the binary, and this screen is the only place it does. It requires a
+ * copy of the licence itself as well, which is what `licenses/COPYING.*` are, so
+ * those are checked here too and are checked for more: a document that has been
+ * truncated or reflowed is no longer the licence it is offered as.
  */
 class NoticesTest {
 
     // Unit tests run with app/ as the working directory.
     private val repoRoot = File("../..")
     private val buildScript = File("build.gradle.kts")
+    private val mainActivity = File("src/main/kotlin/com/vscodroid/MainActivity.kt")
 
     /** The `from(File(repoRoot, "..."))` arguments of the bundleNotices task. */
     private fun copiedPaths(): List<String> {
@@ -50,10 +57,11 @@ class NoticesTest {
     fun `every bundled name is a document the build actually copies`() {
         val copied = copiedPaths()
         assertEquals(
-            Notices.BUNDLED.sorted(),
+            (Notices.BUNDLED + Notices.LICENSE_TEXTS.values).sorted(),
             copied.map { File(it).name }.sorted(),
-            "Notices.BUNDLED and bundleNotices disagree about which documents ship. " +
-                "The app opens assets by basename; the task decides which basenames exist."
+            "Notices.BUNDLED / Notices.LICENSE_TEXTS and bundleNotices disagree about " +
+                "which documents ship. The app opens assets by basename; the task " +
+                "decides which basenames exist."
         )
         for (path in copied) {
             val source = File(repoRoot, path)
@@ -108,6 +116,154 @@ class NoticesTest {
     }
 
     @Test
+    fun `every step of the route to these documents is still taken`() {
+        // Packaging a document is not offering it. About opens the notices, the
+        // notices open the licence texts, and each step is a private method with
+        // one caller: drop the button that calls it and the APK still carries all
+        // five documents, every assertion here still passes, and nothing on a
+        // device can reach any of them. Nothing else notices either. Both methods
+        // stay compiled, their own KDoc keeps naming them, and a string resource
+        // left unreferenced is a lint warning, which does not fail a build whose
+        // abortOnError covers errors.
+        //
+        // Reading the source is what is available: the activity binds a service
+        // and builds a WebView on the way to these dialogs, so there is no seam
+        // to reach them through. It cannot see a caller that is itself
+        // unreachable, or a button whose label stops saying what it opens.
+        check(mainActivity.isFile) {
+            "MainActivity.kt not found at ${mainActivity.absolutePath}, so this " +
+                "test would pass by looking at nothing"
+        }
+        val code = mainActivity.readLines().filterNot {
+            val trimmed = it.trimStart()
+            trimmed.startsWith("//") || trimmed.startsWith("*") || trimmed.startsWith("/*")
+        }
+        for (dialog in listOf("showLicensesDialog", "showLicenseTextsDialog")) {
+            assertTrue(
+                code.any { it.contains("$dialog()") && !it.contains("fun $dialog(") },
+                "Nothing calls $dialog(), so what it shows is packaged and out of " +
+                    "reach: the same state as when these documents lived only in " +
+                    "the repository, at more cost."
+            )
+        }
+    }
+
+    /**
+     * What each licence text has to still be: the name the chooser offers it
+     * under, the version line it opens with, the line it ends on, and the sha256
+     * of every byte.
+     *
+     * The hash is the whole check on the contents; the version and last lines are
+     * there so a failure says which file and which defect rather than "two hex
+     * strings differ". A truncation loses the last line, a file swapped for
+     * another loses the version line, and either way the app would be handing out
+     * something that is not the licence it claims to be.
+     *
+     * The name is a check on something else, and it needs one: these are keyed by
+     * file, so swapping which name opens which file leaves every hash here
+     * satisfied and still puts the wrong licence in front of the reader.
+     *
+     * These are the FSF texts as shipped in Termux's liblzma package, which this
+     * APK redistributes. Re-derive with:
+     *   shasum -a 256 licenses/COPYING.*
+     */
+    private data class Verbatim(
+        val title: String,
+        val version: String,
+        val lastLine: String,
+        val sha256: String
+    )
+
+    private val licenseTexts = mapOf(
+        "COPYING.GPLv2" to Verbatim(
+            "GNU General Public License v2.0",
+            "Version 2, June 1991",
+            "Public License instead of this License.",
+            "edaef632cbb643e4e7a221717a6c441a4c1a7c918e6e4d56debc3d8739b233f6"
+        ),
+        "COPYING.GPLv3" to Verbatim(
+            "GNU General Public License v3.0",
+            "Version 3, 29 June 2007",
+            "<https://www.gnu.org/licenses/why-not-lgpl.html>.",
+            "3972dc9744f6499f0f9b2dbf76696f2ae7ad8af9b23dde66d6af86c9dfb36986"
+        ),
+        "COPYING.LGPLv2.1" to Verbatim(
+            "GNU Lesser General Public License v2.1",
+            "Version 2.1, February 1999",
+            "That's all there is to it!",
+            "20e50fe7aae3e56378ebf0417d9de904f55a0e61e4df315333e632a4d3555d95"
+        )
+    )
+
+    @Test
+    fun `every licence text the app offers opens under the name it is offered as`() {
+        // Two defects, one assertion. A fourth text could be added to the chooser
+        // and ship unchecked, which is the state this whole file exists to end.
+        // And the chooser is a list of names: whoever taps one is told which
+        // licence they are about to be handed, so a name pointing at the other
+        // file hands over the wrong licence while every pin below still passes,
+        // since those are keyed by the file. GPL-2.0 and GPL-3.0 differ on
+        // patents, on tivoization and on how a violation is cured, so which of
+        // the two a recipient is given is the whole of the question.
+        assertEquals(
+            licenseTexts.entries.associate { (asset, pinned) -> pinned.title to asset },
+            Notices.LICENSE_TEXTS.toMap(),
+            "Notices.LICENSE_TEXTS offers a text with no verbatim check here, " +
+                "pins one the app no longer offers, or opens a text under a name " +
+                "that belongs to another licence."
+        )
+
+        // And the name has to be the version the text opens with, or both halves
+        // of a pin could be swapped together and stay green. The FSF writes
+        // "Version 2" where a name in SPDX shape writes v2.0.
+        for (pinned in licenseTexts.values) {
+            val numbered = pinned.title.substringAfterLast(" v").removeSuffix(".0")
+            assertTrue(
+                pinned.version.startsWith("Version $numbered,"),
+                "'${pinned.title}' is pinned to a text opening '${pinned.version}'"
+            )
+        }
+    }
+
+    @Test
+    fun `each licence text is the whole licence, byte for byte`() {
+        // The obligation the source offer does not discharge. GPL-2.0 section 1,
+        // GPL-3.0 section 4 and LGPL-2.1 section 1 each require a copy of the
+        // licence to reach whoever receives the binary, and an edited or
+        // half-copied licence is not a copy of it.
+        val copied = copiedPaths().associateBy { File(it).name }
+        for ((asset, expected) in licenseTexts) {
+            val path = copied[asset]
+            assertNotNull(path, "bundleNotices copies no $asset, so the APK carries no such text")
+            val file = File(repoRoot, path!!)
+            assertTrue(file.isFile, "$path does not exist")
+
+            val bytes = file.readBytes()
+            val text = String(bytes, Charsets.UTF_8)
+            assertTrue(
+                text.lineSequence().take(3).any { it.contains(expected.version) },
+                "$path does not open with '${expected.version}'. It is not the licence " +
+                    "its name claims."
+            )
+            assertEquals(
+                expected.lastLine,
+                text.trimEnd().lines().last().trim(),
+                "$path does not end where the licence ends. A truncated licence text " +
+                    "satisfies nothing."
+            )
+
+            val digest = MessageDigest.getInstance("SHA-256").digest(bytes)
+            assertEquals(
+                expected.sha256,
+                digest.joinToString("") { "%02x".format(it) },
+                "$path is no longer byte-for-byte the licence text. Reflowing, " +
+                    "re-wrapping or 'tidying' one is a modification, and a modified " +
+                    "licence is not the licence."
+            )
+        }
+    }
+
+    @Test
     fun `read returns every document, in order`() {
         val text = Notices.read { name -> ByteArrayInputStream("body of $name".toByteArray()) }
         var cursor = -1
@@ -116,6 +272,24 @@ class NoticesTest {
             assertTrue(at > cursor, "$name is missing from the joined text, or out of order")
             cursor = at
         }
+    }
+
+    @Test
+    fun `a licence text that cannot be read is named, not shown empty`() {
+        // The chooser opens one text at a time and has no other reader, so an
+        // empty view is the failure mode: it reads as a build that ships no
+        // licence rather than one whose asset would not open.
+        val asset = Notices.LICENSE_TEXTS.values.first()
+        assertEquals(
+            Notices.missingMarker(asset),
+            Notices.readOne(asset) { throw IOException("not packaged") },
+            "An unreadable licence text came back as something other than a marker"
+        )
+        assertEquals(
+            "the licence",
+            Notices.readOne(asset) { ByteArrayInputStream("the licence".toByteArray()) },
+            "A readable licence text did not come back whole"
+        )
     }
 
     @Test

--- a/android/app/src/test/kotlin/com/vscodroid/util/NoticesTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/util/NoticesTest.kt
@@ -43,10 +43,16 @@ class NoticesTest {
     private val buildScript = File("build.gradle.kts")
     private val mainActivity = File("src/main/kotlin/com/vscodroid/MainActivity.kt")
 
-    /** The `from(File(repoRoot, "..."))` arguments of the bundleNotices task. */
+    /**
+     * The `from(File(repoRoot, "..."))` arguments of the bundleNotices task.
+     *
+     * Found by name, not by task type. The type has an assertion of its own
+     * below, and a parse anchored on it would answer a change of type with
+     * "the task is gone", which is a different defect and the wrong one to fix.
+     */
     private fun copiedPaths(): List<String> {
         val script = buildScript.readText()
-        val task = script.substringAfter("tasks.register<Copy>(\"bundleNotices\")", "")
+        val task = script.substringAfter("(\"bundleNotices\") {", "")
         assertFalse(task.isEmpty(), "bundleNotices task is gone from build.gradle.kts")
         val body = task.substringBefore("\n}")
         return Regex("""from\(File\(repoRoot,\s*"([^"]+)"\)\)""")
@@ -73,7 +79,7 @@ class NoticesTest {
     @Test
     fun `what the copy writes is packaged, and something makes the copy run`() {
         val script = buildScript.readText()
-        val body = script.substringAfter("tasks.register<Copy>(\"bundleNotices\")", "")
+        val body = script.substringAfter("(\"bundleNotices\") {", "")
             .substringBefore("\n}")
         val destination = Regex("""into\(layout\.buildDirectory\.dir\("([^"]+)"\)\)""")
             .find(body)?.groupValues?.get(1)
@@ -96,6 +102,18 @@ class NoticesTest {
             Regex("dependsOn\\([^)]*bundleNotices").containsMatchIn(script),
             "Nothing depends on bundleNotices, so a clean build packages an empty " +
                 "notices directory."
+        )
+
+        // And it has to clear out what it no longer writes. A plain Copy leaves
+        // the last run's files where they are: with a document renamed or
+        // removed, the old one stayed in that directory and went into the next
+        // incremental APK under a name the repository no longer had. CI checks
+        // out clean and never saw it, which is what makes it worth a gate rather
+        // than a habit.
+        assertTrue(
+            script.contains("tasks.register<Sync>(\"bundleNotices\")"),
+            "bundleNotices is not a Sync, so a document removed or renamed stays " +
+                "in the notices directory and ships from any incremental build."
         )
     }
 

--- a/docs/LEGAL_NOTICES.md
+++ b/docs/LEGAL_NOTICES.md
@@ -69,7 +69,7 @@ Node.js includes V8 (BSD-3-Clause), libuv (MIT), OpenSSL (Apache-2.0), ICU (Unic
 - **Project**: https://git-scm.com
 - **License**: GNU General Public License v2.0 (GPL-2.0-only)
 - **Copyright**: Copyright (c) Junio C Hamano and the Git contributors
-- **Full license**: https://github.com/git/git/blob/master/COPYING
+- **Full license**: `licenses/COPYING.GPLv2`, which ships in the app at **About > Licenses > License Texts**; also https://github.com/git/git/blob/master/COPYING
 - **Source availability**: The source code for the Git binary included in VSCodroid is available from the Termux packages repository at https://github.com/termux/termux-packages
 
 ### Bash
@@ -78,7 +78,7 @@ Node.js includes V8 (BSD-3-Clause), libuv (MIT), OpenSSL (Apache-2.0), ICU (Unic
 - **Version**: not pinned here — from the Termux package index at build time (`scripts/download-termux-tools.sh`)
 - **License**: GNU General Public License v3.0 (GPL-3.0-or-later)
 - **Copyright**: Copyright (c) Free Software Foundation, Inc.
-- **Full license**: https://www.gnu.org/licenses/gpl-3.0.html
+- **Full license**: `licenses/COPYING.GPLv3`, which ships in the app at **About > Licenses > License Texts**; also https://www.gnu.org/licenses/gpl-3.0.html
 - **Source availability**: The source code for the Bash binary included in VSCodroid is available from the Termux packages repository at https://github.com/termux/termux-packages
 
 ### OpenSSH
@@ -102,7 +102,7 @@ Node.js includes V8 (BSD-3-Clause), libuv (MIT), OpenSSL (Apache-2.0), ICU (Unic
 - **Version**: not pinned here — from the Termux package index at build time (`scripts/download-termux-tools.sh`)
 - **License**: GNU General Public License v3.0 (GPL-3.0-or-later)
 - **Copyright**: Copyright (c) Free Software Foundation, Inc.
-- **Full license**: https://www.gnu.org/licenses/gpl-3.0.html
+- **Full license**: `licenses/COPYING.GPLv3`, which ships in the app at **About > Licenses > License Texts**; also https://www.gnu.org/licenses/gpl-3.0.html
 - **Source availability**: The source code for the Make binary included in VSCodroid is available from the Termux packages repository at https://github.com/termux/termux-packages
 
 ### ripgrep
@@ -291,6 +291,7 @@ licence that asks for the notice to travel with the copy.
 
 - **Project**: https://tiswww.case.edu/php/chet/readline/rltop.html
 - **License**: GNU General Public License v3.0 (GPL-3.0-or-later)
+- **Full license**: `licenses/COPYING.GPLv3`, which ships in the app at **About > Licenses > License Texts**
 - **Used by**: bash
 
 ### ncurses
@@ -530,6 +531,26 @@ You may also request a copy of the source code by contacting us (see contact inf
 
 ---
 
+## GPL and LGPL License Texts
+
+The offer above is one obligation; a copy of the licence itself is the other. GPL-2.0 section 1, GPL-3.0 section 4 and LGPL-2.1 section 1 each require the licence to reach whoever receives the binary, and a link to gnu.org is not a copy of it, least of all on a device with no network. So the texts ship:
+
+| Licence | Text | Components it covers |
+|---|---|---|
+| GPL-2.0 | `licenses/COPYING.GPLv2` | Git, `git-remote-curl`, Zstandard, xz / liblzma, Java (OpenJDK) |
+| GPL-3.0 | `licenses/COPYING.GPLv3` | Bash, GNU Make, readline, gdbm, libiconv, xz / liblzma |
+| LGPL-2.1 | `licenses/COPYING.LGPLv2.1` | libiconv, xz / liblzma |
+
+These are the Free Software Foundation's texts as shipped in Termux's `liblzma` package, which is one of the packages this app redistributes, and they are verbatim. `NoticesTest` pins the sha256 of each one: a licence text that has been reflowed, re-wrapped or truncated is no longer the licence, so none of them may be edited.
+
+They reach the device through the same `bundleNotices` task as this document, and are read straight out of the APK at **About > Licenses > License Texts**. They sit behind that chooser rather than inside the notices body because 78 KB of licence in front of the attribution and the source offer would bury the part a reader opened that screen for.
+
+Java is the one component above that arrives in an on-demand pack rather than in the base app, and the text covering it ships in the base app, which every device installing that pack already holds. Its licence is GPL-2.0 with the Classpath Exception, an additional permission that grants rights rather than requiring a copy of anything to travel; the exception is stated at https://openjdk.org/legal/gplv2+ce.html.
+
+GMP, in the Ruby toolchain pack, is LGPL-3.0 and is the one copyleft component with no text here; its licence is named and its source offered above.
+
+---
+
 ## Toolchain Libraries
 
 Shipped inside an on-demand toolchain pack rather than the base app, so they reach
@@ -578,7 +599,7 @@ The following toolchains are available as optional downloads and have their own 
 - **Project**: https://openjdk.org
 - **License**: GNU General Public License v2.0 with Classpath Exception (GPL-2.0 WITH Classpath-exception-2.0)
 - **Copyright**: Copyright (c) Oracle and/or its affiliates
-- **Full license**: https://openjdk.org/legal/gplv2+ce.html
+- **Full license**: `licenses/COPYING.GPLv2`, which ships in the app at **About > Licenses > License Texts**; the Classpath Exception that modifies it is stated at https://openjdk.org/legal/gplv2+ce.html
 
 ---
 

--- a/licenses/COPYING.GPLv2
+++ b/licenses/COPYING.GPLv2
@@ -1,0 +1,338 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Moe Ghoul>, 1 April 1989
+  Moe Ghoul, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/licenses/COPYING.GPLv3
+++ b/licenses/COPYING.GPLv3
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/licenses/COPYING.LGPLv2.1
+++ b/licenses/COPYING.LGPLv2.1
@@ -1,0 +1,501 @@
+                  GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+ <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Moe Ghoul>, 1 April 1990
+  Moe Ghoul, President of Vice
+
+That's all there is to it!


### PR DESCRIPTION
The app redistributes GPL and LGPL binaries: Bash, Git, GNU Make, readline, libiconv, gdbm, liblzma and Zstandard. GPL-2.0 section 1 and GPL-3.0 section 4 both require a copy of the license to accompany the binary. Until now only a gnu.org link did, and a link is not a copy.

Changes:

- `licenses/COPYING.GPLv2`, `licenses/COPYING.GPLv3` and `licenses/COPYING.LGPLv2.1` are added verbatim, taken from the Termux `liblzma` package this app already redistributes and checked byte for byte against the FSF originals.
- `bundleNotices` copies them into the APK beside the two notice documents, using the packaging path that already exists rather than a second one. It becomes a `Sync`, so a document removed from the tree stops shipping from an incremental build.
- About > Licenses gains a **License Texts** button opening a chooser, one entry per license.
- `docs/LEGAL_NOTICES.md` records which text covers which component, including OpenJDK in the Java pack, and each copyleft entry now names the bundled copy ahead of the URL.

Guards, each proven by breaking it:

- Every text is pinned by version line, closing line and sha256, so a truncation or a reflow fails the build. A modified license is not the license.
- The chooser's display name is pinned to the file it opens, so swapping which title opens which text goes red.
- Both steps of the route to the texts are pinned, so deleting either button fails rather than leaving them unreachable with everything green.
- `licenses/` and `NOTICE.md` are declared inputs of the test task. Without that the sha256 pins could not run on the one edit they exist to catch: the task reported UP-TO-DATE against a tampered license.

Cost: 79.5 KB raw, 32.7 KB compressed, against a 500 MB base-module cap. The texts stay in the APK and are never extracted, so first-run storage is unchanged.
