### PR TITLE
fix(toolchain): install from the release the app was built with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Installing a toolchain from Play now checks for space first. Without room it failed partway and left a half-installed toolchain behind.
 - The storage figures in the README can be re-measured on Linux. The command printed a plausible 0 MB there, because it used the macOS spelling of `stat`.
 - Creating a folder no longer overwrites a device document the app could not read, such as one too large to copy. Only the single-file path checked this before.
+- Toolchain downloads now come from the release matching the installed app, instead of whichever is newest. A newer release can retire a payload an older app still offers.
 
 ### Security
 

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Context
 import android.os.StatFs
 import androidx.annotation.StringRes
+import com.vscodroid.BuildConfig
 import com.vscodroid.R
 import android.system.Os
 import com.google.android.play.core.assetpacks.AssetPackManagerFactory
@@ -953,8 +954,31 @@ class ToolchainManager(private val context: Context) {
         }
 
     /**
-     * [zipUrl] with `latest` resolved to the release it names right now, or
-     * [zipUrl] unchanged when it cannot be resolved.
+     * [zipUrl] pointed at a concrete release, or [zipUrl] unchanged when none
+     * can be resolved.
+     *
+     * The release this build belongs to is preferred, and `latest` is the
+     * fallback rather than the first choice. `latest` names whichever release
+     * is newest at the moment of the request, which is not necessarily one this
+     * app was built alongside, and the gap is not theoretical. Measured
+     * 2026-08-19, with `latest` naming v1.1.0:
+     *
+     * ```
+     * releases/latest/download/toolchain_go.zip  -> 404
+     * releases/download/v1.0.0/toolchain_go.zip  -> 200
+     * ```
+     *
+     * An installed v1.0.0 offers Go in its picker, because its own registry
+     * lists it, and v1.1.0 does not publish that ZIP because the entry was
+     * retired. Through `latest` that install can no longer fetch a payload its
+     * own release still carries. The reverse costs the same: a release deleted
+     * after publication moves `latest` backwards, onto a release built before
+     * whatever the installed app now requires.
+     *
+     * Note what this cannot do, because the shape recurs. It ships in an app
+     * version, so it repairs the population that installs that version onward
+     * and nothing already on a device. v1.0.0 keeps resolving through `latest`
+     * forever.
      *
      * The manifest and the payload are two requests minutes apart, and both used
      * to go through `latest` independently, so a release published between them
@@ -991,6 +1015,11 @@ class ToolchainManager(private val context: Context) {
         // 30 s connect and a 30 s read timeout that nothing else here would
         // interrupt.
         if (download.cancelled) return zipUrl
+        ownReleaseAssetUrl(zipUrl)?.let {
+            Logger.i(tag, "Pinned this install to ${it.substringBeforeLast('/')}")
+            return it
+        }
+        if (download.cancelled) return zipUrl
         val latestUrl = latestReleaseUrlFor(zipUrl) ?: return zipUrl
         val pinned = try {
             val conn = URL(latestUrl).openConnection() as HttpURLConnection
@@ -1020,6 +1049,60 @@ class ToolchainManager(private val context: Context) {
         }
         Logger.i(tag, "Pinned this install to ${pinned.substringBeforeLast('/')}")
         return pinned
+    }
+
+    /**
+     * [zipUrl] served from this build's own release, or null.
+     *
+     * Null covers three different things on purpose, because the caller does
+     * the same thing with all of them: this build's version does not name a
+     * tag, no release carries that tag, or the release carries it but not this
+     * asset. Each leaves `latest` as the answer, which is what shipped before
+     * this existed.
+     *
+     * One HEAD against the asset itself rather than against the release page,
+     * because the asset is the question. Measured 2026-08-19, redirects not
+     * followed: a published asset answers 302 and both a missing asset and a
+     * missing tag answer 404, so one request separates every case that matters.
+     * Asking the release page instead would answer 200 for a release whose
+     * toolchain step failed, pin to it, and turn a fallback into a refused
+     * install two requests later.
+     */
+    private fun ownReleaseAssetUrl(zipUrl: String): String? {
+        val ownTag = appReleaseTag(BuildConfig.VERSION_NAME) ?: return null
+        val url = pinnedAssetUrl(zipUrl, ownTag) ?: return null
+        if (assetIsPublished(url)) return url
+        Logger.i(
+            tag,
+            "Release $ownTag does not publish ${zipUrl.substringAfterLast('/')}; " +
+                "falling back to the latest release",
+        )
+        return null
+    }
+
+    /**
+     * Whether the server will serve [url], asked with a HEAD and no body.
+     *
+     * Redirects are not followed, so the 302 that a published asset answers is
+     * the success and there is no transfer behind it. Any failure to ask counts
+     * as no: the caller's fallback is the behaviour that shipped before this,
+     * and a network that cannot answer this cannot serve the payload either.
+     */
+    private fun assetIsPublished(url: String): Boolean = try {
+        val conn = URL(url).openConnection() as HttpURLConnection
+        try {
+            conn.connectTimeout = HTTP_TIMEOUT_MS
+            conn.readTimeout = HTTP_TIMEOUT_MS
+            conn.instanceFollowRedirects = false
+            conn.requestMethod = "HEAD"
+            conn.setRequestProperty("User-Agent", "VSCodroid")
+            conn.responseCode in 200..399
+        } finally {
+            conn.disconnect()
+        }
+    } catch (e: IOException) {
+        Logger.w(tag, "Could not ask whether $url is published: ${e.message}")
+        false
     }
 
     /**
@@ -1980,6 +2063,23 @@ internal fun releaseTagFromLocation(location: String): String? {
         .substringBefore('#')
         .trim('/')
     return if (tag.isNotEmpty() && TAG_CHARS.matches(tag)) tag else null
+}
+
+/**
+ * The release tag a build of [versionName] belongs to, or null.
+ *
+ * `1.1.0` gives `v1.1.0`, matching the tags `release.yml` publishes.
+ *
+ * `-debug` is stripped because it is a `versionNameSuffix` on the debug build
+ * type and not part of any tag; a debug build belongs to the same release its
+ * source does. Nothing else is stripped. A suffix this does not know about
+ * yields a tag no release carries, the probe answers 404, and the caller falls
+ * back to `latest` -- so an unknown suffix costs the old behaviour rather than
+ * a wrong guess at which release the build came from.
+ */
+internal fun appReleaseTag(versionName: String): String? {
+    val version = versionName.removeSuffix("-debug")
+    return if (version.isNotEmpty() && TAG_CHARS.matches(version)) "v$version" else null
 }
 
 /**

--- a/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainDigestTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainDigestTest.kt
@@ -318,7 +318,7 @@ class LatestReleasePinningTest {
     @Test
     fun `every registered toolchain can be pinned to one release`() {
         // The registry-wide version of the test above: one resolution has to
-        // serve all three, or a single install could pin while another does not.
+        // serve every entry, or a single install could pin while another does not.
         val pinned = ToolchainRegistry.available
             .mapNotNull { it.downloadUrl }
             .map { pinnedAssetUrl(it, "v1.1.0") }
@@ -328,6 +328,63 @@ class LatestReleasePinningTest {
             1,
             pinned.filterNotNull().map { manifestUrlFor(it) }.toSet().size,
             "pinned toolchains disagree about the manifest",
+        )
+    }
+
+    // -- appReleaseTag ----------------------------------------------------
+
+    @Test
+    fun `an install reaches the release its own version names`() {
+        // The case this exists for, measured 2026-08-19 while `latest` named
+        // v1.1.0: an installed v1.0.0 still offers Go, v1.1.0 does not publish
+        // that ZIP because the entry was retired, and the two URLs below differ
+        // by 404 against 200. The literal is the one that answers 200.
+        val go = "https://github.com/rmyndharis/VSCodroid/releases/latest/download/toolchain_go.zip"
+
+        val pinned = pinnedAssetUrl(go, appReleaseTag("1.0.0")!!)
+
+        assertEquals(
+            "https://github.com/rmyndharis/VSCodroid/releases/download/v1.0.0/toolchain_go.zip",
+            pinned,
+        )
+    }
+
+    @Test
+    fun `a debug build belongs to the release its source does`() {
+        // `versionNameSuffix` is a build-type detail; no release is ever tagged
+        // with it. Left in, every debug build would probe a tag that does not
+        // exist and quietly fall back to `latest`, which is the behaviour this
+        // replaces.
+        assertEquals("v1.1.0", appReleaseTag("1.1.0-debug"))
+    }
+
+    @Test
+    fun `a version that cannot name a tag resolves to nothing`() {
+        // Null is the fallback signal, so it has to be reachable. A version
+        // carrying a slash would otherwise be pasted into a URL naming
+        // something else entirely.
+        assertNull(appReleaseTag(""))
+        assertNull(appReleaseTag("1.1.0/../../etc"))
+        assertNull(appReleaseTag("1.1 .0"))
+    }
+
+    @Test
+    fun `the tag this build names is one the pinner accepts`() {
+        // The two halves are written apart and only ever meet at runtime. If
+        // they disagreed about the shape of a tag, `pinnedAssetUrl` would
+        // refuse every tag this produces, pinning would revert to `latest`
+        // permanently, and nothing would report it: the fallback is silent by
+        // design because it is also the correct answer for a dev build.
+        val tag = appReleaseTag("1.1.0")!!
+
+        val pinned = ToolchainRegistry.available
+            .mapNotNull { it.downloadUrl }
+            .map { pinnedAssetUrl(it, tag) }
+
+        assertEquals(
+            emptyList<String?>(),
+            pinned.filter { it == null },
+            "the pinner refused a tag this build would hand it",
         )
     }
 }


### PR DESCRIPTION
Sideloaded installs resolve toolchain payloads through
`releases/latest/download/`, which names whichever release is newest at the
moment of the request, not the one the running app was built alongside. The two
diverge as soon as a release adds, retires or reshapes a payload, and the gap is
not theoretical.

Measured 2026-08-19, with `latest` naming v1.1.0:

```
releases/latest/download/toolchain_go.zip  -> 404
releases/download/v1.0.0/toolchain_go.zip  -> 200
```

An installed v1.0.0 offers Go in its picker, because its own registry lists it,
and v1.1.0 does not publish that ZIP because the entry was retired. Through
`latest` that install can no longer fetch a payload its own release still
carries. The reverse costs the same: deleting a release moves `latest`
backwards, onto assets built before whatever the installed app now requires.

## Changes

- `pinLatest` now prefers `releases/download/v<version>/<asset>`, probed with a
  single HEAD. Redirects are not followed: a published asset answers 302, and
  both a missing asset and a missing tag answer 404, so one request separates
  every case that matters.
- The probe is against the asset, not the release page. A release whose
  toolchain step failed answers 200 for its page, which would pin to it and turn
  a fallback into a refused install two requests later.
- Resolving `latest` remains the fallback, covering a build made between
  releases and any version string that cannot name a tag. That is the behaviour
  that shipped before this, so nothing gets worse when the probe says no.
- The debug `versionNameSuffix` is stripped, since no release is tagged with it.

## Impact

Play installs are unaffected: they use Asset Delivery and never reach this path.

This ships in an app version, so it applies from that version onward and not to
installs already on a device. v1.0.0 keeps resolving through `latest`.

## Verification

- 1215 unit tests across 189 suites pass.
- Four cases added to `LatestReleasePinningTest`, including the measured v1.0.0
  URL above. Confirmed to fail when the tag builder is altered, then pass.
- HTTP behaviour above measured directly against the repository's releases.