### PR TITLE
fix(ui): drop the deprecated edge-to-edge APIs Play reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The build moves to Android Gradle plugin 9.3.1 and Gradle 9.5.1, which turns on optimized resource shrinking. Play flagged the old configuration for memory and performance.
 - Kotlin now comes from the Android Gradle plugin rather than a separate plugin, so the compiler is 2.2.10 and the version catalog no longer names one.
 - 97 unused Material and AndroidX resources no longer ship: the date and time pickers, the navigation drawer, fragment transitions and the legacy notification templates.
+- The three deprecated edge-to-edge APIs Play reports are gone from the app. Edge-to-edge, light bar icons and the display cutout are now set directly rather than through a library call that carried them.
 
 ## [1.1.0] - 2026-08-19
 

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -12,7 +12,6 @@ import android.content.ComponentCallbacks2.TRIM_MEMORY_MODERATE
 import android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL
 import android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW
 import android.content.pm.PackageManager
-import android.graphics.Color
 import android.graphics.Typeface
 import android.os.Bundle
 import android.net.Uri
@@ -31,8 +30,7 @@ import android.widget.Toast
 import java.io.File
 import java.io.OutputStream
 import androidx.activity.OnBackPressedCallback
-import androidx.activity.SystemBarStyle
-import androidx.activity.enableEdgeToEdge
+import com.vscodroid.util.drawBehindSystemBars
 import com.vscodroid.util.CrashReporter
 import com.vscodroid.util.StorageManager
 import com.vscodroid.util.WebViewVersion
