### PR TITLE
chore: remove what nothing calls, and correct what moved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The storage figures in the README can be re-measured on Linux. The command printed a plausible 0 MB there, because it used the macOS spelling of `stat`.
 - Creating a folder no longer overwrites a device document the app could not read, such as one too large to copy. Only the single-file path checked this before.
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -249,8 +249,11 @@ extracted size suggests is what leaves setup failing partway.
 These move with every VS Code bump. Re-measure rather than trusting them:
 
 ```bash
-# what the app will extract, and therefore what the storage gate demands
-find android/app/src/main/assets -type f -exec stat -f %z {} + | awk '{s+=$1} END {printf "%.0f MB assets, gate demands %.0f MB\n", s/1048576, s/1048576+64}'
+# what the app will extract, and therefore what the storage gate demands.
+# python3 rather than stat: `stat -f` is the BSD spelling and `stat -c` the GNU one,
+# and the version that shipped here failed on Linux by printing a plausible 0 MB.
+# This also sums the way the gate itself does, in app/build.gradle.kts.
+python3 -c "import os; t=sum(os.path.getsize(os.path.join(r,f)) for r,_,fs in os.walk('android/app/src/main/assets') for f in fs); print(f'{t/1048576:.0f} MB assets, gate demands {t/1048576+64:.0f} MB')"
 ```
 
 ## 🤝 Contributing

--- a/android/app/src/androidTest/kotlin/com/vscodroid/SplashActivityTest.kt
+++ b/android/app/src/androidTest/kotlin/com/vscodroid/SplashActivityTest.kt
@@ -103,12 +103,14 @@ class SplashActivityTest {
             serverJs.exists(),
         )
         val before = serverJs.lastModified()
+        val versionBefore = getSetupPrefs().getString("setup_version", null)
 
         val scenario = ActivityScenario.launch(SplashActivity::class.java)
         Thread.sleep(3000)  // give it time to transition
 
         val version = getSetupPrefs().getString("setup_version", null)
         assertNotNull("setup_version should still be set after skip", version)
+        assertEquals("setup_version changed across a launch that skipped setup", versionBefore, version)
         assertEquals(
             "server.js was rewritten, so extraction ran instead of being skipped",
             before,
@@ -117,19 +119,4 @@ class SplashActivityTest {
         scenario.close()
     }
 
-    @Test
-    fun subsequentLaunch_preservesVersion() {
-        ServerReadyHelper.markSetupComplete(context)
-        val versionBefore = getSetupPrefs().getString("setup_version", null)
-
-        val scenario = ActivityScenario.launch(SplashActivity::class.java)
-        Thread.sleep(3000)
-
-        val versionAfter = getSetupPrefs().getString("setup_version", null)
-        assertTrue(
-            "setup_version should be preserved: before=$versionBefore, after=$versionAfter",
-            versionAfter != null && versionAfter == versionBefore
-        )
-        scenario.close()
-    }
 }

--- a/android/app/src/main/assets/server.js
+++ b/android/app/src/main/assets/server.js
@@ -20,7 +20,6 @@ const HOST = args.host || '127.0.0.1';
 const PORT = parseInt(args.port) || 13337;
 const LOG_LEVEL = args.log || 'info';
 
