### PR TITLE
build(gradle): enable optimized resource shrinking via AGP 9

### DIFF
--- a/.github/workflows/r8.yml
+++ b/.github/workflows/r8.yml
@@ -106,7 +106,7 @@ jobs:
 
       # The shrinker needs compiled classes and processed resources, not the
       # 874 MB asset tree. Measured with --dry-run, which computes the graph
-      # without touching disk: 32 tasks, no mergeReleaseAssets, and therefore
+      # without touching disk: 34 tasks, no mergeReleaseAssets, and therefore
       # never checkPatchFingerprints, which is wired to merge*Assets alone
       # (app/build.gradle.kts, tasks.matching around checkPatchFingerprints).
       #
@@ -135,7 +135,7 @@ jobs:
       # for the first time at tag time. lintVital is the third; it is a separate
       # entry point and needs neither the keystore nor the assets either.
       #
-      # 34 and 28 tasks respectively, neither containing mergeReleaseAssets,
+      # 34 and 22 tasks respectively, neither containing mergeReleaseAssets,
       # checkPatchFingerprints or validateSigningRelease.
       - name: Run the release-only gates
         working-directory: android

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The build moves to Android Gradle plugin 9.3.1 and Gradle 9.5.1, which turns on optimized resource shrinking. Play flagged the old configuration for memory and performance.
+- Kotlin now comes from the Android Gradle plugin rather than a separate plugin, so the compiler is 2.2.10 and the version catalog no longer names one.
+- 97 unused Material and AndroidX resources no longer ship: the date and time pickers, the navigation drawer, fragment transitions and the legacy notification templates.
+
 ## [1.1.0] - 2026-08-19
 
 ### Changed

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -2,7 +2,6 @@ import java.util.Properties
 
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
 }
 
 // Load signing config from signing.properties (local) or env vars (CI)