@@ -374,15 +372,8 @@ class MainActivity : AppCompatActivity() {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        // enableEdgeToEdge() must be called BEFORE super.onCreate().
-        // SystemBarStyle.dark, not the default auto: auto follows the SYSTEM
-        // theme, but this app is always dark (#1E1E1E, no values-night), so in
-        // device light mode the default drew dark icons on a dark background.
-        // dark() pins light icons regardless of device theme.
-        enableEdgeToEdge(
-            statusBarStyle = SystemBarStyle.dark(Color.TRANSPARENT),
-            navigationBarStyle = SystemBarStyle.dark(Color.TRANSPARENT),
-        )
+        // Before super.onCreate(), as the call it replaces required.
+        drawBehindSystemBars()
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 

--- a/android/app/src/main/kotlin/com/vscodroid/SplashActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/SplashActivity.kt
@@ -2,15 +2,12 @@ package com.vscodroid
 
 import android.annotation.SuppressLint
 import android.content.Intent
-import android.graphics.Color
 import android.os.Bundle
 import android.view.View
 import android.widget.Button
 import android.widget.LinearLayout
 import android.widget.ProgressBar
 import android.widget.TextView
-import androidx.activity.SystemBarStyle
-import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.pm.ShortcutInfoCompat
@@ -27,6 +24,7 @@ import com.vscodroid.setup.ToolchainCardMode
 import com.vscodroid.setup.ToolchainPickerAdapter
 import com.vscodroid.setup.ToolchainRegistry
 import com.vscodroid.storage.SafStorageManager
+import com.vscodroid.util.drawBehindSystemBars
 import com.vscodroid.util.Logger
 import com.vscodroid.util.padForSystemBars
 import kotlinx.coroutines.Dispatchers
@@ -53,11 +51,8 @@ class SplashActivity : AppCompatActivity() {
     )
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        // dark(): the app is always dark; auto would follow the system theme (see MainActivity).
-        enableEdgeToEdge(
-            statusBarStyle = SystemBarStyle.dark(Color.TRANSPARENT),
-            navigationBarStyle = SystemBarStyle.dark(Color.TRANSPARENT),
-        )
+        // Before super.onCreate(), as the call it replaces required.
+        drawBehindSystemBars()
         super.onCreate(savedInstanceState)
 
         val setup = FirstRunSetup(this)

--- a/android/app/src/main/kotlin/com/vscodroid/ToolchainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/ToolchainActivity.kt
@@ -1,9 +1,6 @@
 package com.vscodroid
 
-import android.graphics.Color
 import android.os.Bundle
-import androidx.activity.SystemBarStyle
-import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.GridLayoutManager
@@ -11,6 +8,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.play.core.assetpacks.model.AssetPackStatus
 import com.vscodroid.setup.ToolchainManager
+import com.vscodroid.util.drawBehindSystemBars
 import com.vscodroid.util.padForSystemBars
 import com.vscodroid.setup.ToolchainAction
 import com.vscodroid.setup.ToolchainCardMode
@@ -39,11 +37,8 @@ class ToolchainActivity : AppCompatActivity() {
     private lateinit var adapter: ToolchainPickerAdapter
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        // dark(): the app is always dark; auto would follow the system theme (see MainActivity).
-        enableEdgeToEdge(
-            statusBarStyle = SystemBarStyle.dark(Color.TRANSPARENT),
-            navigationBarStyle = SystemBarStyle.dark(Color.TRANSPARENT),
-        )
+        // Before super.onCreate(), as the call it replaces required.
+        drawBehindSystemBars()
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_toolchain)
         findViewById<android.view.View>(R.id.toolchainRoot).padForSystemBars()

--- a/android/app/src/main/kotlin/com/vscodroid/util/ViewInsets.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/util/ViewInsets.kt
@@ -1,7 +1,9 @@
 package com.vscodroid.util
 
+import android.app.Activity
 import android.view.View
 import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 
 /**
@@ -28,4 +30,43 @@ fun View.padForSystemBars(basePx: Int = 0) {
         insets
     }
     ViewCompat.requestApplyInsets(this)
+}
+
+/**
+ * Draws this activity's window behind the system bars, with light bar icons.
+ *
+ * Replaces `androidx.activity.enableEdgeToEdge()`, and the reason is the bundle
+ * rather than the behaviour. Play Console reports three deprecated edge-to-edge
+ * APIs, and all three are inside that one call: `Window.setStatusBarColor` and
+ * `Window.setNavigationBarColor` from `EdgeToEdgeApi26`, `Api29` and `Api35`,
+ * and `LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES` from `Api28` and `Api30`.
+ * Measured from the release dex with `dexdump`, de-obfuscated through this
+ * build's own mapping. Note `Api35`: the references are not confined to the
+ * pre-35 compat half, so trimming the old implementations by minSdk would not
+ * have cleared them. Dropping the call is what removes the classes.
+ *
+ * Nothing is lost by dropping it, because `targetSdk` is 36:
+ *
+ *  - API 35+ enforces edge-to-edge with no opt-out, and the colour setters
+ *    `enableEdgeToEdge` calls there are already no-ops.
+ *  - API 33 and 34 still need the opt-in, which is the `setDecorFitsSystemWindows`
+ *    below. That one is not among the three Play names, and Play Core's asset
+ *    pack code already puts it in the bundle regardless.
+ *  - The scrims were `Color.TRANSPARENT` at every call site, so the deprecated
+ *    setters were being asked for what the platform now does by itself.
+ *  - The display cutout moves to `android:windowLayoutInDisplayCutoutMode` in
+ *    the theme, which is declarative and names `always`, the value API 35+
+ *    forces anyway.
+ *
+ * What is kept is the part the call sites actually needed: light icons pinned
+ * regardless of the device theme. This app is always dark and has no
+ * `values-night`, so the `auto` default drew dark icons on a dark background
+ * whenever the device was in light mode.
+ */
+fun Activity.drawBehindSystemBars() {
+    WindowCompat.setDecorFitsSystemWindows(window, false)
+    WindowCompat.getInsetsController(window, window.decorView).apply {
+        isAppearanceLightStatusBars = false
+        isAppearanceLightNavigationBars = false
+    }
 }

--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -9,6 +9,22 @@
 
         <!-- Window background: VS Code dark editor -->
         <item name="android:windowBackground">@color/colorBackground</item>
+
+        <!-- Transparent bars, so an edge-to-edge window shows the app behind them.
+             Attributes rather than Window.setStatusBarColor/setNavigationBarColor,
+             which is the whole point: Play flags those two calls in the bundle, and
+             the attribute form is not bytecode. API 35+ ignores both and paints the
+             bars from the window background regardless, so this decides API 33 and
+             34 only. Without it those two draw the Material3 default, which is blue
+             against this app's dark editor: measured on an API 33 emulator. -->
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+
+        <!-- Declarative, and it replaces what androidx's enableEdgeToEdge() set
+             from code. API 35+ forces `always` whatever is asked for, so this
+             only decides API 33 and 34; naming the value the platform settles
+             on keeps the two the same. See util/ViewInsets.drawBehindSystemBars. -->
+        <item name="android:windowLayoutInDisplayCutoutMode">always</item>
     </style>
 
 </resources>

--- a/docs/PLAY_EDGE_TO_EDGE.md
+++ b/docs/PLAY_EDGE_TO_EDGE.md
@@ -1,50 +1,115 @@
-# Play Console: "deprecated APIs for edge-to-edge" — read this before investigating
+# Play Console: "deprecated APIs for edge-to-edge"
 
-**The warning is expected, library-sourced, and cannot be cleared today. Do not
-burn a day re-deriving this.** Verified 2026-08-14.
+**Cleared on 2026-08-19. The three flagged APIs are no longer in the bundle.**
 
-Play flags `Window.setStatusBarColor`, `Window.setNavigationBarColor` and
-`LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES` in the app bundle. De-obfuscated
-against this repo's own R8 map (`android/app/build/outputs/mapping/release/mapping.txt`):
+This document said the opposite until that date, and said it firmly: "expected,
+library-sourced, and cannot be cleared today. Do not burn a day re-deriving
+this." The reasoning was wrong in one specific place, and the rest of this file
+exists so the same wrong turn is not taken again.
 
-| Play location | Real symbol |
+## What Play flags, and where it came from
+
+Play named three things: `Window.setStatusBarColor`, `Window.setNavigationBarColor`
+and `LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES`. All three were inside one call,
+`androidx.activity.enableEdgeToEdge()`, which `MainActivity`, `SplashActivity`
+and `ToolchainActivity` each made before `super.onCreate()`.
+
+Measured from the release dex with `dexdump`, de-obfuscated through the build's
+own `mapping.txt`:
+
+| API | Held by |
 |---|---|
-| `a.o.a` | `androidx.activity.EdgeToEdgeApi26.setUp()` |
-| `a.q.a` | `androidx.activity.EdgeToEdgeApi29.setUp()` |
-| `a.n.b` | `androidx.activity.EdgeToEdge` (`enableEdgeToEdge()` internals) |
-| `com.google.android.material.datepicker.n.y` | `MaterialDatePicker.onStart()` |
+| `setStatusBarColor` | `EdgeToEdgeApi26`, `EdgeToEdgeApi29`, `EdgeToEdgeApi35` |
+| `setNavigationBarColor` | `EdgeToEdgeApi26`, `EdgeToEdgeApi29`, `EdgeToEdgeApi35` |
+| `layoutInDisplayCutoutMode` | `EdgeToEdgeApi28`, `EdgeToEdgeApi30` |
+| `setStatusBarContrastEnforced` | `EdgeToEdgeApi29` |
+| `setNavigationBarContrastEnforced` | `EdgeToEdgeApi29`, `EdgeToEdgeApi35` |
 
-(The obfuscated names change every release. A Play location like `a.o.a` is
-class `a.o` plus member `a`, so grep for the CLASS — strip the last segment:
-`grep -nE '^[^ ].* -> a\.o:' .../mapping.txt` — then read the indented member
-lines under that class header for the method. Grepping the full `a.o.a`
-matches nothing: member mappings never appear at column 0.)
+## Why the old conclusion was wrong
 
-Facts, with sources:
+It described the flagged code as "the pre-API-35 compat half" of
+`enableEdgeToEdge()`, and concluded that since Google tells apps to call that
+function, the references are unavoidable.
 
-- The flagged code is the pre-API-35 compat half of `enableEdgeToEdge()` itself —
-  the API Google's other recommendation tells apps to call. On devices below 35
-  it must call the deprecated setters to draw scrims; on 35+ a different path
-  runs. Play's scan is static and flags the bytecode's existence.
-- No androidx.activity release avoids the references — they exist at
-  androidx-main tip-of-tree (`EdgeToEdge.kt`, `@Suppress("DEPRECATION")` on every
-  impl including the API-35 one). Material 1.14.0's `EdgeToEdgeUtils` is
-  identical to alpha09 on this point. Sources: androidx-main `EdgeToEdge.kt`;
-  material tags `1.14.0-alpha09`/`1.14.0`; material issue #4626.
-- `MaterialDatePicker` is not used by app code; R8 keeps it via an
-  AAPT-generated keep rule from Material's own layouts (see
-  `build/outputs/mapping/release/configuration.txt`).
-- `SHORT_EDGES` never executes: minSdk 33 selects the API-30+ path (`ALWAYS`).
-- The warning is a non-blocking recommendation. Evidence (no formal Google
-  statement exists): Flutter team, flutter/flutter#169810 — "know that it will
-  not impact your users"; dotnet/android#10304 (app with the warning published);
-  Google's own SDKs trigger it. Expect it to reappear on every upload until
-  AndroidX changes; that is not a regression.
-- The AAB embeds the R8 map (`BUNDLE-METADATA/.../proguard.map`), so Play
-  already has the mapping — this scan simply reports obfuscated names anyway.
+**`EdgeToEdgeApi35` is in the table above.** The references were never confined
+to the compat half, so the two obvious escapes both fail: raising `minSdk`
+would not reach them, and neither would an `-assumevalues` rule telling R8 that
+`SDK_INT >= 33`. Only dropping the call removes the classes.
 