-const HOME_DIR = process.env.HOME || '/data/data/com.vscodroid/files/home';
 const SERVER_DIR = path.dirname(__filename);
 const REH_DIR = path.join(SERVER_DIR, 'vscode-reh');
 

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -1641,10 +1641,13 @@ class MainActivity : AppCompatActivity() {
                 window.open = function(url) {
                     if (url && /^https?:/.test(url) && typeof AndroidBridge !== 'undefined') {
                         var t = (window.__vscodroid || {}).authToken;
-                        // Only claim the click if the bridge actually opened it. This
-                        // is a development tool: a link the user clicked opens, and
-                        // that includes a LAN dev server, a private registry or a
-                        // staging host the bridge's allow-list does not cover.
+                        // Only claim the click if the bridge actually opened it.
+                        // `openExternalUrl` answers false when the launch itself fails,
+                        // not when it disapproves of the destination: SecurityManager
+                        // has no URL allow-list and says so at the point one used to
+                        // stand. Reading this as a destination filter is the mistake to
+                        // avoid, because it invites re-deriving the fall-through around
+                        // a constraint that is gone.
                         // Swallowing the false here meant the click did nothing and
                         // said nothing; falling through lets the WebView navigation
                         // path open it, which is where opening anything already lives.

--- a/android/app/src/main/kotlin/com/vscodroid/keyboard/KeyInjector.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/keyboard/KeyInjector.kt
@@ -57,24 +57,6 @@ class KeyInjector(private val webView: WebView) {
         Logger.d(tag, "Injected key=$key ctrl=$ctrlKey alt=$altKey shift=$shiftKey")
     }
 
-    fun injectText(text: String) {
-        val escaped = text.replace("\\", "\\\\").replace("'", "\\'").replace("\n", "\\n")
-        val js = """
-            (function() {
-                var target = document.activeElement || document.body;
-                var event = new InputEvent('beforeinput', {
-                    data: '${escaped}',
-                    inputType: 'insertText',
-                    bubbles: true,
-                    cancelable: true,
-                    composed: true
-                });
-                target.dispatchEvent(event);
-            })();
-        """.trimIndent()
-        webView.evaluateJavascript(js, null)
-    }
-
     /**
      * Installs a JS `beforeinput` listener that intercepts soft keyboard text input
      * when ExtraKeyRow modifiers (Ctrl/Alt) are active. Instead of inserting text,

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
@@ -257,33 +257,6 @@ class ToolchainManager(private val context: Context) {
         return result.filter { it.isNotEmpty() }
     }
 
-    fun isInstalled(name: String): Boolean =
-        getInstalledToolchains().contains(name)
-
-    fun getToolchainEnv(name: String): Map<String, String> {
-        val state = readState()
-        for (i in 0 until state.length()) {
-            val obj = state.optJSONObject(i) ?: continue
-            if (obj.optString("name") == name) {
-                val env = obj.optJSONObject("env") ?: return emptyMap()
-                return env.keys().asSequence().associateWith { env.getString(it) }
-            }
-        }
-        return emptyMap()
-    }
-
-    fun getToolchainPathDirs(name: String): List<String> {
-        val state = readState()
-        for (i in 0 until state.length()) {
-            val obj = state.optJSONObject(i) ?: continue
-            if (obj.optString("name") == name) {
-                val arr = obj.optJSONArray("pathDirs") ?: return emptyList()
-                return (0 until arr.length()).map { arr.getString(it) }
-            }
-        }
-        return emptyList()
-    }
-
     // -- Install --
 
     fun install(packName: String) {

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafStorageManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafStorageManager.kt
@@ -85,23 +85,6 @@ class SafStorageManager(private val context: Context) {
         }
     }
 
-    /**
-     * Releases a persisted URI permission and removes the folder from recent list.
-     * Also cleans up the corresponding local mirror directory.
-     */
-    fun revokePermission(uri: Uri) {
-        try {
-            val flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or
-                    Intent.FLAG_GRANT_WRITE_URI_PERMISSION
-            context.contentResolver.releasePersistableUriPermission(uri, flags)
-        } catch (e: SecurityException) {
-            Logger.d(tag, "Permission already revoked for: $uri")
-        }
-        removeFromRecentFolders(uri)
-        cleanupMirror(uri)
-        Logger.i(tag, "Revoked permission and cleaned up: $uri")
-    }
-
     // -- Recent Folders --
 
     /**
@@ -113,7 +96,7 @@ class SafStorageManager(private val context: Context) {
      * the workbench calls whenever it wants the recent list — and made a permission that
      * read as absent for a moment enough to take the mirror of the folder currently open
      * in the editor out from under it. That reclamation lives in [reclaimRevokedMirrors]
-     * and in [revokePermission] now.
+     * alone now.
      */
     /**
      * The device folder whose mirror the workbench has opened, if it opened one.

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
@@ -28,12 +28,13 @@ import kotlin.concurrent.thread
  * the mirror and never reach the device.
  *
  * ## Conflict Resolution
- * Local changes win when both sides changed: the mirror is replaced only when the
- * source is newer, carries no timestamp, or matches in time while differing in size.
+ * Local changes win when both sides changed: the mirror is replaced when it is absent,
+ * when the source is newer, or when the two match in time and differ in size. A source
+ * carrying no timestamp is decided by the synced record instead, because there is no
+ * clock to compare; see [shouldOverwriteMirror] for what that costs.
  * External changes are picked up the next time the folder is opened, which is
- * the only refresh that exists — there is no "Refresh from device" action, and
- * nothing calls [com.vscodroid.util.StorageManager.clearSafMirrors] either, so a
- * mirror cannot be cleared from inside the app. Reopening also removes mirror files
+ * the only refresh that exists: there is no "Refresh from device" action, and nothing
+ * clears a mirror from inside the app either. Reopening also removes mirror files
  * for documents deleted on the device, under the conditions [reconcileDeletions]
  * spells out.
  */

--- a/android/app/src/main/kotlin/com/vscodroid/util/StorageManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/util/StorageManager.kt
@@ -49,25 +49,6 @@ object StorageManager {
     }
 
     /**
-     * Returns a human-readable storage summary string.
-     */
-    fun getStorageSummary(context: Context): String {
-        val breakdown = getStorageBreakdown(context)
-        val sb = StringBuilder()
-        sb.appendLine("Storage Usage:")
-        sb.appendLine("  VS Code Server: ${formatSize(breakdown.getLong("vscode_server"))}")
-        sb.appendLine("  Extensions:     ${formatSize(breakdown.getLong("extensions"))}")
-        sb.appendLine("  User Data:      ${formatSize(breakdown.getLong("user_data"))}")
-        sb.appendLine("  Logs:           ${formatSize(breakdown.getLong("logs"))}")
-        sb.appendLine("  Tools:          ${formatSize(breakdown.getLong("tools"))}")
-        sb.appendLine("  SAF Mirrors:    ${formatSize(breakdown.getLong("saf_mirrors"))}")
-        sb.appendLine("  Cache:          ${formatSize(breakdown.getLong("cache"))}")
-        sb.appendLine("  ─────────────────────")
-        sb.appendLine("  Total:          ${formatSize(breakdown.getLong("total"))}")
-        return sb.toString()
-    }
-
-    /**
      * Clears caches: npm-cache, tmp dir, crash logs, VS Code logs.
      * Returns the number of bytes freed.
      */
@@ -105,18 +86,6 @@ object StorageManager {
         vscodeLogs.mkdirs() // recreate
 
         Logger.i(TAG, "Caches cleared: ${formatSize(freed)} freed")
-        return freed
-    }
-
-    /**
-     * Clears SAF mirror directories (synced copies of external folders).
-     * Users should close any SAF folder first.
-     */
-    fun clearSafMirrors(context: Context): Long {
-        val mirrorsDir = File(context.filesDir, "saf-mirrors")
-        val freed = deleteRecursive(mirrorsDir)
-        mirrorsDir.mkdirs()
-        Logger.i(TAG, "SAF mirrors cleared: ${formatSize(freed)} freed")
         return freed
     }
 

--- a/scripts/build-vscode-oss.sh
+++ b/scripts/build-vscode-oss.sh
@@ -56,7 +56,7 @@ VSCODE_VERSION="${VSCODE_VERSION:?pass it in from the repo VSCODE_VERSION file}"
 # the link from the source to it, which ran through that name.
 #
 # What the pin asserts is stronger than "this is where the tag pointed". All
-# twelve patches in patches/ were applied to this commit, in order, and applied
+# the patches in patches/ were applied to this commit, in order, and applied
 # cleanly. So the bar for changing this file is not that the new tag resolved --
 # it is that the patches still apply to what it resolved to.
 VSCODE_COMMIT="${VSCODE_COMMIT:?pass it in from the repo VSCODE_COMMIT file}"


### PR DESCRIPTION
## Dead code

Six functions had no caller anywhere in the app or its tests, verified by reference count with a positive control rather than by eye:

| Function | Note |
|---|---|
| `KeyInjector.injectText` | also carried an escaper handling `\`, `'` and `\n` but **not** `\r`, which would have failed silently through `evaluateJavascript` had anything wired it up |
| `ToolchainManager.isInstalled` | |
| `ToolchainManager.getToolchainPathDirs` | |
| `SafStorageManager.revokePermission` | already described as dead in a comment beside it |
| `StorageManager.getStorageSummary` | |
| `StorageManager.clearSafMirrors` | already described as dead in a comment beside it |

Two KDoc links pointed at removed functions and are rewritten rather than left dangling. Both were explaining that nothing clears a mirror from inside the app, which stays true and no longer needs a function to prove it.

**Alternative considered:** `revokePermission` and `clearSafMirrors` are the half of an escape hatch that several comments wish existed. Wiring them up is a feature rather than cleanup, so they are removed; if that capability is wanted, say so and it can be built deliberately.

## Corrections

- The `SafSyncEngine` class comment still said the mirror is replaced when the source "carries no timestamp". That stopped being true when the record started deciding that case. Corrected, and pointed at where the cost is written down.
- `assets/server.js` declared `HOME_DIR` and never read it.
- `build-vscode-oss.sh` said "twelve patches" against thirteen. The number is dropped rather than corrected, since it goes stale on the next patch.
- A comment in `injectWindowOpenOverride` explained the fall-through by reference to a bridge allow-list that `SecurityManager` removed and explicitly says it will not have. Reading `openExternalUrl`'s `false` as a destination filter is exactly the mistake that comment invited.

## README

The re-measure command used `stat -f`, the BSD spelling. On GNU coreutils it fails and `awk` receives nothing, so it printed **"0 MB assets, gate demands 64 MB"** and read as a measurement rather than a broken command.

It now uses `python3`, which the build already requires and which sums the way the gate in `build.gradle.kts` does. Run here it prints `810 MB assets, gate demands 874 MB`, matching the table it exists to check.

## Instrumented test

`subsequentLaunch_preservesVersion` asserted that `setup_version` was unchanged, which cannot detect a re-run: setup writes the same `versionName` either way. `subsequentLaunch_skipsExtraction` detects one properly, through `server.js`'s mtime, and now also carries the equality assertion, so the weaker case is removed without losing anything.

## Verification

1208 unit tests across 189 suites, zero failures. `assembleDebugAndroidTest` compiles. Lint unchanged at 53 warnings and 17 baselined. Six repo self-check gates pass.