### PR TITLE
docs: prepare 1.1.0, and name Copilot Chat in the privacy policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-08-19
+
 ### Changed
 
 - The build manifest now records the app version, versionCode and commit, so a published artifact can be traced to the build that produced it.
@@ -519,7 +521,8 @@ This release represents the cumulative work across milestones M0 through M5, bri
 - Health check polling for server readiness
 - Android intent handling for "Open with VSCodroid"
 
-[Unreleased]: https://github.com/rmyndharis/VSCodroid/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/rmyndharis/VSCodroid/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/rmyndharis/VSCodroid/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/rmyndharis/VSCodroid/compare/v0.2.9...v1.0.0
 [0.2.9]: https://github.com/rmyndharis/VSCodroid/compare/v0.2.8...v0.2.9
 [0.2.8]: https://github.com/rmyndharis/VSCodroid/compare/v0.2.5...v0.2.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extension signature verification is off by default. The editor build has no signature-checking component, so every marketplace install stopped on a warning that could never clear.
 - The Accounts and Manage icons are back at the bottom of the activity bar. A build-time stylesheet had hidden them, leaving touch users no route to Settings or sign-in.
 - Holding Ctrl, Alt or Shift on the key row now matches tapping it. Behaviour change: holding a modifier that is already on switches it off.
-- When a previous editor server survives, the app serves that one instead of starting a second it cannot use. It still cannot stop a server it did not start, and now says so.
+- When a previous editor server survives, the app serves that one instead of starting a second it cannot use.
 - Any address the editor asks to open now opens. Previously a LAN dev server was dropped or opened depending on which internal route the editor used, with nothing said either way.
 - The Get Started screen no longer states bundled tool versions, which had been wrong for two releases, and no longer says Java and Ruby are coming; both install today.
 - The Get Started terminal step shows command and output in the step text. The illustration carrying them is hidden on any phone under 950 CSS pixels wide.
@@ -347,7 +347,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Five checks that could not fail now can, each confirmed by breaking what it guards and watching it go red.
 - The on-device suite no longer passes git's HTTPS helper when the helper is absent, or when the check could not run at all.
 - Two on-device checks no longer report a working install as broken, and the toolchain shortcut check now proves the shortcut opens its screen, not merely that it exists.
-- The rule deciding which addresses may open in your browser is actually exercised by tests. Its `http://` branch had never run, because the URL parser it used is unavailable off-device and the failure was swallowed.
 - Building from source reports a missing Android NDK immediately instead of twenty minutes in. Set `REQUIRE_NDK=0` to skip.
 - Following the contributing guide's build steps produces the same app CI builds. Three steps were missing, and a check now fails the build when the documented steps and CI diverge.
 - Build and release workflows no longer fail when the runner's package index is out of date.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The same check now covers the Ruby and Java toolchain downloads, the Python bundling step, and the glibc compatibility layer, each of which previously shipped unexamined.
 - The Python bundling step fails when the interpreter's runtime library is absent, installs it under the name the launcher links against, and removes standard libraries from earlier versions.
 - The bundled SQLite engine is checked against the JavaScript shipped beside it. A mismatch shows up on device as chat failing to pick a model.
-- Node.js headers are checked against the digest nodejs.org publishes, the last download taken on trust.
 - All toolchain downloads use one package mirror. Three still pointed at a host the others had left while sharing a cached index, so a build could resolve from one and fetch from another.
 - The musl loader now comes from a supported Alpine branch, and an index older than 30 days fails the build. The previous branch stopped receiving fixes in April; its signature still verified.
 - The loopback bind on the editor server's command line is pinned by a test. A wildcard bind would have put the editor on the phone's network without failing anything.
@@ -72,7 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed twenty-six tracked files that nothing built, ran or opened, including the cross-compilation scripts replaced when binaries began coming from Termux.
 - Six releases that shipped without a changelog entry now have one, reconstructed from commit history and marked as such. Two footer links named a tag that never existed.
 
