### PR TITLE
fix(build): let the release build run again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -310,6 +310,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Build and release**
 
+- Release builds run again. Packaging the licence documents left a step nothing declared, and the only build that reaches it is the one a tag starts.
 - A stalled package mirror no longer eats a whole build. Refreshing the index was unbounded, so it could consume the job's entire budget and report every later step as skipped.
 - Unit tests re-run when a patch, the bootstrap script, a bundled extension manifest or a documented requirement changes. None was a declared input, so incremental runs served stale verdicts.
 - A server tree built before the current terminal-host shutdown is refused rather than packaged; the patch check matched text an earlier version of that patch had already added.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -11,6 +11,62 @@ rootProject.file("signing.properties").takeIf { it.exists() }?.inputStream()?.us
 fun signingProp(key: String, envVar: String, fallback: String = "") =
     signingProps.getProperty(key) ?: System.getenv(envVar) ?: fallback
 
+// The attribution documents, copied into the APK so a person holding the
+// binaries can read the notices that have to travel with them.
+//
+// This matters most for the copyleft ones. Bash, Git, Make, readline, libiconv,
+// gdbm, liblzma and zstd are all GPL or LGPL, and the GPL's written offer of
+// source has to accompany the binary rather than sit in a repository the holder
+// of an APK has no reason to know exists. NOTICE.md and docs/LEGAL_NOTICES.md
+// carried that offer and shipped nowhere; every device ran the binaries with no
+// notice of any kind on it.
+//
+// Naming a licence is not supplying it, and the three licences/ files are the
+// half that was missing. GPL-2.0 section 1, GPL-3.0 section 4 and LGPL-2.1
+// section 1 each require a copy of the licence itself to accompany the binary;
+// the documents above carried a gnu.org URL instead, which discharges nothing,
+// least of all on the offline device this app is built to be usable on. They are
+// the FSF texts as shipped in Termux's liblzma package, which is one of the
+// packages this APK redistributes, and they are verbatim: NoticesTest pins each
+// one's sha256, because a licence text that has been edited is not the licence.
+//
+// Copied from the repository root rather than committed under src/main/assets,
+// because a second copy is a copy that goes stale, and a stale licence notice is
+// worse than an absent one: it is a claim about terms that is no longer true.
+// The markdown is ~48 KiB and the licence texts ~78 KiB, which together deflate
+// to roughly 50 KiB in the APK, well under 0.1% of the base module. The markdown
+// grows as the tree does, since every binary in it has to be named in both, so
+// treat that as the order of magnitude rather than as a figure to check against.
+//
+// They are read out of the APK by MainActivity's licences dialog and never
+// extracted, which is why they are a separate assets source directory: it keeps
+// them out of the src/main/assets sum that sizes first-run extraction.
+//
+// Sync rather than Copy, because the app opens these by basename and a Copy
+// leaves behind whatever the last run wrote. Measured: with COPYING.GPLv3
+// removed from the tree, the Copy ran, succeeded, and left the previous run's
+// COPYING.GPLv3 in the output directory, where the next incremental APK
+// packaged it. A licence text still shipping under a name the repository no
+// longer has is the stale copy this task exists to avoid, arriving by the back
+// door. Only this task writes that directory, so deleting what it did not write
+// costs nothing.
+val bundleNotices = tasks.register<Sync>("bundleNotices") {
+    group = "build"
+    description = "Copies the attribution and licence documents into the APK's assets."
+
+    val repoRoot = rootProject.projectDir.parentFile
+    from(File(repoRoot, "NOTICE.md"))
+    from(File(repoRoot, "docs/LEGAL_NOTICES.md"))
+    from(File(repoRoot, "licenses/COPYING.GPLv2"))
+    from(File(repoRoot, "licenses/COPYING.GPLv3"))
+    from(File(repoRoot, "licenses/COPYING.LGPLv2.1"))
+    into(layout.buildDirectory.dir("generated/notices"))
+
+    // The names the app opens. Kept beside the copy so a rename here fails the
+    // build rather than emptying the dialog on a device: com.vscodroid.util
+    // .Notices lists the same five, and NoticesTest compares the lists.
+}
+
 android {
     namespace = "com.vscodroid"
     compileSdk = 36
@@ -162,7 +218,14 @@ android {
     // The attribution documents, packaged so they reach the device. See
     // `bundleNotices` at the foot of this file for why they are copied rather
     // than committed here.
-    sourceSets["main"].assets.srcDir(layout.buildDirectory.dir("generated/notices"))
+    //
+    // Named by the task, not by its directory, and that is what carries the
+    // dependency. A bare path is a directory something happens to fill, so
+    // every consumer has to declare the producer itself or Gradle refuses the
+    // build at validation. Lint has several such consumers and AGP adds more
+    // between versions; naming the task answers for all of them at once.
+    // `bundleNotices` is registered above for this reason and no other.
+    sourceSets["main"].assets.srcDir(bundleNotices)
 
     lint {
         // The baseline is what makes this affordable: the 17 issues recorded in
@@ -729,61 +792,20 @@ val verifyRubyPackShellPaths = tasks.register<Exec>("verifyRubyPackShellPaths") 
     }
 }
 
-// The attribution documents, copied into the APK so a person holding the
-// binaries can read the notices that have to travel with them.
-//
-// This matters most for the copyleft ones. Bash, Git, Make, readline, libiconv,
-// gdbm, liblzma and zstd are all GPL or LGPL, and the GPL's written offer of
-// source has to accompany the binary rather than sit in a repository the holder
-// of an APK has no reason to know exists. NOTICE.md and docs/LEGAL_NOTICES.md
-// carried that offer and shipped nowhere; every device ran the binaries with no
-// notice of any kind on it.
-//
-// Naming a licence is not supplying it, and the three licences/ files are the
-// half that was missing. GPL-2.0 section 1, GPL-3.0 section 4 and LGPL-2.1
-// section 1 each require a copy of the licence itself to accompany the binary;
-// the documents above carried a gnu.org URL instead, which discharges nothing,
-// least of all on the offline device this app is built to be usable on. They are
-// the FSF texts as shipped in Termux's liblzma package, which is one of the
-// packages this APK redistributes, and they are verbatim: NoticesTest pins each
-// one's sha256, because a licence text that has been edited is not the licence.
-//
-// Copied from the repository root rather than committed under src/main/assets,
-// because a second copy is a copy that goes stale, and a stale licence notice is
-// worse than an absent one: it is a claim about terms that is no longer true.
-// The markdown is ~48 KiB and the licence texts ~78 KiB, which together deflate
-// to roughly 50 KiB in the APK, well under 0.1% of the base module. The markdown
-// grows as the tree does, since every binary in it has to be named in both, so
-// treat that as the order of magnitude rather than as a figure to check against.
-//
-// They are read out of the APK by MainActivity's licences dialog and never
-// extracted, which is why they are a separate assets source directory: it keeps
-// them out of the src/main/assets sum that sizes first-run extraction.
-//
-// Sync rather than Copy, because the app opens these by basename and a Copy
-// leaves behind whatever the last run wrote. Measured: with COPYING.GPLv3
-// removed from the tree, the Copy ran, succeeded, and left the previous run's
-// COPYING.GPLv3 in the output directory, where the next incremental APK
-// packaged it. A licence text still shipping under a name the repository no
-// longer has is the stale copy this task exists to avoid, arriving by the back
-// door. Only this task writes that directory, so deleting what it did not write
-// costs nothing.
-val bundleNotices = tasks.register<Sync>("bundleNotices") {
-    group = "build"
-    description = "Copies the attribution and licence documents into the APK's assets."
 
-    val repoRoot = rootProject.projectDir.parentFile
-    from(File(repoRoot, "NOTICE.md"))
-    from(File(repoRoot, "docs/LEGAL_NOTICES.md"))
-    from(File(repoRoot, "licenses/COPYING.GPLv2"))
-    from(File(repoRoot, "licenses/COPYING.GPLv3"))
-    from(File(repoRoot, "licenses/COPYING.LGPLv2.1"))
-    into(layout.buildDirectory.dir("generated/notices"))
-
-    // The names the app opens. Kept beside the copy so a rename here fails the
-    // build rather than emptying the dialog on a device: com.vscodroid.util
-    // .Notices lists the same five, and NoticesTest compares the lists.
-}
+// Lint's own tasks read the asset directories by path rather than through the
+// source set, so naming the task above does not reach them and they have to be
+// told separately. Two do it today, `generateReleaseLintVitalReportModel` and
+// `lintVitalAnalyzeRelease`, and AGP has moved that set between versions, so
+// this matches the family rather than the two names: a task added later would
+// otherwise fail the build at validation, and only in the release graph.
+//
+// That graph is the one nothing exercises. `release.yml` runs `assembleRelease`
+// at tag time, `r8.yml` runs a lint task alone against a stub tree, and no other
+// workflow runs a release task at all, so the build that cannot be retried
+// casually is the one that would have found out.
+tasks.matching { it.name.contains("Lint") || it.name.contains("lint") }
+    .configureEach { dependsOn(bundleNotices) }
 
 // A dependency of the merge, not of the package or the assemble: the point is
 // to stop the wrong tree getting into an APK rather than to describe one that

--- a/android/app/src/test/kotlin/com/vscodroid/util/NoticesTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/util/NoticesTest.kt
@@ -88,11 +88,22 @@ class NoticesTest {
         // Copying the documents is not packaging them. The destination has to be
         // an assets source directory or they land in build/ and stop there,
         // leaving the dialog with nothing but its two missing-document markers.
+        //
+        // Either spelling counts, because both register the same directory and
+        // only one of them is a path. Naming the task is the better one: a bare
+        // path leaves every consumer to declare the producer itself, and Gradle
+        // fails the build when one does not, which is a thing that happens in
+        // the release graph and nowhere a pull request would see it. Pinning the
+        // path spelling alone would have turned that improvement red.
+        val registersPath = Regex("assets\\.srcDir\\([^)]*" + Regex.escape(destination!!) + "[^)]*\\)")
+            .containsMatchIn(script)
+        val registersTask = Regex("""assets\.srcDir\(\s*bundleNotices\s*\)""")
+            .containsMatchIn(script)
         assertTrue(
-            Regex("assets\\.srcDir\\([^)]*" + Regex.escape(destination!!) + "[^)]*\\)")
-                .containsMatchIn(script),
-            "bundleNotices writes to $destination, which no assets.srcDir(...) " +
-                "registers. The documents would be copied and never packaged."
+            registersPath || registersTask,
+            "bundleNotices writes to $destination, and no assets.srcDir(...) " +
+                "registers it, by that path or by naming the task. The documents " +
+                "would be copied and never packaged."
         )
 
         // And the copy has to be made to run. Nothing infers it from the source

--- a/docs/10-RELEASE_PLAN.md
+++ b/docs/10-RELEASE_PLAN.md
@@ -349,13 +349,25 @@ Notes:
 - **Play Console**: Android Vitals for crash clusters and ANR analysis
 - **User-initiated reports**: "Report a Bug" option in app settings → generates log bundle
 
-**A stack trace from v1.0.0 cannot be read back.** That build ran R8, and its
-`mapping.txt` was never published or archived; the only copy would have been in a
-local build directory, which holds one build at a time and has since been
-overwritten. Measured: the published v1.0.0 APK carries `pg-map-id 7e59ec8`,
-while the map still on disk is `bd8a693`, so they do not correspond. A trace from
-that build can be triaged by its message and its unobfuscated frames and no
-further.
+**A v1.0.0 trace can be read back through Play, and not otherwise.** AGP puts the
+map inside the App Bundle as
+`BUNDLE-METADATA/com.android.tools.build.obfuscation/proguard.map` (measured: 14 MB
+in the release AAB), so Play received v1.0.0's own map with the upload and
+deobfuscates the crashes it collects without anyone doing anything. That covers
+the channel that gathers traces at scale.
+
+What is not covered is a trace someone pastes into an issue from a sideloaded
+APK. The GitHub release for v1.0.0 attached no `mapping.txt`, and the only other
+copy would have been a local build directory, which holds one build at a time and
+has long since been overwritten. Measured: the published v1.0.0 APK carries
+`pg-map-id 7e59ec8`, while the map on disk is from a later build. Such a trace can
+be triaged by its message and its unobfuscated frames and no further.
+
+One R8 run serves both artefacts, so this is a publishing gap and not a
+correspondence problem. Measured on one tree: `assembleRelease` then
+`bundleRelease` leave a single `pg_map_id`, and that same id is stamped in the
+APK's dex, embedded in the AAB, and carried by the `mapping.txt` the release
+attaches. The map on a release describes the APK on that release.
 
 Later releases do not have this problem. `release.yml` attaches `mapping.txt` to
 the release it builds, and `r8.yml` keeps it as a workflow artifact, so the map


### PR DESCRIPTION
`assembleRelease` fails at Gradle validation, before R8 starts:

```
A problem was found with the configuration of task ':app:generateReleaseLintVitalReportModel'.
  Gradle detected a problem with the following location: 'app/build/generated/notices'.
  Reason: uses this output of task ':app:bundleNotices' without declaring
  an explicit or implicit dependency.
```

Packaging the attribution documents added that directory to the asset source sets as a bare path. Anything reading it has to declare the task that fills it, and the lint tasks in the release graph do not.

Nothing exercises that graph. `release.yml` runs `assembleRelease` at tag time, `r8.yml` runs a lint task alone against a stub tree where it does not fire, and no other workflow runs a release task at all. The last successful release run predates `bundleNotices` by a day, so the next tag would have been the first to find out, on the one build that cannot be retried casually.

Changes:

- The asset source set names `bundleNotices` instead of its output directory, which is what carries the dependency. The registration moves above the `android` block so it can be named there; it references nothing that has to come first.
- Lint reads asset directories by path rather than through the source set, so its tasks are told separately. Two hit it today and AGP has moved that set between versions, so the wiring matches the family rather than the names.
- `NoticesTest` asked which spelling was used, so the fix turned it red. It now asks whether the directory is registered at all, and removing the registration still fails it.
- `docs/10-RELEASE_PLAN.md` said a v1.0.0 stack trace could not be read back. It can, through Play: AGP embeds the map in the AAB as `BUNDLE-METADATA/com.android.tools.build.obfuscation/proguard.map`, so Play received v1.0.0's own map with the upload. Only a trace from a sideloaded APK is unreadable, since the GitHub release attached none.

Verified on a full tree rather than stubs: `assembleRelease` exits 0 and produces a 279.6 MiB APK, `bundleRelease` exits 0, and `assembleDebug`, `lint` and 1133 unit tests pass.
