### PR TITLE
fix(storage): let the record decide when there is no clock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- On a device provider that reports no modification time, reopening a folder no longer replaces edits made in the editor. It refreshes only files still identical to what the last sync wrote.
 - A device folder's local copy is no longer deleted when it falls off the recent list. Anything written there that never reached the device, a cloned repository included, was the only copy.
 
 ### Changed

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
@@ -162,6 +162,16 @@ class SafSyncEngine(private val context: Context) {
         // before it asks the clock anything.
         val unfinishedUploads = uploadsInFlight().toMutableSet()
 
+        // Loaded for the same reason and read the same way: what the last sync wrote,
+        // as (path, mtime, size) lines. Phase 2 needs it only for providers that omit
+        // COLUMN_LAST_MODIFIED, where there is no clock to compare and the record is the
+        // only thing that can tell this app's own copy from an edit made since. Read
+        // once here rather than per document; [reconcileDeletions] reads the same file
+        // again in phase 3, after phase 2 may have changed what is on disk.
+        val previouslyRecorded = readSyncedRecord(
+            File(mirrorDir.path + SYNCED_RECORD_SUFFIX)
+        ).let { if (it.firstOrNull() == RECORD_HEADER) it.drop(1).toHashSet() else emptySet() }
+
         // Phase 2: Create directories and copy files
         for (doc in documents) {
             val localPath = File(mirrorDir, doc.relativePath)
@@ -214,7 +224,9 @@ class SafSyncEngine(private val context: Context) {
                 }
                 if (!shouldOverwriteMirror(
                         localPath.exists(), localPath.lastModified(), localPath.length(),
-                        doc.lastModified, doc.size
+                        doc.lastModified, doc.size,
+                        mirrorIsOurCopy = identityLine(doc.relativePath, localPath)
+                            in previouslyRecorded,
                     )
                 ) {
                     keptLocal++
@@ -1661,17 +1673,17 @@ class SafSyncEngine(private val context: Context) {
          *   "newer, keep it" — freezing the truncation in place forever and letting
          *   the write-back push it onto the device. Different sizes mean the mirror is
          *   not a copy of the source, whatever the clocks say.
-         * - An unknown source timestamp (0) must still copy. COLUMN_LAST_MODIFIED is
-         *   optional, and treating unknown as "keep" would freeze such folders
-         *   permanently: nothing in the app can clear a mirror, so there would be no
-         *   way out short of clearing app data. Copying is what the old code did, and
-         *   it is the behaviour that heals itself.
+         * - An unknown source timestamp (0) is decided by [mirrorIsOurCopy], not by the
+         *   clock, because there is no clock to ask. COLUMN_LAST_MODIFIED is optional and
+         *   arrives as 0 from MTP, some USB-OTG and some network providers.
          *
-         *   ⚠️ Know what it costs before relying on the protections built on top of this.
-         *   On such a provider this branch fires every time, so every reopen replaces a
-         *   local edit that has not been written back — and [reconcileDeletions]'s record
-         *   cannot help, because the file it would have vouched for is already gone. The
-         *   folder heals; the edit does not.
+         *   Both obvious answers are wrong. "Always copy" freezes nothing but replaces a
+         *   local edit on every reopen, which is what this used to do. "Always keep"
+         *   protects the edit and freezes the folder for ever, since nothing in the app
+         *   can clear a mirror. The record settles it without guessing: if the mirror is
+         *   still exactly what the last sync wrote there, it is this app's own copy and
+         *   the device is entitled to replace it, so the folder still heals. If it is
+         *   not, it holds something written since, and that is the only copy.
          *
          * The comparison is only sound because [copyDocumentToLocal] stamps the mirror
          * with the source's own timestamp, so both sides come from the same clock.
@@ -1681,13 +1693,21 @@ class SafSyncEngine(private val context: Context) {
             mirrorModified: Long,
             mirrorSize: Long,
             sourceModified: Long,
-            sourceSize: Long
+            sourceSize: Long,
+            /**
+             * Whether the mirror file is byte-identical to the line the last sync
+             * recorded for it. No default: there is one production caller and it has the
+             * record in hand, and a default here would let a future caller answer the
+             * question by not thinking about it.
+             */
+            mirrorIsOurCopy: Boolean,
         ): Boolean = when {
             !mirrorExists -> true
-            // The provider did not report a time. Unknown must not freeze the folder:
-            // nothing in the app can clear a mirror, so copying is the behaviour that
-            // heals itself.
-            sourceModified == 0L -> true
+            // The provider did not report a time, so the record answers instead: our
+            // own copy may be replaced, anything else is the only copy. A mirror with no
+            // record behind it is not ours to overwrite either, which is the direction
+            // reconcileDeletions already fails in.
+            sourceModified == 0L -> mirrorIsOurCopy
             sourceModified > mirrorModified -> true
             // A newer local copy wins, whatever its size. Checking size before this
             // was the defect: almost every edit changes a file's length, so almost

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
@@ -168,9 +168,14 @@ class SafSyncEngine(private val context: Context) {
         // only thing that can tell this app's own copy from an edit made since. Read
         // once here rather than per document; [reconcileDeletions] reads the same file
         // again in phase 3, after phase 2 may have changed what is on disk.
-        val previouslyRecorded = readSyncedRecord(
-            File(mirrorDir.path + SYNCED_RECORD_SUFFIX)
-        ).let { if (it.firstOrNull() == RECORD_HEADER) it.drop(1).toHashSet() else emptySet() }
+        // `by lazy` rather than eagerly: only the no-timestamp branch reads it, and a
+        // provider that reports times never asks. Building it eagerly meant one string
+        // per mirrored file held for the length of a sync that would not look at any of
+        // them, which on a large folder is real memory for nothing.
+        val previouslyRecorded: Set<String> by lazy {
+            readSyncedRecord(File(mirrorDir.path + SYNCED_RECORD_SUFFIX))
+                .let { if (it.firstOrNull() == RECORD_HEADER) it.drop(1).toHashSet() else emptySet() }
+        }
 
         // Phase 2: Create directories and copy files
         for (doc in documents) {
@@ -238,6 +243,17 @@ class SafSyncEngine(private val context: Context) {
                         recordIdentity(recorded, doc.relativePath, localPath)
                     }
                     unfetched.remove(localPath.absolutePath)
+                    if (doc.lastModified == 0L) {
+                        // At Logger.i, not d: this file stops receiving device-side
+                        // changes from here on, and a user asking why their folder does
+                        // not update needs this line to exist in a bug report.
+                        Logger.i(
+                            tag,
+                            "Kept ${doc.relativePath} and stopped tracking the device " +
+                                "copy: the provider reports no modification time and " +
+                                "this file no longer matches what the last sync wrote",
+                        )
+                    }
                     Logger.d(tag, "Kept local copy: ${doc.relativePath}")
                     filesDone++
                     onProgress(filesDone, totalFiles)
@@ -1707,6 +1723,22 @@ class SafSyncEngine(private val context: Context) {
             // own copy may be replaced, anything else is the only copy. A mirror with no
             // record behind it is not ours to overwrite either, which is the direction
             // reconcileDeletions already fails in.
+            //
+            // ⚠️ What this costs, stated because it is permanent and the old behaviour
+            // did not have it. Once a file here answers false it can never answer true
+            // again: it is not copied, so `copyDocumentToLocal` never records it, and
+            // the equal-timestamp branch cannot record it either because a real file's
+            // mtime is never 0. Device-side changes to that file stop arriving, and no
+            // size comparison rescues it, because this clause returns before the size
+            // clause below is reached.
+            //
+            // Kept anyway, because the alternative is worse and is what shipped: with no
+            // timestamp there is nothing to tell a device edit from a local one, and the
+            // old answer assumed the device always won, so every reopen destroyed the
+            // local edit. This one assumes the local edit wins once the two diverge. It
+            // loses updates; the other lost work. Note the divergence usually resolves
+            // itself in content if not in bookkeeping: the watcher writes the local edit
+            // out on the next save, after which both sides hold the same bytes.
             sourceModified == 0L -> mirrorIsOurCopy
             sourceModified > mirrorModified -> true
             // A newer local copy wins, whatever its size. Checking size before this

--- a/android/app/src/test/kotlin/com/vscodroid/storage/InitialSyncWiringTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/InitialSyncWiringTest.kt
@@ -175,6 +175,37 @@ class InitialSyncWiringTest {
         assertEquals(listOf("notes.txt"), openedDocuments)
     }
 
+    /**
+     * The cost of the clause above, pinned so it is a decision rather than a surprise.
+     *
+     * Once a file on a timestamp-less provider diverges from the record it can never be
+     * vouched for again: it is not copied, so nothing records it, and the equal-timestamp
+     * branch cannot record it because a real file's mtime is never 0. Device-side changes
+     * to that file stop arriving, and a size change does not rescue it, because the
+     * clause returns before the size comparison.
+     *
+     * Kept because the alternative is what shipped: with nothing to compare, the old
+     * answer assumed the device always won and destroyed the local edit on every reopen.
+     */
+    @Test
+    fun `a diverged file on a timestamp-less provider stops receiving device changes`() {
+        val local = mirrorHolding("notes.txt", "edited in the editor!", 1_700_000_060_000)
+        deviceFolderHolding("notes.txt", "a different length on the device", modified = 0)
+
+        sync()
+        sync()
+
+        assertEquals(
+            "edited in the editor!", local.readText(),
+            "the local edit survives, which is the point",
+        )
+        assertEquals(
+            emptyList<String>(), openedDocuments,
+            "and the device copy is never read again, even though its length differs: " +
+                "this is the permanent cost of having no clock to compare",
+        )
+    }
+
     @Test
     fun `an edit made on the device reaches the mirror`() {
         val local = mirrorHolding("notes.txt", "stale copy", 1_700_000_000_000)

--- a/android/app/src/test/kotlin/com/vscodroid/storage/InitialSyncWiringTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/InitialSyncWiringTest.kt
@@ -132,6 +132,49 @@ class InitialSyncWiringTest {
         assertEquals(emptyList<String>(), openedDocuments, "the engine read the document it should have left alone")
     }
 
+    /**
+     * A provider that reports no modification time, which is legal: COLUMN_LAST_MODIFIED
+     * is optional and MTP, some USB-OTG and some network providers omit it.
+     *
+     * With no clock to compare, the engine used to copy unconditionally, so every reopen
+     * of such a folder replaced whatever the editor had written since. The record decides
+     * instead, and these two are the wire: they prove initialSync hands
+     * shouldOverwriteMirror the answer, not just that the predicate would use it.
+     */
+    @Test
+    fun `with no reported time a mirror the record cannot vouch for is kept`() {
+        val local = mirrorHolding("notes.txt", "edited in the editor!", 1_700_000_060_000)
+        deviceFolderHolding("notes.txt", "from the device", modified = 0)
+
+        sync()
+
+        assertEquals(
+            "edited in the editor!", local.readText(),
+            "with no timestamp to compare, an edit the record does not know about is the " +
+                "only copy and must not be replaced",
+        )
+        assertEquals(emptyList<String>(), openedDocuments)
+    }
+
+    /** The other side, and the reason "always keep" is not the answer either. */
+    @Test
+    fun `with no reported time a mirror the record vouches for is refreshed`() {
+        val local = mirrorHolding("notes.txt", "what the last sync wrote", 1_700_000_060_000)
+        File(mirror.path + SafSyncEngine.SYNCED_RECORD_SUFFIX).writeText(
+            SafSyncEngine.RECORD_HEADER + "\n" +
+                SafSyncEngine(context).identityLine("notes.txt", local)
+        )
+        deviceFolderHolding("notes.txt", "changed on the phone", modified = 0)
+
+        sync()
+
+        assertEquals(
+            "changed on the phone", local.readText(),
+            "the mirror is this app's own copy, so the folder must not freeze",
+        )
+        assertEquals(listOf("notes.txt"), openedDocuments)
+    }
+
     @Test
     fun `an edit made on the device reaches the mirror`() {
         val local = mirrorHolding("notes.txt", "stale copy", 1_700_000_000_000)

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafSyncEngineTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafSyncEngineTest.kt
@@ -155,7 +155,7 @@ class SafSyncEngineTest {
             assertTrue(
                 SafSyncEngine.shouldOverwriteMirror(
                     mirrorExists = false, mirrorModified = 0, mirrorSize = 0,
-                    sourceModified = 1_700_000_000_000, sourceSize = 4096
+                    sourceModified = 1_700_000_000_000, sourceSize = 4096, mirrorIsOurCopy = false
                 ),
                 "First sync must copy: there is nothing to lose"
             )
@@ -166,7 +166,7 @@ class SafSyncEngineTest {
             assertTrue(
                 SafSyncEngine.shouldOverwriteMirror(
                     mirrorExists = true, mirrorModified = 1_700_000_000_000, mirrorSize = 4096,
-                    sourceModified = 1_700_000_060_000, sourceSize = 4096
+                    sourceModified = 1_700_000_060_000, sourceSize = 4096, mirrorIsOurCopy = false
                 ),
                 "An edit made outside the app should reach the mirror"
             )
@@ -179,7 +179,7 @@ class SafSyncEngineTest {
             assertFalse(
                 SafSyncEngine.shouldOverwriteMirror(
                     mirrorExists = true, mirrorModified = 1_700_000_060_000, mirrorSize = 4096,
-                    sourceModified = 1_700_000_000_000, sourceSize = 4096
+                    sourceModified = 1_700_000_000_000, sourceSize = 4096, mirrorIsOurCopy = false
                 ),
                 "A newer local edit must survive reopening the folder"
             )
@@ -190,7 +190,7 @@ class SafSyncEngineTest {
             assertFalse(
                 SafSyncEngine.shouldOverwriteMirror(
                     mirrorExists = true, mirrorModified = 1_700_000_000_000, mirrorSize = 4096,
-                    sourceModified = 1_700_000_000_000, sourceSize = 4096
+                    sourceModified = 1_700_000_000_000, sourceSize = 4096, mirrorIsOurCopy = false
                 ),
                 "Same timestamp and same size means the copy is current"
             )
@@ -209,7 +209,7 @@ class SafSyncEngineTest {
             assertFalse(
                 SafSyncEngine.shouldOverwriteMirror(
                     mirrorExists = true, mirrorModified = 1_700_000_060_000, mirrorSize = 700_000,
-                    sourceModified = 1_700_000_000_000, sourceSize = 2_000_000
+                    sourceModified = 1_700_000_000_000, sourceSize = 2_000_000, mirrorIsOurCopy = false
                 ),
                 "A newer local edit must survive regardless of how its length changed"
             )
@@ -222,26 +222,41 @@ class SafSyncEngineTest {
             assertTrue(
                 SafSyncEngine.shouldOverwriteMirror(
                     mirrorExists = true, mirrorModified = 1_700_000_000_000, mirrorSize = 4096,
-                    sourceModified = 1_700_000_000_000, sourceSize = 8192
+                    sourceModified = 1_700_000_000_000, sourceSize = 8192, mirrorIsOurCopy = false
                 ),
                 "Equal timestamps with different lengths means the device copy changed"
             )
         }
 
+        /**
+         * COLUMN_LAST_MODIFIED is optional; MTP, some USB-OTG and network providers leave
+         * it null, which arrives as 0. With no clock to compare, the record decides.
+         *
+         * These two are one rule seen from both sides, and each is the other's control.
+         * Copying unconditionally, which is what this did before, replaced a local edit
+         * on every reopen. Keeping unconditionally would freeze the folder for ever,
+         * since nothing in the app can clear a mirror.
+         */
         @Test
-        fun `copies when the provider reports no timestamp`() {
-            // COLUMN_LAST_MODIFIED is optional; MTP, some USB-OTG and network
-            // providers leave it null, which arrives as 0. Treating unknown as
-            // "keep" would freeze those folders permanently, and nothing in the
-            // app can clear a mirror: clearSafMirrors and revokePermission have
-            // no callers. Copying is what the previous behaviour did, and it is
-            // the one that heals itself.
+        fun `an unknown timestamp refreshes a mirror the last sync wrote`() {
             assertTrue(
                 SafSyncEngine.shouldOverwriteMirror(
                     mirrorExists = true, mirrorModified = 1_700_000_000_000, mirrorSize = 4096,
-                    sourceModified = 0, sourceSize = 4096
+                    sourceModified = 0, sourceSize = 4096, mirrorIsOurCopy = true
                 ),
-                "An unknown source timestamp must not freeze the mirror"
+                "the mirror is this app's own copy, so the folder must not freeze"
+            )
+        }
+
+        @Test
+        fun `an unknown timestamp keeps a mirror that has changed since`() {
+            assertFalse(
+                SafSyncEngine.shouldOverwriteMirror(
+                    mirrorExists = true, mirrorModified = 1_700_000_000_000, mirrorSize = 4096,
+                    sourceModified = 0, sourceSize = 4096, mirrorIsOurCopy = false
+                ),
+                "the mirror no longer matches what was recorded for it, so it holds an " +
+                    "edit that was never written back and is the only copy"
             )
         }
 
@@ -250,7 +265,7 @@ class SafSyncEngineTest {
             assertTrue(
                 SafSyncEngine.shouldOverwriteMirror(
                     mirrorExists = false, mirrorModified = 0, mirrorSize = 0,
-                    sourceModified = 0, sourceSize = 4096
+                    sourceModified = 0, sourceSize = 4096, mirrorIsOurCopy = false
                 ),
                 "A missing mirror file must still be fetched even without timestamps"
             )
@@ -280,9 +295,10 @@ class SafSyncEngineTest {
                     mirrorModified = 1_700_000_000_000L,
                     mirrorSize = 1024,
                     sourceModified = doc.lastModified,
-                    sourceSize = doc.size
+                    sourceSize = doc.size, mirrorIsOurCopy = true
                 ),
-                "a document with no reported time must be copied, not treated as older"
+                "a document with no reported time must reach the unknown-time branch " +
+                    "rather than falling through to the clock comparison"
             )
         }
     }


### PR DESCRIPTION
`COLUMN_LAST_MODIFIED` is optional. MTP, some USB-OTG and some network providers omit it, and it arrives as `0`. `shouldOverwriteMirror` treated that as "copy", so reopening such a folder replaced whatever the editor had written since. Its own comment named the cost already: *the folder heals; the edit does not.*

## Why neither obvious answer works

- **Copy always** is what it did, and it destroys the edit on every reopen.
- **Keep always** protects the edit and freezes the folder for ever, since nothing in the app can clear a mirror. `clearSafMirrors` and `revokePermission` have no callers.

The suggested one-liner, `sourceModified == 0L -> mirrorSize != sourceSize`, is not a clean improvement either: it protects a same-length local edit but makes a same-length device change never arrive.

## What decides instead

The synced record, which already exists and is written every sync. If the mirror is still byte-identical to the line recorded for it, it is this app's own copy and the device is entitled to replace it, so the folder still heals. If it is not, something was written there since and that is the only copy.

`initialSync` reads the record once before phase 2 and hands the answer down. `reconcileDeletions` still reads the file again in phase 3, deliberately, because phase 2 may have changed what is on disk in between.

`mirrorIsOurCopy` has **no default**. There is one production caller and it has the record in hand; a default would let a future caller answer the question by not thinking about it. The compiler named all nine test call sites instead, which is the point of omitting it.

## Tests

Four, arranged so each direction is the other's control:

- the predicate **refreshes** a mirror the record vouches for, so the folder cannot freeze
- the predicate **keeps** a mirror that no longer matches, so the edit survives
- two wire tests through `initialSync`, proving it hands the predicate the answer rather than the predicate merely being capable of using one

Reverting the clause to `-> true` turns exactly the two "keeps" red and leaves the two "refreshes" green, which is the shape that says the change is scoped to the defect.

1201 unit tests across 188 suites, zero failures.

## Scope

This covers the no-timestamp case only. The separate finding that `initialSync` never uploads a mirror file newer than the device document is not in this diff.

## What it costs, found in review after the fact

Once a file on a timestamp-less provider answers `false` here it can **never answer `true` again**. It is not copied, so `copyDocumentToLocal` never records it, and the equal-timestamp branch cannot record it either because a real file's mtime is never 0. Device-side changes to that file stop arriving, and no size comparison rescues it: the clause returns before the size clause is reached.

Recording the kept file is not the way out. The record means "this is what we wrote from the device", and the reclaim gate reads it with that meaning. Recording a local edit there would have the reclaim delete the user's only copy, which is the defect that gate exists for.

So the trade stands: with no timestamp there is nothing to tell a device edit from a local one. The old answer assumed the device always won and destroyed the local edit on every reopen. This one assumes the local edit wins once the two diverge. **It loses updates where the other lost work**, and the divergence usually resolves itself in content anyway, because the watcher writes the local edit out on the next save.

The frozen case now logs at info, and a test pins it so it stays a decision rather than a surprise.
