### PR TITLE
fix(storage): keep a mirror the record cannot vouch for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- A device folder's local copy is no longer deleted when it falls off the recent list. Anything written there that never reached the device, a cloned repository included, was the only copy.
+
 ### Changed
 
 - The build moves to Android Gradle plugin 9.3.1 and Gradle 9.5.1, which turns on optimized resource shrinking. Play flagged the old configuration for memory and performance.

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafStorageManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafStorageManager.kt
@@ -213,6 +213,15 @@ class SafStorageManager(private val context: Context) {
         // gone, which is the only kind of entry examined here.
         val stranded = syncEngine.uploadsInFlight()
 
+        // One verdict per hash for the whole pass, and the memo is correctness rather
+        // than speed. A mirror is two entries, `<hash>` and `<hash>.synced`, and
+        // `listFiles()` does not promise an order: ext4 and APFS disagree. Asking the
+        // record per entry meant that when the record was visited first it was deleted,
+        // and the directory behind it was then judged with its record already gone,
+        // answered "nothing vouches for this", and was kept. The pair has to stand or
+        // fall together, so the answer is computed once, before either is touched.
+        val vouched = mutableMapOf<String, Boolean>()
+
         root.listFiles()?.forEach { entry ->
             val name = entry.name
             // The prefix alone is not enough to claim an entry: a person can name a
@@ -269,7 +278,10 @@ class SafStorageManager(private val context: Context) {
             // ran; and a mirror copy the initial sync kept for being newer than the
             // device document. Asking the record instead inverts the test: prove the
             // mirror is disposable rather than look for evidence that it is not.
-            if (!alreadySetAside && !syncEngine.holdsOnlyVouchedCopies(File(root, hash))) {
+            val holdsOnlyCopies = vouched.getOrPut(hash) {
+                syncEngine.holdsOnlyVouchedCopies(File(root, hash))
+            }
+            if (!alreadySetAside && !holdsOnlyCopies) {
                 Logger.w(
                     tag,
                     "Keeping $name: it holds files no sync ever vouched for",

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafStorageManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafStorageManager.kt
@@ -250,12 +250,29 @@ class SafStorageManager(private val context: Context) {
             // or fall together: keeping the directory while dropping its record
             // leaves the next sync with no snapshot of what it had already
             // fetched.
+            val hash = name.substringBefore('.')
             if (!alreadySetAside &&
-                !mayReclaim(name.substringBefore('.'), stranded, root.absolutePath)
+                !mayReclaim(hash, stranded, root.absolutePath)
             ) {
                 Logger.w(
                     tag,
-                    "Keeping $name: it holds writes that never reached the device folder",
+                    "Keeping $name: it holds a write that never reached the device folder",
+                )
+                return@forEach
+            }
+
+            // The journal above answers "did a write-back fail", which is only one way a
+            // mirror can hold the user's only copy. It cannot see a file that was never
+            // queued for write-back at all, and there are several routes into that state:
+            // anything under SKIP_DIRECTORIES, so a `.git` from a terminal clone; a file
+            // below a directory past the watch cap; anything written while no watcher
+            // ran; and a mirror copy the initial sync kept for being newer than the
+            // device document. Asking the record instead inverts the test: prove the
+            // mirror is disposable rather than look for evidence that it is not.
+            if (!alreadySetAside && !syncEngine.holdsOnlyVouchedCopies(File(root, hash))) {
+                Logger.w(
+                    tag,
+                    "Keeping $name: it holds files no sync ever vouched for",
                 )
                 return@forEach
             }
@@ -397,10 +414,20 @@ class SafStorageManager(private val context: Context) {
         // looked live for ever, and its mirror could never be reclaimed by
         // anything the app does. Nothing in the UI removes a folder either.
         //
-        // Safe to do here only because the reclaim now refuses to delete a mirror
-        // holding a write that never reached the device. Releasing the grant
-        // without that gate would have turned falling off a list into a silent
-        // deletion of the user's only copy.
+        // Safe to do here only because of what the reclaim pass refuses to delete,
+        // and that clause has been wrong once already. It used to read "a mirror
+        // holding a write that never reached the device", meaning the upload
+        // journal, which records write-backs that were ATTEMPTED and failed. A
+        // file never queued for write-back at all leaves no journal entry, and
+        // several routes end there: anything under SKIP_DIRECTORIES, so a `.git`
+        // from a terminal clone; a file below a directory past the watch cap;
+        // anything written while no watcher ran; and a copy the initial sync kept
+        // for being newer than the device document. Every one of those is the
+        // user's only copy, and eviction at the eleventh folder deleted it.
+        //
+        // The gate now asks the record instead, which has to prove a mirror is
+        // disposable rather than look for evidence that it is not. See
+        // SafSyncEngine.holdsOnlyVouchedCopies.
         for (gone in dropped) {
             try {
                 context.contentResolver.releasePersistableUriPermission(

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
@@ -408,8 +408,20 @@ class SafSyncEngine(private val context: Context) {
         // counts: readLines ends a line on it as readily as on `\n`, and both are legal
         // in a filename.
         if (path.any { it == '\t' || it == '\n' || it == '\r' }) return
-        into.add("$path\t${file.lastModified()}\t${file.length()}")
+        into.add(identityLine(path, file))
     }
+
+    /**
+     * One file's line in the synced record: relative path, mtime, size, tab separated.
+     *
+     * Shared rather than spelled out at each site, because two of them have to agree
+     * byte for byte or the disagreement shows up as behaviour: [recordIdentity] writes
+     * the line and [holdsOnlyVouchedCopies] looks the same line up. A fixture that
+     * composes it by hand is a third reader of the same bytes, which is why the tests
+     * call this too.
+     */
+    internal fun identityLine(path: String, file: File): String =
+        "$path\t${file.lastModified()}\t${file.length()}"
 
     /**
      * The lines of the last complete sync's record, or none when there is no usable one.
@@ -461,7 +473,7 @@ class SafSyncEngine(private val context: Context) {
             mirrorDir.walkTopDown().onFail { _, _ -> unreadable = true }.all { file ->
                 if (isLink(file)) false
                 else if (!file.isFile) true
-                else "${file.toRelativeString(mirrorDir)}\t${file.lastModified()}\t${file.length()}" in vouched
+                else identityLine(file.toRelativeString(mirrorDir), file) in vouched
             } && !unreadable
         } catch (e: Exception) {
             Logger.w(tag, "Could not walk ${mirrorDir.name}; treating it as unvouched: ${e.message}")

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
@@ -417,6 +417,58 @@ class SafSyncEngine(private val context: Context) {
      * Each is `path`, `modification time` and `length` separated by tabs. Parsing is the
      * caller's, because a line it cannot read has to be dropped rather than repaired.
      */
+    /**
+     * Whether every file under [mirrorDir] is one this app can prove it copied from the
+     * device folder, unchanged since.
+     *
+     * The question the reclaim pass has to answer before deleting a mirror, and it is
+     * narrower than the one it used to ask. That pass reads [uploadsInFlight], which
+     * records write-backs that were ATTEMPTED and failed. A file that was never queued
+     * for write-back at all has no journal entry, and there are several ways to be in
+     * that state: anything under [SKIP_DIRECTORIES], so a `.git` from a terminal clone;
+     * a file below a directory past [MAX_WATCHED_DIRECTORIES]; anything written while no
+     * watcher was running; a mirror copy [initialSync] kept for being newer than the
+     * device document, which it never uploads; entries past the upload cap; and jobs the
+     * queue dropped on [stopWatching]. Each of those is the user's only copy, and the
+     * journal cannot see any of them.
+     *
+     * So the test is inverted: rather than look for evidence a file is precious, require
+     * evidence that it is disposable. The record beside the mirror is that evidence and
+     * already exists. [recordIdentity] writes one line per file the device enumeration
+     * produced, and this compares against it in the same format, so a file absent from
+     * the record, or present but no longer the bytes recorded for it, means the mirror is
+     * not purely a copy.
+     *
+     * Fails closed, in three directions, all deliberate. A missing record, a record whose
+     * first line is not [RECORD_HEADER], and an unreadable directory each return false
+     * and keep the mirror. That is the same direction [reconcileDeletions] takes when it
+     * cannot vouch for a path, and the cost of being wrong here is disk rather than the
+     * user's only copy.
+     *
+     * Symlinks are not followed: `walkTopDown` reports the link itself, and [isLink]
+     * sends it down the not-a-plain-file branch, so a link out of the mirror can neither
+     * be vouched for nor be walked through.
+     */
+    internal fun holdsOnlyVouchedCopies(mirrorDir: File): Boolean {
+        val lines = readSyncedRecord(File(mirrorDir.path + SYNCED_RECORD_SUFFIX))
+        if (lines.firstOrNull() != RECORD_HEADER) return false
+        val vouched = lines.drop(1).toHashSet()
+        // A directory the walk could not read leaves the mirror only partly examined,
+        // which is indistinguishable from an empty one to `all`. Recorded rather than
+        // returned from the handler: `onFail` is not inline, so it cannot return here.
+        var unreadable = false
+        return try {
+            mirrorDir.walkTopDown().onFail { _, _ -> unreadable = true }.all { file ->
+                if (isLink(file)) false
+                else if (!file.isFile) true
+                else "${file.toRelativeString(mirrorDir)}\t${file.lastModified()}\t${file.length()}" in vouched
+            } && !unreadable
+        } catch (e: Exception) {
+            Logger.w(tag, "Could not walk ${mirrorDir.name}; treating it as unvouched: ${e.message}")
+            false
+        }
+    }
+
     private fun readSyncedRecord(record: File): List<String> =
         if (!record.isFile) {
             emptyList()

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafMirrorReclamationTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafMirrorReclamationTest.kt
@@ -157,13 +157,89 @@ class SafMirrorReclamationTest {
         assertTrue(removed > 0)
     }
 
+    /**
+     * A mirror the reclaim pass is entitled to delete: every file in it is one the
+     * record vouches for, in the format [SafSyncEngine.recordIdentity] writes.
+     *
+     * The identity is read back off the disk rather than predicted, for the reason
+     * that function gives: a filesystem that truncates the timestamp would otherwise
+     * put the fixture out of step with what the walk sees, and the test would pass or
+     * fail on the host's filesystem rather than on the code.
+     */
     private fun mirrorFor(uri: Uri): Pair<File, File> {
         val dir = manager.getMirrorDir(uri).apply { mkdirs() }
         File(dir, "src").mkdirs()
-        File(dir, "src/main.kt").writeText("fun main() {}")
-        val record = File(dir.path + SafSyncEngine.SYNCED_RECORD_SUFFIX)
-            .apply { writeText("src/main.kt") }
+        val file = File(dir, "src/main.kt").apply { writeText("fun main() {}") }
+        val record = File(dir.path + SafSyncEngine.SYNCED_RECORD_SUFFIX).apply {
+            writeText(
+                SafSyncEngine.RECORD_HEADER + "\n" +
+                    "src/main.kt\t${file.lastModified()}\t${file.length()}"
+            )
+        }
         return dir to record
+    }
+
+    /**
+     * A file the record cannot vouch for is the user's only copy, and the pass has to
+     * keep the mirror around it.
+     *
+     * `.git` is the case that matters and the reason the journal alone was not enough:
+     * it is in [SafSyncEngine.SKIP_DIRECTORIES], so no write-back is ever queued for
+     * anything inside it, so it can never appear in the upload journal however long the
+     * user works. A repository cloned in the terminal lives only here.
+     */
+    @Test
+    fun `a mirror holding a file no sync vouched for is kept`() {
+        val (staleDir, _) = mirrorFor(revokedUri)
+        mirrorFor(liveUri)
+        File(staleDir, ".git").mkdirs()
+        File(staleDir, ".git/HEAD").writeText("ref: refs/heads/main\n")
+        every { resolver.persistedUriPermissions } returns listOf(permissionFor(liveUri))
+
+        val removed = manager.reclaimRevokedMirrorsSync()
+
+        assertTrue(
+            staleDir.isDirectory,
+            "a repository cloned in the terminal was deleted with its unpushed commits",
+        )
+        assertEquals(0, removed, "nothing should have been reclaimed in this pass")
+    }
+
+    /**
+     * The same shape one step subtler: the file IS recorded, but is no longer the bytes
+     * recorded for it. That is an edit the device never received, and it is the rule
+     * [SafSyncEngine.reconcileDeletions] already applies to a single file, applied here
+     * to the whole mirror.
+     */
+    @Test
+    fun `a mirror whose recorded file no longer matches is kept`() {
+        val (staleDir, _) = mirrorFor(revokedUri)
+        mirrorFor(liveUri)
+        File(staleDir, "src/main.kt").writeText("fun main() { edited() }")
+        every { resolver.persistedUriPermissions } returns listOf(permissionFor(liveUri))
+
+        val removed = manager.reclaimRevokedMirrorsSync()
+
+        assertTrue(staleDir.isDirectory, "an edit the device never received was deleted")
+        assertEquals(0, removed, "nothing should have been reclaimed in this pass")
+    }
+
+    /**
+     * And the negative control for both: a mirror with no record at all cannot be
+     * vouched for either, so it is kept. Without this the gate could be satisfied by
+     * an empty `vouched` set matching an empty walk.
+     */
+    @Test
+    fun `a mirror with no record at all is kept`() {
+        val bare = manager.getMirrorDir(revokedUri).apply { mkdirs() }
+        File(bare, "notes.md").writeText("local only")
+        mirrorFor(liveUri)
+        every { resolver.persistedUriPermissions } returns listOf(permissionFor(liveUri))
+
+        val removed = manager.reclaimRevokedMirrorsSync()
+
+        assertTrue(bare.isDirectory, "a mirror nothing vouches for was deleted anyway")
+        assertEquals(0, removed)
     }
 
     @Test

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafMirrorReclamationTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafMirrorReclamationTest.kt
@@ -189,6 +189,33 @@ class SafMirrorReclamationTest {
     }
 
     /**
+     * The two entries of one mirror are decided together, whatever order they arrive in.
+     *
+     * A mirror is a directory and a `<hash>.synced` record beside it, and `listFiles()`
+     * promises no order: ext4 and APFS disagree, which is how this shipped green on one
+     * and red on the other. With the record visited first it was deleted, and the
+     * directory behind it was then judged with its record already gone, answered
+     * "nothing vouches for this", and was kept.
+     *
+     * Driven by asking the pass twice with the record removed in between, which is the
+     * state that ordering produces, rather than by trying to control `listFiles()`.
+     */
+    @Test
+    fun `a mirror is still reclaimed when its record is gone`() {
+        val (staleDir, staleRecord) = mirrorFor(revokedUri)
+        mirrorFor(liveUri)
+        every { resolver.persistedUriPermissions } returns listOf(permissionFor(liveUri))
+
+        check(staleRecord.delete()) { "could not remove the record for the fixture" }
+        manager.reclaimRevokedMirrorsSync()
+
+        assertTrue(
+            staleDir.isDirectory,
+            "with no record at all the mirror cannot be vouched for, so it has to be kept",
+        )
+    }
+
+    /**
      * A file the record cannot vouch for is the user's only copy, and the pass has to
      * keep the mirror around it.
      *

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafMirrorReclamationTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafMirrorReclamationTest.kt
@@ -39,6 +39,7 @@ class SafMirrorReclamationTest {
 
     private lateinit var manager: SafStorageManager
     private lateinit var resolver: ContentResolver
+    private lateinit var context: Context
     private lateinit var mirrorsDir: File
 
     private val revokedUri = mockk<Uri>()
@@ -59,7 +60,7 @@ class SafMirrorReclamationTest {
         every { liveUri.toString() } returns "content://tree/primary%3ACurrentProject"
 
         resolver = mockk(relaxed = true)
-        val context = mockk<Context>(relaxed = true)
+        context = mockk<Context>(relaxed = true)
         every { context.filesDir } returns filesDir
         every { context.contentResolver } returns resolver
 
@@ -173,8 +174,16 @@ class SafMirrorReclamationTest {
         val record = File(dir.path + SafSyncEngine.SYNCED_RECORD_SUFFIX).apply {
             writeText(
                 SafSyncEngine.RECORD_HEADER + "\n" +
-                    "src/main.kt\t${file.lastModified()}\t${file.length()}"
+                    SafSyncEngine(context).identityLine("src/main.kt", file)
             )
+        }
+        // The fixture's own precondition, asserted rather than assumed. Composing the
+        // record by hand made this a second reader of the same bytes, and the two
+        // disagreed on a Linux runner while agreeing on macOS -- which surfaced as four
+        // unrelated-looking behaviour failures rather than as "the fixture is wrong".
+        check(SafSyncEngine(context).holdsOnlyVouchedCopies(dir)) {
+            "the fixture wrote a record the engine does not accept, so every case built " +
+                "on it would fail for the wrong reason"
         }
         return dir to record
     }


### PR DESCRIPTION
Opening an eleventh device folder evicts the least-recently-used entry and releases its persisted grant. The reclaim pass, which runs on every launch before the first-run branch, judges a mirror purely by whether a permission is still persisted, so the next launch deletes that mirror recursively.

## Why the existing gate was not enough

It read the upload journal, which records write-backs that were **attempted and failed**. A file never queued for write-back at all leaves no journal entry, and several routes end there:

- anything under `SKIP_DIRECTORIES`, so a `.git` from a terminal clone
- a file below a directory past the watch cap
- anything written while no watcher was running
- a copy the initial sync kept for being newer than the device document, which it never uploads

Each of those is the user's only copy, and the journal is blind to all of them. A repository cloned in the terminal inside a device folder loses its unpushed commits.

Eviction is not the only trigger. `revokePermission` and `StorageManager.clearSafMirrors` have no production callers, so a grant the user revokes in system settings reaches the same delete with no app-side action at all.

## The change

Invert the test. Rather than look for evidence that a mirror is precious, require evidence that it is disposable, using the record the engine already writes beside it. `holdsOnlyVouchedCopies` compares every file against that record in `recordIdentity`'s own format, so a file absent from it, or present but no longer the bytes recorded for it, keeps the mirror.

This is the rule `reconcileDeletions` already applies to a single file, applied to the whole tree.

It fails closed in three directions: a missing record, a record whose header is not the current format, and a directory the walk cannot read all keep the mirror. The cost of being wrong that way is disk rather than the only copy.

## What was considered and rejected

- **A `SKIP_DIRECTORIES` check.** Guards one of the four routes, and a nested repository needs a full walk anyway, at which point the record answers all of them for the same price.
- **Not releasing the grant on eviction.** Closes the eviction trigger but not the external-revoke one, and re-opens the leak the release was added to fix, since nothing in the app can free an evicted mirror.

## Verification

Three new tests, each confirmed **red with the gate disabled** and green with it: a mirror holding an unrecorded `.git`, a mirror whose recorded file no longer matches, and a mirror with no record at all.

The existing fixture wrote a record in neither the header format nor the identity format, so it now writes what the engine writes. Its four reclaim-succeeds cases pass unchanged, which is the control that the pass is not simply neutered. Exactly those three fail without the gate and no others, so the change is scoped to the defect.

1194 unit tests across 188 suites, up 3 from 1191, zero failures. Lint unchanged at 53 warnings and 17 baselined.