### PR TITLE
fix(storage): retry a stranded edit, and say when one gives up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - On a device provider that reports no modification time, reopening a folder no longer replaces edits made in the editor. It refreshes only files still identical to what the last sync wrote.
+- Reopening a device folder now writes back an edit the watcher never carried out, instead of leaving it in the app forever.
+- A save that cannot reach the device folder now says so, once per burst, instead of failing silently and looking like a save that worked.
 - A device folder's local copy is no longer deleted when it falls off the recent list. Anything written there that never reached the device, a cloned repository included, was the only copy.
 
 ### Changed

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -378,6 +378,18 @@ class MainActivity : AppCompatActivity() {
         setContentView(R.layout.activity_main)
 
         safManager = SafStorageManager(this)
+        // A save that never reached the device folder looks exactly like one that did.
+        // The engine has no screen, so the notice is wired here; it is throttled inside
+        // the manager, because a provider that starts refusing refuses everything.
+        safManager.onWriteBackFailed { file ->
+            runOnUiThread {
+                Toast.makeText(
+                    this@MainActivity,
+                    getString(R.string.saf_write_back_failed, file.name),
+                    Toast.LENGTH_LONG,
+                ).show()
+            }
+        }
 
         setupWebView()
         setupExtraKeyRow()

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafStorageManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafStorageManager.kt
@@ -30,6 +30,31 @@ class SafStorageManager(private val context: Context) {
     private val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
     private val syncEngine = SafSyncEngine(context)
 
+    /**
+     * Told when a write-back has given up on a file, once per burst.
+     *
+     * Forwarded from the engine rather than set on it directly, so the caller does not
+     * have to know the engine exists. [MainActivity] is the one caller, because saying
+     * anything needs a screen.
+     *
+     * Throttled here rather than at the call site: a provider that has started refusing
+     * refuses everything, and the editor saves on a timer, so the unthrottled version is
+     * a wall of the same notice. Globally rather than per file, for the same reason. The
+     * user's problem is the folder.
+     */
+    fun onWriteBackFailed(announce: (File) -> Unit) {
+        syncEngine.onWriteBackFailed = { file ->
+            val now = System.currentTimeMillis()
+            if (shouldAnnounce(now, lastFailureAnnouncedAt)) {
+                lastFailureAnnouncedAt = now
+                announce(file)
+            }
+        }
+    }
+
+    @Volatile
+    private var lastFailureAnnouncedAt = 0L
+
     // -- Permission Management --
 
     /**
@@ -582,6 +607,20 @@ class SafStorageManager(private val context: Context) {
          * whatever it named is already unreachable.
          */
         internal const val DISCARD_PREFIX = "discarded-"
+
+        /** How long one write-back failure notice suppresses the next. */
+        internal const val FAILURE_NOTICE_INTERVAL_MS = 10_000L
+
+        /**
+         * Whether a failure at [now] is far enough from [lastAnnouncedAt] to be said.
+         *
+         * A function rather than an inline comparison so the rule can be asserted: the
+         * wiring around it reaches a Toast, which no JVM test here can see. The first
+         * failure of a session announces, because a zero last-announced time is further
+         * back than any interval.
+         */
+        internal fun shouldAnnounce(now: Long, lastAnnouncedAt: Long): Boolean =
+            now - lastAnnouncedAt >= FAILURE_NOTICE_INTERVAL_MS
     }
 }
 

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
@@ -153,6 +153,7 @@ class SafSyncEngine(private val context: Context) {
          * out, so an unforeseen one defaults to "never a candidate".
          */
         val recorded = mutableListOf<String>()
+        var uploadsDone = 0
 
         Logger.i(tag, "Enumerated ${documents.size} items ($totalFiles files)")
 
@@ -235,12 +236,30 @@ class SafSyncEngine(private val context: Context) {
                     )
                 ) {
                     keptLocal++
-                    // Inside this branch the provider reported a time (an unknown one
-                    // copies) and the mirror is not older, so equal means the mirror is
-                    // already this document and can be vouched for, while strictly newer
-                    // means it holds an edit that has not been written back and cannot.
+                    // Inside this branch the mirror is not older, so equal means the
+                    // mirror is already this document and can be vouched for, while
+                    // strictly newer means it holds an edit that has not been written
+                    // back and cannot.
                     if (localPath.lastModified() == doc.lastModified) {
                         recordIdentity(recorded, doc.relativePath, localPath)
+                    } else if (doc.lastModified > 0L &&
+                        localPath.lastModified() > doc.lastModified
+                    ) {
+                        // Strictly newer with a time to compare against: an edit the
+                        // watcher never carried out. That happens whenever the watcher
+                        // was not running -- the app was killed, the directory sat past
+                        // the watch cap, or the write-back gave up -- and until now
+                        // nothing ever retried it. The prose around this feature calls
+                        // reopening the folder the way back; this is what makes that
+                        // true.
+                        //
+                        // Only when the provider reported a time. An unknown one arrives
+                        // as 0, and every real mirror timestamp is greater than 0, so
+                        // without this guard every file in such a folder would look
+                        // newer and be pushed over the device document on every reopen.
+                        uploadsDone++
+                        Logger.i(tag, "Writing back a newer mirror copy: ${doc.relativePath}")
+                        writeLocalToSaf(localPath, doc.uri)
                     }
                     unfetched.remove(localPath.absolutePath)
                     if (doc.lastModified == 0L) {
@@ -283,7 +302,8 @@ class SafSyncEngine(private val context: Context) {
             tag,
             "Initial sync complete: $filesDone files ($skippedLarge too large, " +
                 "$failedCopies could not be copied, $keptLocal kept, " +
-                "${recorded.size} vouched for, $removed removed) in ${elapsed}ms"
+                "$uploadsDone written back, ${recorded.size} vouched for, " +
+                "$removed removed) in ${elapsed}ms"
         )
     }
 
@@ -840,6 +860,7 @@ class SafSyncEngine(private val context: Context) {
                 attempts++
             } catch (e: SecurityException) {
                 Logger.e(tag, "Permission revoked while writing back: ${localFile.name}")
+                onWriteBackFailed(localFile)
                 return
             } catch (e: Exception) {
                 attempts++
@@ -850,10 +871,29 @@ class SafSyncEngine(private val context: Context) {
                     "Write-back of ${localFile.name} did not finish; its device copy " +
                         "is recorded as not to be trusted"
                 )
+                onWriteBackFailed(localFile)
                 return
             }
         }
     }
