### PR TITLE
fix(build): refuse a shell under any app's data directory

### DIFF
--- a/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
@@ -997,7 +997,8 @@ class FirstRunSetup(
         // Update .npmrc on every launch — nativeLibDir changes on APK reinstall
         val npmrc = File(context.filesDir, "home/.npmrc")
         val bashPath = "$nativeLibDir/libbash.so"
-        // script-shell: use bundled bash for npm lifecycle scripts (Android has no /bin/sh)
+        // script-shell: use bundled bash for npm lifecycle scripts, because
+        // npm's fallback is a POSIX shell and this app's scripts assume bash
         // os[]: install optional deps for both linux and android so tools like
         // @rollup/rollup-android-arm64 get installed alongside linux fallbacks
         val expectedContent = "script-shell=$bashPath\nos[]=linux\nos[]=android\n"
@@ -1007,9 +1008,12 @@ class FirstRunSetup(
             // before it writes, so a write that runs out of disk leaves an empty
             // `.npmrc` rather than the previous one. Empty means no
             // `script-shell`, and npm then hands every lifecycle script to
-            // `/bin/sh`, which Android does not have, so `npm install` fails on
-            // any package with a postinstall, for a reason nothing on screen
-            // connects to storage.
+            // `/bin/sh`. That path does exist on Android, as a symlink into
+            // `/system/bin` -- measured on an API 36 emulator, `ls -l /bin/sh`
+            // and `/system/bin/sh` are the same 312024-byte mksh. So the failure
+            // is not ENOENT but a shell that is not bash: a postinstall using
+            // `[[`, arrays or `source` dies with a syntax error, for a reason
+            // nothing on screen connects to storage.
             //
             // Nothing repairs it either: repairTruncatedSetupFiles covers
             // `.bashrc` and `settings.json`, and an empty `.npmrc` is

--- a/android/app/src/test/kotlin/com/vscodroid/setup/BashrcAtomicityTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/BashrcAtomicityTest.kt
@@ -280,9 +280,10 @@ class BashrcAtomicityTest {
      * `.npmrc` is written by the same call and matters for a different reason.
      *
      * It carries `script-shell`, which points npm at the bundled bash. Without
-     * that line npm falls back to `/bin/sh`, which Android does not have, so every
-     * package with a lifecycle script fails to install, and nothing on screen
-     * connects that to storage.
+     * that line npm falls back to `/bin/sh`. That path exists on Android, as a
+     * symlink into `/system/bin`, so the failure is not ENOENT: it is mksh
+     * running a script written for bash, which dies on `[[`, arrays or `source`.
+     * Nothing on screen connects that to storage.
      *
      * The file also sits outside every repair: `repairTruncatedSetupFiles` covers
      * `.bashrc` and `settings.json`, and an emptied `.npmrc` cannot be told from
@@ -302,8 +303,8 @@ class BashrcAtomicityTest {
             "script-shell=/old/bash\n",
             npmrc.readText(),
             "the previous .npmrc was destroyed by a write that could not finish; an empty " +
-                "one means no script-shell, and npm then hands lifecycle scripts to a " +
-                "/bin/sh that does not exist on Android",
+                "one means no script-shell, and npm then hands lifecycle scripts to " +
+                "/bin/sh, which on Android is mksh rather than the bash they assume",
         )
     }
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -583,7 +583,7 @@ the same kind of function and are reached the same way.
 What a function cannot reach is anything that never gets to bash. Those starts
 receive the file rather than the function, and Android refuses it:
 
-- `make`, whose recipes run under `/bin/sh` rather than the bash VSCodroid sets up
+- `make`, whose recipes run under `/system/bin/sh` rather than the bash VSCodroid sets up
 - processes an extension starts, including language servers
 - a compiler that starts its own sub-tools
 - a script run by its own path instead of through bash

--- a/scripts/patch-default-shell.py
+++ b/scripts/patch-default-shell.py
@@ -147,6 +147,7 @@ so the shared checker would fail builds that are correct.
 
 import argparse
 import pathlib
+import re
 import stat
 import sys
 import typing
@@ -247,9 +248,26 @@ for _form in FORMS:
                          "source with NUL, which is not whitespace there")
 
 
-def carries_termux_shell(data: bytes) -> bool:
-    """The invariant --check enforces, on the bytes of one file."""
-    return TERMUX_SH in data
+# Any shell under any app's private data directory, not only Termux's.
+#
+# The rewriter knows one spelling and pads it in place, so it can only fix the
+# Termux one. The detector has no such excuse, and had the same narrowness: the
+# failure that motivated this whole file was reported as
+# `/data/data/com.vscodroid/files/usr/bin/sh`, the app's OWN prefix, which the
+# Termux literal does not match. SELinux refuses `execve` on anything under
+# `app_data_file` whoever owns it, so every such path is unrunnable and the
+# check should say so rather than only recognising the one it can repair.
+APP_DATA_SH = re.compile(rb"/data/data/[A-Za-z0-9._]+/files/usr/bin/sh")
+
+
+def carries_unrunnable_shell(data: bytes) -> "bytes | None":
+    """The invariant --check enforces, on the bytes of one file.
+
+    Returns the offending path, so a hit on a prefix this file cannot rewrite
+    can say which one it found instead of naming Termux's.
+    """
+    hit = APP_DATA_SH.search(data)
+    return hit.group(0) if hit else None
 
 
 def patch(path: pathlib.Path) -> bool:
@@ -320,7 +338,7 @@ def patch(path: pathlib.Path) -> bool:
     # to keep it.
     after = path.read_bytes()
     kept_length = len(after) == len(data) or not form.pad
-    if not kept_length or carries_termux_shell(after) or form.marker not in after:
+    if not kept_length or carries_unrunnable_shell(after) or form.marker not in after:
         print(f"  ERROR: {path} is not what the rewrite intended", file=sys.stderr)
         return False
 
@@ -379,18 +397,23 @@ def check(directory: pathlib.Path) -> bool:
                 print(f"  FAIL   {name} is not a regular file")
                 ok = False
                 continue
-            carries = carries_termux_shell(target.read_bytes())
+            carries = carries_unrunnable_shell(target.read_bytes())
         except OSError as e:
             print(f"  FAIL   {name}: {e}")
             ok = False
             continue
         if carries:
-            print(f"  FAIL   {name} names {TERMUX_SH.decode()}")
+            print(f"  FAIL   {name} names {carries.decode()}")
+            if carries != TERMUX_SH:
+                print("         and that is not a prefix this file can rewrite. "
+                      "SELinux refuses execve on anything under an app's data "
+                      "directory, so no such path is runnable; the binary has to "
+                      "be built or fetched with a shell outside one.")
             ok = False
 
     n = len(targets)
     print(f"  {n} file{'' if n == 1 else 's'} checked for a shell under "
-          "Termux's prefix")
+          "any app's data directory")
     return ok
 
 