-- README, the user guide and the requirements specification now carry storage figures that match the gate: 810 MB of assets, 875 MB required before extraction, about 1.15 GB with all toolchains. The README promised 500 MB while setup refuses under 875 MB.
+- README, the user guide and the requirements specification now carry storage figures that match the gate: 810 MB of assets, 875 MB required before extraction, about 990 MB with both toolchains. The README promised 500 MB while setup refuses under 875 MB.
 - The milestone checklist says a ticked box records what was true when it was ticked. It is the only planning document still tracking open work, so it carries a note rather than a historical marker.
 - The milestone log and implementation plan no longer record a process-liveness check as the fix for the white screen on reopen. A contributor could reintroduce it as precedent.
 - The milestone checklist no longer plans on-device CI as a hosted device lab. Nothing in the workflows starts the app, and arm64 runners cannot boot an emulator.
@@ -113,7 +112,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **GitHub Copilot Chat works on device**: platform packages aliased under the name Android resolves, the SDK entry ships again, and `@vscode/sqlite3` is rebuilt for Bionic.
 - **Claude Code extension support**: the marketplace serves its musl build, the CLI starts through the bundled musl loader, and a loopback DNS proxy gives musl binaries name resolution.
 - A glibc compatibility shim so prebuilt glibc-only addons load against Bionic, supplying the `__isoc99_` scanf family, the ctype tables and `copy_file_range`, and translating differently-numbered constants.
-- Toolchain downloads, the server tarball, npm, extensions and every bundled tool are verified against the strongest digest their source publishes; a missing digest fails the build.
+- Toolchain downloads, the server tarball, npm, extensions and every bundled tool are verified against a digest pinned in this repository rather than one the serving host supplies alongside the file; a missing digest fails the build.
 - Every release carries a manifest of what it was built from: editor version and commit, plus the version and checksum of each bundled tool.
 - The privacy policy describes Android backup, which copies `~/.vscodroid/data/Machine` to your Google account. SSH keys, tokens, projects and toolchains are excluded by an allowlist.
 - Two checks hold the bridge API documentation to the code: one reads the compiled class for method existence, the other reads source for parameter names, order, nullability and return types.

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ adb install android/app/build/outputs/apk/debug/app-debug.apk
 | + Each toolchain (on-demand)           | 9-53 MB per language |
 | Free space required to install         | ~875 MB              |
 | Extracted to internal storage (core)   | ~810 MB              |
-| Extracted, plus all three toolchains   | ~1.15 GB             |
+| Extracted, plus both toolchains        | ~990 MB              |
 | RAM usage (typical)                    | ~400-700 MB          |
 
 The install figure is larger than what the app ends up occupying because extraction

--- a/docs/02-SRS.md
+++ b/docs/02-SRS.md
@@ -203,7 +203,7 @@ VSCodroid is NOT a cloud IDE, a Termux wrapper, or a custom editor. It is the ac
 | NFR-RES-02 | RAM usage (4GB device minimum) | Functional without OOM | P0 |
 | NFR-RES-03 | Phantom process count | ≤ 5 in typical use | P0 |
 | NFR-RES-04 | AAB base download size | < 200 MB (core); toolchains 20-100 MB each (on-demand) | P1 |
-| NFR-RES-05 | Runtime storage (core extracted) | ~810 MB; ~1.15 GB with all toolchains | P1 |
+| NFR-RES-05 | Runtime storage (core extracted) | ~810 MB; ~990 MB with both toolchains | P1 |
 | NFR-RES-06 | Battery drain during active session | < 15% per hour | P2 |
 | NFR-RES-06a | Battery drain during idle session (foreground, no input) | < 5% per hour | P2 |
 | NFR-RES-07 | V8 heap limit | An eighth of device RAM, held between 256 MB and 768 MB | P1 |

--- a/docs/10-RELEASE_PLAN.md
+++ b/docs/10-RELEASE_PLAN.md
@@ -161,17 +161,21 @@ Examples:
 
 ### 3.2 Version Code (Android)
 
