### PR TITLE
test(ui): pin the toolchain card and popup placement

### DIFF
--- a/android/app/src/main/kotlin/com/vscodroid/SplashActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/SplashActivity.kt
@@ -22,6 +22,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.google.android.play.core.assetpacks.model.AssetPackStatus
 import com.vscodroid.setup.FirstRunSetup
 import com.vscodroid.setup.ToolchainManager
+import com.vscodroid.setup.ToolchainCardMode
 import com.vscodroid.setup.ToolchainPickerAdapter
 import com.vscodroid.setup.ToolchainRegistry
 import com.vscodroid.storage.SafStorageManager
@@ -278,7 +279,7 @@ class SplashActivity : AppCompatActivity() {
         val continueBtn = findViewById<Button>(R.id.continueButton)
         val skipBtn = findViewById<TextView>(R.id.skipButton)
 
-        val adapter = ToolchainPickerAdapter(ToolchainPickerAdapter.Mode.PICKER)
+        val adapter = ToolchainPickerAdapter(ToolchainCardMode.PICKER)
         grid.layoutManager = GridLayoutManager(this, 2)
         grid.adapter = adapter
 

--- a/android/app/src/main/kotlin/com/vscodroid/ToolchainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/ToolchainActivity.kt
@@ -12,6 +12,8 @@ import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.play.core.assetpacks.model.AssetPackStatus
 import com.vscodroid.setup.ToolchainManager
 import com.vscodroid.util.padForSystemBars
+import com.vscodroid.setup.ToolchainAction
+import com.vscodroid.setup.ToolchainCardMode
 import com.vscodroid.setup.ToolchainPickerAdapter
 import com.vscodroid.setup.ToolchainRegistry
 import com.vscodroid.util.Logger
@@ -53,19 +55,19 @@ class ToolchainActivity : AppCompatActivity() {
         toolbar.setNavigationOnClickListener { finish() }
 
         // Set up grid with MANAGER mode adapter
-        adapter = ToolchainPickerAdapter(ToolchainPickerAdapter.Mode.MANAGER)
+        adapter = ToolchainPickerAdapter(ToolchainCardMode.MANAGER)
         adapter.setInstalled(toolchainManager.getInstalledToolchains())
 
         adapter.onAction = { packName, action ->
             when (action) {
-                ToolchainPickerAdapter.Action.INSTALL,
-                ToolchainPickerAdapter.Action.RETRY -> {
+                ToolchainAction.INSTALL,
+                ToolchainAction.RETRY -> {
                     toolchainManager.install(packName)
                 }
-                ToolchainPickerAdapter.Action.REMOVE -> {
+                ToolchainAction.REMOVE -> {
                     showRemoveConfirmation(packName)
                 }
-                ToolchainPickerAdapter.Action.CANCEL -> {
+                ToolchainAction.CANCEL -> {
                     toolchainManager.cancel(packName)
                     adapter.updateState(packName, AssetPackStatus.NOT_INSTALLED, 0)
                 }

--- a/android/app/src/main/kotlin/com/vscodroid/keyboard/LongPressPlacement.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/keyboard/LongPressPlacement.kt
@@ -1,0 +1,37 @@
+package com.vscodroid.keyboard
+
+/** Where a popup's top-left corner goes, in screen coordinates. */
+data class PopupPosition(val x: Int, val y: Int)
+
+/**
+ * Where the long-press alternates popup goes, with no Android types in it.
+ *
+ * Split out of [LongPressPopup] because the arithmetic is the part that can be
+ * wrong: the popup is wider than the key it belongs to, so centring it means
+ * starting to the left of the anchor, and it has to clear the finger that is
+ * still holding that key down. Both are sign mistakes that leave a popup on
+ * screen, in the wrong place, with nothing to report.
+ */
+object LongPressPlacement {
+
+    /**
+     * Centres a [popupWidth] by [popupHeight] popup horizontally on an anchor at
+     * [anchorLeft], [anchorTop] of width [anchorWidth], and puts it [gapPx]
+     * above the anchor's top edge.
+     *
+     * The anchor position is the one [android.view.View.getLocationOnScreen]
+     * reports, so the result is in screen coordinates too. It is not clamped to
+     * the display: a key near either edge yields a popup that starts off screen.
+     */
+    fun above(
+        anchorLeft: Int,
+        anchorTop: Int,
+        anchorWidth: Int,
+        popupWidth: Int,
+        popupHeight: Int,
+        gapPx: Int,
+    ): PopupPosition = PopupPosition(
+        x = anchorLeft + (anchorWidth - popupWidth) / 2,
+        y = anchorTop - popupHeight - gapPx,
+    )
+}

--- a/android/app/src/main/kotlin/com/vscodroid/keyboard/LongPressPopup.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/keyboard/LongPressPopup.kt
@@ -75,14 +75,20 @@ class LongPressPopup(
         // Position centered above anchor
         val location = IntArray(2)
         anchor.getLocationOnScreen(location)
-        val x = location[0] + (anchor.width - popupWidth) / 2
-        val y = location[1] - popupHeight - dpToPx(4)
+        val at = LongPressPlacement.above(
+            anchorLeft = location[0],
+            anchorTop = location[1],
+            anchorWidth = anchor.width,
+            popupWidth = popupWidth,
+            popupHeight = popupHeight,
+            gapPx = dpToPx(4),
+        )
 
         popup = PopupWindow(container, popupWidth, popupHeight, true).apply {
             setBackgroundDrawable(ColorDrawable(context.getColor(R.color.colorPopupBg)))
             elevation = dpToPx(4).toFloat()
             isOutsideTouchable = true
-            showAtLocation(anchor, Gravity.NO_GRAVITY, x, y)
+            showAtLocation(anchor, Gravity.NO_GRAVITY, at.x, at.y)
         }
     }
 

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainCardState.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainCardState.kt
@@ -1,0 +1,141 @@
+package com.vscodroid.setup
+
+import com.google.android.play.core.assetpacks.model.AssetPackStatus
+
+/** Which screen the cards are on. */
+enum class ToolchainCardMode {
+    /** First-run selection: tapping a card ticks it. */
+    PICKER,
+
+    /** Settings screen: each card offers one action. */
+    MANAGER,
+}
+
+/** What a card's action button offers. */
+enum class ToolchainAction { INSTALL, REMOVE, CANCEL, RETRY }
+
+/** What a card's status line says. */
+enum class ToolchainBadge { NONE, INSTALLED, FAILED }
+
+/**
+ * Everything one toolchain card shows, decided without a View.
+ *
+ * The nullable fields are absences rather than defaults: no progress bar at all
+ * is not the same card as a progress bar reading zero, and no button at all is
+ * not the same card as a disabled one.
+ */
+data class ToolchainCard(
+    /** PICKER only: the card is ticked and outlined. */
+    val selected: Boolean = false,
+    val badge: ToolchainBadge = ToolchainBadge.NONE,
+    /** Progress bar percentage, or null when the card carries no progress bar. */
+    val progressPercent: Int? = null,
+    /** The action button's offer, or null when the card carries no button. */
+    val action: ToolchainAction? = null,
+)
+
+/**
+ * The toolchain card's data logic, with no Android types in it.
+ *
+ * It holds what the two screens know about each toolchain (ticked, installed,
+ * last download report) and turns that into the card to draw. Kept apart from
+ * [ToolchainPickerAdapter] so the decisions can be asserted without a
+ * RecyclerView: which report counts as "still downloading", which of installed
+ * and failed wins, and whether a name from the install record matches a pack
+ * name at all. Getting any of those wrong offers "Install" for something already
+ * on disk, or hides the only button that starts a download, and both are silent.
+ */
+class ToolchainCardState(private val mode: ToolchainCardMode) {
+
+    /** The cards, in the order they are drawn. */
+    val items: List<ToolchainRegistry.ToolchainInfo> = ToolchainRegistry.available
+
+    private val selected = mutableSetOf<String>()
+    private val installed = mutableSetOf<String>()
+    private val downloadStatus = mutableMapOf<String, Int>()
+    private val downloadPercent = mutableMapOf<String, Int>()
+
+    /** Position of [packName] among [items], or -1 when no card shows it. */
+    fun positionOf(packName: String): Int = items.indexOfFirst { it.packName == packName }
+
+    /**
+     * Replaces what is on disk with [packNames].
+     *
+     * The install record names toolchains the short way ("go"), the cards name
+     * them the pack way ("toolchain_go"), so each name is normalised on the way
+     * in. Both spellings are accepted because both reach here.
+     */
+    fun setInstalled(packNames: Collection<String>) {
+        installed.clear()
+        installed.addAll(packNames.map { name ->
+            if (name.startsWith("toolchain_")) name else "toolchain_$name"
+        })
+    }
+
+    /**
+     * Folds one download report in and returns the position whose card it
+     * changed, or -1 for a pack no card shows.
+     *
+     * COMPLETED and NOT_INSTALLED also move the pack in and out of the installed
+     * set, so a card is right immediately rather than after the next
+     * [setInstalled].
+     */
+    fun updateState(packName: String, status: Int, percent: Int): Int {
+        downloadStatus[packName] = status
+        downloadPercent[packName] = percent
+
+        if (status == AssetPackStatus.COMPLETED) {
+            installed.add(packName)
+        }
+        if (status == AssetPackStatus.NOT_INSTALLED) {
+            installed.remove(packName)
+        }
+        return positionOf(packName)
+    }
+
+    /** PICKER: ticks [packName] if it is not ticked, unticks it if it is. */
+    fun toggleSelection(packName: String) {
+        if (!selected.remove(packName)) selected.add(packName)
+    }
+
+    /** A snapshot of what is ticked, safe to hold while the user carries on tapping. */
+    fun selectedPackNames(): Set<String> = selected.toSet()
+
+    /** The card to draw for [packName] on this screen. */
+    fun card(packName: String): ToolchainCard = when (mode) {
+        ToolchainCardMode.PICKER -> ToolchainCard(selected = packName in selected)
+        ToolchainCardMode.MANAGER -> managerCard(packName)
+    }
+
+    private fun managerCard(packName: String): ToolchainCard {
+        val status = downloadStatus[packName]
+        return when {
+            status in IN_FLIGHT -> ToolchainCard(
+                progressPercent = downloadPercent[packName] ?: 0,
+                action = ToolchainAction.CANCEL,
+            )
+            status == AssetPackStatus.FAILED -> ToolchainCard(
+                badge = ToolchainBadge.FAILED,
+                action = ToolchainAction.RETRY,
+            )
+            packName in installed -> ToolchainCard(
+                badge = ToolchainBadge.INSTALLED,
+                action = ToolchainAction.REMOVE,
+            )
+            else -> ToolchainCard(action = ToolchainAction.INSTALL)
+        }
+    }
+
+    private companion object {
+        /**
+         * Reports that mean the download is still going somewhere, so the card
+         * keeps offering Cancel rather than a second Install.
+         */
+        val IN_FLIGHT = listOf(
+            AssetPackStatus.DOWNLOADING,
+            AssetPackStatus.PENDING,
+            AssetPackStatus.WAITING_FOR_WIFI,
+            AssetPackStatus.TRANSFERRING,
+        )
+    }
+}

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainPickerAdapter.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainPickerAdapter.kt
@@ -10,7 +10,6 @@ import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.card.MaterialCardView
-import com.google.android.play.core.assetpacks.model.AssetPackStatus
 import com.vscodroid.R
 
 /**
@@ -19,52 +18,34 @@ import com.vscodroid.R
  * Two modes:
  * - PICKER: first-run selection (tap toggles checkmark, reports via [onSelectionChanged])
  * - MANAGER: settings screen (shows installed/downloading/action buttons, reports via [onAction])
+ *
+ * What each card should say is decided by [ToolchainCardState], which has no
+ * Android types in it and is pinned by ToolchainCardStateTest. This class only
+ * puts that decision on screen.
  */
 class ToolchainPickerAdapter(
-    private val mode: Mode,
+    private val mode: ToolchainCardMode,
 ) : RecyclerView.Adapter<ToolchainPickerAdapter.ViewHolder>() {
-
-    enum class Mode { PICKER, MANAGER }
-
-    enum class Action { INSTALL, REMOVE, CANCEL, RETRY }
 
     /** PICKER mode: called when selection set changes. */
     var onSelectionChanged: ((selected: Set<String>) -> Unit)? = null
 
     /** MANAGER mode: called when an action button is tapped. */
-    var onAction: ((packName: String, action: Action) -> Unit)? = null
+    var onAction: ((packName: String, action: ToolchainAction) -> Unit)? = null
 
-    private val items = ToolchainRegistry.available.toList()
-    private val selected = mutableSetOf<String>()
-    private val installed = mutableSetOf<String>()
-    private val downloadStatus = mutableMapOf<String, Int>()
-    private val downloadPercent = mutableMapOf<String, Int>()
+    private val cards = ToolchainCardState(mode)
 
-    fun getSelectedPackNames(): Set<String> = selected.toSet()
+    fun getSelectedPackNames(): Set<String> = cards.selectedPackNames()
 
     @SuppressLint("NotifyDataSetChanged")
     fun setInstalled(packNames: Collection<String>) {
-        installed.clear()
-        installed.addAll(packNames.map { name ->
-            if (name.startsWith("toolchain_")) name else "toolchain_$name"
-        })
+        cards.setInstalled(packNames)
         notifyDataSetChanged()
     }
 
     fun updateState(packName: String, status: Int, percent: Int) {
-        downloadStatus[packName] = status
-        downloadPercent[packName] = percent
-        val pos = items.indexOfFirst { it.packName == packName }
+        val pos = cards.updateState(packName, status, percent)
         if (pos >= 0) notifyItemChanged(pos)
-
-        // On COMPLETED, add to installed set
-        if (status == AssetPackStatus.COMPLETED) {
-            installed.add(packName)
-        }
-        // On NOT_INSTALLED (after uninstall), remove from installed set
-        if (status == AssetPackStatus.NOT_INSTALLED) {
-            installed.remove(packName)
-        }
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
@@ -74,7 +55,7 @@ class ToolchainPickerAdapter(
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        val info = items[position]
+        val info = cards.items[position]
         val ctx = holder.itemView.context
 
         holder.name.text = info.shortLabel
@@ -90,15 +71,15 @@ class ToolchainPickerAdapter(
         )
 
         when (mode) {
-            Mode.PICKER -> bindPickerMode(holder, info)
-            Mode.MANAGER -> bindManagerMode(holder, info, ctx)
+            ToolchainCardMode.PICKER -> bindPickerMode(holder, info)
+            ToolchainCardMode.MANAGER -> bindManagerMode(holder, info, ctx)
         }
     }
 
-    override fun getItemCount() = items.size
+    override fun getItemCount() = cards.items.size
 
     private fun bindPickerMode(holder: ViewHolder, info: ToolchainRegistry.ToolchainInfo) {
-        val isSelected = info.packName in selected
+        val isSelected = cards.card(info.packName).selected
         val card = holder.card
 
         // Visual selection state
@@ -115,13 +96,9 @@ class ToolchainPickerAdapter(
         holder.downloadProgress.visibility = View.GONE
 
         card.setOnClickListener {
-            if (info.packName in selected) {
-                selected.remove(info.packName)
-            } else {
-                selected.add(info.packName)
-            }
+            cards.toggleSelection(info.packName)
             notifyItemChanged(holder.bindingAdapterPosition)
-            onSelectionChanged?.invoke(selected.toSet())
+            onSelectionChanged?.invoke(cards.selectedPackNames())
         }
     }
 
@@ -131,9 +108,7 @@ class ToolchainPickerAdapter(
         ctx: android.content.Context,
     ) {
         val card = holder.card
-        val isInstalled = info.packName in installed
-        val status = downloadStatus[info.packName]
-        val percent = downloadPercent[info.packName] ?: 0
+        val state = cards.card(info.packName)
 
         // No selection visuals in manager mode
         card.strokeWidth = 0
@@ -142,55 +117,36 @@ class ToolchainPickerAdapter(
         card.setOnClickListener(null)
         card.isClickable = false
 
-        val isDownloading = status in listOf(
-            AssetPackStatus.DOWNLOADING,
-            AssetPackStatus.PENDING,
-            AssetPackStatus.WAITING_FOR_WIFI,
-            AssetPackStatus.TRANSFERRING,
-        )
-        val isFailed = status == AssetPackStatus.FAILED
-
-        when {
-            isDownloading -> {
-                holder.statusBadge.visibility = View.GONE
-                holder.downloadProgress.visibility = View.VISIBLE
-                holder.downloadProgress.progress = percent
-                holder.actionButton.visibility = View.VISIBLE
-                holder.actionButton.text = ctx.getString(R.string.toolchain_cancel)
-                holder.actionButton.setOnClickListener {
-                    onAction?.invoke(info.packName, Action.CANCEL)
-                }
-            }
-            isFailed -> {
+        when (state.badge) {
+            ToolchainBadge.NONE -> holder.statusBadge.visibility = View.GONE
+            ToolchainBadge.FAILED -> {
                 holder.statusBadge.visibility = View.VISIBLE
                 holder.statusBadge.text = ctx.getString(R.string.progress_failed)
                 holder.statusBadge.setTextColor(ctx.getColor(R.color.colorError))
-                holder.downloadProgress.visibility = View.GONE
-                holder.actionButton.visibility = View.VISIBLE
-                holder.actionButton.text = ctx.getString(R.string.progress_retry)
-                holder.actionButton.setOnClickListener {
-                    onAction?.invoke(info.packName, Action.RETRY)
-                }
             }
-            isInstalled -> {
+            ToolchainBadge.INSTALLED -> {
                 holder.statusBadge.visibility = View.VISIBLE
                 holder.statusBadge.text = ctx.getString(R.string.toolchain_installed)
                 holder.statusBadge.setTextColor(ctx.getColor(R.color.colorSuccess))
-                holder.downloadProgress.visibility = View.GONE
-                holder.actionButton.visibility = View.VISIBLE
-                holder.actionButton.text = ctx.getString(R.string.toolchain_remove)
-                holder.actionButton.setOnClickListener {
-                    onAction?.invoke(info.packName, Action.REMOVE)
-                }
             }
-            else -> {
-                holder.statusBadge.visibility = View.GONE
-                holder.downloadProgress.visibility = View.GONE
-                holder.actionButton.visibility = View.VISIBLE
-                holder.actionButton.text = ctx.getString(R.string.toolchain_install)
-                holder.actionButton.setOnClickListener {
-                    onAction?.invoke(info.packName, Action.INSTALL)
-                }
+        }
+
+        val percent = state.progressPercent
+        if (percent == null) {
+            holder.downloadProgress.visibility = View.GONE
+        } else {
+            holder.downloadProgress.visibility = View.VISIBLE
+            holder.downloadProgress.progress = percent
+        }
+
+        val action = state.action
+        if (action == null) {
+            holder.actionButton.visibility = View.GONE
+        } else {
+            holder.actionButton.visibility = View.VISIBLE
+            holder.actionButton.text = ctx.getString(labelFor(action))
+            holder.actionButton.setOnClickListener {
+                onAction?.invoke(info.packName, action)
             }
         }
     }
@@ -207,6 +163,13 @@ class ToolchainPickerAdapter(
     }
 
     companion object {
+        private fun labelFor(action: ToolchainAction): Int = when (action) {
+            ToolchainAction.INSTALL -> R.string.toolchain_install
+            ToolchainAction.REMOVE -> R.string.toolchain_remove
+            ToolchainAction.CANCEL -> R.string.toolchain_cancel
+            ToolchainAction.RETRY -> R.string.progress_retry
+        }
+
         private fun Int.dpToPx(view: View): Int =
             (this * view.resources.displayMetrics.density).toInt()
     }

--- a/android/app/src/test/kotlin/com/vscodroid/keyboard/LongPressPlacementTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/keyboard/LongPressPlacementTest.kt
@@ -1,0 +1,121 @@
+package com.vscodroid.keyboard
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import kotlin.math.abs
+
+/**
+ * Tests for [LongPressPlacement].
+ *
+ * The alternates popup is drawn under a finger that is still holding the key
+ * down, so the two things it must do are sit above that key and line up with it.
+ * Both are one sign or one operand away from a popup that is still on screen,
+ * still tappable, and covering either the finger or the wrong key. Nothing
+ * reports that; the user just misses.
+ *
+ * Measurements come from a real view at draw time, which is why they are
+ * arguments here rather than read inside: this is the whole calculation, running
+ * without a display.
+ */
+class LongPressPlacementTest {
+
+    /** A key roughly 48dp wide at density 2, sitting partway across the row. */
+    private val anchorLeft = 200
+    private val anchorTop = 900
+    private val anchorWidth = 96
+
+    private fun centreOf(left: Int, width: Int) = left + width / 2.0
+
+    @Test
+    fun `a popup wider than the key is centred on it`() {
+        // The normal case: three or four alternates over one key.
+        val at = LongPressPlacement.above(
+            anchorLeft = anchorLeft,
+            anchorTop = anchorTop,
+            anchorWidth = anchorWidth,
+            popupWidth = 300,
+            popupHeight = 120,
+            gapPx = 8,
+        )
+
+        assertEquals(centreOf(anchorLeft, anchorWidth), centreOf(at.x, 300))
+        assertTrue(at.x < anchorLeft, "a wider popup has to start left of the key it belongs to")
+    }
+
+    @Test
+    fun `a popup narrower than the key is centred on it too`() {
+        // One alternate on a wide key. Anchoring to the left edge instead of the
+        // centre is the mistake that still looks plausible on a wide key.
+        val at = LongPressPlacement.above(
+            anchorLeft = anchorLeft,
+            anchorTop = anchorTop,
+            anchorWidth = 300,
+            popupWidth = 96,
+            popupHeight = 120,
+            gapPx = 8,
+        )
+
+        assertEquals(centreOf(anchorLeft, 300), centreOf(at.x, 96))
+        assertTrue(at.x > anchorLeft, "a narrower popup has to start right of the key's left edge")
+    }
+
+    @Test
+    fun `an odd difference in width still lands within a pixel of the centre`() {
+        val at = LongPressPlacement.above(
+            anchorLeft = anchorLeft,
+            anchorTop = anchorTop,
+            anchorWidth = 101,
+            popupWidth = 300,
+            popupHeight = 120,
+            gapPx = 8,
+        )
+
+        val drift = abs(centreOf(at.x, 300) - centreOf(anchorLeft, 101))
+        assertTrue(drift <= 1.0, "the popup centre is $drift px off the key centre")
+    }
+
+    @Test
+    fun `the popup clears the top of the key by exactly the gap it was given`() {
+        // Above, not below. Below puts the popup under the finger that opened
+        // it, and the alternate the user wants is the one they cannot see.
+        //
+        // Both numbers move at run time, the height with the number of
+        // alternates and the font scale, the gap with the density, so several
+        // pairs go through: a formula that folds either into a constant is
+        // right on the one device that constant was read from.
+        for ((popupHeight, gapPx) in listOf(120 to 8, 64 to 12, 253 to 3)) {
+            val at = LongPressPlacement.above(
+                anchorLeft = anchorLeft,
+                anchorTop = anchorTop,
+                anchorWidth = anchorWidth,
+                popupWidth = 300,
+                popupHeight = popupHeight,
+                gapPx = gapPx,
+            )
+
+            val popupBottom = at.y + popupHeight
+            val given = "popup height $popupHeight, gap $gapPx"
+            assertTrue(
+                popupBottom < anchorTop,
+                "the popup runs down to $popupBottom, over a key at $anchorTop ($given)",
+            )
+            assertEquals(
+                gapPx, anchorTop - popupBottom,
+                "the gap above the key is not the one asked for ($given)",
+            )
+        }
+    }
+
+    @Test
+    fun `the key's position on screen moves the popup with it`() {
+        // getLocationOnScreen, so both numbers are absolute. Dropping either one
+        // pins every popup to the top left corner of the display, which is where
+        // a popup goes when the offset is computed but never added.
+        val atOrigin = LongPressPlacement.above(0, 0, anchorWidth, 300, 120, 8)
+        val moved = LongPressPlacement.above(300, 900, anchorWidth, 300, 120, 8)
+
+        assertEquals(300, moved.x - atOrigin.x)
+        assertEquals(900, moved.y - atOrigin.y)
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainCardStateTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainCardStateTest.kt
@@ -1,0 +1,315 @@
+package com.vscodroid.setup
+
+import com.google.android.play.core.assetpacks.model.AssetPackStatus
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * Tests for [ToolchainCardState], the data half of the toolchain cards.
+ *
+ * A card is the only way a user installs or removes a toolchain, and every way
+ * of getting it wrong is quiet: the button says Install for something already on
+ * disk, or says nothing at all where the only download button should be. None of
+ * that is reachable through the adapter, which needs a RecyclerView and an
+ * inflated layout; all of it is reachable from here.
+ *
+ * The two screens differ in what they may show, which is why the mode is a
+ * constructor argument and not a flag consulted at draw time: a picker card that
+ * grew a manager card's button would take the tap that ticks it, and first-run
+ * setup would then download nothing.
+ */
+class ToolchainCardStateTest {
+
+    private val go = "toolchain_go"
+    private val ruby = "toolchain_ruby"
+
+    private fun manager() = ToolchainCardState(ToolchainCardMode.MANAGER)
+    private fun picker() = ToolchainCardState(ToolchainCardMode.PICKER)
+
+    @Nested
+    inner class InstalledSet {
+
+        @Test
+        fun `the short names the install record holds are recognised as installed`() {
+            // ToolchainManager.getInstalledToolchains() reads the "name" field of
+            // each pack manifest, which the download scripts write as "go",
+            // "ruby", "java". The cards are keyed by pack name. Matching the two
+            // spellings literally leaves every installed toolchain offering
+            // Install, and taking that offer re-downloads a payload the user
+            // already has.
+            val state = manager()
+            state.setInstalled(listOf("go"))
+            assertEquals(ToolchainAction.REMOVE, state.card(go).action)
+            assertEquals(ToolchainBadge.INSTALLED, state.card(go).badge)
+        }
+
+        @Test
+        fun `pack names are recognised too, in the same list`() {
+            val state = manager()
+            state.setInstalled(listOf("toolchain_go", "ruby"))
+            assertEquals(ToolchainAction.REMOVE, state.card(go).action)
+            assertEquals(ToolchainAction.REMOVE, state.card(ruby).action)
+        }
+
+        @Test
+        fun `a later list replaces the earlier one rather than adding to it`() {
+            // ToolchainActivity calls this again in onStart, so a removal
+            // performed anywhere else has to be able to take a toolchain out.
+            // Merging would leave Remove on a card with nothing behind it.
+            val state = manager()
+            state.setInstalled(listOf("go", "ruby"))
+            state.setInstalled(listOf("ruby"))
+
+            assertEquals(ToolchainAction.INSTALL, state.card(go).action)
+            assertEquals(ToolchainAction.REMOVE, state.card(ruby).action)
+        }
+
+        @Test
+        fun `a toolchain nothing has said anything about offers Install`() {
+            val card = manager().card(go)
+            assertEquals(ToolchainAction.INSTALL, card.action)
+            assertEquals(ToolchainBadge.NONE, card.badge)
+            assertNull(card.progressPercent, "an idle card carries no progress bar")
+        }
+    }
+
+    @Nested
+    inner class DownloadReports {
+
+        @Test
+        fun `every state the download can sit in offers Cancel, not a second Install`() {
+            // Only DOWNLOADING arrives promptly. PENDING and WAITING_FOR_WIFI can
+            // last minutes, and TRANSFERRING covers the unpack at the end. A card
+            // showing Install through any of them invites a second fetch of the
+            // same pack.
+            for (status in listOf(
+                AssetPackStatus.DOWNLOADING,
+                AssetPackStatus.PENDING,
+                AssetPackStatus.WAITING_FOR_WIFI,
+                AssetPackStatus.TRANSFERRING,
+            )) {
+                val state = manager()
+                state.updateState(go, status, 10)
+                assertEquals(
+                    ToolchainAction.CANCEL, state.card(go).action,
+                    "status $status left the card without a way to stop the download",
+                )
+                assertEquals(ToolchainBadge.NONE, state.card(go).badge, "status $status")
+            }
+        }
+
+        @Test
+        fun `a download in progress shows the percent last reported for it`() {
+            val state = manager()
+            state.updateState(go, AssetPackStatus.DOWNLOADING, 42)
+            assertEquals(42, state.card(go).progressPercent)
+
+            state.updateState(go, AssetPackStatus.DOWNLOADING, 77)
+            assertEquals(77, state.card(go).progressPercent, "the bar has to follow the report")
+        }
+
+        @Test
+        fun `a failed download offers Retry and says so`() {
+            val state = manager()
+            state.updateState(go, AssetPackStatus.FAILED, 0)
+
+            val card = state.card(go)
+            assertEquals(ToolchainAction.RETRY, card.action)
+            assertEquals(ToolchainBadge.FAILED, card.badge)
+            assertNull(card.progressPercent, "a stopped download must not leave a bar behind")
+        }
+
+        @Test
+        fun `a completed download turns the card into an installed one at once`() {
+            // Nothing re-reads the install record between the report and the next
+            // draw, so a card that waits for setInstalled reads Install for a
+            // toolchain that has just finished installing.
+            val state = manager()
+            state.updateState(go, AssetPackStatus.COMPLETED, 100)
+
+            val card = state.card(go)
+            assertEquals(ToolchainAction.REMOVE, card.action)
+            assertEquals(ToolchainBadge.INSTALLED, card.badge)
+            assertNull(card.progressPercent)
+        }
+
+        @Test
+        fun `a cancelled or uninstalled pack goes back to offering Install`() {
+            // ToolchainActivity reports NOT_INSTALLED itself after cancelling, and
+            // it is also what Play reports once a pack is removed. A card stuck on
+            // Remove leaves no way to install the toolchain again.
+            val state = manager()
+            state.setInstalled(listOf("go"))
+            state.updateState(go, AssetPackStatus.NOT_INSTALLED, 0)
+
+            val card = state.card(go)
+            assertEquals(ToolchainAction.INSTALL, card.action)
+            assertEquals(ToolchainBadge.NONE, card.badge)
+        }
+
+        @Test
+        fun `a report about one toolchain leaves the other cards alone`() {
+            // The listener is registered for the app, not for one fetch, so
+            // reports for several packs reach the same adapter. Sharing one
+            // status between the cards would put Retry on a toolchain that never
+            // failed, and hide Install on the one the user is looking at.
+            val state = manager()
+            state.setInstalled(listOf("ruby"))
+            state.updateState(go, AssetPackStatus.FAILED, 0)
+
+            assertEquals(ToolchainAction.RETRY, state.card(go).action)
+            assertEquals(ToolchainAction.REMOVE, state.card(ruby).action)
+        }
+
+        @Test
+        fun `a download still running hides the installed badge behind Cancel`() {
+            // Reinstall over an existing copy: while it runs the only useful
+            // button is the one that stops it.
+            val state = manager()
+            state.setInstalled(listOf("go"))
+            state.updateState(go, AssetPackStatus.DOWNLOADING, 5)
+
+            assertEquals(ToolchainAction.CANCEL, state.card(go).action)
+            assertEquals(5, state.card(go).progressPercent)
+        }
+
+        @Test
+        fun `a failed report outranks the install record behind it`() {
+            // A toolchain already on disk can still be carrying a failed
+            // report: a reinstall over it that dies partway, or a copy that
+            // wrote the install record and then threw on its way out. The card
+            // shows one of the two facts, and the failure is the one the user
+            // can still act on.
+            val state = manager()
+            state.setInstalled(listOf("go"))
+            state.updateState(go, AssetPackStatus.FAILED, 0)
+
+            val card = state.card(go)
+            assertEquals(ToolchainAction.RETRY, card.action)
+            assertEquals(ToolchainBadge.FAILED, card.badge)
+        }
+    }
+
+    @Nested
+    inner class Positions {
+
+        @Test
+        fun `a report names the position of the card it changed`() {
+            val state = manager()
+            val expected = ToolchainRegistry.available.indexOfFirst { it.packName == ruby }
+            assertTrue(expected >= 0, "the registry no longer lists $ruby")
+            assertEquals(expected, state.updateState(ruby, AssetPackStatus.DOWNLOADING, 1))
+        }
+
+        @Test
+        fun `a report for a pack no card shows names no position`() {
+            // The adapter turns this into notifyItemChanged, so anything other
+            // than a refusal repaints a card belonging to a different toolchain.
+            assertEquals(-1, manager().updateState("toolchain_haskell", AssetPackStatus.FAILED, 0))
+            assertEquals(-1, manager().positionOf("toolchain_haskell"))
+        }
+    }
+
+    @Nested
+    inner class PickerMode {
+
+        @Test
+        fun `the picker offers no buttons, whatever the download reports say`() {
+            // The picker card's whole job is to take a tap and tick itself. A
+            // button drawn over it takes that tap instead, and Continue then
+            // starts no downloads at all.
+            val state = picker()
+            state.setInstalled(listOf("go"))
+            state.updateState(go, AssetPackStatus.DOWNLOADING, 50)
+
+            val card = state.card(go)
+            assertNull(card.action, "a picker card must carry no action button")
+            assertEquals(ToolchainBadge.NONE, card.badge)
+            assertNull(card.progressPercent)
+        }
+
+        @Test
+        fun `tapping a card twice leaves it unticked`() {
+            // Untick is the only way out of a 179 MB download the user has
+            // changed their mind about; there is no other control on that screen.
+            val state = picker()
+            state.toggleSelection(go)
+            assertTrue(state.card(go).selected)
+            assertEquals(setOf(go), state.selectedPackNames())
+
+            state.toggleSelection(go)
+            assertFalse(state.card(go).selected, "a second tap has to untick the card")
+            assertEquals(emptySet<String>(), state.selectedPackNames())
+        }
+
+        @Test
+        fun `ticking one card does not tick the others`() {
+            val state = picker()
+            state.toggleSelection(go)
+            assertFalse(state.card(ruby).selected)
+        }
+
+        @Test
+        fun `the selection handed out does not change under its holder`() {
+            // SplashActivity reads the set, marks the picker shown, and only then
+            // starts the downloads. A live view of the selection would let a tap
+            // arriving in between change what gets downloaded.
+            val state = picker()
+            state.toggleSelection(go)
+            val handedOut = state.selectedPackNames()
+
+            state.toggleSelection(ruby)
+
+            assertEquals(setOf(go), handedOut)
+        }
+    }
+}
+
+/**
+ * The boundary the tests above rely on.
+ *
+ * They pin what each download status does to a card, and they pin it in
+ * [ToolchainCardState]. Deciding it again inside the adapter would put it back
+ * where no test can run it: binding a card needs a RecyclerView and an inflated
+ * layout, and this project has no Robolectric. That failure is silent, since
+ * every test in this file would stay green while the screen followed different
+ * rules.
+ *
+ * Status names are the tell, so that is what this reads. The adapter is welcome
+ * to know about actions and badges; it is not welcome to know what
+ * AssetPackStatus.FAILED means.
+ */
+class ToolchainAdapterBoundaryTest {
+
+    private val source = File("src/main/kotlin/com/vscodroid/setup/ToolchainPickerAdapter.kt")
+
+    /**
+     * Comments are stripped first: this file is named in the adapter's KDoc, and
+     * a prose mention of a status must not be read as a decision.
+     */
+    private fun code(): String {
+        check(source.isFile) {
+            "ToolchainPickerAdapter.kt not found at ${source.absolutePath}; this test would " +
+                "otherwise pass by looking at nothing"
+        }
+        return source.readText()
+            .replace(Regex("""/\*.*?\*/""", RegexOption.DOT_MATCHES_ALL), " ")
+            .replace(Regex("""//[^\n]*"""), " ")
+    }
+
+    @Test
+    fun `the adapter does not decide anything from a download status`() {
+        val body = code()
+        assertTrue(body.length > 1000, "read ${body.length} characters, which is not the adapter")
+        assertFalse(
+            body.contains("AssetPackStatus"),
+            "the adapter is reading download statuses again, so what a status means to a card " +
+                "is decided somewhere no unit test can reach it",
+        )
+    }
+}

--- a/docs/12-IMPLEMENTATION_PLAN.md
+++ b/docs/12-IMPLEMENTATION_PLAN.md
@@ -2089,7 +2089,7 @@ android/app/src/main/res/layout/
 
 1. **Day 1-2** — First-run Toolchain Picker (integrated in `SplashActivity`):
    - `showToolchainPicker()` displays grid of available toolchains after first-run setup
-   - `ToolchainPickerAdapter(ToolchainCardMode.PICKER)` — tap toggles checkmark, shows size per toolchain
+   - `ToolchainPickerAdapter(ToolchainCardMode.PICKER)`: tap toggles checkmark, shows size per toolchain
    - "What do you code in?" title with Continue + Skip buttons
    - `shouldShowPicker()` / `markPickerShown()` via SharedPreferences
 
@@ -2100,7 +2100,7 @@ android/app/src/main/res/layout/
    - Failed packs skip to next; all done → launch `MainActivity`
 
 3. **Day 4** — Settings > Toolchains (`ToolchainActivity`):
-   - `ToolchainPickerAdapter(ToolchainCardMode.MANAGER)` — shows installed/available/downloading state
+   - `ToolchainPickerAdapter(ToolchainCardMode.MANAGER)`: shows installed/available/downloading state
    - Action buttons: Install, Remove (with confirmation dialog), Cancel, Retry
    - Opened from `AndroidBridge.openToolchainSettings()`
    - Refreshes installed state on `onStart()`

--- a/docs/12-IMPLEMENTATION_PLAN.md
+++ b/docs/12-IMPLEMENTATION_PLAN.md
@@ -2089,7 +2089,7 @@ android/app/src/main/res/layout/
 
 1. **Day 1-2** — First-run Toolchain Picker (integrated in `SplashActivity`):
    - `showToolchainPicker()` displays grid of available toolchains after first-run setup
-   - `ToolchainPickerAdapter(Mode.PICKER)` — tap toggles checkmark, shows size per toolchain
+   - `ToolchainPickerAdapter(ToolchainCardMode.PICKER)` — tap toggles checkmark, shows size per toolchain
    - "What do you code in?" title with Continue + Skip buttons
    - `shouldShowPicker()` / `markPickerShown()` via SharedPreferences
 
@@ -2100,7 +2100,7 @@ android/app/src/main/res/layout/
    - Failed packs skip to next; all done → launch `MainActivity`
 
 3. **Day 4** — Settings > Toolchains (`ToolchainActivity`):
-   - `ToolchainPickerAdapter(Mode.MANAGER)` — shows installed/available/downloading state
+   - `ToolchainPickerAdapter(ToolchainCardMode.MANAGER)` — shows installed/available/downloading state
    - Action buttons: Install, Remove (with confirmation dialog), Cancel, Retry
    - Opened from `AndroidBridge.openToolchainSettings()`
    - Refreshes installed state on `onStart()`


### PR DESCRIPTION
Two pieces of UI logic decided real outcomes with no test able to reach them: what a toolchain card offers, and where the long-press alternates popup lands. Running either needed a RecyclerView with an inflated layout, or a measured view, so both went uncovered and both fail quietly.

`ToolchainCardState` now holds the data half of `ToolchainPickerAdapter`: the ticked set, the installed set, the last download report per pack, and the card that follows from them. It has no Android types, so it runs on the JVM. The adapter keeps the binding and nothing else. `Mode` and `Action` move out of the adapter to `ToolchainCardMode` and `ToolchainAction`. `LongPressPlacement.above()` takes the anchor and popup measurements and returns the position `LongPressPopup` used to compute inline.

No behaviour changes. That claim is measured, not asserted: a temporary harness drove the previous decision chain, transcribed verbatim from `main`, and the new class through all ten `AssetPackStatus` values crossed with installed state, percent and call order, and compared the rendered badge, bar and button. Identical in all 120 combinations, and the harness was proven able to see a divergence by reintroducing one.

Tests: 18 cases on the card state, 5 on the placement, and a guard that fails if the adapter starts reading `AssetPackStatus` again, which would put the decision back out of reach. Every case was checked against a deliberately wrong implementation; 21 mutations, all caught. Two that initially were not: a failed download outranking the install record behind it, and a placement formula that ignores both the popup height and the gap. Both are now pinned.

Left as they are, both predating this change and recorded rather than fixed: `REQUIRES_USER_CONFIRMATION` is not treated as in flight, so a card behind Play's confirmation dialog reads Install; and the popup position is not clamped to the display.

Refs #239
