### PR TITLE
perf(storage): do not walk a mirror the pass already exempts

### DIFF
--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafStorageManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafStorageManager.kt
@@ -278,10 +278,15 @@ class SafStorageManager(private val context: Context) {
             // ran; and a mirror copy the initial sync kept for being newer than the
             // device document. Asking the record instead inverts the test: prove the
             // mirror is disposable rather than look for evidence that it is not.
-            val holdsOnlyCopies = vouched.getOrPut(hash) {
-                syncEngine.holdsOnlyVouchedCopies(File(root, hash))
-            }
-            if (!alreadySetAside && !holdsOnlyCopies) {
+            // `&&` first, so the walk never runs for an entry the next line exempts.
+            // A `discarded-` entry is an earlier pass's leftover whose verdict is already
+            // made, and asking anyway walked the whole tree that is about to be deleted,
+            // on every launch until the delete finally succeeded.
+            if (!alreadySetAside &&
+                !vouched.getOrPut(hash) {
+                    syncEngine.holdsOnlyVouchedCopies(File(root, hash))
+                }
+            ) {
                 Logger.w(
                     tag,
                     "Keeping $name: it holds files no sync ever vouched for",


### PR DESCRIPTION
Found while reviewing #279 against its own call graph after it merged.

The reclaim gate computed its verdict **before** testing whether the entry was one it exempts:

```kotlin
val holdsOnlyCopies = vouched.getOrPut(hash) { ... }   // always
if (!alreadySetAside && !holdsOnlyCopies) { ... }      // then exempts
```

A `discarded-` entry is an earlier pass's leftover whose decision is already made. The walk therefore ran over a tree that was about to be deleted, on every launch until the delete finally succeeded, and stored a verdict under a key nothing would read again.

Behaviour is unchanged. `alreadySetAside` short-circuited the condition either way, so the verdict was computed and then ignored.

**No test is added, deliberately.** Nothing can tell the two versions apart without asserting on the implementation, and `an entry left behind by an interrupted pass is finished off` already covers what the pass does. A test here would be shape, not behaviour.

1198 unit tests, zero failures; lint unchanged at 53 warnings and 17 baselined.