### PR TITLE
fix(webview): stop proxying arbitrary hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Content rendered in the editor can no longer read workspace files across origins. Served files are readable by anyone, and a page in the built-in browser could fetch one.
 - A webview can no longer name an arbitrary file and have the app read it with the editor's own credential. The route that did was reachable but unused.
+- The editor can no longer make the app fetch an arbitrary web address on its behalf. The route reached any host, including addresses only this device can see.
 
 ### Fixed
 

--- a/android/app/src/main/kotlin/com/vscodroid/webview/VSCodroidWebViewClient.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/webview/VSCodroidWebViewClient.kt
@@ -625,13 +625,21 @@ class VSCodroidWebViewClient(
                 )
             }
 
-            if (scheme == "http" || scheme == "https") {
-                // Remote resource — proxy through to actual URL
-                val query = uri.query
-                val queryPart = if (!query.isNullOrEmpty()) "?$query" else ""
-                val actualUrl = "$scheme://$authority$path$queryPart"
-                return proxyToLocalhost(actualUrl, "GET", "resource:$authority$path")
-            }
+            // An `http`/`https` arm sat here and forwarded to `$scheme://$authority$path`,
+            // whatever host the page named. It went out correctly without the connection
+            // token, so it did not leak a credential, but it did lend this app's network
+            // identity to any page the editor renders: a way to reach a LAN address or a
+            // loopback service the page could not reach itself.
+            //
+            // Removed rather than restricted, for the same reason as the branch below and
+            // on the same evidence. Nothing produces the form: `pre()` in the shipped
+            // workbench returns an http or https URI unchanged rather than encoding it
+            // into the resource host, and no bundled extension contains one. Both were
+            // grepped, each against a control proving the search was live.
+            //
+            // Remote content in a webview still loads normally. It does so through the
+            // WebView's own navigation, which is where reaching anything already lives;
+            // this arm was a second route into the same place with no restriction on it.
 
             // A catch-all for every other scheme with an authority used to sit here,
             // proxying to `http://127.0.0.1:$port$path` with the connection token

--- a/android/app/src/test/kotlin/com/vscodroid/webview/ConnectionTokenLoggingTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/ConnectionTokenLoggingTest.kt
@@ -149,6 +149,41 @@ class ConnectionTokenLoggingTest {
     }
 
     /**
+     * An `https` resource host is refused rather than forwarded.
+     *
+     * An arm here used to proxy `https+host.vscode-resource.vscode-cdn.net/path` out to
+     * `https://host/path`, whatever host the page named. It went without the connection
+     * token, so no credential left, but it lent this app's network identity to any page
+     * the editor renders, including reaching a LAN or loopback address the page could
+     * not reach itself.
+     *
+     * Nothing produced the form: the shipped workbench returns http and https URIs
+     * unchanged rather than encoding them into the resource host, and no bundled
+     * extension contains one. This case is what notices the arm coming back.
+     */
+    @Test
+    fun `an https resource host is refused rather than forwarded`() {
+        val deadPort = ServerSocket(0, 0, InetAddress.getByName("127.0.0.1")).use { it.localPort }
+
+        VSCodroidWebViewClient.interceptCdnRequest(
+            cdnRequest("https+example.test.vscode-resource.vscode-cdn.net", "/probe.txt"),
+            deadPort, token, emptyList(), emptyList(), { null },
+        )
+
+        assertTrue(
+            logged.none { it.contains("resource:example.test") },
+            "the forwarding arm is back: a page named a host and the app went to it. " +
+                "Logged:\n" + logged.joinToString("\n") { "  $it" },
+        )
+        assertTrue(
+            logged.any { it.contains("Unknown resource scheme") },
+            "the refusal should say which scheme it refused. Logged:\n" +
+                logged.joinToString("\n") { "  $it" },
+        )
+        assertNothingLeaked()
+    }
+
+    /**
      * An unknown scheme is refused, and no tokened URL is built for it.
      *
      * This case used to assert the opposite: that the request DID reach a branch


### PR DESCRIPTION
The resource interceptor accepted `http+host` and `https+host` in the
vscode-resource authority and forwarded the request to that host. The connection
token was not attached, so no credential left the app, but any page the editor
renders could reach an address through the app's network identity, including a
LAN or loopback service the page cannot reach itself.

Nothing produces the form:

- The shipped workbench returns http and https URIs unchanged rather than
  encoding them into the resource host (5 sites in
  `workbench.web.main.internal.js`).
- No bundled extension contains one. Control: 2 files under the same trees do
  mention `vscode-resource`, so the search was live.

## Changes

- Remove the `http`/`https` arm from `interceptResourceRequest`. A request in
  that form now takes the unknown-scheme path and is refused, which already logs
  what it refused.
- Add a case to `ConnectionTokenLoggingTest` asserting the refusal and that no
  outbound request is made.

## Impact

Remote content in a webview still loads. It does so through the webview's own
navigation, which this does not touch; the removed arm was a second route into
the same place with no restriction on it.

## Verification

- 1215 unit tests across 189 suites pass.
- The new case was confirmed to fail with the arm restored, then pass with it
  removed.