### PR TITLE
fix(webview): decide who may read a served resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Content rendered in the editor can no longer read workspace files across origins. Served files are readable by anyone, and a page in the built-in browser could fetch one.
+- A webview can no longer name an arbitrary file and have the app read it with the editor's own credential. The route that did was reachable but unused.
+
 ### Fixed
 
 - A device folder's local copy is no longer deleted when it falls off the recent list. Anything written there that never reached the device, a cloned repository included, was the only copy.

--- a/android/app/src/main/kotlin/com/vscodroid/webview/VSCodroidWebViewClient.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/webview/VSCodroidWebViewClient.kt
@@ -520,7 +520,9 @@ class VSCodroidWebViewClient(
                 // filesystem, and every workbench asset takes one of them.
                 return interceptResourceRequest(
                     uri, host, resourceAuthority, port, token,
-                    resourceRootsInForce(resourceRoots, sensitiveLocations, openFolder())
+                    resourceRootsInForce(resourceRoots, sensitiveLocations, openFolder()),
+                    request.requestHeaders?.entries
+                        ?.firstOrNull { it.key.equals("Origin", ignoreCase = true) }?.value,
                 )
             }
 
@@ -550,7 +552,7 @@ class VSCodroidWebViewClient(
          */
         private fun interceptResourceRequest(
             uri: Uri, host: String, resourceAuthority: String, port: Int, token: String?,
-            resourceRoots: List<String>
+            resourceRoots: List<String>, origin: String?
         ): WebResourceResponse? {
             val prefix = host.removeSuffix(".$resourceAuthority")
             val parts = prefix.split("+", limit = 2)
@@ -559,6 +561,32 @@ class VSCodroidWebViewClient(
             val path = uri.path ?: return notFound("No path")
 
             if (scheme == "file" || scheme == "vscode-remote") {
+                // Files served here carry `Access-Control-Allow-Origin: *`, which is what
+                // makes them readable by whatever asked. The published roots decide WHICH
+                // files; this decides WHO may read one, and until it existed the answer
+                // was anybody. A remote page in the bundled Simple Browser could fetch a
+                // workspace file and read the body, with no network involved.
+                //
+                // Measured on an API 37 emulator rather than assumed, because the whole
+                // gate rests on the header being there: of 42 intercepted requests, 29
+                // carried `Origin` and it was always `http://127.0.0.1:<port>`, the
+                // workbench's own. The `.vscode-cdn.net` arm is read from the shipped
+                // bundle instead, where `webviewContentExternalBaseUrlTemplate` resolves
+                // webview documents to `https://{{uuid}}.vscode-cdn.net/...`.
+                //
+                // A missing header is served, deliberately. The other 13 were no-cors
+                // subresource loads -- `<img>`, `<link>`, `<script src>` -- which send no
+                // `Origin` and cannot read the body anyway, so demanding one would break
+                // every extension webview to close nothing.
+                //
+                // ⚠️ Residual, stated rather than implied: an HTML file our own branch
+                // serves gets an origin ending `.vscode-cdn.net` and passes. Closing that
+                // wants `Sec-Fetch-Dest` gating, which is unverified here and risks
+                // extensions that frame their own local HTML.
+                if (origin != null && !isOurOrigin(origin, port)) {
+                    Logger.w(TAG, "Resource refused, foreign origin: $origin")
+                    return notFound("Access denied")
+                }
                 // Local file resource — serve directly from filesystem.
                 // Both "file" and "vscode-remote" schemes use local paths in VSCodroid
                 // since the server runs on the same device.
@@ -605,14 +633,25 @@ class VSCodroidWebViewClient(
                 return proxyToLocalhost(actualUrl, "GET", "resource:$authority$path")
             }
 
-            // For other schemes with authority, proxy through localhost server
-            if (authority.isNotEmpty()) {
-                val query = uri.query
-                val queryPart = if (!query.isNullOrEmpty()) "?$query" else ""
-                val localUrl = withToken("http://127.0.0.1:$port$path$queryPart", token)
-                return proxyToLocalhost(localUrl, "GET", "remote-resource:$path")
-            }
-
+            // A catch-all for every other scheme with an authority used to sit here,
+            // proxying to `http://127.0.0.1:$port$path` with the connection token
+            // appended. It is gone rather than tightened, and restoring it needs a
+            // reason better than the one it had.
+            //
+            // Both halves of `path` and the query were the page's to choose, and the
+            // token turned that into an authenticated request. The server routes
+            // `/vscode-remote-resource` after its token gate and then reads
+            // `query.path` as an absolute path, so this branch answered
+            // `…/vscode-remote-resource?path=<anything>` with the file: the SSH key
+            // and the token file included, which is what `sensitiveLocations` exists
+            // to keep out of the branch above. The response is same-origin to a
+            // document the caller can frame, and the server sends no
+            // X-Frame-Options, so reading it back needed no further trick.
+            //
+            // Nothing asked for it. The workbench encodes only `file` and
+            // `vscode-remote` into the resource host, and no bundled extension
+            // produces the form. The `Unknown resource scheme` line below is the
+            // signal if something did: it names the scheme.
             Logger.w(TAG, "Unknown resource scheme: $scheme (host=$host)")
             return notFound("Unknown scheme: $scheme")
         }
@@ -630,8 +669,9 @@ class VSCodroidWebViewClient(
                 val contentType = conn.contentType ?: guessMimeType(url)
                 val encoding = conn.contentEncoding
 
-                // `url` has been through withToken() by both callers that reach
-                // here against our own server.
+                // `url` has been through withToken() when it names our own server.
+                // One caller does now, the CDN rewrite; the unknown-scheme fallback
+                // that was the second is gone.
                 Logger.d(TAG, "CDN redirect: $logTag -> ${redactToken(url)} ($responseCode)")
 
                 val responseStream = if (responseCode < 400) {
@@ -686,6 +726,12 @@ class VSCodroidWebViewClient(
             }
         }
 
+        /** Whether [origin] is the workbench itself or one of its webview documents. */
+        private fun isOurOrigin(origin: String, port: Int): Boolean =
+            origin == "http://127.0.0.1:$port" ||
+                origin == "http://localhost:$port" ||
+                (origin.startsWith("https://") && origin.endsWith(".vscode-cdn.net"))
+
         private fun notFound(detail: String): WebResourceResponse {
             return WebResourceResponse(
                 "text/plain", "utf-8", 404, "Not Found",
@@ -726,6 +772,11 @@ class VSCodroidWebViewClient(
          * that function: one of its callers proxies http/https resources to
          * whatever host an extension's webview references, and putting the token
          * there would hand our credential to that host.
+         *
+         * The reason that separation is load-bearing rather than tidy: a third
+         * caller once did append the token to a page-controlled path, which is
+         * the defect removed from interceptResourceRequest. Keeping the token an
+         * explicit step is what makes such a call visible in a diff.
          */
         private fun withToken(url: String, token: String?): String {
             if (token.isNullOrEmpty()) return url

--- a/android/app/src/test/kotlin/com/vscodroid/webview/ConnectionTokenLoggingTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/ConnectionTokenLoggingTest.kt
@@ -149,34 +149,42 @@ class ConnectionTokenLoggingTest {
     }
 
     /**
-     * The resource branch that proxies through our own server, which is the other
-     * caller of `withToken`.
+     * An unknown scheme is refused, and no tokened URL is built for it.
      *
-     * The scheme has to be one the interceptor does not handle itself. This case
-     * was written with `vscode-remote+authority`, which takes the
-     * `file || vscode-remote` branch instead: with no published roots the request
-     * resolves to `Refused` and returns before `withToken` or the proxy is ever
-     * reached. It passed, on the refusal's own log line — and
-     * [assertNothingLeaked]'s "something was logged" control could not tell,
-     * because something *was*.
+     * This case used to assert the opposite: that the request DID reach a branch
+     * appending the connection token, proven by the `remote-resource:` tag only
+     * that branch logs. That branch is gone. It proxied to
+     * `http://127.0.0.1:$port$path` with the token attached, where both the path
+     * and the query were the page's to choose, so a webview could name the
+     * server's `/vscode-remote-resource` route and read any absolute path with
+     * this app's credential.
      *
-     * So the control here names the branch rather than counting lines. Only the
-     * proxy path builds a `remote-resource:` tag, so finding it in the log is
-     * proof the tokened URL was actually constructed.
+     * The tag is therefore the control in reverse now: finding it would mean the
+     * branch is back. Keeping the case rather than deleting it is the point, since
+     * a deleted test cannot notice a restoration.
      */
     @Test
-    fun `the resource proxy does not log the token`() {
+    fun `an unknown resource scheme is refused without building a tokened URL`() {
         val deadPort = ServerSocket(0, 0, InetAddress.getByName("127.0.0.1")).use { it.localPort }
 
+        // The return value is deliberately not inspected. Refusing and serving both
+        // produce a WebResourceResponse, and its getters throw "not mocked" under the
+        // stub android.jar -- the same limitation that made `resourceOutcome` a value
+        // rather than a branch. The log is what distinguishes the two here.
         VSCodroidWebViewClient.interceptCdnRequest(
             cdnRequest("custom+authority.vscode-resource.vscode-cdn.net", "/some/asset.css"),
             deadPort, token, emptyList(), emptyList(), { null },
         )
 
         assertTrue(
-            logged.any { it.contains("remote-resource:") },
-            "the request never reached the branch that appends the token, so this case " +
-                "proves nothing. Logged instead:\n" + logged.joinToString("\n") { "  $it" },
+            logged.none { it.contains("remote-resource:") },
+            "the tokened proxy branch is back. Logged:\n" +
+                logged.joinToString("\n") { "  $it" },
+        )
+        assertTrue(
+            logged.any { it.contains("Unknown resource scheme") },
+            "the refusal should say which scheme it refused. Logged:\n" +
+                logged.joinToString("\n") { "  $it" },
         )
         assertNothingLeaked()
     }

--- a/android/app/src/test/kotlin/com/vscodroid/webview/ResourceInterceptionWiringTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/ResourceInterceptionWiringTest.kt
@@ -81,15 +81,100 @@ class ResourceInterceptionWiringTest {
     @AfterEach
     fun tearDown() = unmockkAll()
 
-    /** A resource request for [path], shaped the way the workbench sends one. */
-    private fun requestFor(path: String): WebResourceRequest {
+    /**
+     * A resource request for [path], shaped the way the workbench sends one.
+     *
+     * [origin] is stubbed explicitly, including when it is null, because the fixture is
+     * `relaxed`: an unstubbed `requestHeaders` answers with an empty map, which the
+     * origin gate reads as "no Origin" and serves. Every case here would therefore pass
+     * whatever the gate did, which is what the cases below exist to avoid.
+     */
+    private fun requestFor(path: String, origin: String? = null): WebResourceRequest {
         val uri = mockk<Uri>(relaxed = true)
         every { uri.host } returns "file+.vscode-resource.vscode-cdn.net"
         every { uri.path } returns path
         every { uri.query } returns null
         val request = mockk<WebResourceRequest>(relaxed = true)
         every { request.url } returns uri
+        every { request.requestHeaders } returns
+            if (origin == null) emptyMap() else mapOf("Origin" to origin)
         return request
+    }
+
+    /**
+     * A page that is not the workbench cannot read a workspace file.
+     *
+     * The served file carries `Access-Control-Allow-Origin: *`, so before the gate the
+     * answer to "who may read this" was anybody who could reach the interceptor -- and
+     * a remote page in the bundled Simple Browser can, with no network involved.
+     *
+     * Proved by making the file unreadable rather than by the log alone, the same way
+     * `a refused resource is never opened` does: if the refusal did not happen, the open
+     * would, and the fixture would throw.
+     */
+    @Test
+    fun `a foreign origin is refused before the file is opened`() {
+        val unreadable = File(workspace, "secret.txt").apply {
+            writeText("x")
+            check(setReadable(false, false)) { "could not make the fixture unreadable" }
+        }
+
+        VSCodroidWebViewClient.interceptCdnRequest(
+            requestFor(unreadable.absolutePath, origin = "https://evil.example"),
+            PORT, null, published, sensitive, { workspace.absolutePath },
+        )
+
+        assertTrue(
+            warnings.any { it.contains("foreign origin") && it.contains("https://evil.example") },
+            "the refusal should name the origin it refused. Logged:\n" +
+                warnings.joinToString("\n") { "  $it" },
+        )
+    }
+
+    /**
+     * The workbench's own origin still serves, or the gate has closed the app to itself.
+     *
+     * This case and the one below it assert the ABSENCE of a refusal, so neither goes red
+     * if the gate is deleted. That is deliberate and worth saying plainly: only
+     * `a foreign origin is refused before the file is opened` detects the gate going
+     * missing, measured by disabling it. These two guard the other direction, which is the
+     * one that breaks the editor rather than the one that leaks a file.
+     */
+    @Test
+    fun `the workbench origin is served`() {
+        val file = File(workspace, "ok.txt").apply { writeText("hello") }
+
+        VSCodroidWebViewClient.interceptCdnRequest(
+            requestFor(file.absolutePath, origin = "http://127.0.0.1:$PORT"),
+            PORT, null, published, sensitive, { workspace.absolutePath },
+        )
+
+        assertTrue(
+            warnings.none { it.contains("foreign origin") },
+            "the workbench was refused its own file. Logged:\n" +
+                warnings.joinToString("\n") { "  $it" },
+        )
+    }
+
+    /**
+     * And a webview document's origin, which is where extension content lives:
+     * `webviewContentExternalBaseUrlTemplate` in the shipped bundle resolves to
+     * `https://{{uuid}}.vscode-cdn.net/...`.
+     */
+    @Test
+    fun `a webview origin is served`() {
+        val file = File(workspace, "asset.css").apply { writeText("body{}") }
+
+        VSCodroidWebViewClient.interceptCdnRequest(
+            requestFor(file.absolutePath, origin = "https://0f7c2b1a-uuid.vscode-cdn.net"),
+            PORT, null, published, sensitive, { workspace.absolutePath },
+        )
+
+        assertTrue(
+            warnings.none { it.contains("foreign origin") },
+            "an extension webview was refused its own resource. Logged:\n" +
+                warnings.joinToString("\n") { "  $it" },
+        )
     }
 
     private fun intercept(path: String, openFolder: String?) = assertNotNull(


### PR DESCRIPTION
> Stacked on #279. Base is `fix/saf-reclaim-vouched-copies`; retarget to `main` once that merges.

Two gaps in the resource server, both reachable from content the editor renders. Neither is about the navigation allowlist this project deliberately does not have: the question here is narrower, what our own interceptor does with a request it receives.

## 1. The unknown-scheme fallback, removed

It caught every scheme with a non-empty authority and proxied to `http://127.0.0.1:$port$path` **with the connection token appended**, where both the path and the query were the page's to choose.

The server routes `/vscode-remote-resource` after its token gate and then reads `query.path` as an absolute path, so the branch answered with any file on the device: the SSH key and the connection-token file included, which is exactly what `sensitiveLocations` exists to keep out of the branch above it. The response is same-origin to a document the caller can frame, and the server sends no `X-Frame-Options`, so reading it back needed no further trick.

Nothing asked for it. The workbench encodes only `file` and `vscode-remote` into the resource host, and no bundled extension produces the form (grep over the extension tree: 0 matches, control: 2 files mention `vscode-resource` at all). It is deleted rather than tightened, and the `Unknown resource scheme` line that remains names the scheme if something did depend on it.

## 2. Served files gated on the requesting origin

They carry `Access-Control-Allow-Origin: *`, so the published roots decided *which* files and nothing decided *who*. `simple-browser` ships among the built-in extensions, so a remote page in the editor could `fetch()` a workspace file and read the body with no network involved.

**The gate rests on the `Origin` header being present, so that was measured rather than assumed.** Of 42 requests intercepted on an API 37 emulator, 29 carried `Origin` and every one was `http://127.0.0.1:<port>`. The `.vscode-cdn.net` arm is read from the shipped bundle, where `webviewContentExternalBaseUrlTemplate` resolves webview documents to `https://{{uuid}}.vscode-cdn.net/`.

A missing header still serves, deliberately: the other 13 were no-cors subresource loads (`<img>`, `<link>`, `<script src>`), which cannot read a body anyway, so demanding an `Origin` would break every extension webview to close nothing. The residual case, an HTML file our own branch serves and an attacker frames, is written into the comment rather than left implied.

## Tests

Four, each checked against the code it guards rather than assumed to guard it:

- the retargeted unknown-scheme case goes **red if the branch returns** (verified by restoring it)
- the foreign-origin case goes **red if the gate is removed** (verified by disabling it)
- the two served-origin cases assert the *absence* of a refusal, so they do **not** detect removal; they guard over-refusal, which is the failure that breaks the editor. The comment says so plainly rather than leaving a reader to assume all four do the same work.

The existing interception fixture used a `relaxed` mock, so `requestHeaders` was unstubbed and every case would have passed whatever the gate did. It now stubs the origin explicitly, `null` included.

`WebResourceResponse` getters throw "not mocked" under the stub `android.jar`, so the refusal is proved by the log and by making the fixture file unreadable, the discipline that file already used.

## Verification

1197 unit tests across 188 suites, up 3, zero failures. Built as a signed release and run on **API 33 and API 37**: the editor loads, the terminal runs, and neither `foreign origin` nor `Unknown resource scheme` appears in either log, so nothing legitimate is being refused.

## Not in this diff

The `http`/`https` resource branch is an adjacent open proxy: it forwards to any host with no restriction, correctly without the token. The workbench cannot produce such a URL and no bundled extension does. It is left for a separate decision, because the two branches fail differently and folding them in would make a regression ambiguous.