-What WAS actionable was the sibling recommendation ("Edge-to-edge may not
-display for all users"): three real insets defects were found and fixed —
-display cutout in landscape, the Toolchains/first-run screens, and status-bar
-icon contrast in device light mode. See the CHANGELOG entries that landed with
-this document for what each one was.
+The second half of the premise had also expired. `enableEdgeToEdge()` is the
+right call when an app needs edge-to-edge on API levels that do not enforce it.
+This app's `targetSdk` is 36, and API 35+ enforces edge-to-edge with **no
+opt-out**, so on every device at or above 35 the function was setting colours
+through setters the platform had already turned into no-ops.
+
+## What replaced it
+
+`util/ViewInsets.drawBehindSystemBars()`, plus three attributes in
+`values/themes.xml`. Each piece maps to something the old call did:
+
+| `enableEdgeToEdge()` did | Now |
+|---|---|
+| opt into edge-to-edge below API 35 | `WindowCompat.setDecorFitsSystemWindows(window, false)` |
+| pin light system bar icons | `WindowInsetsControllerCompat.isAppearanceLight*Bars = false` |
+| set both bars transparent | `android:statusBarColor` / `android:navigationBarColor` in the theme |
+| set the cutout mode | `android:windowLayoutInDisplayCutoutMode` in the theme |
+
+The bar colours and the cutout mode move to attributes rather than disappearing,
+and that is the point: Play's scan reads bytecode, and an attribute is not a
+method call. It is also honest about scope, because API 35+ ignores all three
+attributes and paints the bars from the window background anyway. They decide
+API 33 and 34 and nothing else.
+
+`setDecorFitsSystemWindows` stays in the bundle and that is fine. It is not one
+of the three Play named, and Play Core's asset pack code puts it there
+regardless of what this app calls.
+
+## The regression that testing caught
+
+Dropping the transparent scrims is invisible on API 35+ and very visible below
+it. On an API 33 emulator the status bar came back **blue**, the Material3
+default, against the app's dark editor. The theme attributes above are what fix
+it. Anyone changing this area should test on API 33 as well as a current image;
+an API 37 emulator cannot see this class of defect at all, because every API
+involved is already a no-op there.
+
+## Measurements
+
+Release APK, `dexdump` over `classes.dex`, before and after:
+
+| Reference | Before | After |
+|---|---|---|
+| `Window.setStatusBarColor` | 3 | 0 |
+| `Window.setNavigationBarColor` | 3 | 0 |
+| `Window.setStatusBarContrastEnforced` | 1 | 0 |
+| `Window.setNavigationBarContrastEnforced` | 2 | 0 |
+| `layoutInDisplayCutoutMode` written from code | 2 | 0 |
+| `androidx.activity.EdgeToEdge*` classes | 8 | 0 |
+| `Window.setDecorFitsSystemWindows` | 2 | 2 |
+
+`MaterialDatePicker.onStart()` was a fourth source and is already gone, removed
+by the optimized resource shrinking that arrived with AGP 9: with Material's
+date-picker layouts shrunk away, the AAPT-generated keep rule that held the
+class no longer applied.
+
+## Reading an obfuscated Play location
+
+Still useful, and unchanged. A location like `a.o.a` is class `a.o` plus member
+`a`. Grep for the **class**, stripping the last segment:
+
+```
+grep -nE '^[^ ].* -> a\.o:' android/app/build/outputs/mapping/release/mapping.txt
+```
+
+then read the indented member lines under that class header. Grepping the full
+`a.o.a` matches nothing, because member mappings never appear at column 0. The
+obfuscated names change every release, so re-derive them per upload.
+
+## The sibling recommendation
+
+"Edge-to-edge may not display for all users" is a different item and was always
+actionable. Three real insets defects were found and fixed under it: the display
+cutout in landscape, the Toolchains and first-run screens, and status-bar icon
+contrast in device light mode. The app's insets handling lives in
+`util/ViewInsets.padForSystemBars`, with its own listeners in `MainActivity` and
+`ExtraKeyRow` where the IME inset has to be folded in as well.


### PR DESCRIPTION
Play Console names three deprecated APIs in the bundle: `Window.setStatusBarColor`, `Window.setNavigationBarColor` and `LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES`. All three came from a single call, `androidx.activity.enableEdgeToEdge()`, made by `MainActivity`, `SplashActivity` and `ToolchainActivity` before `super.onCreate()`.

## Why it can be dropped

`targetSdk` is 36, and API 35+ enforces edge-to-edge with no opt-out, so the colour setters that call reached for there were already no-ops. Every call site passed `Color.TRANSPARENT` for both scrims, which is what the platform now does by itself.

What the call sites actually needed was light system bar icons pinned regardless of the device theme: this app is always dark and has no `values-night`, so the `auto` default drew dark icons on a dark background whenever the device was in light mode.

## Changes

- `util/ViewInsets.drawBehindSystemBars()` opts into edge-to-edge below API 35 and pins the icon appearance. `setDecorFitsSystemWindows` is not one of the three names Play reports, and Play Core's asset pack code already puts it in the bundle regardless.
- The bar colours and the cutout mode move to `values/themes.xml` attributes. Play's scan reads bytecode, and an attribute is not a method call. API 35+ ignores all three and paints from the window background anyway, so they decide API 33 and 34 only.
- `docs/PLAY_EDGE_TO_EDGE.md` rewritten. It previously concluded this could not be cleared.

## Why the earlier conclusion was wrong

It described the flagged code as the pre-API-35 compat half of `enableEdgeToEdge()` and reasoned that the call is unavoidable. But `EdgeToEdgeApi35` holds the references too, so neither raising `minSdk` nor an `-assumevalues` rule telling R8 that `SDK_INT >= 33` would have reached them. Only dropping the call removes the classes.

## Measurements

`dexdump` over the release APK, de-obfuscated through this build's own `mapping.txt`:

| Reference | Before | After |
|---|---|---|
| `Window.setStatusBarColor` | 3 | 0 |
| `Window.setNavigationBarColor` | 3 | 0 |
| `Window.setStatusBarContrastEnforced` | 1 | 0 |
| `Window.setNavigationBarContrastEnforced` | 2 | 0 |
| `layoutInDisplayCutoutMode` written from code | 2 | 0 |
| `androidx.activity.EdgeToEdge*` classes | 8 | 0 |
| `Window.setDecorFitsSystemWindows` | 2 | 2 |

The last row is the control: Play Core's references stay, so the scan is still reading the dex rather than returning zeros for an empty file.

`MaterialDatePicker.onStart()` was a fourth source and is already gone, removed by the optimized resource shrinking that arrived with AGP 9 once Material's date-picker layouts were shrunk away.

## Verification

Run on two emulators, because one cannot show this class of defect.

- **API 33, arm64.** The transparent scrims turn out to be load-bearing here: without the theme attributes the status bar came back Material3 blue against the dark editor. Caught and fixed before this PR was opened.
- **API 37, arm64, 16 KB pages.** Every API involved is already a no-op, so the API 33 defect is invisible there. Unchanged before and after.

Both render correctly with light bar icons, content padded out of the bars, and a working terminal. `FATAL EXCEPTION` and `E/AndroidRuntime` are zero on both, over roughly 2400 log lines each. 1191 unit tests across 188 suites, unchanged. Lint reports the same 53 warnings and 17 baselined entries as before.