### PR DESCRIPTION
The sweep that keeps an unrunnable shell out of the bundled binaries defined its whole invariant as one literal, Termux's prefix. The failure it exists to prevent was reported as `/data/data/com.vscodroid/files/usr/bin/sh`, this app's own prefix, which that literal does not match.

SELinux refuses `execve` on anything under an app's data directory whoever owns it, so every such path is equally unrunnable. The detector was blind to all but one spelling of a class it was written to cover, which is the same silence the original report describes: a binary ships green and fails on device three layers from the cause.

The rewriter is unchanged and still knows only the Termux form, because that is the only one it can pad in place without changing the file's length. What changed is the question the check asks. A hit on a prefix it cannot repair now fails with that stated, rather than passing unnoticed or being rewritten blind. Proved by planting both spellings in a scratch directory: the app-prefixed file passed the old check and fails the new one, and the real trees stay green.

Three comments and a test docstring claimed Android has no `/bin/sh`, which npm's fallback would then hit. Measured on an API 36 emulator: `/bin/sh` is a symlink into `/system/bin` and resolves to the same 312024-byte mksh. The `script-shell` pin is still correct, for the reason that mksh is not bash rather than that the path is absent, so a lifecycle script using `[[`, arrays or `source` dies on a syntax error rather than ENOENT. The user guide said `make`'s recipes run under `/bin/sh`; the binary names `/system/bin/sh`.

1191 unit tests pass.