+
+    /**
+     * Told when a write-back has given up on [File]. Does nothing until something wires
+     * it up, and [MainActivity] is what does.
+     *
+     * The default is a no-op rather than a Toast, and that is not squeamishness about
+     * layers. A default that touched `Looper.getMainLooper()` threw "not mocked" in every
+     * existing JVM test that drives a failing write-back, which is a fair warning: this
+     * class has no screen and should not reach for one. The layer that owns a screen
+     * decides how to say it.
+     *
+     * Both exits leave the file's journal entry in place, so the data is already safe:
+     * the reclaim pass reads that journal and refuses to delete the mirror. What was
+     * missing is the user knowing, and the two are not the same fact. A save that never
+     * reached the device folder looks exactly like one that did, and the difference only
+     * shows when the app is uninstalled and the work is gone.
+     */
+    internal var onWriteBackFailed: (File) -> Unit = {}
 
     private fun uploadJournal(): File = File(context.filesDir, UPLOADS_IN_FLIGHT_FILE)
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -112,4 +112,8 @@
     <string name="shortcut_toolchains_short">Toolchains</string>
     <string name="shortcut_toolchains_long">Manage toolchains</string>
     <string name="toolchain_size_download_and_installed">%1$s download, %2$s installed</string>
+    <!-- Shown when a save could not be written out to the device folder. Names the
+         consequence rather than the error: the user's next decision is whether to
+         copy the file out before uninstalling, not which exception was thrown. -->
+    <string name="saf_write_back_failed">%1$s did not reach the device folder. The only copy is inside VSCodroid.</string>
 </resources>

