### PR TITLE
docs(setup): freeze the server-tree pivot against the shipping version

### DIFF
--- a/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
@@ -145,11 +145,12 @@ class FirstRunSetup(
             // [installedExtractionBytes] the reasons for measuring only `server/`.
             //
             // Asking for the whole asset total unconditionally is what this replaced,
-            // and it was survivable only by accident: PIVOT_VERSION_CODE happens to
-            // equal the current versionCode, so every upgrade reaching this line so
-            // far had its old server tree deleted a few lines above and measured a
-            // device with that room already given back. The next release has no such
-            // deletion, and the demand would have been 874 MiB free ON TOP OF the
+            // and it was survivable only by accident: while PIVOT_VERSION_CODE was
+            // still ahead of every installed build, each upgrade reaching this line
+            // had its old server tree deleted a few lines above and measured a device
+            // with that room already given back. That accident has now expired, which
+            // is what this arithmetic exists for: an upgrade from the Code - OSS tree
+            // deletes nothing, and the demand would have been 874 MiB free ON TOP OF the
             // 810 MiB the install already occupies, refused on the splash screen,
             // with a Retry button that measures the same thing for ever and a
             // MainActivity that never runs, so nothing the app offers can free a byte.
@@ -2293,9 +2294,18 @@ claude() {
          * built from source. Upgrades from anything earlier need the old server
          * tree removed rather than merged into.
          *
-         * Must match versionCode in app/build.gradle.kts for the release that
-         * ships the new tree; a mismatch means the migration either never runs or
-         * runs for users who do not need it.
+         * Frozen, and deliberately not tied to the shipping versionCode. The
+         * comparison is `fromVersionCode < PIVOT`, asked of the code a device is
+         * upgrading FROM, so the value has to name the boundary in history where
+         * the tree changed origin and then never move again. versionCode 10 is
+         * the last release carrying the pre-built server and must trigger; 12 is
+         * the first carrying the Code - OSS tree and must not. 11 sits between
+         * them and was burned by a failed upload, so no device holds it.
+         *
+         * Raising it to match a later versionCode is the tempting mistake: every
+         * upgrade would then delete a 700 MB server tree it already had correct
+         * and unpack it again, on every release, with no symptom but the wait.
+         * [ServerTreePivotTest] fails if it moves.
          */
         private const val PIVOT_VERSION_CODE = 11
     }

--- a/android/app/src/test/kotlin/com/vscodroid/setup/ServerTreePivotTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/ServerTreePivotTest.kt
@@ -1,0 +1,60 @@
+package com.vscodroid.setup
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins `PIVOT_VERSION_CODE`, which names a boundary in this project's history
+ * and must never move again.
+ *
+ * `runPreExtractionMigrations` asks `fromVersionCode < PIVOT`, of the code a
+ * device is upgrading FROM. So the value is not a property of the release being
+ * built, it is the point where the server tree changed origin: everything
+ * before it carries a pre-built VS Code Server that has to be deleted rather
+ * than merged into, and everything from it onward carries the Code - OSS tree
+ * that must be left alone.
+ *
+ * The mistake this guards is raising it to match the shipping versionCode, which
+ * the constant's own documentation used to ask for. Every upgrade would then
+ * delete a 700 MB server tree it already had correct and unpack it again, on
+ * every release, and the only symptom would be that upgrading takes minutes.
+ * Nothing else in the app would look wrong.
+ *
+ * Both bounds are settled history rather than judgement, which is why they can
+ * be asserted at all. Read through reflection because the constant is private
+ * and there is no reason to widen it for a test.
+ */
+class ServerTreePivotTest {
+
+    private val pivot: Int by lazy {
+        val field = FirstRunSetup::class.java.getDeclaredField("PIVOT_VERSION_CODE")
+        field.isAccessible = true
+        field.getInt(null)
+    }
+
+    /** versionCode 10 shipped v1.0.0 and its pre-built server. It must trigger. */
+    @Test
+    fun `the last release carrying the old tree still triggers the migration`() {
+        assertTrue(
+            10 < pivot,
+            "PIVOT_VERSION_CODE is $pivot, so an upgrade from v1.0.0 (versionCode 10) " +
+                "would keep its pre-built server tree and merge the new one into it",
+        )
+    }
+
+    /**
+     * versionCode 12 is the first release carrying the Code - OSS tree; 11 was
+     * burned by a failed upload and reached no device. Anything from 12 onward
+     * already has the right tree, so the migration must not fire for it.
+     */
+    @Test
+    fun `the first release carrying the new tree does not trigger it`() {
+        assertTrue(
+            pivot <= 12,
+            "PIVOT_VERSION_CODE is $pivot, past the release that first shipped the " +
+                "Code - OSS tree. Every upgrade would delete a correct server tree " +
+                "and unpack it again. The constant names a point in history and does " +
+                "not track the shipping versionCode.",
+        )
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/setup/StoragePreflightTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/StoragePreflightTest.kt
@@ -27,10 +27,11 @@ import java.nio.file.Files
  *
  * The gate used to ask every install for the whole asset tree plus slack,
  * 874 MiB at the current pin, whether or not the device already held 810 MiB
- * of it. That was survivable only by coincidence: `PIVOT_VERSION_CODE` equals
- * the shipping `versionCode`, so every upgrade that has reached the check so far
+ * of it. That was survivable only by coincidence: while `PIVOT_VERSION_CODE`
+ * was still ahead of every installed build, each upgrade that reached the check
  * had its previous server tree deleted a few lines earlier and measured a device
- * with that room given back. The next release has no such deletion, and the
+ * with that room given back. That coincidence has expired, an upgrade from the
+ * Code - OSS tree deletes nothing, and the
  * demand would have been 874 MiB free on top of the 810 MiB already occupied:
  * refused on the splash screen, with a Retry button that measures the same thing
  * for ever and a `MainActivity` that never runs, so nothing the app offers can


### PR DESCRIPTION
`PIVOT_VERSION_CODE` names the point in this project's history where the server tree changed origin: everything before it carries a pre-built VS Code Server that has to be deleted rather than merged into, and everything from it onward carries the Code - OSS tree that must be left alone. `runPreExtractionMigrations` compares it against the code a device is upgrading *from*, so it is not a property of the release being built.

Its own documentation asked for the opposite, that it match the versionCode in `build.gradle.kts` for the release shipping the new tree. Read at any later release that reads as an instruction to raise it. Doing so would make every upgrade delete a 700 MB server tree it already had correct and unpack it again, on every release, and the only symptom would be that upgrading takes minutes.

Two further comments, one at the storage pre-flight call site and one in `StoragePreflightTest`, argued from a coincidence that has since expired: that the pivot was still ahead of every installed build, so any upgrade reaching the pre-flight had just had its old tree deleted. Both were written in the present tense and now describe something untrue. The reasoning they record is still why the pre-flight measures rather than assumes, so it is kept and re-tensed rather than removed.

`ServerTreePivotTest` bounds the constant by the two releases that settle it: versionCode 10 shipped v1.0.0 and its pre-built server, so it must trigger the migration; versionCode 12 is the first carrying the Code - OSS tree, so it must not. Raising the pivot to 13 fails the second case, which is the mutation this was checked against. No behaviour changes; 1150 unit tests pass.