### PR TITLE
fix(toolchains): say why a Play toolchain download failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,6 +236,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **Toolchains**
 
 - A toolchain install that fails now says why: out of space, no connection, not in this release, or a download that did not match. It said only "Failed".
+- On a Play Store install that reason is given too. Play's error code went only to the log, so a full disk and a dropped connection read alike there.
 - A sideloaded toolchain install resolves `latest` once and takes both the digest and the payload from that release, so a release published mid-download no longer refuses the install.
 - Installed toolchains can be run. Android refuses to execute any file in an app's data directory, so terminal commands are handed to the system loader. **The redirect is shell functions, so its reach is the shell's reach**: `make`, directly executed scripts and extension-spawned processes still hit the binary directly and are refused. **Go cannot compile** even in the terminal, because `go build` starts its own compiler directly.
 - Tasks, npm scripts and anything run through `bash -c` now find npm, npx and the toolchain commands, which existed only in interactive shells. Direct execution and `sh -c` still cannot.

--- a/android/app/src/main/kotlin/com/vscodroid/SplashActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/SplashActivity.kt
@@ -21,6 +21,7 @@ import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.play.core.assetpacks.model.AssetPackStatus
 import com.vscodroid.setup.FirstRunSetup
+import com.vscodroid.setup.ToolchainFailure
 import com.vscodroid.setup.ToolchainManager
 import com.vscodroid.setup.ToolchainPickerAdapter
 import com.vscodroid.setup.ToolchainRegistry