--- a/android/app/src/test/kotlin/com/vscodroid/storage/InitialSyncWiringTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/InitialSyncWiringTest.kt
@@ -61,6 +61,7 @@ class InitialSyncWiringTest {
     private lateinit var resolver: ContentResolver
     private lateinit var context: Context
     private var openedDocuments = mutableListOf<String>()
+    private var writtenDocuments = mutableListOf<String>()
 
     /** One file in the device folder, described to the engine through a fake cursor. */
     private fun deviceFolderHolding(name: String, contents: String, modified: Long) {
@@ -88,6 +89,10 @@ class InitialSyncWiringTest {
             openedDocuments.add(name)
             ByteArrayInputStream(contents.toByteArray())
         }
+        every { resolver.openOutputStream(any(), "wt") } answers {
+            writtenDocuments.add(name)
+            java.io.ByteArrayOutputStream()
+        }
     }
 
     private fun mirrorHolding(name: String, contents: String, modified: Long): File =
@@ -103,6 +108,7 @@ class InitialSyncWiringTest {
     @BeforeEach
     fun setUp() {
         openedDocuments = mutableListOf()
+        writtenDocuments = mutableListOf()
 
         mockkStatic(android.util.Log::class)
         every { android.util.Log.i(any(), any()) } returns 0
@@ -203,6 +209,73 @@ class InitialSyncWiringTest {
             emptyList<String>(), openedDocuments,
             "and the device copy is never read again, even though its length differs: " +
                 "this is the permanent cost of having no clock to compare",
+        )
+    }
+
+    /**
+     * And not when the provider reports no time. That arrives as 0, and every real
+     * mirror timestamp is greater than 0, so without the guard every file in such a
+     * folder looks newer and is pushed over the device document on every reopen.
+     */
+    @Test
+    fun `a mirror is not written back when the provider reports no time`() {
+        mirrorHolding("notes.txt", "edited in the editor!", 1_700_000_060_000)
+        deviceFolderHolding("notes.txt", "from the device", modified = 0)
+
+        sync()
+
+        assertEquals(emptyList<String>(), writtenDocuments)
+    }
+
+    /**
+     * Reopening the folder is the way back for an edit the watcher never carried out.
+     *
+     * The mirror being strictly newer means exactly that: the app was killed, the
+     * directory sat past the watch cap, or the write-back gave up. Before this the
+     * branch counted the file as "kept" and moved on, so the edit stayed in the mirror
+     * for ever and the prose calling reopening a recovery path was not true.
+     */
+    @Test
+    fun `a mirror newer than the device document is written back on reopen`() {
+        mirrorHolding("notes.txt", "edited in the editor!", 1_700_000_060_000)
+        deviceFolderHolding("notes.txt", "from the device", 1_700_000_000_000)
+
+        sync()
+
+        assertEquals(
+            listOf("notes.txt"), writtenDocuments,
+            "the newer mirror copy was never offered to the device",
+        )
+    }
+
+    /**
+     * A write-back that gives up says so.
+     *
+     * Both exits already leave the file's journal entry in place, so the data is safe:
+     * the reclaim pass reads that journal and refuses to delete the mirror. What was
+     * missing is the user knowing, and those are not the same fact. A save that never
+     * reached the device folder looks exactly like one that did, and the difference only
+     * shows when the app is uninstalled and the work is gone.
+     *
+     * Driven through the seam rather than the Toast: Toast needs a looper no unit test
+     * here has, and what is being asserted is that the exit announces at all.
+     */
+    @Test
+    fun `a write-back that gives up announces the file`() {
+        mirrorHolding("notes.txt", "edited in the editor!", 1_700_000_060_000)
+        deviceFolderHolding("notes.txt", "from the device", 1_700_000_000_000)
+        every { resolver.openOutputStream(any(), "wt") } throws SecurityException("revoked")
+
+        val announced = mutableListOf<String>()
+        runBlocking {
+            SafSyncEngine(context)
+                .apply { onWriteBackFailed = { announced.add(it.name) } }
+                .initialSync(mockk<Uri>(relaxed = true), mirror) { _, _ -> }
+        }
+
+        assertEquals(
+            listOf("notes.txt"), announced,
+            "the write-back gave up and told nobody",
         )
     }
 

--- a/android/app/src/test/kotlin/com/vscodroid/storage/WriteBackNoticeWiringTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/WriteBackNoticeWiringTest.kt
@@ -1,0 +1,75 @@
+package com.vscodroid.storage
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * A write-back that gives up has to reach a screen, and nothing in the sync engine has
+ * one.
+ *
+ * Two halves, and the failure this pins is the first one going missing quietly. The
+ * engine's seam defaults to a no-op, deliberately: a default that reached for
+ * `Looper.getMainLooper()` threw "not mocked" in every existing test that drives a
+ * failing write-back. That makes the wiring load-bearing rather than decorative, and an
+ * unwired seam is indistinguishable from the silence this was meant to end.
+ */
+class WriteBackNoticeWiringTest {
+
+    private val activity = File("../../android/app/src/main/kotlin/com/vscodroid/MainActivity.kt")
+
+    /**
+     * Read from the source rather than driven through the Activity, which needs a device.
+     *
+     * ⚠️ Its ceiling, measured rather than assumed: wrapping the call in `if (false)`
+     * leaves this green. It catches the wiring being deleted, which is the likely
+     * regression, and cannot catch it being made unreachable. The behaviour either side
+     * of it is covered where it can be: the engine announcing is pinned by
+     * InitialSyncWiringTest, and the throttle by the case below.
+     */
+    @Test
+    fun `MainActivity asks to be told when a write-back gives up`() {
+        assertTrue(activity.isFile, "MainActivity.kt is not where this test expects it")
+        val source = activity.readText()
+
+        assertTrue(
+            Regex("""safManager\.onWriteBackFailed\s*\{""").containsMatchIn(source),
+            "nothing wires the write-back notice, so a save that never reached the " +
+                "device folder is silent again",
+        )
+        assertTrue(
+            Regex("""saf_write_back_failed""").containsMatchIn(source),
+            "the notice does not name the string that tells the user what happened",
+        )
+    }
+
+    /**
+     * The throttle belongs to the manager, so one refusing provider is one notice.
+     *
+     * Asserted as a rule rather than as a constant: the number is a product decision and
+     * may move, but "the first failure speaks and the next one inside the interval does
+     * not" is the behaviour.
+     */
+    @Test
+    fun `the first failure is announced and a prompt second one is not`() {
+        val interval = SafStorageManager.FAILURE_NOTICE_INTERVAL_MS
+        // A wall-clock value, because that is what the caller passes. Toy numbers put
+        // the first failure inside the interval of a zero last-announced time and made
+        // this assert the opposite of the shipped behaviour.
+        val now = 1_700_000_000_000L
+
+        assertTrue(
+            SafStorageManager.shouldAnnounce(now = now, lastAnnouncedAt = 0),
+            "the first failure of a session has to be said",
+        )
+        assertFalse(
+            SafStorageManager.shouldAnnounce(now = now + interval - 1, lastAnnouncedAt = now),
+            "a provider that refuses everything would otherwise bury the editor",
+        )
+        assertTrue(
+            SafStorageManager.shouldAnnounce(now = now + interval, lastAnnouncedAt = now),
+            "the notice has to come back, or a later failure is silent again",
+        )
+    }
+}


### PR DESCRIPTION
Two halves of the same silence.

## Reopening a folder is now the recovery path the prose claims

`initialSync`'s kept-local branch already knew the mirror held an edit that had not been written back: it declines to vouch for the file for exactly that reason. It then counted the file as "kept" and moved on, so the edit stayed in the mirror for ever.

Reopening now writes such a file out, but only when the provider reported a time. An unknown one arrives as `0` and every real mirror timestamp beats it, so without that guard every file in such a folder would be pushed over the device document on every reopen.

The sync summary counts the uploads, so a folder that has been quietly stranded says how much it just moved.

## A write-back that gives up now says so

`writeLocalToSaf` gives up in two places, on a `SecurityException` and after two failed attempts, and both only logged.

The data was already safe: both leave the file's journal entry in place, and the reclaim pass refuses to delete a mirror holding one. What was missing is the user knowing, and those are not the same fact. A save that never reached the device folder looks exactly like one that did, and the difference only shows when the app is uninstalled and the work is gone.

## Where the notice lives, and why not in the engine

The seam defaults to a no-op and `MainActivity` wires it. That is not layering for its own sake: a default that reached for `Looper.getMainLooper()` threw `not mocked` in every existing JVM test that drives a failing write-back. The engine has no screen and should not reach for one.

The throttle sits in `SafStorageManager`, globally rather than per file, because a provider that starts refusing refuses everything and the editor saves on a timer. The user's problem is the folder, not the filename.

## Tests

Each change is checked against the code it guards. Disabling the upload path and both announcements turns exactly those tests red and no others.

- a mirror newer than the device document is written back on reopen
- a mirror is **not** written back when the provider reports no time, which is the guard's own control
- a write-back that gives up announces the file, driven through the seam because `Toast` needs a looper no unit test here has
- the throttle: the first failure speaks, a prompt second does not, and a later one does again

One weakness is recorded rather than hidden. The wiring test reads `MainActivity.kt` as source, and **wrapping the call in `if (false)` leaves it green** — measured, not assumed. It catches the wiring being deleted, which is the likely regression, and cannot catch it being made unreachable. Its docstring says so, and the behaviour either side of it is covered where it can be.

189 suites, 1203 tests, zero failures.