### PR TITLE
fix(server): reclaim a connection another client superseded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,8 +162,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - An unreadable `toolchains.json` no longer deletes `toolchain-env.sh` on every launch, which took working Go and Ruby commands out of every new terminal.
 
 **Server lifecycle**
-- A server that has stopped for good now says so on the page, with a Try again button, instead of leaving "Starting server..." on screen for the life of the app.
 
+- A crashed editor window no longer leaves a file watcher running for three hours. Enough of them and Android kills the whole app.
+- A server that has stopped for good now says so on the page, with a Try again button, instead of leaving "Starting server..." on screen for the life of the app.
 - A session that adopted a surviving server now says on its notification that extensions, git and npm cannot reach the network, and that restarting fixes it. It failed silently.
 - Reopening the app while the server is still coming up no longer lands on a connection-refused page. Readiness now comes from the health check rather than from whether a process exists.
 - A start that fails while no window is open is reported to the next window that opens, instead of leaving a loading screen that never changes.

--- a/patches/0013-shorten-grace-when-a-client-is-already-connected.patch
+++ b/patches/0013-shorten-grace-when-a-client-is-already-connected.patch
@@ -1,0 +1,116 @@
+Shorten the reconnection grace when another client is already connected.
+
+Every WebView renderer crash leaks one file watcher process, and it holds it
+for three hours. Measured on an API 33 emulator by crashing the renderer three
+times: bootstrap-fork --type=fileWatcher went 2, 3, 4, 5, one per crash, none
+reaped, all five still parented to the editor server. Android caps an app at 32
+phantom processes and kills the whole app past that; this project's own budget
+is 3 to 5.
+
+The watcher's life is the management connection's life. A SessionFileWatcher is
+created per client session and disposed when the last listener on its fileChange
+emitter goes away; that listener is the IPC subscription, removed only by
+ChannelServer.dispose(), which runs only from onDidClientDisconnect, which is
+ManagementConnection.onClose. So a connection that lingers keeps a forked
+watcher for exactly as long as it lingers.
+
+Upstream already has the mechanism for not lingering, and it does not fire here.
+shortenReconnectionGraceTimeIfNecessary is edge-triggered: the server sweeps
+every connection when a NEW one arrives, and each sweep returns early unless
+that connection is already in the disconnected state. On Android the order is
+inverted and it is inverted every time. A crashed renderer never sends a
+graceful disconnect, the dead socket is not observed for a further 30 seconds,
+and MainActivity recreates the WebView immediately, so the replacement connects
+about 0.6 seconds after the crash. Measured across four crashes: the new
+connection arrived at +0.6s and the old socket closed at +30.000s, every time.
+The sweep therefore runs while the doomed connection still looks connected, does
+nothing, and half a minute later that connection schedules the full grace with
+nothing left to shorten it.
+
+The one connection that was reaped in that run is the control: a second crash
+happened 52 seconds after the first, which is after the first connection's
+detection window, so the sweep found it disconnected and shortened it. It died
+on schedule five minutes later.
+
+This makes the same decision level-triggered instead. When a socket closes, ask
+whether another management connection is live right now, and if one is, take the
+short grace immediately rather than waiting to be swept by an arrival that has
+already happened. The policy is unchanged: this is the same conclusion
+shortenReconnectionGraceTimeIfNecessary reaches, reached at the moment the
+information is actually available.
+
+The last remaining connection still gets the full grace, which is the case the
+long timer exists for: nothing has superseded it, so a client may yet come back
+to it.
+
+The predicate is passed in rather than reaching for the server, and it defaults
+to returning false, so the class keeps working unchanged for any caller that
+does not supply one.
+
+diff --git a/src/vs/server/node/remoteExtensionHostAgentServer.ts b/src/vs/server/node/remoteExtensionHostAgentServer.ts
+index e7ae07d..8a77dcc 100644
+--- a/src/vs/server/node/remoteExtensionHostAgentServer.ts
++++ b/src/vs/server/node/remoteExtensionHostAgentServer.ts
+@@ -421,7 +421,14 @@ class RemoteExtensionHostAgentServer extends Disposable implements IServerAPI {
+ 				}
+ 
+ 				protocol.sendControl(VSBuffer.fromString(JSON.stringify({ type: 'ok' })));
+-				const con = new ManagementConnection(this._logService, reconnectionToken, remoteAddress, protocol, this._reconnectionGraceTime);
++				const con = new ManagementConnection(this._logService, reconnectionToken, remoteAddress, protocol, this._reconnectionGraceTime, () => {
++					for (const key in this._managementConnections) {
++						if (key !== reconnectionToken && !this._managementConnections[key].isAwaitingDisposal) {
++							return true;
++						}
++					}
++					return false;
++				});
+ 				this._socketServer.acceptConnection(con.protocol, con.onClose);
+ 				this._managementConnections[reconnectionToken] = con;
+ 				this._allReconnectionTokens.add(reconnectionToken);
+diff --git a/src/vs/server/node/remoteExtensionManagement.ts b/src/vs/server/node/remoteExtensionManagement.ts
+index 4a38e83..017d747 100644
+--- a/src/vs/server/node/remoteExtensionManagement.ts
++++ b/src/vs/server/node/remoteExtensionManagement.ts
+@@ -53,7 +53,8 @@ export class ManagementConnection {
+ 		private readonly _reconnectionToken: string,
+ 		remoteAddress: string,
+ 		protocol: PersistentProtocol,
+-		reconnectionGraceTime: number
++		reconnectionGraceTime: number,
++		private readonly _hasOtherLiveConnection: () => boolean = () => false
+ 	) {
+ 		this._reconnectionGraceTime = reconnectionGraceTime;
+ 		const defaultShortGrace = ProtocolConstants.ReconnectionShortGraceTime;
+@@ -76,6 +77,17 @@ export class ManagementConnection {
+ 			this._cleanResources();
+ 		});
+ 		this._socketCloseListener = this.protocol.onSocketClose(() => {
++			// Level triggered, because the edge has already passed. A renderer that
++			// crashes never disconnects gracefully and its dead socket is noticed
++			// tens of seconds later, by which time the replacement client has long
++			// since connected and swept a connection that still looked alive. Asking
++			// here reaches the same conclusion shortenReconnectionGraceTimeIfNecessary
++			// would have, at the moment the answer exists.
++			if (this._hasOtherLiveConnection()) {
++				this._log(`The client has disconnected while another client is connected, will wait for reconnection ${printTime(this._reconnectionShortGraceTime)} before disposing...`);
++				this._disconnectRunner2.schedule();
++				return;
++			}
+ 			this._log(`The client has disconnected, will wait for reconnection ${printTime(this._reconnectionGraceTime)} before disposing...`);
+ 			// The socket has closed, let's give the renderer a certain amount of time to reconnect
+ 			this._disconnectRunner1.schedule();
+@@ -88,6 +100,14 @@ export class ManagementConnection {
+ 		this._logService.info(`[${this._remoteAddress}][${this._reconnectionToken.substr(0, 8)}][ManagementConnection] ${_str}`);
+ 	}
+ 
++	/**
++	 * True once the socket has closed and this connection is only waiting to be
++	 * reclaimed. Read by other connections deciding which grace time to take.
++	 */
++	public get isAwaitingDisposal(): boolean {
++		return this._disconnectRunner1.isScheduled() || this._disconnectRunner2.isScheduled();
++	}
++
+ 	public shortenReconnectionGraceTimeIfNecessary(): void {
+ 		if (this._disconnectRunner2.isScheduled()) {
+ 			// we are disconnected and already running the short reconnection timer

--- a/patches/fingerprints.txt
+++ b/patches/fingerprints.txt
@@ -68,3 +68,4 @@
 0010 moduleignore keep|-|edits build/.moduleignore, so its proof is the file surviving into the tree; verify-server-tree.py requires that path
 0011 walkthrough brand|out/nls.messages.js|Get Started with VSCodroid
 0012 callback route|out/server-main.js|==="/callback"
+0013 level grace|out/server-main.js|while another client is connected


### PR DESCRIPTION
Every WebView renderer crash left a file watcher process running for three hours. Measured on an API 33 emulator across three crashes: `bootstrap-fork --type=fileWatcher` went 2, 3, 4, 5, none reaped, all five still parented to the editor server. Android caps an app at 32 phantom processes and kills the whole app past that, and a renderer crash is what happens under memory pressure, which is when that cap is already tight.

A watcher lives exactly as long as its management connection. Upstream already shortens a superseded connection's grace, and that shortening never fired here because it is edge triggered: the server sweeps every connection when a new one arrives, and each sweep returns early unless the connection is already disconnected. On Android the order is inverted every time. A crashed renderer never disconnects gracefully, its dead socket is not observed for a further 30 seconds, and the replacement WebView connects after 0.6. Measured across four crashes, every one of them. So the sweep runs against a connection that still looks alive, does nothing, and half a minute later that connection takes the full grace with nothing left to shorten it.

`patches/0013` asks the question when the socket closes instead, which is when the answer exists. The policy is unchanged: this is the same conclusion `shortenReconnectionGraceTimeIfNecessary` reaches. The last remaining connection still gets the full grace, which is the case that timer is for.

Verified on the device, with the rebuilt server extracted:

```
  baseline: 1 watcher
  after 3 crashes: 4
  +5m: 4
  +6m: 1
```

and the log names the mechanism: three times `The client has disconnected while another client is connected, will wait for reconnection 5m before disposing`, then three `short grace time of 5m has expired, so the connection will be disposed`. Before the fix the same run produced three `3h` waits and no disposals at all.

Closes #259