@@ -324,14 +325,16 @@ class SplashActivity : AppCompatActivity() {
         // Set up toolchain manager
         val manager = ToolchainManager(this)
         toolchainManager = manager
+        val alreadySaid = mutableSetOf<ToolchainFailure>()
         manager.onStateChange = { packName, status, percent, why ->
             runOnUiThread {
                 handleDownloadState(packName, status, percent)
                 // The row has space for one word and the reason is a sentence, so
                 // it is said here rather than squeezed in there. Without it the
                 // queue moves on and the only record of WHY is in logcat.
-                if (why != null) {
-                    Toast.makeText(this, getString(why.message), Toast.LENGTH_LONG).show()
+                val reason = reasonToAnnounce(why, alreadySaid)
+                if (reason != null) {
+                    Toast.makeText(this, getString(reason.message), Toast.LENGTH_LONG).show()
                 }
             }
         }
@@ -626,3 +629,25 @@ internal fun isTerminalPackStatus(status: Int): Boolean = when (status) {
  */
 internal fun isCurrentDownload(packName: String, queue: List<String>, index: Int): Boolean =
     packName == queue.getOrNull(index)
+
+/**
+ * The reason worth putting on screen, or null when it has been said already.
+ *
+ * Toasts stack rather than replace: each one holds the screen for about three
+ * and a half seconds, and the queue starts the next download the moment one
+ * fails, so failures that share a cause arrive back to back. Three packs picked
+ * at first run and one full disk meant three identical messages in a row, most
+ * of them over the editor, because the splash screen is gone by then.
+ *
+ * Per reason and not per pack: a second pack failing for the same cause tells
+ * the user nothing they cannot already act on, while a different cause does and
+ * still gets through. [alreadySaid] belongs to one run of the queue, so a later
+ * attempt says it again.
+ *
+ * File scope so it can be tested without an Activity; this project's unit tests
+ * have no Robolectric.
+ */
+internal fun reasonToAnnounce(
+    why: ToolchainFailure?,
+    alreadySaid: MutableSet<ToolchainFailure>,
+): ToolchainFailure? = if (why != null && alreadySaid.add(why)) why else null

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
@@ -9,6 +9,7 @@ import android.system.Os
 import com.google.android.play.core.assetpacks.AssetPackManagerFactory
 import com.google.android.play.core.assetpacks.AssetPackState
 import com.google.android.play.core.assetpacks.AssetPackStateUpdateListener
+import com.google.android.play.core.assetpacks.model.AssetPackErrorCode
 import com.google.android.play.core.assetpacks.model.AssetPackStatus
 import com.vscodroid.util.Logger
 import org.json.JSONArray
@@ -77,9 +78,9 @@ class ToolchainManager(private val context: Context) {
     /**
      * A failure, and why.
      *
-     * There is no overload without a reason, which is the point: every one of
-     * the twelve failure sites had to name one, and a thirteenth cannot be added
-     * without doing the same.
+     * There is no overload without a reason, which is the point: every failure
+     * site has to name one, and a new one cannot be added without doing the
+     * same. Counting them here would only rot; the compiler does the counting.
      */
     private fun fail(packName: String, why: ToolchainFailure) {
         onStateChange?.invoke(packName, AssetPackStatus.FAILED, 0, why)
@@ -492,7 +493,13 @@ class ToolchainManager(private val context: Context) {
         // Don't fire onStateChange for COMPLETED here — the real COMPLETED fires
         // after copyFromAssetPack() finishes extraction (line in copyFromAssetPack).
         // Firing it twice would cause downloadNext() to be called twice, skipping packs.
-        if (status != AssetPackStatus.COMPLETED) {
+        //
+        // FAILED is held back for a different reason: report() has no way to say
+        // why, and this is the only place that knows. It is emitted below through
+        // fail() instead, still exactly once and still carrying FAILED, which is
+        // what keeps isTerminalPackStatus moving the first-run queue past it. A
+        // pack that stops emitting FAILED strands every pack queued behind it.
+        if (status != AssetPackStatus.COMPLETED && status != AssetPackStatus.FAILED) {
             report(packName, status, percent)
         }
 
@@ -518,7 +525,9 @@ class ToolchainManager(private val context: Context) {
                 }
             }
             AssetPackStatus.FAILED -> {
-                Logger.e(tag, "Pack $packName download failed: errorCode=${state.errorCode()}")
+                val code = state.errorCode()
+                Logger.e(tag, "Pack $packName download failed: errorCode=$code")
+                fail(packName, toolchainFailureFor(code))
             }
             AssetPackStatus.REQUIRES_USER_CONFIRMATION -> {
                 // Downloads exceeding 200MB or Play-determined thresholds need user
@@ -1677,8 +1686,60 @@ enum class ToolchainFailure(@StringRes val message: Int) {
     NOT_PUBLISHED(R.string.toolchain_failed_not_published),
     DIGEST(R.string.toolchain_failed_digest),
     CORRUPT(R.string.toolchain_failed_corrupt),
+    // Reached from both delivery paths, so its message names what Play will not
+    // do rather than which build is running: a sideloaded install with no ZIP for
+    // this pack, and a Play install Play does not recognise as one of its own.
+    // Naming the build type is wrong for the second, which shouldUseHttpFallback
+    // has already classified as a Play install.
     PLAY_REQUIRED(R.string.toolchain_failed_play),
     INTERNAL(R.string.toolchain_failed_internal),
+}
+
+/**
+ * Play's error code for a failed asset pack, in the terms [ToolchainFailure] speaks.
+ *
+ * The Play delivery path reported FAILED with no reason at all. The code went to
+ * logcat and stopped there, so a Play Store user was left with the bare word that
+ * the HTTP path had already stopped showing, for a full disk and a dropped
+ * connection alike. Nothing new is said here; the existing vocabulary is simply
+ * reached from the other delivery path.
+ *
+ * Grouped by what the user can do, like the enum itself, and taken from what each
+ * code is documented to mean rather than from what its name resembles:
+ *
+ *  - `NETWORK_ERROR` is "unable to obtain the asset pack details", so
+ *    [ToolchainFailure.NETWORK]: a better connection is the answer.
+ *  - `INSUFFICIENT_STORAGE` is a download refused for space, so
+ *    [ToolchainFailure.STORAGE]: freeing space is the answer.
+ *  - `PACK_UNAVAILABLE` is "the asset pack wasn't included in the App Bundle that
+ *    was published", which is this app's own release not carrying it, so
+ *    [ToolchainFailure.NOT_PUBLISHED]: waiting for an update is the only answer.
+ *  - `APP_NOT_OWNED` and `UNRECOGNIZED_INSTALLATION` both say Play does not
+ *    recognise this copy of the app as one it delivered, and Play serves asset
+ *    packs only to copies it does, so [ToolchainFailure.PLAY_REQUIRED].
+ *
+ * Everything else is [ToolchainFailure.INTERNAL] on purpose, including codes with
+ * an inviting name. `APP_UNAVAILABLE` is "the requesting app is unavailable",
+ * which is about the app or the user's access to it and not about the pack, so
+ * sending it to `NOT_PUBLISHED` would tell someone this toolchain is missing from
+ * a release that carries it. `ACCESS_DENIED`, `API_NOT_AVAILABLE`,
+ * `INVALID_REQUEST`, `DOWNLOAD_NOT_FOUND` and `CONFIRMATION_NOT_REQUIRED` name
+ * conditions no message in the enum can act on, and the last three are this
+ * app's own mistakes rather than the user's.
+ *
+ * Two documented codes cannot be named here at all: `PLAY_STORE_NOT_FOUND` (-11)
+ * and `NETWORK_UNRESTRICTED` (-12) appear in the library's own IntDef listing but
+ * are not declared by asset-delivery 2.2.2, so they arrive as numbers this build
+ * has no constant for and fall through with the rest. Every code that lands in
+ * INTERNAL is still in the log line beside this call, raw.
+ */
+internal fun toolchainFailureFor(errorCode: Int): ToolchainFailure = when (errorCode) {
+    AssetPackErrorCode.NETWORK_ERROR -> ToolchainFailure.NETWORK
+    AssetPackErrorCode.INSUFFICIENT_STORAGE -> ToolchainFailure.STORAGE
+    AssetPackErrorCode.PACK_UNAVAILABLE -> ToolchainFailure.NOT_PUBLISHED
+    AssetPackErrorCode.APP_NOT_OWNED,
+    AssetPackErrorCode.UNRECOGNIZED_INSTALLATION -> ToolchainFailure.PLAY_REQUIRED
+    else -> ToolchainFailure.INTERNAL
 }
 
 /** The digest manifest's filename, as `release.yml` writes it beside the ZIPs. */

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -81,7 +81,7 @@
     <string name="toolchain_failed_not_published">This toolchain is not in the current release. Try again after the next app update.</string>
     <string name="toolchain_failed_digest">The download did not match what the release published. Try again.</string>
     <string name="toolchain_failed_corrupt">The download was incomplete. Try again.</string>
-    <string name="toolchain_failed_play">This toolchain installs only on Play Store builds.</string>
+    <string name="toolchain_failed_play">Play delivers this toolchain only to apps it installed. Install from the Play Store and try again.</string>
     <string name="toolchain_failed_internal">Install failed. The app log has the details.</string>
     <string name="progress_cancel">Cancel</string>
     <string name="progress_retry">Retry</string>

--- a/android/app/src/test/kotlin/com/vscodroid/AnnouncedReasonTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/AnnouncedReasonTest.kt
@@ -1,0 +1,79 @@
+package com.vscodroid
+
+import com.vscodroid.setup.ToolchainFailure
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for [reasonToAnnounce], which decides whether a failed pack's reason is
+ * worth a Toast or has been said already.
+ *
+ * The reason itself is the point of the callback, so the rule cannot be "say it
+ * once and never again": it is per cause, per run of the download queue. A
+ * first-run pick of three toolchains that all fail on a full disk is one fact
+ * the user can act on, and Toasts queue rather than replace, so saying it three
+ * times holds roughly ten seconds of the screen they moved on to. Two different
+ * causes are two facts and both still get through.
+ *
+ * Same boundary as the other predicates lifted out of SplashActivity: these pin
+ * the rule, not the call. [DownloadStateWiringTest] covers the call.
+ */
+class AnnouncedReasonTest {
+
+    private val alreadySaid = mutableSetOf<ToolchainFailure>()
+
+    @Test
+    fun `a first failure is announced`() {
+        assertEquals(
+            ToolchainFailure.STORAGE,
+            reasonToAnnounce(ToolchainFailure.STORAGE, alreadySaid),
+        )
+    }
+
+    @Test
+    fun `the same cause twice is announced once`() {
+        // The queue starts the next download the moment one fails, so packs
+        // sharing a cause fail back to back with nothing between the messages.
+        reasonToAnnounce(ToolchainFailure.STORAGE, alreadySaid)
+
+        assertNull(
+            reasonToAnnounce(ToolchainFailure.STORAGE, alreadySaid),
+            "a second pack out of space adds nothing the user can act on",
+        )
+    }
+
+    @Test
+    fun `a second cause is still announced`() {
+        // The half that makes this a filter rather than a mute. Getting it wrong
+        // is worse than the repeat: the user is told to free space and never told
+        // the next pack failed for a reason freeing space will not fix.
+        reasonToAnnounce(ToolchainFailure.STORAGE, alreadySaid)
+
+        assertEquals(
+            ToolchainFailure.NETWORK,
+            reasonToAnnounce(ToolchainFailure.NETWORK, alreadySaid),
+            "a different cause is a different fact and has not been said",
+        )
+    }
+
+    @Test
+    fun `progress carries no reason and says nothing`() {
+        // Every non-failure status arrives here with a null reason, which is most
+        // of them: percentage updates land on this line several times a second.
+        assertNull(reasonToAnnounce(null, alreadySaid))
+    }
+
+    @Test
+    fun `a later run of the queue may repeat itself`() {
+        // The set is built in startDownloads, so it lives exactly as long as one
+        // pass over the picked toolchains. A user who frees space and installs
+        // again has to be told why it failed the second time too.
+        reasonToAnnounce(ToolchainFailure.STORAGE, alreadySaid)
+
+        assertEquals(
+            ToolchainFailure.STORAGE,
+            reasonToAnnounce(ToolchainFailure.STORAGE, mutableSetOf()),
+        )
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/PackStatusTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/PackStatusTest.kt
@@ -155,19 +155,19 @@ class DownloadStateWiringTest {
 
     private val source = File("src/main/kotlin/com/vscodroid/SplashActivity.kt")
 
-    private fun handleDownloadStateBody(): String {
+    private fun bodyOf(declaration: String): String {
         check(source.isFile) {
             "SplashActivity.kt not found at ${source.absolutePath} — this test would " +
                 "otherwise pass by looking at nothing"
         }
         val text = source.readText()
-        val declaration = text.indexOf("private fun handleDownloadState(")
-        check(declaration >= 0) {
-            "handleDownloadState is gone from SplashActivity.kt; this guard names it, so " +
-                "renaming it means deciding again where the two calls are pinned"
+        val start = text.indexOf(declaration)
+        check(start >= 0) {
+            "$declaration is gone from SplashActivity.kt; this guard names it, so " +
+                "renaming it means deciding again where its calls are pinned"
         }
 
-        val open = text.indexOf('{', declaration)
+        val open = text.indexOf('{', start)
         var depth = 0
         var i = open
         while (i < text.length) {
@@ -176,7 +176,7 @@ class DownloadStateWiringTest {
             if (depth == 0) break
             i++
         }
-        check(depth == 0) { "no closing brace found for handleDownloadState" }
+        check(depth == 0) { "no closing brace found for $declaration" }
         return text.substring(open, i + 1)
     }
 
@@ -196,7 +196,7 @@ class DownloadStateWiringTest {
 
     @Test
     fun `handleDownloadState still consults both predicates`() {
-        val raw = handleDownloadStateBody()
+        val raw = bodyOf("private fun handleDownloadState(")
 
         // The brace matcher is the weak part, so it is bounded rather than trusted:
         // an extraction that ran to the end of the file would contain both names for
@@ -220,6 +220,29 @@ class DownloadStateWiringTest {
             body.contains("isTerminalPackStatus("),
             "handleDownloadState no longer asks whether the status is terminal, so the " +
                 "queue stops advancing and first-run setup stalls on the progress screen",
+        )
+    }
+
+    /**
+     * The same gap one method over: [AnnouncedReasonTest] pins what may be said
+     * twice, and nothing there notices if the Toast stops asking.
+     */
+    @Test
+    fun `startDownloads still filters a reason it has already given`() {
+        // 1,961 characters when this was written, against handleDownloadState's
+        // 3,758 in a file of 29,742. Bounded for the same reason as above: an
+        // extraction that ran past its own method would find the name somewhere
+        // else and report a deleted filter as a live one.
+        val raw = bodyOf("private fun startDownloads(")
+        check(raw.length in 500..8000) {
+            "extracted ${raw.length} characters of startDownloads, which means the " +
+                "extraction is wrong rather than the code"
+        }
+
+        assertTrue(
+            code(raw).contains("reasonToAnnounce("),
+            "the failure Toast is no longer filtered, so packs failing for one cause " +
+                "queue one long Toast each, most of them over the editor",
         )
     }
 }

--- a/android/app/src/test/kotlin/com/vscodroid/setup/PlayFailureReasonTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/PlayFailureReasonTest.kt
@@ -1,0 +1,301 @@
+package com.vscodroid.setup
+
+import android.content.Context
+import com.google.android.play.core.assetpacks.AssetPackManager
+import com.google.android.play.core.assetpacks.AssetPackManagerFactory
+import com.google.android.play.core.assetpacks.AssetPackState
+import com.google.android.play.core.assetpacks.AssetPackStateUpdateListener
+import com.google.android.play.core.assetpacks.model.AssetPackErrorCode
+import com.google.android.play.core.assetpacks.model.AssetPackStatus
+import com.vscodroid.isTerminalPackStatus
+import com.vscodroid.util.Logger
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Tests for [toolchainFailureFor], the translation of Play's asset pack error
+ * codes into the reasons the two toolchain screens display.
+ *
+ * These pin the rule only. What carries it, that the FAILED branch actually
+ * calls this and that the reason reaches the callback exactly once, is
+ * [PlayFailureWiringTest] below: a mapping nothing consults is as silent as no
+ * mapping at all, and that is the shape the original defect had.
+ */
+class PlayFailureReasonTest {
+
+    @Test
+    fun `a network code sends the user to their connection`() {
+        assertEquals(
+            ToolchainFailure.NETWORK,
+            toolchainFailureFor(AssetPackErrorCode.NETWORK_ERROR),
+        )
+    }
+
+    @Test
+    fun `a storage code sends the user to free space`() {
+        assertEquals(
+            ToolchainFailure.STORAGE,
+            toolchainFailureFor(AssetPackErrorCode.INSUFFICIENT_STORAGE),
+        )
+    }
+
+    @Test
+    fun `a pack missing from the published bundle sends the user to the next update`() {
+        // PACK_UNAVAILABLE is documented as the pack not being in the App Bundle
+        // that was published, which is the same condition the HTTP path calls
+        // NOT_PUBLISHED when the release carries no ZIP for it.
+        assertEquals(
+            ToolchainFailure.NOT_PUBLISHED,
+            toolchainFailureFor(AssetPackErrorCode.PACK_UNAVAILABLE),
+        )
+    }
+
+    @Test
+    fun `an install Play did not deliver is told that is the requirement`() {
+        listOf(
+            AssetPackErrorCode.APP_NOT_OWNED,
+            AssetPackErrorCode.UNRECOGNIZED_INSTALLATION,
+        ).forEach {
+            assertEquals(
+                ToolchainFailure.PLAY_REQUIRED,
+                toolchainFailureFor(it),
+                "code $it means Play does not recognise this copy of the app",
+            )
+        }
+    }
+
+    @Test
+    fun `an unavailable app is not reported as an unpublished toolchain`() {
+        // The tempting one, and the reason this test exists. APP_UNAVAILABLE is
+        // documented as the app, its version code, or the user's access to it
+        // being what Play cannot serve. NOT_PUBLISHED would name the toolchain
+        // instead and send the user to wait for an update that would change
+        // nothing, so the honest answer is the one that says to read the log
+        // rather than a wrong one that sounds specific.
+        assertEquals(
+            ToolchainFailure.INTERNAL,
+            toolchainFailureFor(AssetPackErrorCode.APP_UNAVAILABLE),
+        )
+    }
+
+    @Test
+    fun `codes naming a condition no message can act on stay internal`() {
+        listOf(
+            AssetPackErrorCode.ACCESS_DENIED,
+            AssetPackErrorCode.API_NOT_AVAILABLE,
+            AssetPackErrorCode.INVALID_REQUEST,
+            AssetPackErrorCode.DOWNLOAD_NOT_FOUND,
+            AssetPackErrorCode.CONFIRMATION_NOT_REQUIRED,
+            AssetPackErrorCode.INTERNAL_ERROR,
+            AssetPackErrorCode.NO_ERROR,
+        ).forEach {
+            assertEquals(
+                ToolchainFailure.INTERNAL,
+                toolchainFailureFor(it),
+                "code $it has no reason in the enum that the user could act on",
+            )
+        }
+    }
+
+    @Test
+    fun `a code this build has no constant for stays internal`() {
+        // PLAY_STORE_NOT_FOUND and NETWORK_UNRESTRICTED are in the library's own
+        // IntDef listing but are not declared by asset-delivery 2.2.2, so they can
+        // only arrive as numbers. A later library version adding codes must not be
+        // able to reach anything other than the catch-all either.
+        listOf(-11, -12, -9999).forEach {
+            assertEquals(
+                ToolchainFailure.INTERNAL,
+                toolchainFailureFor(it),
+                "code $it is not one this build can name",
+            )
+        }
+    }
+}
+
+/**
+ * The wiring [PlayFailureReasonTest] cannot reach: that a Play pack ending in
+ * FAILED emits its reason, once, without stalling the first-run queue.
+ *
+ * Three things have to hold together and each fails silently on its own. The
+ * FAILED branch has to call [toolchainFailureFor] at all, which it did not: it
+ * logged the code and returned, leaving the row red with no explanation. The
+ * status still has to be FAILED, because that is what [isTerminalPackStatus]
+ * reads to move the queue on, and a pack that stops reporting a terminal status
+ * strands every pack behind it. And it has to be one callback rather than two,
+ * because the first-run screen advances on each one, so a second would skip
+ * whichever pack came next.
+ *
+ * COMPLETED is held back by the same `if`, for the older of the two reasons, and
+ * is covered here too: the two clauses live on one line, so an edit aimed at one
+ * of them can drop the other, and either loss reports a status twice.
+ *
+ * Driven through the real listener rather than a source-text check: the manager
+ * registers it with [AssetPackManager], so a mocked manager hands the test the
+ * exact object Play would call.
+ */
+class PlayFailureWiringTest {
+
+    @TempDir
+    lateinit var filesDir: File
+
+    private lateinit var context: Context
+    private lateinit var packManager: AssetPackManager
+    private val listener = slot<AssetPackStateUpdateListener>()
+
+    /**
+     * Every callback the manager made: pack, status, reason.
+     *
+     * Thread-safe because it has to be: the install a COMPLETED pack triggers
+     * runs on the manager's own executor and reports from there.
+     */
+    private val events = CopyOnWriteArrayList<Triple<String, Int, ToolchainFailure?>>()
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(Logger)
+        every { Logger.d(any(), any()) } just Runs
+        every { Logger.i(any(), any()) } just Runs
+        every { Logger.w(any(), any(), any()) } just Runs
+        every { Logger.e(any(), any(), any()) } just Runs
+
+        packManager = mockk(relaxed = true)
+        every { packManager.registerListener(capture(listener)) } just Runs
+        mockkStatic(AssetPackManagerFactory::class)
+        every { AssetPackManagerFactory.getInstance(any()) } returns packManager
+
+        context = mockk(relaxed = true)
+        every { context.filesDir } returns filesDir
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    /** The listener the manager gave Play, with the callback recorder behind it. */
+    private fun playListener(): AssetPackStateUpdateListener {
+        val manager = ToolchainManager(context)
+        manager.onStateChange = { pack, status, _, why ->
+            events.add(Triple(pack, status, why))
+        }
+        manager.registerListener()
+        check(listener.isCaptured) { "the manager registered no listener with Play" }
+        return listener.captured
+    }
+
+    private fun state(status: Int, errorCode: Int): AssetPackState {
+        val state = mockk<AssetPackState>(relaxed = true)
+        every { state.name() } returns "toolchain_go"
+        every { state.status() } returns status
+        every { state.errorCode() } returns errorCode
+        return state
+    }
+
+    @Test
+    fun `a failed pack reports why, once, and still ends the queue's wait`() {
+        playListener().onStateUpdate(
+            state(AssetPackStatus.FAILED, AssetPackErrorCode.INSUFFICIENT_STORAGE),
+        )
+
+        assertEquals(
+            1,
+            events.size,
+            "a failed pack must be reported exactly once; the first-run screen " +
+                "advances on every report, so a second skips the next toolchain",
+        )
+        assertEquals("toolchain_go", events[0].first)
+        assertEquals(
+            ToolchainFailure.STORAGE,
+            events[0].third,
+            "the reason never left the log line, which is the whole defect",
+        )
+        assertEquals(AssetPackStatus.FAILED, events[0].second)
+        assertTrue(
+            isTerminalPackStatus(events[0].second),
+            "the status reported must still end the first-run queue's wait, or " +
+                "every toolchain queued behind this one is stranded",
+        )
+    }
+
+    @Test
+    fun `the raw error code is still logged`() {
+        // The reason on screen is a sentence for the user; the code is what a bug
+        // report needs, and it is the only record left of the codes that map to
+        // INTERNAL.
+        playListener().onStateUpdate(
+            state(AssetPackStatus.FAILED, AssetPackErrorCode.APP_UNAVAILABLE),
+        )
+
+        verify {
+            Logger.e(any(), match { it.contains("errorCode=-1") }, any())
+        }
+    }
+
+    @Test
+    fun `a completed pack is not reported before its files are installed`() {
+        // COMPLETED from Play means the pack has arrived, not that the toolchain
+        // works: the copy, the chmod and the symlinks still have to run, and the
+        // report the first-run screen advances on belongs to the end of that. Sent
+        // from here as well, it arrives twice, the screen advances twice, and
+        // whichever toolchain was picked after this one is silently skipped.
+        //
+        // There is nothing to install in a test, so the install path ends in a
+        // failure. Waiting for that report is what makes this deterministic: the
+        // report under test would be the synchronous one, so by the time the
+        // asynchronous one lands it would already be in the list.
+        every { packManager.getPackLocation(any()) } returns null
+
+        playListener().onStateUpdate(
+            state(AssetPackStatus.COMPLETED, AssetPackErrorCode.NO_ERROR),
+        )
+        awaitInstallReport()
+
+        assertTrue(
+            events.none { it.second == AssetPackStatus.COMPLETED },
+            "COMPLETED was reported from the state update as well as from the " +
+                "install, so the first-run queue steps twice: $events",
+        )
+    }
+
+    /** Blocks until the install path, on the manager's own thread, has reported. */
+    private fun awaitInstallReport() {
+        val deadline = System.currentTimeMillis() + 5_000
+        while (events.isEmpty() && System.currentTimeMillis() < deadline) {
+            Thread.sleep(10)
+        }
+        check(events.isNotEmpty()) {
+            "the install reported nothing within 5s, so this test would pass by " +
+                "looking before the report it exists to look after"
+        }
+    }
+
+    @Test
+    fun `a pack still downloading reports progress with no reason`() {
+        // The other half of the routing change. Progress and success have no
+        // reason to give and must keep flowing through the unchanged path.
+        playListener().onStateUpdate(
+            state(AssetPackStatus.DOWNLOADING, AssetPackErrorCode.NO_ERROR),
+        )
+
+        assertEquals(1, events.size)
+        assertEquals(AssetPackStatus.DOWNLOADING, events[0].second)
+        assertNull(events[0].third, "a download in progress has not failed")
+    }
+}


### PR DESCRIPTION
A toolchain download that fails on a Play Store install shows no reason. The row turns red reading "Failed" and Play's error code reaches logcat and nowhere else, so a full disk, a dropped connection and a pack missing from the published bundle read alike. The reason channel already exists and both screens already display it; only the Play Asset Delivery path never filled it in.

Changes:

- `toolchainFailureFor()` maps `AssetPackErrorCode` onto the existing `ToolchainFailure` values, following what each code is documented to mean and what the user can do about it: `NETWORK_ERROR` to NETWORK, `INSUFFICIENT_STORAGE` to STORAGE, `PACK_UNAVAILABLE` to NOT_PUBLISHED, `APP_NOT_OWNED` and `UNRECOGNIZED_INSTALLATION` to PLAY_REQUIRED. Codes with no honest answer stay INTERNAL rather than borrowing a message that sounds specific and names the wrong thing, and the raw code is still logged.
- The FAILED branch emits through `fail()` instead of falling through `report()`. It stays one callback carrying `AssetPackStatus.FAILED`, so the first-run queue advances past a failed pack exactly as before.
- The reason is announced once per cause per queue run. Three toolchains failing on a full disk previously meant three stacked long toasts on the first-run screen; a second, different cause still gets through, because muting it would tell a user to free space and never tell them the next pack failed for something freeing space cannot fix.
- `toolchain_failed_play` is reworded. It read "This toolchain installs only on Play Store builds", which is written for the opposite situation and is now also shown to someone whose Play install Play no longer recognises.

Verified by unit tests, including three that drive the real listener the manager registers with Play and assert the reason, the status and that exactly one callback fires. Emitting under a non-terminal status, or twice, each fails a test: those are the two ways this could have stranded every toolchain behind a failed one.
