### PR TITLE
fix(storage): guard the recursive upload the way the event path is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Creating a folder no longer overwrites a device document the app could not read, such as one too large to copy. Only the single-file path checked this before.
+
 ### Security
 
 - Content rendered in the editor can no longer read workspace files across origins. Served files are readable by anyone, and a page in the built-in browser could fetch one.

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
@@ -970,7 +970,28 @@ class SafSyncEngine(private val context: Context) {
             } ?: return null
 
             if (localFile.isFile) {
-                writeLocalToSaf(localFile, docUri)
+                // The same question [handleMirrorEvent] asks before queueing a job, asked
+                // again here because this path does not come through it. A directory
+                // create, or a move whose other half never arrived, walks the tree
+                // through [createChildrenInSaf] and reaches every child directly.
+                //
+                // `existingDocId != null` IS the provider answer for this child, already
+                // paid for above, so unlike the event path this costs no extra binder
+                // call. A file this sync could not read, whose document still exists on
+                // the device, would otherwise be written back as whatever placeholder the
+                // mirror holds -- truncating a document nothing here has ever seen.
+                if (writeWouldReplaceUnreadDocument(
+                        localFile.absolutePath, existingDocId != null, unfetched,
+                    )
+                ) {
+                    Logger.w(
+                        tag,
+                        "Not writing ${localFile.name} back: the device holds a document " +
+                            "there that this sync never read, and writing would replace it",
+                    )
+                } else {
+                    writeLocalToSaf(localFile, docUri)
+                }
             }
             // Cache the document ID for future write-back lookups, but only when the
             // parent is one this cache knows. A miss is not "the parent is the root" --
@@ -1308,8 +1329,17 @@ class SafSyncEngine(private val context: Context) {
         // may have been deleted on the device since. When it has, the local file
         // is an ordinary new file and uploads normally. The binder walk costs
         // something only for paths in the set, which is normally empty.
+        //
+        // The set is therefore tested twice, here and inside the predicate, and the
+        // outer one is not a duplicate: it is what keeps [providerHoldsDocument] off
+        // the common path. [createOneInSaf] needs no such guard, because there the
+        // provider's answer is already in hand.
         if (localFile.absolutePath in unfetched &&
-            providerHoldsDocument(safTreeUri, relativePath)
+            writeWouldReplaceUnreadDocument(
+                localFile.absolutePath,
+                providerHoldsDocument(safTreeUri, relativePath),
+                unfetched,
+            )
         ) {
             Logger.w(
                 tag,
@@ -1676,6 +1706,28 @@ class SafSyncEngine(private val context: Context) {
          * The comparison is only sound because [copyDocumentToLocal] stamps the mirror
          * with the source's own timestamp, so both sides come from the same clock.
          */
+        /**
+         * Whether writing [localPath] back would replace a device document this sync
+         * never read.
+         *
+         * Extracted because two paths ask it and only one of them can be reached from a
+         * JVM test. [handleMirrorEvent] asks before queueing a job; [createOneInSaf] asks
+         * again while walking into a directory, which no event-driven test can drive here
+         * at all, since delivering a directory event constructs a `FileObserver` and that
+         * runs a static initializer reaching native code (see [SafWatchCoverageTest]).
+         * Naming the rule once is what lets it be asserted at all, and what stops the two
+         * call sites drifting apart, which is how the second one came to be missing it.
+         *
+         * [deviceHoldsDocument] is the provider's answer, not a guess: the set alone is a
+         * memory of what this sync could not read, and the document may have been deleted
+         * on the device since, in which case the local file is an ordinary new file.
+         */
+        internal fun writeWouldReplaceUnreadDocument(
+            localPath: String,
+            deviceHoldsDocument: Boolean,
+            unfetched: Set<String>,
+        ): Boolean = deviceHoldsDocument && localPath in unfetched
+
         internal fun shouldOverwriteMirror(
             mirrorExists: Boolean,
             mirrorModified: Long,

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafWriteBackFilterTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafWriteBackFilterTest.kt
@@ -137,4 +137,34 @@ class SafWriteBackFilterTest {
             )
         }
     }
+
+    /**
+     * The rule both write-back paths apply, asserted directly.
+     *
+     * It is a predicate rather than an inline condition because only one of its two call
+     * sites can be reached from a JVM test: delivering the directory event that drives
+     * the other constructs a `FileObserver`, whose static initializer reaches native code
+     * (see SafWatchCoverageTest). The recursive path went without this check for exactly
+     * that reason, so naming the rule is what makes the second site visible.
+     */
+    @Test
+    fun `a write is refused only when the device still holds a document the sync never read`() {
+        val unread = "/data/mirror/archive/big.zip"
+        val read = "/data/mirror/notes.md"
+        val unfetched = setOf(unread)
+
+        assertTrue(
+            SafSyncEngine.writeWouldReplaceUnreadDocument(unread, true, unfetched),
+            "a document the sync never read, still on the device, must not be written over",
+        )
+        assertFalse(
+            SafSyncEngine.writeWouldReplaceUnreadDocument(unread, false, unfetched),
+            "the set is a memory, not a permanent refusal: with the device document gone " +
+                "the local file is an ordinary new file",
+        )
+        assertFalse(
+            SafSyncEngine.writeWouldReplaceUnreadDocument(read, true, unfetched),
+            "a document the sync did read is the mirror's own copy and belongs on the device",
+        )
+    }
 }


### PR DESCRIPTION
`handleMirrorEvent` refuses to write a file back when the device still holds a document this sync never read: one too large to copy, or one whose copy failed. `createOneInSaf` reached the same write without asking.

That path is not reached through the event guard. A directory create walks the tree through `createChildrenInSaf` and arrives at every child directly, so the placeholder sitting in the mirror replaced a document nothing here has ever seen.

The check costs nothing extra there: `existingDocId != null` is the provider's answer for that child, already paid for a few lines above.

## Why it became a predicate

Only one of the two call sites can be reached from a JVM test. Delivering the directory event that drives the recursive path constructs a `FileObserver`, whose static initializer reaches native code a plain JVM test cannot satisfy, which `SafWatchCoverageTest` already records for its own reasons.

I found that by trying: the end-to-end test failed on `Method startWatching in android.os.FileObserver not mocked`, after an earlier attempt failed because the fixture models a flat device folder and a nested display name is not a legal path segment. The harness extension that second attempt needed is not kept, since the predicate makes it unnecessary.

Naming the rule once is what lets it be asserted, and what stops the two sites drifting apart, which is how the second one came to be missing it in the first place. This matches how `mayReclaim`, `shouldOverwriteMirror` and `resourceOutcome` are already shaped here.

## One thing that reads like a duplicate and is not

The event path now tests set membership twice, once outside the predicate and once inside. The outer test is what keeps `providerHoldsDocument`'s binder walk off the common path, where the set is empty. `createOneInSaf` needs no such guard because the provider's answer is already in hand. Both are said in place.

## Verification

1199 unit tests across 188 suites, zero failures. The new case asserts all three arms of the rule: a document still on the device and never read is refused; the same path with the device document gone is allowed, because the set is a memory rather than a permanent refusal; and a document the sync did read is allowed.