### PR TITLE
fix(setup): show extraction moving, and check space on the Play path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- First-run setup now shows progress while it extracts the editor, instead of holding at 5% for minutes and looking like it has hung.
+- Installing a toolchain from Play now checks for space first. Without room it failed partway and left a half-installed toolchain behind.
 - The storage figures in the README can be re-measured on Linux. The command printed a plausible 0 MB there, because it used the macOS spelling of `stat`.
 - Creating a folder no longer overwrites a device document the app could not read, such as one too large to copy. Only the single-file path checked this before.
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -159,6 +159,15 @@ android {
             "BUNDLED_USR_BYTES",
             "${fileTree("src/main/assets/usr").files.sumOf { it.length() }}L"
         )
+        // The server tree on its own, so extraction can report real progress across it
+        // rather than sitting at one number for the minutes it takes. It is by far the
+        // largest single step, and computed the same way as its siblings so it cannot
+        // drift from what is actually packaged.
+        buildConfigField(
+            "long",
+            "BUNDLED_SERVER_BYTES",
+            "${fileTree("src/main/assets/vscode-reh").files.sumOf { it.length() }}L"
+        )
         buildConfigField(
             "long",
             "BUNDLED_EXTENSION_BYTES",

--- a/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
@@ -223,8 +223,33 @@ class FirstRunSetup(
 
             // The reh-web download carries the web client inside this same tree,
             // so this one extraction is both the server and the workbench.
-            reportProgress("Extracting server files...", 5)
-            if (!extractAssetDir("vscode-reh", "server/vscode-reh")) incomplete += "vscode-reh"
+            reportProgress("Extracting server files...", SERVER_PROGRESS_START)
+            // The one step long enough for a still bar to read as a hang: the server
+            // tree is the bulk of the assets and takes minutes on a mid-range phone.
+            // A force-quit at that point produces exactly the partial tree the retry
+            // below exists to clean up, so the bar moving is not decoration.
+            //
+            // Driven by bytes against the figure the build computed from the very tree
+            // being packaged, so it cannot drift, and reported only when the whole
+            // percent changes: 55 updates rather than one per file across 16,891 of
+            // them. Capped, because a tree fetched after the APK was built would
+            // otherwise run the bar past the step.
+            var serverBytes = 0L
+            var serverPercent = SERVER_PROGRESS_START
+            val extracted = extractAssetDir("vscode-reh", "server/vscode-reh") { bytes ->
+                serverBytes += bytes
+                if (BuildConfig.BUNDLED_SERVER_BYTES > 0) {
+                    val span = SERVER_PROGRESS_END - SERVER_PROGRESS_START
+                    val next = SERVER_PROGRESS_START +
+                        (serverBytes * span / BuildConfig.BUNDLED_SERVER_BYTES).toInt()
+                            .coerceAtMost(span)
+                    if (next > serverPercent) {
+                        serverPercent = next
+                        reportProgress("Extracting server files...", next)
+                    }
+                }
+            }
+            if (!extracted) incomplete += "vscode-reh"
 
             reportProgress("Extracting server bootstrap...", 60)
             for (script in listOf("server.js", "process-monitor.js", "platform-fix.js", "dns-proxy.js")) {
@@ -379,29 +404,42 @@ class FirstRunSetup(
      * Nothing on device verifies those trees are complete;
      * `verify-server-tree.py` checks the build, not the install.
      */
-    private fun extractAssetDir(assetPath: String, destPath: String): Boolean {
+    /**
+     * @param onBytes told how many bytes each extracted file wrote, so a caller can
+     *   report progress across a step that would otherwise show none. Null for the
+     *   short steps, where the cost of reporting outweighs what it shows.
+     */
+    private fun extractAssetDir(
+        assetPath: String,
+        destPath: String,
+        onBytes: ((Long) -> Unit)? = null,
+    ): Boolean {
         val destDir = File(context.filesDir, destPath)
         return try {
             val assets = context.assets.list(assetPath) ?: return true
             if (assets.isEmpty()) {
-                return extractAssetFile(assetPath, destPath)
+                return extractAssetFile(assetPath, destPath, onBytes)
             }
             destDir.mkdirs()
             // Every child is attempted even after one fails, so the log names
             // all of them rather than only the first.
             var ok = true
             for (asset in assets) {
-                if (!extractAssetDir("$assetPath/$asset", "$destPath/$asset")) ok = false
+                if (!extractAssetDir("$assetPath/$asset", "$destPath/$asset", onBytes)) ok = false
             }
             ok
         } catch (e: IOException) {
             Logger.d(tag, "Treating $assetPath as file (not directory)")
-            extractAssetFile(assetPath, destPath)
+            extractAssetFile(assetPath, destPath, onBytes)
         }
     }
 
     /** @return false only when the asset existed and its copy failed. */
-    private fun extractAssetFile(assetPath: String, destPath: String): Boolean {
+    private fun extractAssetFile(
+        assetPath: String,
+        destPath: String,
+        onBytes: ((Long) -> Unit)? = null,
+    ): Boolean {
         val destFile = File(context.filesDir, destPath)
         destFile.parentFile?.mkdirs()
 
@@ -419,6 +457,11 @@ class FirstRunSetup(
             }
 
         val written = input.use { stream -> writeAtomically(destFile) { output -> stream.copyTo(output) } }
+        // Reported from the destination rather than from copyTo's return, because the
+        // write goes through a temporary file and a rename: a failed copy leaves the
+        // destination as it was, and counting bytes that never landed would run the bar
+        // past the end of a step that had not finished.
+        if (written) onBytes?.invoke(destFile.length())
         if (!written) {
             Logger.w(tag, "Failed to write $destPath; it keeps whatever it held before")
         }
@@ -2132,6 +2175,10 @@ claude() {
     }
 
     companion object {
+        /** The band the server extraction reports across; the next step opens at 60. */
+        private const val SERVER_PROGRESS_START = 5
+        private const val SERVER_PROGRESS_END = 60
+
         private const val KEY_VERSION = "setup_version"
         private const val KEY_VERSION_CODE = "setup_version_code"
 

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
@@ -483,6 +483,27 @@ class ToolchainManager(private val context: Context) {
                         val location = assetPackManager.getPackLocation(packName)
                         val assetsPath = location?.assetsPath()
                         if (assetsPath != null) {
+                            // The same pre-flight downloadViaHttp does, for the same
+                            // reason and with a smaller figure. installFromDirectory
+                            // copies the whole tree into usr/, and without this the
+                            // copy fails partway on a full device: an IOException
+                            // reported as INTERNAL, and half a toolchain left in usr/
+                            // under no manifest, which is what made every retry start
+                            // from less space than the last.
+                            val required = packInstallBytes(
+                                ToolchainRegistry.find(packName)?.estimatedSize ?: 0L
+                            )
+                            val available = StatFs(context.filesDir.absolutePath).availableBytes
+                            if (available < required) {
+                                Logger.e(
+                                    tag,
+                                    "Not enough disk space for $packName: " +
+                                        "${available / 1_000_000} MB available, " +
+                                        "${required / 1_000_000} MB required",
+                                )
+                                fail(packName, ToolchainFailure.STORAGE)
+                                return@execute
+                            }
                             installFromDirectory(packName, File(assetsPath))
                             assetPackManager.removePack(packName)
                             Logger.i(tag, "Removed asset pack $packName (freed duplicate storage)")
@@ -1631,6 +1652,19 @@ internal const val SPACE_BUFFER = 50_000_000L
  */
 internal fun toolchainInstallBytes(unpackedBytes: Long): Long =
     unpackedBytes * 2 + SPACE_BUFFER
+
+/**
+ * What a Play Asset Delivery install needs free, given its unpacked size.
+ *
+ * One tree rather than two, and the difference is where the first copy already
+ * sits. Play writes the pack outside `filesDir` before this app is told about
+ * it, so the only allocation the install makes is the copy into `usr/`, and
+ * `removePack` frees Play's copy afterwards. Charging for both would refuse
+ * devices for room they never need at once, which is the mistake the HTTP
+ * figure above was corrected for in the other direction.
+ */
+internal fun packInstallBytes(unpackedBytes: Long): Long =
+    unpackedBytes + SPACE_BUFFER
 
 /**
  * Copies a tree, refusing rather than shrugging when a directory cannot be read.

--- a/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainInstallSpaceTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainInstallSpaceTest.kt
@@ -36,6 +36,32 @@ class ToolchainInstallSpaceTest {
         assertEquals(2 * 34_000_000L + SPACE_BUFFER, toolchainInstallBytes(34_000_000L))
     }
 
+    /**
+     * The Play path holds one copy, not two, and the difference is where the first sits.
+     *
+     * Play writes the pack outside `filesDir` before this app hears about it, so the
+     * only allocation the install makes is the copy into `usr/`, and `removePack` frees
+     * Play's copy afterwards. Charging for both would refuse devices for room they never
+     * need at once, which is the mirror of the mistake the HTTP figure was corrected for.
+     */
+    @Test
+    fun `the Play reservation charges for the copy it makes and not for Play's own`() {
+        assertEquals(146_000_000L + SPACE_BUFFER, packInstallBytes(146_000_000L))
+        assertEquals(SPACE_BUFFER, packInstallBytes(0L))
+    }
+
+    /** And it is genuinely the smaller of the two, or the two paths have been swapped. */
+    @Test
+    fun `the Play reservation is smaller than the HTTP one for every shipped toolchain`() {
+        for (info in ToolchainRegistry.available) {
+            assertTrue(
+                packInstallBytes(info.estimatedSize) < toolchainInstallBytes(info.estimatedSize),
+                "${info.packName}: the Play path should ask for less than the HTTP path, " +
+                    "since Play has already written the tree it copies from",
+            )
+        }
+    }
+
     /** Ruby cleared the old gate only by accident; state the margin rather than rely on it. */
     @Test
     fun `every shipped toolchain is charged for both copies`() {


### PR DESCRIPTION
Two places where a long operation gave nothing back.

## The progress bar sat at 5%

`reportProgress` fired at 5, then the next call was at 60, with a recursion over 16,891 files between them. On a mid-range phone that is minutes of a still bar, which reads as a hang and invites a force-quit. A force-quit there produces exactly the partial tree the retry path exists to clean up.

It now reports by **bytes** against `BUNDLED_SERVER_BYTES`, a new `buildConfigField` computed from the tree being packaged in the same way its three siblings are, so the figure cannot drift from what actually ships.

Reported only when the whole percent changes, which is 55 updates rather than one per file, and capped so a server tree fetched after the APK was built cannot run the bar past the step.

**Measured on a real first run** on an API 37 emulator: 37 distinct updates climbing to 59, then the next step opens at 60 as before, and setup completes to 100 with no crash. Previously the same run reported 5 and then 60.

## The Play path never checked for space

`downloadViaHttp` has a pre-flight; the Asset Delivery branch went straight to `installFromDirectory`, which copies the whole tree into `usr/` exactly as the HTTP path does. Without room the copy failed partway, was reported as `INTERNAL` rather than `STORAGE`, and left half a toolchain in `usr/` under no manifest, so each retry started from less space than the last.

`packInstallBytes` is a **sibling** of `toolchainInstallBytes` rather than a reuse of it, and asks for one tree instead of two. Play writes the pack outside `filesDir` before this app hears about it, so the only allocation the install makes is the copy, and `removePack` frees Play's afterwards. Charging for both would refuse devices for room they never need at once, which is the mirror of the mistake the HTTP figure was corrected for.

Two tests: the figure itself, and that it is genuinely smaller than the HTTP one for every shipped toolchain, so the two cannot be swapped without a red.

## Verification

1210 unit tests across 189 suites, zero failures. Extraction verified on device as above.