### PR TITLE
docs: drop a local-only path from the file tree listing

### DIFF
--- a/docs/12-IMPLEMENTATION_PLAN.md
+++ b/docs/12-IMPLEMENTATION_PLAN.md
@@ -186,7 +186,6 @@ flowchart LR
 ```
 Files to create:
 ├── .gitignore
-├── CLAUDE.md                      ← already exists
 ├── MILESTONES.md                  ← already exists
 ├── README.md                      ← already exists
 ├── LICENSE                        ← already exists


### PR DESCRIPTION
`docs/12-IMPLEMENTATION_PLAN.md` listed a file that `.gitignore` excludes, inside a
tree of files the plan proposed creating. The entry was marked "already exists", so
it was never something the plan asked anyone to create, and naming a local-only path
in a tracked document puts it in the public record for no benefit.

The surrounding entries are unchanged.