### PR TITLE
docs(release): cover account creation in the Data Safety guidance

### DIFF
--- a/docs/10-RELEASE_PLAN.md
+++ b/docs/10-RELEASE_PLAN.md
@@ -294,7 +294,30 @@ it turns on one bundled feature.
 | Is sharing optional? | **Yes, users can choose.** The feature is inert until the user signs in to GitHub, and the extension can be disabled or uninstalled from the Extensions view. |
 | Purpose | **App functionality.** No analytics, no advertising, no personalisation, no fraud prevention. |
 | Encrypted in transit? | **Yes**, over HTTPS. |
-| Can users request deletion? | Through GitHub, under GitHub's terms. This project stores none of it and so can delete none of it. |
+| Which methods of account creation does your app support? | **My app does not allow users to create an account.** There is no account system here at all, and the OAuth path only relays a callback for an extension signing in to a service the user already belongs to. |
+| Can users login to your app with accounts created outside of the app? | **No.** Nothing here authenticates anyone. There is no login gate, no session, and only three activities: splash, editor, toolchain picker. The editor opens with everything available. |
+| Can users request deletion? | **No.** The console wants a yes or a no, and this project runs no server and stores nothing, so it can delete nothing. Deletion of what Copilot sent is GitHub's, under GitHub's terms. |
+
+Ticking no account creation opens a follow-up asking whether users can log
+in with accounts made elsewhere, and the answer is no for the same reason.
+Signing in to GitHub is an extension authenticating to a third party; the
+token that comes back is written by `callback.html` into the WebView's
+localStorage, where it belongs to the editor. The app holds no account and
+no session, and the test that settles it is that someone can use every part
+of this app without ever signing in to anything.
+
+The deletion question is marked optional and offers a third choice about
+automatic deletion within ninety days. That choice describes data you hold
+and age out. This project holds none, so the answer stays a plain no.
+
+The account-creation question is the one worth pausing on, because the wrong
+answer is the tempting one. The form says it covers accounts made "by
+redirecting users to a webpage where they can create an account", and GitHub's
+sign-in page does carry a sign-up link, so ticking OAuth looks conservative.
+It is not. Ticking it asserts that this app supports account creation, which
+engages Play's account deletion policy and obliges the listing to publish a
+route for deleting accounts that this project never creates, never holds and
+cannot delete. The question asks about the app's own accounts; it has none.
 
 Everything else the app touches stays on the device or goes only where the user
 sent it: Git remotes they configured, package registries they invoked, SSH hosts


### PR DESCRIPTION
Section 5.4 was added so the Play Console Data Safety form and `docs/PRIVACY_POLICY.md` could not drift apart without anyone noticing. It answered most of the form but not all of it, which showed up while the form was being filled in.

Three questions had no usable answer.

The console asks which methods of account creation the app supports, and the section was silent. It supports none: there is no account system in the app, and the OAuth path is a callback relay for an extension signing in to a service the user already belongs to. Answering that opens a follow-up on whether users can log in with accounts made elsewhere, also unanswered here, and also no.

The deletion question was answered with prose about GitHub terms. The console wants one of three choices and takes nothing else.

## Changes

* Add a row for account creation, answered as none, and a row for the outside-account login follow-up, answered as no.
* Rewrite the deletion row so it gives an answer the console will accept, and note why the ninety day auto-deletion choice does not apply to a project that holds nothing.
* Record why OAuth is the wrong tick despite looking like the cautious one. It asserts that the app supports account creation, which engages the Play account deletion policy and would oblige the listing to publish a deletion route for accounts this project never creates, never holds and cannot delete.

## Verification

Checked against the app rather than against intent. `signUp`, `createAccount`, `registerUser`, `accountManager`, `isLoggedIn`, `currentUser` and `SessionManager` return nothing across the Kotlin sources. The manifest registers three activities, none of them a login. The only OAuth handling is the `callback.html` relay in `MainActivity` with Custom Tabs in `AndroidBridge`, and the token it carries lands in the WebView localStorage owned by the editor.

Documentation only. No code, no rebuild, and the published binary is unaffected.