-```kotlin
-// Monotonically increasing integer for Play Store
-// Format: XYYZZPP
-// X  = major (1 digit)
-// YY = minor (2 digits)
-// ZZ = patch (2 digits)
-// PP = build (2 digits, for hotfixes)
+A plain counter, incremented by one for every build uploaded to Play, and
+unrelated to the versionName. 1.0.0 shipped as 10; 1.1.0 ships as 12, because 11
+was uploaded and burned.
 
-// Example: 1.2.3 build 1 = 1020301
-versionCode = major * 1_000_000 + minor * 10_000 + patch * 100 + build
+```kotlin
+versionCode = 12
+versionName = "1.1.0"
 ```
+
+This document described an encoded scheme, `major * 1_000_000 + minor * 10_000 +
+patch * 100 + build`, which no release has used. Following it would take the next
+build from 12 to 1,010,000, and Play never accepts a lower versionCode than one
+already uploaded, so the million in between would be gone permanently. The two
+numbers are deliberately independent: `versionName` is a label for people and may
+repeat, `versionCode` is an identity Play enforces and may not.
 
 ---
 
@@ -265,7 +269,7 @@ list says so outright, because a listing is read before the guide is.
 
 | Policy | Compliance |
 |--------|-----------|
-| Binary execution | On a Play install, every binary is delivered by Play. Core tools (Node.js, Python, Git, bash, tmux, make, ripgrep, ssh) ship as `.so` in the base APK's `jniLibs`. The optional toolchains — **Go, Ruby and Java 17; those three and no others** — are never in the APK and arrive as on-demand asset packs, selected by the user and fetched by Play. Note that the app has a second delivery path outside Play's scope: an install whose installing package is not `com.android.vending` (sideload, debug build, `adb install`) downloads the same toolchains as ZIPs over HTTPS from this project's GitHub Releases. Pre-compiled development tools for developer use. |
+| Binary execution | On a Play install, every binary is delivered by Play. Core tools (Node.js, Python, Git, bash, tmux, make, ripgrep, ssh) ship as `.so` in the base APK's `jniLibs`. The optional toolchains (**Ruby and Java 17, those two and no others**) are never in the APK and arrive as on-demand asset packs, selected by the user and fetched by Play. Note that the app has a second delivery path outside Play's scope: an install whose installing package is not `com.android.vending` (sideload, debug build, `adb install`) downloads the same toolchains as ZIPs over HTTPS from this project's GitHub Releases. Pre-compiled development tools for developer use. |
 | Foreground Service (specialUse) | Local development server powering the code editor. Must run persistently to serve the IDE UI and handle file operations. |
 | Permissions | The manifest declares four, and nothing else: INTERNET (extension marketplace, toolchain downloads), FOREGROUND_SERVICE + FOREGROUND_SERVICE_SPECIAL_USE (dev server), POST_NOTIFICATIONS (service notification). **No WAKE_LOCK and no MANAGE_EXTERNAL_STORAGE** — this row claimed both as "optional" and neither was ever declared; MANAGE_EXTERNAL_STORAGE would pull in a Play declaration process the app has no need of. External folders are reached through SAF, which is a user grant per folder and not a permission. No camera/mic/location/contacts. Check against `AndroidManifest.xml` before submitting, not against this row. |
 | Privacy | No telemetry collected. No personal data transmitted. All data stays on device. Privacy policy available at [URL]. |

--- a/docs/PRIVACY_POLICY.md
+++ b/docs/PRIVACY_POLICY.md
@@ -1,13 +1,15 @@
 # VSCodroid Privacy Policy
 
 **Effective Date: February 13, 2026**
-**Last Updated: August 18, 2026**
+**Last Updated: August 19, 2026**
 
 ## Summary
 
 VSCodroid is a fully offline code editor for Android. **We** do not collect, transmit, or store any personal data — there is no server of ours for anything to reach. Your code and files stay on your device unless you send them somewhere yourself, for example by pushing to a Git remote.
 
-Two exceptions to "nothing leaves the device", both under your control and neither involving us: Android's own backup service copies your editor settings to your Google account if you have backup switched on (see **Android Backup** below), and anything you ask the app to fetch — an extension, a toolchain, an `npm install` — is a request you initiated (see **Network Access**).
+Three exceptions to "nothing leaves the device", all under your control and none involving us. Android's own backup service copies your editor settings to your Google account if you have backup switched on (see **Android Backup** below). Anything you ask the app to fetch (an extension, a toolchain, an `npm install`) is a request you initiated (see **Network Access**).
+
+The third is different in kind and worth reading before you use it: the app bundles **GitHub Copilot Chat**, and once you sign in to GitHub and use it, what you ask it and the code it attaches as context go to GitHub. That is the one feature here that sends your own work to someone else. It does nothing until you sign in, and it can be disabled or uninstalled.
 
 ---
 
@@ -36,6 +38,16 @@ If an extension asks you to sign in — to GitHub, for example — the app hands
 What comes back is a single opaque value that the editor itself issued and is waiting for. The app passes it to the editor page without reading, parsing or storing it, and without sending it anywhere. It is accepted only while a sign-in is plausibly in flight — the app records when it last opened a browser, and a callback arriving outside a ten-minute window from that moment is discarded rather than delivered, so another app on your device cannot inject one at will.
 
 Any tokens the editor keeps afterwards are stored locally in the app's private storage on your device.
+
+### GitHub Copilot Chat (Bundled, User-Initiated)
+
+VSCodroid bundles **GitHub Copilot Chat**, published by GitHub, and the editor is configured to use it as its chat provider. The extension loads when the editor starts, and it is not something this app disables.
+
+It has no account to work against until you sign in to GitHub, which happens through the browser flow described above, and its features are unavailable until you do.
+
+Once you are signed in and you use it, **what you send goes to GitHub**. That means the message you type and the material the extension decides to attach as context, which normally includes code from the file you are working in and can include other parts of the project. That exchange is between you and GitHub under GitHub's terms and privacy statement (https://docs.github.com/site-policy). VSCodroid does not proxy it, read it, or keep a copy, and it is the only feature in this app that sends anything you write to a service we did not have to name elsewhere in this policy.
+
+If you would rather it were not there, disable or uninstall **GitHub Copilot Chat** from the Extensions view; the editor works without it.
 
 ### Git Operations (User-Initiated)
 
@@ -83,7 +95,7 @@ To turn it off entirely, use Android's own control: **Settings → Google → Ba
 - We do **not** serve advertisements
 - We do **not** collect device identifiers, IP addresses, or location data
 - We do **not** use cookies for tracking purposes
-- We do **not** share any data with third parties
+- We do **not** share any data with third parties. One thing this app ships does, and it is named rather than tucked under this line: GitHub Copilot Chat sends what you ask it, and the code it attaches as context, to GitHub, once you have signed in and used it. See the section above
 - We do **not** send Microsoft telemetry. To be exact about how, because the earlier wording here said the telemetry code "has been removed from the VS Code source" and that is not what was done: the code is still in the editor build, and it is switched off and given nowhere to report to. `telemetryOptIn` is false in the product configuration applied at build time, both `telemetryOptIn` and `enableTelemetry` are set false again at every start, and the built `product.json` carries no telemetry endpoint for it to reach. Disabled and unaddressed, rather than deleted
 
 ## Data Stored on Your Device
@@ -102,8 +114,9 @@ All of this data is removed when you uninstall the app or clear the app's data t
 
 ## Third-Party Services
 
-VSCodroid itself includes no third-party analytics, advertising, or tracking SDKs. The only third-party services integrated at the system level are:
+VSCodroid itself includes no third-party analytics, advertising, or tracking SDKs. The third-party services it integrates are:
 
+- **GitHub Copilot Chat**: Bundled with the app and configured as the editor's chat provider. Unused until you sign in to GitHub; from then on what you ask it and the code it attaches go to GitHub, under GitHub's terms and privacy statement. It can be disabled or uninstalled from the Extensions view.
 - **Google Play Asset Delivery**: Used solely for downloading optional language toolchain packs on Play Store installs. This is a Google Play Store feature and is governed by Google's privacy policy.
 - **GitHub Releases**: Used solely for downloading those same toolchain packs on installs that did not come from the Play Store. Governed by GitHub's privacy policy.
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -700,7 +700,7 @@ VS Code's web client runs as a single window. You cannot open multiple VS Code w
 
 ### Storage
 
-Core installation extracts approximately 810 MB to internal storage. With all three toolchains installed, expect around 1.15 GB. Setup needs about 875 MB free before it starts, which is more than it ends up occupying because extraction needs room to work; the app quotes that figure if it refuses to start. Beyond it, keep a few hundred MB free for node_modules, build artifacts and caches.
+Core installation extracts approximately 810 MB to internal storage. With both toolchains installed, expect around 990 MB. Setup needs about 875 MB free before it starts, which is more than it ends up occupying because extraction needs room to work; the app quotes that figure if it refuses to start. Beyond it, keep a few hundred MB free for node_modules, build artifacts and caches.
 
 ---
 


### PR DESCRIPTION
Dates the section the tag will point at, and moves the compare links so Unreleased starts from v1.1.0 rather than v1.0.0.

The date is the day the tag is cut rather than the day the section was started. It sat at an earlier date through a release that was prepared and then held, and a changelog entry dated before the code it describes is the kind of small wrong fact that outlives everyone who could correct it.