@@ -319,6 +318,10 @@ dependencies {
     testImplementation(libs.junit.jupiter)
     testImplementation(libs.junit.jupiter.api)
     testRuntimeOnly(libs.junit.jupiter.engine)
+    // Gradle 9 no longer puts the JUnit Platform launcher on the test runtime
+    // classpath by itself. Without it every JVM test fails before any test
+    // class is loaded, with "Could not start Gradle Test Executor".
+    testRuntimeOnly(libs.junit.platform.launcher)
     testImplementation(libs.mockk)
     // org.json is on the test classpath, so a JVM test CAN parse JSON. Parse the
     // manifest and assert on the parsed object. Do not pattern-match its text and do

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,4 +1,3 @@
 plugins {
     alias(libs.plugins.android.application) apply false
-    alias(libs.plugins.kotlin.android) apply false
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -3,3 +3,22 @@ android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
 android.suppressUnsupportedCompileSdk=36
+
+# AGP 9 refuses a Provider passed to the legacy source-set API, which is how
+# `sourceSets["main"].assets.srcDir(bundleNotices)` registers the notices the
+# licences screen opens. Naming the task rather than its path is deliberate and
+# is what carries the producer edge; the alternative AGP offers, the Variant
+# API's addGeneratedSourceDirectory, needs a task exposing a DirectoryProperty,
+# and bundleNotices is a Sync precisely so a renamed document does not survive
+# in the packaged tree. NoticesTest pins all three of those properties against
+# defects each of them has already shipped once.
+#
+# What AGP warns is lost with this set is the automatic task dependency. That is
+# already declared by hand and deliberately by family rather than by name, on
+# every merge*Assets and every lint task, so the edge this would drop is one
+# nothing here was relying on being inferred.
+#
+# ⚠️ Temporary: AGP 10 removes the opt-out. Migrating then means giving
+# bundleNotices a DirectoryProperty output and teaching NoticesTest the new
+# spelling, without losing the Sync semantics it asserts.
+android.sourceset.disallowProvider=false

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,6 +1,5 @@
 [versions]
-agp = "8.9.1"
-kotlin = "2.1.0"
+agp = "9.3.1"
 coreKtx = "1.16.0"
 appcompat = "1.7.0"
 webkit = "1.12.1"
@@ -35,6 +34,7 @@ play-asset-delivery-ktx = { group = "com.google.android.play", name = "asset-del
 junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter", version.ref = "junit" }
 junit-jupiter-api = { group = "org.junit.jupiter", name = "junit-jupiter-api", version.ref = "junit" }
 junit-jupiter-engine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version.ref = "junit" }
+junit-platform-launcher = { group = "org.junit.platform", name = "junit-platform-launcher" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 mockk-android = { group = "io.mockk", name = "mockk-android", version.ref = "mockk" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
@@ -48,4 +48,3 @@ androidx-test-uiautomator = { group = "androidx.test.uiautomator", name = "uiaut
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Play Console reports the R8 configuration as causing higher memory use and lower performance, asking for two things: optimized resource shrinking, and an Android Gradle plugin of 9.0 or higher.

These are one action. `android.r8.optimizedResourceShrinking` does not exist before AGP 8.12, so it cannot be set on 8.9.1; verified against `BooleanOption` in the 8.9.1 jar, which knows only the earlier `optimizedShrinking` and `integratedResourceShrinking`. On AGP 9 the optimized shrinker is automatic wherever `isShrinkResources = true` is already set, and it is.

## Changes

- AGP 8.9.1 to 9.3.1, Gradle 8.11.1 to 9.5.1.
- Kotlin comes from AGP's built-in support. The separate plugin is an error under AGP 9, so it is removed from both build files, and the version catalog no longer names a Kotlin version it does not choose. The compiler is 2.2.10.
- `junit-platform-launcher` is now declared. Gradle 9 stops putting it on the test runtime classpath, and without it every JVM test fails before a test class loads.
- `android.sourceset.disallowProvider=false` keeps `assets.srcDir(bundleNotices)` working. The Variant API alternative needs a task exposing a `DirectoryProperty`, and `bundleNotices` is a `Sync` precisely so a renamed document cannot survive in the packaged tree. AGP 10 removes the opt-out; the reasoning and the migration are written where it is set.
- `r8.yml` task counts re-measured against the new graph.

## Impact

Resource shrinking now runs inside `minifyReleaseWithR8` rather than as a separate pass, so resources are traced together with code. 97 unused Material and AndroidX resources are dropped and none added: the date and time pickers, the navigation drawer, fragment transitions, and the legacy notification templates. None of them is reachable from this app, which has no `RemoteViews`, no custom notification layout, and no picker or drawer in any layout.

Base module goes from 271.1 to 270.8 MiB compressed. The size win is small because the app is almost entirely assets, not resources; the Play finding is about memory and performance rather than size.

AGP 9 also embeds a `libripgrep.so.sym` entry that 8.9.1 did not, and it is worth recording as carrying nothing. That file is itself stripped: zero `FUNC`/`OBJECT` entries, no `.symtab`, no `.debug_*`, measured with `llvm-readelf --symbols` against the original as a control. So the symbols archive attached to a release grows by 4.77 MB of dead weight rather than gaining debug information, and Play's "no debug symbols" warning is no closer to being answered.

## Verification

Built as a signed release bundle and APK against the real 873 MB asset tree, not stubs, and installed on an arm64 emulator running API 37 with a 16 KB page size.

- 1191 unit tests pass, 188 suites, unchanged from before the upgrade.
- `assembleDebug`, `assembleDebugAndroidTest`, `lint`, `optimizeReleaseResources` and `lintVitalRelease` all succeed. `lintVitalRelease` reports no errors or warnings, and the lint baseline still filters exactly its 17 entries.
- All 31 `@JavascriptInterface` bridge methods keep their names through R8, checked against `mapping.txt`; every member of `ProcessManager` is renamed, which confirms obfuscation ran.
- `extractNativeLibs="true"` survives in the merged manifest, and all 11 bundled binaries are extracted to `nativeLibraryDir` with execute permission on device.
- The five notice documents reach the bundle and the APK. Deleting the generated directory re-runs `bundleNotices` through the declared edge and restores them to the merged assets.
- The `__generated__` directory that `ignoreAssetsPattern` protects still ships: 11 files in source, 11 in the bundle.
- No app-owned resource is among the 97 removed, and all five app layouts remain.
- On device: first-run setup completes, the server starts and answers, the workbench loads, a bash terminal opens and `node --version` returns v24.18.0. No `FATAL`, `ClassNotFoundException`, `NoSuchMethodError`, `Resources$NotFoundException`, `VerifyError` or `UnsatisfiedLinkError` anywhere in the session log.
