### PR TITLE
docs(storage): point the timestamp-less limitation at its issue

### DIFF
--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
@@ -1831,6 +1831,12 @@ class SafSyncEngine(private val context: Context) {
             // loses updates; the other lost work. Note the divergence usually resolves
             // itself in content if not in bookkeeping: the watcher writes the local edit
             // out on the next save, after which both sides hold the same bytes.
+            //
+            // Tracked as #286. A real fix has to tell a device change from a local one
+            // without a clock, which means comparing content rather than metadata: a
+            // per-file digest beside the mtime and size [identityLine] already writes.
+            // That puts a hash over every mirrored file into each sync, so it wants
+            // measuring before it is taken.
             sourceModified == 0L -> mirrorIsOurCopy
             sourceModified > mirrorModified -> true
             // A newer local copy wins, whatever its size. Checking size before this

--- a/android/app/src/test/kotlin/com/vscodroid/storage/InitialSyncWiringTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/InitialSyncWiringTest.kt
@@ -192,6 +192,9 @@ class InitialSyncWiringTest {
      *
      * Kept because the alternative is what shipped: with nothing to compare, the old
      * answer assumed the device always won and destroyed the local edit on every reopen.
+     *
+     * This test locks the limitation rather than the fix. When #286 lands it should go
+     * red, and the case that replaces it asserts the device change arriving.
      */
     @Test
     fun `a diverged file on a timestamp-less provider stops receiving device changes`() {


### PR DESCRIPTION
The comment at `SafSyncEngine.kt:1820` explains why a diverged file on a provider that reports no modification time stops receiving device-side changes, and why the obvious fix would reintroduce a worse defect. What it does not say is where to follow the question.

A reader reasonably concludes the limitation is untracked, and then either re-derives the whole argument or takes the fix the comment warns against.

Both the comment and the test that locks the behaviour now name #286. The test also says plainly that it pins the limitation rather than the fix, so it is expected to go red when a real fix lands rather than to be quietly deleted alongside it.

Comment only. 1208 unit tests, zero failures.