### PR TITLE
fix(release): correct the upgrade gate and the toolchain claims

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -128,6 +128,13 @@ jobs:
       - name: Check the bundled extensions match the notices
         run: python3 scripts/check-bundled-extensions.py
 
+      # The picker is built from ToolchainRegistry.available; nothing else that
+      # names a toolchain is. Withdrawing one left seven documents and the
+      # in-app walkthrough still offering it, so the app promised a language it
+      # would then refuse to install.
+      - name: Check no document offers a withdrawn toolchain
+        run: python3 scripts/check-toolchain-claims.py
+
       # `git apply --stat` parses a patch without needing the tree it applies to,
       # so the one thing that cannot be checked on a pull request -- whether the
       # patches still apply -- is separated here from the thing that can: whether

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,6 +199,9 @@ jobs:
       - name: Check the welcome screen states nothing that goes stale
         run: python3 scripts/check-welcome-claims.py
 
+      - name: Check no document offers a withdrawn toolchain
+        run: python3 scripts/check-toolchain-claims.py
+
       - name: Check the device suite can still read what it asserts
         run: bash scripts/device-test.sh --self-check
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,12 +77,13 @@ jobs:
           # versions, and this setting is right whatever the location is.
           persist-credentials: false
 
-      # A tag whose versionName does not match the one in build.gradle.kts is the
-      # quietest way to ship a broken upgrade. FirstRunSetup.isFirstRun() gates on
-      # versionName, so an unchanged one means existing installs skip setup
-      # entirely: no extraction, and no migration, while the release itself looks
-      # completely normal. Nothing downstream notices, and the symptom on a device
-      # is an app running against files from the previous version.
+      # A tag that does not name the version it builds makes every later question
+      # about what a device is running unanswerable: the tag is the only durable
+      # record tying a published artefact to a tree. Setup itself no longer rests
+      # on the name alone, FirstRunSetup.setupIsStale compares the versionCode
+      # too, but the release notes, the store listing and any bug report still
+      # say the name, and a tag that disagrees with it points them all at the
+      # wrong commit.
       - name: Check the tag matches the app version
         env:
           TAG: ${{ github.ref_name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **Setup and storage**
 
 - Upgrading re-extracts even when the version name is unchanged. Setup compared the name alone, and two builds have carried 1.1.0, so the first would have kept the old server tree.
+- The storage check counts a withdrawn toolchain's space. It read sizes through the registry, which no longer lists Go, so a device holding it could run out of disk mid-setup.
 - First run asks for as much free space as unpacking needs, measured from what the app carries. The old figure was 500 MB against a tree now over 800 MB, so devices in between failed partway with "Setup failed".
 - Updating no longer asks for room the install already occupies. What is unpacked is credited, so an update asks about 177 MB instead of 874 MB.
 - That credit now covers `usr/` and the extensions directory too, not just the server tree. Both are shared with installed toolchains and gallery extensions, which are subtracted, so a device with 177 MB free is no longer refused an update that needed 334 MB only on paper.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Holding Ctrl, Alt or Shift on the key row now matches tapping it. Behaviour change: holding a modifier that is already on switches it off.
 - When a previous editor server survives, the app serves that one instead of starting a second it cannot use. It still cannot stop a server it did not start, and now says so.
 - Any address the editor asks to open now opens. Previously a LAN dev server was dropped or opened depending on which internal route the editor used, with nothing said either way.
-- The Get Started screen no longer states bundled tool versions, which had been wrong for two releases, and no longer says Go, Java and Ruby are coming; all three install today.
+- The Get Started screen no longer states bundled tool versions, which had been wrong for two releases, and no longer says Java and Ruby are coming; both install today.
 - The Get Started terminal step shows command and output in the step text. The illustration carrying them is hidden on any phone under 950 CSS pixels wide.
 - The Get Started screen names **Manage toolchains**, the label the launcher actually shows, instead of **Toolchains**.
 - VSCodroid no longer offers itself in Android's "Open with" list for source files. It advertised twenty file types and opened none of them.
@@ -53,7 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The three release-only gates (code shrinker, resource shrinker, lintVital) now run weekly and when their inputs change, instead of first running on the day a release is tagged.
 - The release checks the bundle against store size limits before publishing, rather than failing at upload with the download release already public.
 - Every bundled executable and shared library is checked before packaging for architecture, resolvable dependencies and 16 KB page alignment. Previously only Node and the native addons were.
-- The same check now covers the Go, Ruby and Java toolchain downloads, the Python bundling step, and the glibc compatibility layer, each of which previously shipped unexamined.
+- The same check now covers the Ruby and Java toolchain downloads, the Python bundling step, and the glibc compatibility layer, each of which previously shipped unexamined.
 - The Python bundling step fails when the interpreter's runtime library is absent, installs it under the name the launcher links against, and removes standard libraries from earlier versions.
 - The bundled SQLite engine is checked against the JavaScript shipped beside it. A mismatch shows up on device as chat failing to pick a model.
 - Node.js headers are checked against the digest nodejs.org publishes, the last download taken on trust.
@@ -159,7 +159,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Python stopped working after some app updates, because the interpreter is replaced every time while its libraries were unpacked only on a version change. The app now repairs that at launch.
 - Two app instances could run first-run setup concurrently; setup is now single-flight.
 - Deleting the projects folder from a file manager no longer leaves the app permanently broken until you clear app data.
-- An unreadable `toolchains.json` no longer deletes `toolchain-env.sh` on every launch, which took working Go and Ruby commands out of every new terminal.
+- An unreadable `toolchains.json` no longer deletes `toolchain-env.sh` on every launch, which took working toolchain commands out of every new terminal.
 
 **Server lifecycle**
 
@@ -240,13 +240,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **Toolchains**
 
 - The Go toolchain is withdrawn. It ran but could not compile, and an install that still has it is removed on first launch, freeing 179 MB.
+- The Get Started screen no longer offers Go, and neither do the README, user guide or privacy policy. The picker had already dropped it.
 - A toolchain install that fails now says why: out of space, no connection, not in this release, or a download that did not match. It said only "Failed".
 - On a Play Store install that reason is given too. Play's error code went only to the log, so a full disk and a dropped connection read alike there.
 - A sideloaded toolchain install resolves `latest` once and takes both the digest and the payload from that release, so a release published mid-download no longer refuses the install.
-- Installed toolchains can be run. Android refuses to execute any file in an app's data directory, so terminal commands are handed to the system loader. **The redirect is shell functions, so its reach is the shell's reach**: `make`, directly executed scripts and extension-spawned processes still hit the binary directly and are refused. **Go cannot compile** even in the terminal, because `go build` starts its own compiler directly.
+- Installed toolchains can be run. Android refuses to execute any file in an app's data directory, so terminal commands are handed to the system loader. **The redirect is shell functions, so its reach is the shell's reach**: `make`, directly executed scripts and extension-spawned processes still hit the binary directly and are refused.
 - Tasks, npm scripts and anything run through `bash -c` now find npm, npx and the toolchain commands, which existed only in interactive shells. Direct execution and `sh -c` still cannot.
 - You can add and remove languages after first run. Touch and hold the app icon and choose **Manage toolchains**. The picker is shown once and previously had no other way in.
-- **`go build` would have failed with a permission error in the next release.** The Go manifest named only `go` and `gofmt`, leaving the compiler, linker and assembler unrunnable. The manifest is now built from the toolchain itself.
 - **The Ruby toolchain was missing six commands**, `rake` among them. It shipped a fixed list; it now installs whatever the Ruby release provides.
 - Ruby's `fiddle` could never load, because the library it links was not part of the download.
 - **The Java toolchain could not start on 16 KB page devices.** A JDK dependency was built for 4 KB pages, and three further libraries that could never load no longer ship.
@@ -340,9 +340,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **Documentation**
 
 - The white-screen fix no longer sends readers to Clear Data without saying it deletes every project, and now lists how to rescue unsaved work first.
-- The Go toolchain card and the user guide now say Go cannot compile on device. The guide demonstrated `go run`, while the limit was stated only here and in the device checklist.
 - The user guide's list of bundled extensions matches what ships. It named two that are not included and listed an included one under "extensions to install".
-- The on-device toolchain checklist can be followed. Its five rows pointed at a Settings screen that does not exist, and expected `go build` to succeed.
+- The on-device toolchain checklist can be followed. Its five rows pointed at a Settings screen that does not exist.
 - Fourteen disagreements between the bridge API documentation and the bridge, including an SSH argument documented as a key type when it is the comment, and seven methods missing entirely.
 - Several documents described things the app no longer does: a fork rather than an MIT build, Rust and C/C++ toolchains, Play-only delivery, and a release-asset list omitting the toolchain downloads.
 - The attribution for Code - OSS reproduces the copyright line exactly as the shipped licence file has it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Setup and storage**
 
+- Upgrading re-extracts even when the version name is unchanged. Setup compared the name alone, and two builds have carried 1.1.0, so the first would have kept the old server tree.
 - First run asks for as much free space as unpacking needs, measured from what the app carries. The old figure was 500 MB against a tree now over 800 MB, so devices in between failed partway with "Setup failed".
 - Updating no longer asks for room the install already occupies. What is unpacked is credited, so an update asks about 177 MB instead of 874 MB.
 - That credit now covers `usr/` and the extensions directory too, not just the server tree. Both are shared with installed toolchains and gallery extensions, which are subtracted, so a device with 177 MB free is no longer refused an update that needed 334 MB only on paper.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -481,10 +481,11 @@ Output: `android/app/build/outputs/apk/debug/app-debug.apk` (debug package name:
 ### Version Bump
 
 `versionCode` and `versionName` both live in `android/app/build.gradle.kts`, and both have
-to move. They are not interchangeable: `FirstRunSetup.isFirstRun()` compares the stored
-`versionName` against the installed one, so a release that bumps only `versionCode` never
-re-extracts the assets, while `getPreviousVersionCode()` and the migrations it feeds read
-`versionCode`. `markSetupComplete()` stores the pair together.
+to move. They are not interchangeable. `FirstRunSetup.setupIsStale()` compares both, so either one
+moving re-extracts the assets, and the versionCode is what makes that reliable: Play
+refuses a repeated versionCode, while nothing stops two builds declaring one versionName.
+`getPreviousVersionCode()` and the migrations it feeds threshold on `versionCode` alone.
+`markSetupComplete()` stores the pair together.
 
 ### Release Build
 

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -139,7 +139,6 @@ GMP is copyleft; its source offer is in `docs/LEGAL_NOTICES.md` beside the rest.
 
 | Software | License | URL |
 |----------|---------|-----|
-| Go | BSD 3-Clause | https://go.dev |
 | Ruby | BSD 2-Clause | https://www.ruby-lang.org |
 | OpenJDK | GPL v2 + Classpath | https://openjdk.org |
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ If you are **ready to learn**, you should be able to **start today**.
 - **Offline-First** — Code without an internet connection. Everything runs locally on your device.
 - **Mobile-Optimized**: Extra Key Row (Ctrl, Alt, Tab, Esc, F1-F12, symbols, cursor trackpad), touch-friendly UI, clipboard bridge.
 - **SSH Out of the Box** — Bundled OpenSSH client and `ssh-keygen`, preconfigured with sane defaults (ed25519, keepalive, `accept-new`).
-- **Language Picker** — Select your languages; Go/Ruby/Java install on demand — via Play Asset Delivery on Play installs, or direct download on sideloaded installs.
+- **Language Picker** — Select your languages; Ruby and Java install on demand — via Play Asset Delivery on Play installs, or direct download on sideloaded installs.
 - **Dev Server Preview** — Preview a running dev server in an editor tab beside your code, or hand it to the device's browser.
 
 ## 📸 Screenshots
@@ -186,7 +186,7 @@ flowchart TD
 
 1. **Install** from [Google Play](https://play.google.com/store/apps/details?id=com.vscodroid).
 2. Open the app. Core binaries extract automatically the first time, behind a progress bar.
-3. Pick your languages (Go, Ruby, Java). They install automatically.
+3. Pick your languages (Ruby, Java). They install automatically.
 4. Start coding. Editor, terminal, and tools are ready.
 
 > You can also download APKs directly from [GitHub Releases](https://github.com/rmyndharis/VSCodroid/releases).
@@ -196,7 +196,7 @@ flowchart TD
 | Tier                         | What                                                        | How                                                      |
 | ---------------------------- | ----------------------------------------------------------- | -------------------------------------------------------- |
 | **Core (Base APK)**          | Node.js, npm, Python 3, Git, Bash, SSH, tmux, make, ripgrep | Available immediately                                    |
-| **Toolchains (Asset Packs)** | Go, Ruby, Java                                              | Select in Language Picker — Play Asset Delivery, or direct download on sideloaded installs |
+| **Toolchains (Asset Packs)** | Ruby, Java                                                  | Select in Language Picker — Play Asset Delivery, or direct download on sideloaded installs |
 
 ## 🔨 Building from Source
 

--- a/android/app/src/main/assets/extensions/vscodroid.vscodroid-welcome-1.2.2/media/tools.svg
+++ b/android/app/src/main/assets/extensions/vscodroid.vscodroid-welcome-1.2.2/media/tools.svg
@@ -30,21 +30,18 @@
   <!-- Divider -->
   <line x1="40" y1="118" x2="240" y2="118" stroke="var(--vscode-editorWidget-border)" stroke-width="1" stroke-dasharray="4 3"/>
 
-  <!-- Installable on demand. Not dimmed and not labelled "coming soon": all
-       three ship today, and the picture saying otherwise is what sent users
+  <!-- Installable on demand. Not dimmed and not labelled "coming soon": both
+       ship today, and the picture saying otherwise is what sent users
        away from toolchains already sitting on their device. Rust and C/C++
        were deferred with no module, pack or registry entry, so they are not
        here at all rather than promised. -->
   <text x="140" y="140" font-family="sans-serif" font-size="10" fill="var(--vscode-descriptionForeground)" text-anchor="middle">Install on demand</text>
 
   <g>
-    <rect x="40" y="150" width="60" height="24" rx="4" fill="var(--vscode-badge-background)" opacity="0.15"/>
-    <text x="70" y="166" font-family="sans-serif" font-size="9" fill="var(--vscode-foreground)" text-anchor="middle">Go</text>
+    <rect x="75" y="150" width="60" height="24" rx="4" fill="var(--vscode-badge-background)" opacity="0.15"/>
+    <text x="105" y="166" font-family="sans-serif" font-size="9" fill="var(--vscode-foreground)" text-anchor="middle">Java 17</text>
 
-    <rect x="110" y="150" width="60" height="24" rx="4" fill="var(--vscode-badge-background)" opacity="0.15"/>
-    <text x="140" y="166" font-family="sans-serif" font-size="9" fill="var(--vscode-foreground)" text-anchor="middle">Java 17</text>
-
-    <rect x="180" y="150" width="60" height="24" rx="4" fill="var(--vscode-badge-background)" opacity="0.15"/>
-    <text x="210" y="166" font-family="sans-serif" font-size="9" fill="var(--vscode-foreground)" text-anchor="middle">Ruby</text>
+    <rect x="145" y="150" width="60" height="24" rx="4" fill="var(--vscode-badge-background)" opacity="0.15"/>
+    <text x="175" y="166" font-family="sans-serif" font-size="9" fill="var(--vscode-foreground)" text-anchor="middle">Ruby</text>
   </g>
 </svg>

--- a/android/app/src/main/assets/extensions/vscodroid.vscodroid-welcome-1.2.2/package.json
+++ b/android/app/src/main/assets/extensions/vscodroid.vscodroid-welcome-1.2.2/package.json
@@ -45,7 +45,7 @@
           {
             "id": "tools",
             "title": "Your development tools",
-            "description": "VSCodroid comes with everything you need to start coding:\n\n$(check) **Node.js** + npm — ready\n\n$(check) **Python** + pip — ready\n\n$(check) **Git** — ready\n\n$(check) **make** — ready\n\n**Go**, **Java 17** and **Ruby** install on demand. Touch and hold the VSCodroid icon on your home screen and pick **Manage toolchains**.\n\n[Got It](command:vscodroid.welcome.toolsDismissed)",
+            "description": "VSCodroid comes with everything you need to start coding:\n\n$(check) **Node.js** + npm — ready\n\n$(check) **Python** + pip — ready\n\n$(check) **Git** — ready\n\n$(check) **make** — ready\n\n**Java 17** and **Ruby** install on demand. Touch and hold the VSCodroid icon on your home screen and pick **Manage toolchains**.\n\n[Got It](command:vscodroid.welcome.toolsDismissed)",
             "media": {
               "svg": "media/tools.svg"
             },

--- a/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
@@ -40,11 +40,12 @@ class FirstRunSetup(
 
     enum class SetupResult { SUCCESS, LOW_STORAGE, ERROR }
 
-    fun isFirstRun(): Boolean {
-        val installedVersion = prefs.getString(KEY_VERSION, null)
-        val currentVersion = getCurrentVersion()
-        return installedVersion != currentVersion
-    }
+    fun isFirstRun(): Boolean = setupIsStale(
+        prefs.getString(KEY_VERSION, null),
+        prefs.getInt(KEY_VERSION_CODE, 0),
+        getCurrentVersion(),
+        getCurrentVersionCode(),
+    )
 
     suspend fun runSetup(): SetupResult = setupMutex.withLock {
         // Two Splash instances can exist at once (noHistory + standard
@@ -2694,6 +2695,40 @@ internal const val OWN_EXTENSION_PREFIX = "vscodroid."
  */
 internal fun bundledDirsToExtract(present: List<String>, bundled: List<String>): List<String> =
     bundled.filter { it.startsWith(OWN_EXTENSION_PREFIX) || it !in present }
+
+/**
+ * Whether the setup recorded on this device belongs to a build other than the
+ * one now running, and therefore has to be redone.
+ *
+ * Both halves of the identity are compared, and the versionCode is the half
+ * that carries the guarantee. A versionName is a label a build declares about
+ * itself and nothing stops two builds declaring the same one: 1.1.0 was
+ * published under versionCode 11 and then again under 12. Comparing the label
+ * alone, which is what this did, answers "same build" for those two -- so a
+ * device holding the first takes the second, skips setup entirely, and keeps
+ * running the older server tree under the newer app. Nothing reports it,
+ * because from the app's side setup completed; it completed for a different
+ * build.
+ *
+ * Play refuses an upload whose versionCode is not greater than the last, so the
+ * code cannot repeat where the name can. Comparing both means the name stays
+ * free to be whatever a release wants to call itself.
+ *
+ * A stored code of 0 is the value getInt returns when the
+ * key was never written, which is any install predating the code being
+ * recorded. Those are treated as stale, which redoes an extraction that is
+ * idempotent, rather than trusting a record that was never made.
+ *
+ * Pure, and takes the four values rather than a Context, so the decision can be
+ * pinned by a unit test; the reads themselves are one call each and have no
+ * branch to get wrong.
+ */
+internal fun setupIsStale(
+    storedName: String?,
+    storedCode: Int,
+    currentName: String,
+    currentCode: Int,
+): Boolean = storedName != currentName || storedCode != currentCode
 
 /**
  * The manifest rewrite failed, as distinct from the manifest being unreadable.

--- a/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
@@ -2831,7 +2831,7 @@ private val ATOMIC_WRITE_LOCK = Any()
  * `server/` is 700 of the tree's 810 MiB and nothing but extraction writes
  * there, so every byte counted is a byte the next unpack genuinely writes over.
  * The other two are shared ground: toolchains install into `usr/`, Java is
- * 146 MB unpacked, Go 163 MB, `npm install -g` lands there too, and
+ * 146 MB unpacked, `npm install -g` lands there too, and
  * `home/.vscodroid/extensions` fills with whatever the user takes from the
  * gallery. Crediting those would subtract bytes that overwriting does not give
  * back, and that failure is the worse one: the gate passes, extraction runs out

--- a/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
@@ -89,10 +89,11 @@ class FirstRunSetup(
             0L
         } else {
             val state = JSONArray(record.readText())
-            (0 until state.length()).sumOf { i ->
-                val name = state.optJSONObject(i)?.optString("name").orEmpty()
-                ToolchainRegistry.find(name)?.estimatedSize ?: 0L
-            }
+            toolchainBytesFor(
+                (0 until state.length()).mapNotNull {
+                    state.optJSONObject(it)?.optString("name")?.ifEmpty { null }
+                }
+            )
         }
     } catch (e: Exception) {
         Logger.w(tag, "Could not read installed toolchains; crediting none of usr/: ${e.message}")
@@ -2723,6 +2724,34 @@ internal fun bundledDirsToExtract(present: List<String>, bundled: List<String>):
  * pinned by a unit test; the reads themselves are one call each and have no
  * branch to get wrong.
  */
+/**
+ * How much of `filesDir` the toolchains named in `toolchains.json` occupy.
+ *
+ * A withdrawn toolchain is still counted. `ToolchainRegistry.find` answers null
+ * for one, and reading a size through it alone therefore returns 0 for the
+ * toolchains most likely to be sitting on a device right now: the ones
+ * installed before the withdrawal. The pre-flight subtracts this figure from
+ * what it credits as reusable, so a 0 credits space that is occupied, passes a
+ * device that should have been refused, and the extraction it admits runs out
+ * of disk partway with the toolchain still where it was.
+ *
+ * The retired lookup strips the prefix itself rather than going through
+ * [toolchainShortName], which resolves through the registry and so returns a
+ * retired name unchanged by design -- the pass-through that keeps an uninstall
+ * working after a row is dropped. `toolchains.json` records the short form
+ * today (see the manifests written by `download-ruby.sh` and `download-java.sh`)
+ * and this reads either, because the cost of guessing wrong is a toolchain that
+ * silently counts as nothing.
+ *
+ * An unrecognised name contributes nothing, which is the same answer as before
+ * for a record this build has never heard of.
+ */
+internal fun toolchainBytesFor(names: List<String>): Long = names.sumOf { name ->
+    ToolchainRegistry.find(name)?.estimatedSize
+        ?: RETIRED_TOOLCHAINS[name.removePrefix("toolchain_")]
+        ?: 0L
+}
+
 internal fun setupIsStale(
     storedName: String?,
     storedCode: Int,

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
@@ -1405,18 +1405,21 @@ class ToolchainManager(private val context: Context) {
     fun repairInstalledToolchains() {
         ioExecutor.execute {
             try {
+                // First, and before the env file is rewritten below. A retired
+                // toolchain's wrappers go with it rather than being written out
+                // again, and the repair that follows does not spend the launch
+                // walking and chmod-ing several thousand files that are about to
+                // be deleted. Go's tree alone is that size.
+                removeRetiredToolchainsSync()
+            } catch (e: Exception) {
+                Logger.w(tag, "Could not remove a retired toolchain: ${e.message}")
+            }
+            try {
                 repairInstalledToolchainsSync()
             } catch (e: Exception) {
                 // A failed repair leaves the marker unset, so the next launch
                 // tries again. Nothing else depends on it having run.
                 Logger.w(tag, "Toolchain repair pass failed: ${e.message}")
-            }
-            try {
-                // Before the env file is rewritten, so a retired toolchain's
-                // wrappers go with it rather than being written out again.
-                removeRetiredToolchainsSync()
-            } catch (e: Exception) {
-                Logger.w(tag, "Could not remove a retired toolchain: ${e.message}")
             }
             try {
                 // Unconditionally, and separately from the repair above, because
@@ -1800,7 +1803,21 @@ internal fun toolchainFailureFor(errorCode: Int): ToolchainFailure = when (error
  * too. It ran, it printed a version, and it could not build a program, for
  * 179 MB.
  */
-private val RETIRED_TOOLCHAINS = setOf("go")
+/**
+ * Toolchains no longer offered, against the space each still occupies on a
+ * device that installed one before it was withdrawn.
+ *
+ * The size is here rather than left to `ToolchainRegistry.find`, which answers
+ * null for anything it no longer offers. A caller reading a size through the
+ * registry gets 0 for exactly these, and the storage pre-flight is one such
+ * caller: 0 makes it believe more of `filesDir` is reusable than is, which is
+ * the direction that admits a device it should have refused and then runs out
+ * of disk partway through extraction.
+ *
+ * Keyed by short name, the form [toolchainShortName] produces, so a record
+ * written as either `go` or `toolchain_go` resolves.
+ */
+internal val RETIRED_TOOLCHAINS = mapOf("go" to 179_000_000L)
 
 private const val MANIFEST_NAME = "toolchains.sha256"
 

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -28,8 +28,8 @@
   - `saf-mirrors` — local copies of folders the user picked through SAF. The
     originals are the documents; these are rebuilt on reopening.
   - `sharedpref` — load-bearing, and the least obvious entry on this list.
-    `FirstRunSetup.isFirstRun()` answers from `setup_version` in those
-    preferences. Restore them onto a device whose `filesDir` is empty and the app
+    `FirstRunSetup.isFirstRun()` answers from `setup_version` and
+    `setup_version_code` in those preferences. Restore them onto a device whose `filesDir` is empty and the app
     concludes setup has already run, skips extraction entirely, and starts a
     server with no server to start. `PortFinder` keeps the port there too, which
     the workbench's IndexedDB is bound to and which means nothing on a new

--- a/android/app/src/test/kotlin/com/vscodroid/setup/RetiredToolchainTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/RetiredToolchainTest.kt
@@ -152,7 +152,7 @@ class RetiredToolchainTest {
             .getDeclaredField("RETIRED_TOOLCHAINS")
         retiredField.isAccessible = true
         @Suppress("UNCHECKED_CAST")
-        val retired = retiredField.get(null) as Set<String>
+        val retired = (retiredField.get(null) as Map<String, Long>).keys
 
         assertTrue(retired.isNotEmpty(), "nothing is retired, so this test proves nothing; delete it or the sweep")
         val offered = ToolchainRegistry.available

--- a/android/app/src/test/kotlin/com/vscodroid/setup/SetupStalenessTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/SetupStalenessTest.kt
@@ -1,0 +1,54 @@
+package com.vscodroid.setup
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for [setupIsStale], which decides whether first-run setup has to be
+ * redone for the build now running.
+ *
+ * The direction that matters is the quiet one. Answering "stale" when it is not
+ * costs an extraction the user waits through and that leaves the same tree
+ * behind. Answering "current" when it is not skips extraction entirely, so the
+ * app runs new Kotlin against the previous release's server tree, reports
+ * nothing, and looks exactly like a successful upgrade.
+ *
+ * The case that motivates the versionCode half is first: one versionName worn
+ * by two builds is not hypothetical here, it is what 1.1.0 did across
+ * versionCode 11 and 12.
+ */
+class SetupStalenessTest {
+
+    @Test
+    fun `one versionName worn by two builds is still an upgrade`() {
+        assertTrue(setupIsStale("1.1.0", 11, "1.1.0", 12))
+    }
+
+    @Test
+    fun `the same build is not an upgrade`() {
+        assertFalse(setupIsStale("1.1.0", 12, "1.1.0", 12))
+    }
+
+    @Test
+    fun `a changed versionName is an upgrade even at the same code`() {
+        assertTrue(setupIsStale("1.0.0", 12, "1.1.0", 12))
+    }
+
+    @Test
+    fun `a fresh install has recorded nothing`() {
+        assertTrue(setupIsStale(null, 0, "1.1.0", 12))
+    }
+
+    @Test
+    fun `an install predating the versionCode record is redone once`() {
+        // getInt's default for a key never written. Trusting it as a match
+        // would skip setup on the strength of a record that does not exist.
+        assertTrue(setupIsStale("1.1.0", 0, "1.1.0", 12))
+    }
+
+    @Test
+    fun `a downgrade is an upgrade, because the tree still has to change`() {
+        assertTrue(setupIsStale("1.1.0", 12, "1.0.0", 11))
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainBytesTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainBytesTest.kt
@@ -1,0 +1,54 @@
+package com.vscodroid.setup
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for [toolchainBytesFor], which tells the storage pre-flight how much of
+ * `filesDir` the installed toolchains already occupy.
+ *
+ * One direction is expensive and the other is not, which is why the withdrawn
+ * case is first. Counting too much costs a user one round of freeing space they
+ * did not strictly need to free. Counting too little credits the extraction
+ * space that is not there, so the pre-flight admits a device it should have
+ * refused, and the user gets "Setup failed" partway through with no figure to
+ * act on, on every retry, because the toolchain stays where it is.
+ *
+ * A withdrawn toolchain is the likeliest thing to be sitting on a device on the
+ * launch that matters: the retirement sweep has not run yet the first time the
+ * pre-flight asks.
+ */
+class ToolchainBytesTest {
+
+    @Test
+    fun `a withdrawn toolchain still occupies its space`() {
+        assertEquals(179_000_000L, toolchainBytesFor(listOf("go")))
+    }
+
+    @Test
+    fun `and does so under either name the record may use`() {
+        assertEquals(179_000_000L, toolchainBytesFor(listOf("toolchain_go")))
+    }
+
+    @Test
+    fun `an offered toolchain is read from the registry`() {
+        val ruby = ToolchainRegistry.find("ruby")!!.estimatedSize
+        assertEquals(ruby, toolchainBytesFor(listOf("ruby")))
+    }
+
+    @Test
+    fun `withdrawn and offered are counted together`() {
+        val java = ToolchainRegistry.find("java")!!.estimatedSize
+        assertEquals(179_000_000L + java, toolchainBytesFor(listOf("go", "java")))
+    }
+
+    @Test
+    fun `a name this build has never heard of contributes nothing`() {
+        assertEquals(0L, toolchainBytesFor(listOf("cobol")))
+    }
+
+    @Test
+    fun `nothing installed is nothing occupied`() {
+        assertEquals(0L, toolchainBytesFor(emptyList()))
+    }
+}

--- a/docs/04-TECHNICAL_SPEC.md
+++ b/docs/04-TECHNICAL_SPEC.md
@@ -805,7 +805,8 @@ this side, which is not the `User/` path it looks like it should be; see
 restored copy survives the new device's first run.
 
 Notably excluded by omission, and least obvious: `sharedpref`.
-`FirstRunSetup.isFirstRun()` answers from `setup_version` in those preferences, so
+`FirstRunSetup.isFirstRun()` answers from `setup_version` and `setup_version_code`
+in those preferences, so
 restoring them onto a device with an empty `filesDir` would make the app conclude
 setup had already run, skip extraction entirely, and start a server that is not
 there.

--- a/docs/10-RELEASE_PLAN.md
+++ b/docs/10-RELEASE_PLAN.md
@@ -154,7 +154,7 @@ PATCH: Bug fixes, security patches
 
 Examples:
   1.0.0  — First public release
-  1.1.0  — Updated to VS Code 1.97, added Go toolchain
+  1.1.0  - Updated to VS Code 1.133, withdrew the Go toolchain
   1.1.1  — Fixed WebView crash on Samsung devices
   2.0.0  — Major architecture change (hypothetical)
 ```

--- a/docs/LEGAL_NOTICES.md
+++ b/docs/LEGAL_NOTICES.md
@@ -502,7 +502,7 @@ VSCodroid is built using the Android SDK and NDK provided by Google.
 
 ## Google Play Asset Delivery
 
-On Play Store installs, on-demand toolchain packs (Go, Ruby, Java) are delivered via Google Play Asset Delivery, a feature of Google Play. On installs that did not come from the Play Store, the same packs are downloaded as ZIPs from this project's GitHub Releases (https://github.com/rmyndharis/VSCodroid/releases), which the terms below do not govern.
+On Play Store installs, on-demand toolchain packs (Ruby, Java) are delivered via Google Play Asset Delivery, a feature of Google Play. On installs that did not come from the Play Store, the same packs are downloaded as ZIPs from this project's GitHub Releases (https://github.com/rmyndharis/VSCodroid/releases), which the terms below do not govern.
 
 - **Terms**: https://play.google.com/about/developer-distribution-agreement.html
 
@@ -580,13 +580,6 @@ others under **GPL Source Code Availability** above.
 
 The following toolchains are available as optional downloads and have their own licenses:
 
-### Go
-
-- **Project**: https://go.dev
-- **License**: BSD-3-Clause License
-- **Copyright**: Copyright (c) 2009-2024 The Go Authors
-- **Full license**: https://go.dev/LICENSE
-
 ### Ruby
 
 - **Project**: https://www.ruby-lang.org
@@ -612,7 +605,6 @@ The following toolchains are available as optional downloads and have their own 
 - **Python** is a trademark of the Python Software Foundation.
 - **npm** is a trademark of npm, Inc.
 - **Java** and **OpenJDK** are trademarks of Oracle Corporation.
-- **Go** and the Go Gopher are trademarks of Google LLC.
 - **Ruby** is a trademark of Yukihiro Matsumoto.
 - **Google Play** is a trademark of Google LLC.
 

--- a/docs/PRIVACY_POLICY.md
+++ b/docs/PRIVACY_POLICY.md
@@ -43,7 +43,7 @@ When you push, pull, clone or fetch, the bundled Git client connects directly to
 
 ### Toolchain Downloads (User-Initiated)
 
-Additional programming language toolchains (Go, Ruby, Java 17) can be downloaded on-demand. There are two delivery paths, and the app chooses between them at runtime by asking Android which package installed it:
+Additional programming language toolchains (Ruby, Java 17) can be downloaded on-demand. There are two delivery paths, and the app chooses between them at runtime by asking Android which package installed it:
 
 - **Installed from the Google Play Store** (the installing package is `com.android.vending`): the toolchain arrives as a Google Play Asset Delivery pack, handled by the Google Play Store infrastructure. Google's privacy policy applies to Play Store interactions: https://policies.google.com/privacy.
 - **Installed any other way** -- a sideloaded APK, a debug build, `adb install` -- or when the installing package cannot be read at all: the app downloads a ZIP over HTTPS from this project's GitHub Releases (https://github.com/rmyndharis/VSCodroid/releases), following GitHub's redirect to its release-asset host. GitHub's privacy policy applies to that download.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -25,7 +25,7 @@ A practical guide to using VSCodroid -- the full VS Code IDE running natively on
 
 1. **Install**. Download from the [Play Store](#) or [GitHub Releases](https://github.com/rmyndharis/VSCodroid/releases). The core download is approximately 135 MB, and you need about 875 MB free for the extraction that follows.
 2. **Binary extraction** -- On first launch, VSCodroid extracts bundled tools (Node.js, Python, Git, Bash, and others) to internal storage. About 810 MB lands on disk, unpacked one file at a time behind a progress bar, so allow minutes rather than seconds on a slower device. The ~875 MB above is that payload plus the working room setup insists on before it will start. It only happens once.
-3. **Language Picker** -- A prompt asks "What do you code in?" with options for Go, Ruby, and Java. This is the only time you are *asked*, but not your only chance to choose: touch and hold the app icon and pick **Manage toolchains** to add or remove them later. Whatever you select downloads there on the setup screen, one at a time; a download that fails is skipped and the rest continue. Skip goes straight to the editor.
+3. **Language Picker** -- A prompt asks "What do you code in?" with options for Ruby and Java. This is the only time you are *asked*, but not your only chance to choose: touch and hold the app icon and pick **Manage toolchains** to add or remove them later. Whatever you select downloads there on the setup screen, one at a time; a download that fails is skipped and the rest continue. Skip goes straight to the editor.
 4. **Ready** -- The VS Code editor loads with terminal, file explorer, and all bundled tools available immediately.
 
 ### Default File Locations
@@ -461,7 +461,6 @@ Beyond the bundled tools (Node.js, Python, Git, Bash), VSCodroid offers addition
 
 | Language | Download Size | Installed Size | Includes |
 |----------|--------------|----------------|----------|
-| Go | On-demand | ~179 MB | go, gofmt |
 | Ruby | On-demand | ~34 MB | ruby, gem, irb |
 | Java (OpenJDK) | On-demand | ~146 MB | java, javac, jar |
 
@@ -491,13 +490,6 @@ it.
 New terminals automatically pick up toolchain PATH changes. No app restart is needed.
 
 ```bash
-# Go: the toolchain installs and runs, but it cannot compile on Android.
-# `go build` and `go run` are refused. See Known Limitations below.
-go version
-go env GOROOT
-mkdir hello && cd hello
-go mod init hello
-
 # Ruby
 ruby -v
 gem install sinatra
@@ -577,12 +569,12 @@ The status bar shows a phantom process count. This tells you how many background
 
 Packages that require C/C++ compilation (node-gyp) fail on VSCodroid because there is no C compiler on the device. This affects packages like `better-sqlite3`, `bcrypt`, `sharp`, `canvas`, and `node-sass`. Pure JavaScript or WASM alternatives exist for most of them (see the [Web Development](#package-compatibility) section).
 
-### Toolchains Run Only Through bash, and Go Cannot Compile
+### Toolchains Run Only Through bash
 
 Android refuses to execute any file inside an app's data directory, which is
 where installed toolchains live. VSCodroid works around this by defining a shell
 function for each toolchain binary that hands the file to the system loader, so
-typing `go`, `ruby` or `javac` in a terminal works.
+typing `ruby` or `javac` in a terminal works.
 
 The same definitions reach bash when it is not your terminal, so a VS Code task,
 an npm lifecycle script and `bash -c "..."` find them too. `npm` and `npx` are
@@ -595,11 +587,6 @@ receive the file rather than the function, and Android refuses it:
 - processes an extension starts, including language servers
 - a compiler that starts its own sub-tools
 - a script run by its own path instead of through bash
-
-That third case is why **Go cannot compile on VSCodroid**. `go build` and
-`go run` start the compiler, assembler and linker as separate programs, and
-those starts do not go through the shell function. `go version`, `go env` and
-`go mod` work; building does not.
 
 Ruby and Java are reached the same way and hit the same wall whenever something
 starts them without a shell, an extension or a Makefile recipe for example.

--- a/scripts/check-toolchain-claims.py
+++ b/scripts/check-toolchain-claims.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Refuse a document that offers a toolchain the app no longer installs.
+
+    check-toolchain-claims.py
+
+Withdrawing a toolchain is a one-line change to `ToolchainRegistry.available`,
+and the picker follows it immediately because the picker is built from that
+list. Nothing else is. Seven places name the toolchains in prose instead, and
+when Go was withdrawn all seven kept offering it: the README's feature list and
+its "pick your languages" step, the user guide's size table and its worked
+example, the privacy policy's description of what may be downloaded, both
+attribution documents, and worst of the set, the Get Started walkthrough and
+its illustration, which are shown to every new user inside the app.
+
+The picker was right and everything a user reads was wrong, so the app promised
+a language it then would not offer.
+
+`check-welcome-claims.py` reads two of those files and did not catch it, which
+is the useful part of the story rather than an aside: that check asks whether
+the screen states a version number or says "coming soon". Both questions are
+sound and neither is this one. A file being covered by some gate is not the
+same as the claim in it being covered.
+
+One rule. In a file whose job is to tell a user what they can install, a
+retired toolchain's name may not appear at all. There is no attempt to judge
+whether a given sentence offers or merely mentions it: the files listed here
+carry no history, so any mention reads as an offer. The CHANGELOG is therefore
+not among them. It is where a withdrawal is supposed to be described.
+
+The names to look for are not derived from the retired identifier. `"go"` as a
+substring is in "going" and "Google", and a check that searched for it would
+report the whole English language. They are written out per identifier below,
+and an identifier with no entry is a hard failure rather than a silent pass, so
+retiring a second toolchain cannot quietly check nothing.
+"""
+
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+MANAGER = ROOT / "android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt"
+WELCOME = ROOT / "android/app/src/main/assets/extensions/vscodroid.vscodroid-welcome-1.2.2"
+
+# Files that answer "what can I install", and are read by a user rather than by
+# a maintainer. Design documents under docs/ are deliberately absent: they
+# record what was planned, and correcting them backwards would destroy the
+# record. The CHANGELOG is absent for the same reason, more sharply.
+OFFER_FILES = [
+    ROOT / "README.md",
+    ROOT / "NOTICE.md",
+    ROOT / "docs/USER_GUIDE.md",
+    ROOT / "docs/PRIVACY_POLICY.md",
+    ROOT / "docs/LEGAL_NOTICES.md",
+    WELCOME / "package.json",
+    WELCOME / "media/tools.svg",
+]
+
+# How each retired identifier is written where a human reads it. The command
+# forms are here because a worked example teaches the toolchain as firmly as a
+# table row does, and the user guide's was six lines of `go mod init`.
+RETIRED_SPELLINGS = {
+    "go": [
+        r"\bGo\b",
+        r"\bgolang\b",
+        r"\bgofmt\b",
+        r"\bgo (?:build|run|version|env|mod|get|install|test|vet)\b",
+    ],
+}
+
+# Ordinary English that the capitalised name collides with. Kept narrow on
+# purpose: a line excused here is a line this check cannot see.
+INNOCENT = re.compile(
+    r"Go (?:to|back|ahead|live)\b|on-the-go|Google|\bGo Gopher\b|Let's Go\b"
+)
+
+
+def retired_ids():
+    """The identifiers `ToolchainManager` says are withdrawn."""
+    text = MANAGER.read_text(encoding="utf-8")
+    match = re.search(r"RETIRED_TOOLCHAINS\s*=\s*setOf\(([^)]*)\)", text)
+    if not match:
+        sys.exit("FAIL could not read RETIRED_TOOLCHAINS from ToolchainManager.kt")
+    return re.findall(r'"([^"]+)"', match.group(1))
+
+
+def main():
+    ids = retired_ids()
+    if not ids:
+        print("ok      nothing is retired, so nothing can be offered in error")
+        return 0
+
+    missing = [i for i in ids if i not in RETIRED_SPELLINGS]
+    if missing:
+        sys.exit(
+            f"FAIL {', '.join(missing)} is retired but has no entry in "
+            "RETIRED_SPELLINGS, so this check would pass without looking"
+        )
+
+    patterns = [
+        (i, re.compile(p)) for i in ids for p in RETIRED_SPELLINGS[i]
+    ]
+
+    findings = []
+    for path in OFFER_FILES:
+        if not path.exists():
+            sys.exit(f"FAIL {path.relative_to(ROOT)} is listed here but absent")
+        for n, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            if INNOCENT.search(line):
+                continue
+            for ident, pattern in patterns:
+                if pattern.search(line):
+                    findings.append(
+                        (path.relative_to(ROOT), n, ident, line.strip()[:96])
+                    )
+                    break
+
+    if findings:
+        print(f"FAIL {len(findings)} offer(s) of a withdrawn toolchain:")
+        for path, n, ident, line in findings:
+            print(f"  {path}:{n}  names '{ident}': {line}")
+        print(
+            "  -> the picker is built from ToolchainRegistry.available and no "
+            "longer offers it; a user reading this is promised a language the "
+            "app will not install"
+        )
+        return 1
+
+    print(
+        f"ok      {len(OFFER_FILES)} user-facing files offer none of "
+        f"{', '.join(ids)}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-toolchain-claims.py
+++ b/scripts/check-toolchain-claims.py
@@ -77,12 +77,28 @@ INNOCENT = re.compile(
 
 
 def retired_ids():
-    """The identifiers `ToolchainManager` says are withdrawn."""
+    """The identifiers `ToolchainManager` says are withdrawn.
+
+    Reads the declaration rather than a copy, and treats a declaration it cannot
+    parse as a failure rather than as an empty answer. Those two outcomes look
+    identical downstream -- no identifiers, so nothing to look for, so every file
+    passes -- and only one of them means the tree is clean.
+    """
     text = MANAGER.read_text(encoding="utf-8")
-    match = re.search(r"RETIRED_TOOLCHAINS\s*=\s*setOf\(([^)]*)\)", text)
+    match = re.search(
+        r"RETIRED_TOOLCHAINS\s*(?::[^=]+)?=\s*(setOf|mapOf)\(([^)]*)\)", text
+    )
     if not match:
         sys.exit("FAIL could not read RETIRED_TOOLCHAINS from ToolchainManager.kt")
-    return re.findall(r'"([^"]+)"', match.group(1))
+    body = match.group(2)
+    # mapOf entries are `"name" to <size>`; setOf entries are bare strings.
+    ids = re.findall(r'"([^"]+)"\s+to\b', body) or re.findall(r'"([^"]+)"', body)
+    if body.strip() and not ids:
+        sys.exit(
+            "FAIL RETIRED_TOOLCHAINS was found but no identifier could be read "
+            f"from it: {body.strip()[:80]!r}. Passing here would check nothing."
+        )
+    return ids
 
 
 def main():


### PR DESCRIPTION
Three corrections found while checking the tree against what this release actually ships.

**The upgrade gate.** `isFirstRun()` compared only the stored `versionName`. That is a label a build declares about itself, and 1.1.0 has been declared twice: once under versionCode 11, and again under 12. A device holding the first would install the second, be told setup had already run, and go on using the previous server tree under the newer app, reporting nothing. Setup now compares the versionCode as well, which Play guarantees cannot repeat. Both values were already written by `markSetupComplete()`; only the comparison ignored one. The decision moves into a pure `setupIsStale()`.

**The toolchain claims.** The Language Picker is built from `ToolchainRegistry.available`, and nothing else that names a toolchain is. Withdrawing Go left eight places still offering it: the README's feature list, first-run steps and tier table, the user guide's picker description, size table and worked example, the privacy policy, both attribution documents, and the Get Started walkthrough with its illustration, which is the app's own landing screen. All eight are corrected, and `scripts/check-toolchain-claims.py` now refuses any user-facing file naming a withdrawn toolchain, wired into lint and release.

**The space a withdrawn toolchain still takes.** `installedToolchainBytes()` read sizes through `ToolchainRegistry.find`, which answers null for Go, so Go counted as zero on exactly the devices that have it. The storage pre-flight subtracts that figure from what it credits as reusable, so a zero admits a device it should refuse. `RETIRED_TOOLCHAINS` now carries the size. The retirement sweep also moves ahead of the permission repair, which was chmod-ing several thousand files immediately before deleting them.

1148 unit tests pass. Each guard was confirmed by breaking what it protects and watching the right cases go red.
