### PR TITLE
docs: write down the Data Safety answers

### DIFF
--- a/docs/10-RELEASE_PLAN.md
+++ b/docs/10-RELEASE_PLAN.md
@@ -272,8 +272,40 @@ list says so outright, because a listing is read before the guide is.
 | Binary execution | On a Play install, every binary is delivered by Play. Core tools (Node.js, Python, Git, bash, tmux, make, ripgrep, ssh) ship as `.so` in the base APK's `jniLibs`. The optional toolchains (**Ruby and Java 17, those two and no others**) are never in the APK and arrive as on-demand asset packs, selected by the user and fetched by Play. Note that the app has a second delivery path outside Play's scope: an install whose installing package is not `com.android.vending` (sideload, debug build, `adb install`) downloads the same toolchains as ZIPs over HTTPS from this project's GitHub Releases. Pre-compiled development tools for developer use. |
 | Foreground Service (specialUse) | Local development server powering the code editor. Must run persistently to serve the IDE UI and handle file operations. |
 | Permissions | The manifest declares four, and nothing else: INTERNET (extension marketplace, toolchain downloads), FOREGROUND_SERVICE + FOREGROUND_SERVICE_SPECIAL_USE (dev server), POST_NOTIFICATIONS (service notification). **No WAKE_LOCK and no MANAGE_EXTERNAL_STORAGE** — this row claimed both as "optional" and neither was ever declared; MANAGE_EXTERNAL_STORAGE would pull in a Play declaration process the app has no need of. External folders are reached through SAF, which is a user grant per folder and not a permission. No camera/mic/location/contacts. Check against `AndroidManifest.xml` before submitting, not against this row. |
-| Privacy | No telemetry collected. No personal data transmitted. All data stays on device. Privacy policy available at [URL]. |
+| Privacy | No telemetry collected and nothing sent to any server of ours. One bundled feature does send user content to a third party and must be declared: GitHub Copilot Chat, which is inert until the user signs in to GitHub, after which the prompt and the code it attaches as context go to GitHub. Everything else stays on device. See §5.4 and https://rmyndharis.github.io/VSCodroid/privacy-policy.html |
 | Content rating | No user-generated content, no social features, no violence, no mature content. |
+
+### 5.4 Data Safety Declaration
+
+What to enter in the Play Console's Data Safety form. It lives here because the
+form has to agree with `docs/PRIVACY_POLICY.md` and nothing else in this
+repository held the answers, so the two could drift with nobody able to notice.
+When the policy changes, change this in the same commit.
+
+The declaration is short because the app collects nothing itself. The whole of
+it turns on one bundled feature.
+
+| Question | Answer |
+|----------|--------|
+| Does your app collect or share any of the required user data types? | **Yes.** Not by the app itself, but GitHub Copilot Chat ships bundled and sends user content to GitHub. Answering no would be a false declaration. |
+| Data type | **App activity → Other user-generated content**, and **Files and docs**, both only through Copilot Chat: the message the user types and the code the extension attaches as context. |
+| Collected or shared? | **Shared.** It goes to GitHub, a third party. Nothing reaches any server operated by this project, which has none. |
+| Is it processed ephemerally? | Do not claim ephemeral processing. GitHub's retention is GitHub's to state, not ours. |
+| Is sharing optional? | **Yes, users can choose.** The feature is inert until the user signs in to GitHub, and the extension can be disabled or uninstalled from the Extensions view. |
+| Purpose | **App functionality.** No analytics, no advertising, no personalisation, no fraud prevention. |
+| Encrypted in transit? | **Yes**, over HTTPS. |
+| Can users request deletion? | Through GitHub, under GitHub's terms. This project stores none of it and so can delete none of it. |
+
+Everything else the app touches stays on the device or goes only where the user
+sent it: Git remotes they configured, package registries they invoked, SSH hosts
+they named, and the extension registry when they browse it. None of that is
+collection or sharing under Play's definition, because the app is not the party
+receiving it.
+
+Android's backup service copies `~/.vscodroid/data/Machine`, the editor
+settings, to the user's own Google account when device backup is on. That is a
+platform feature rather than app collection, and it is described in the privacy
+policy under **Android Backup**.
 
 ---
 


### PR DESCRIPTION
The policy-compliance table said "No telemetry collected. No personal data transmitted. All data stays on device." That was the same false statement the privacy policy carried until this release: GitHub Copilot Chat ships bundled and sends the user prompt and the code it attaches to GitHub. This row matters more than most prose here, because it is what someone consults while filling in the Play Console.

The Data Safety form had no source of truth anywhere in this repository. It has to agree with `PRIVACY_POLICY.md`, and with nothing written down the two could drift with nobody able to notice, which is how the omission this corrects survived in the first place.

Section 5.4 now carries the answers question by question, derived from what the app does rather than from what would be convenient to declare: **shared** rather than collected, **not** ephemeral, optional because the feature is inert until sign-in and can be uninstalled, purpose **app functionality**. It also states plainly what is not collection under Play definitions, Git remotes and package registries and SSH hosts the user chose, and separates the Android backup of editor settings as a platform feature.

No code changes and no rebuild. The binary published as v1.1.0 is unaffected.