### PR TITLE
fix(storage): let a timestamp-less folder come back into step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Installing a toolchain from Play now checks for space first. Without room it failed partway and left a half-installed toolchain behind.
 - The storage figures in the README can be re-measured on Linux. The command printed a plausible 0 MB there, because it used the macOS spelling of `stat`.
 - Creating a folder no longer overwrites a device document the app could not read, such as one too large to copy. Only the single-file path checked this before.
+- On a device folder whose provider reports no modification time, a file you edit now reaches the device again, and later device changes reach the editor.
 - Toolchain downloads now come from the release matching the installed app, instead of whichever is newest. A newer release can retire a payload an older app still offers.
 - Closing the editor or swiping the app away no longer keeps the destroyed screen and its view tree in memory until the app is next opened.
 

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
@@ -243,6 +243,35 @@ class SafSyncEngine(private val context: Context) {
                     // back and cannot.
                     if (localPath.lastModified() == doc.lastModified) {
                         recordIdentity(recorded, doc.relativePath, localPath)
+                    } else if (doc.lastModified == 0L &&
+                        recordedSizeFor(doc.relativePath, previouslyRecorded) == doc.size
+                    ) {
+                        // No clock, the mirror has diverged from the record, and the
+                        // device document is still the length the record says we wrote.
+                        // So the divergence is ours alone: the device copy has not moved
+                        // since, and pushing the mirror over it loses nothing.
+                        //
+                        // This is what unfreezes the file. Recording the new identity is
+                        // truthful only because the write-back happened first: after it,
+                        // the device holds these bytes, which is exactly what the record
+                        // claims and what `holdsOnlyVouchedCopies` reads it to mean. The
+                        // next sync then sees its own copy again and device changes reach
+                        // this path once more.
+                        //
+                        // Ordered write-then-record, never the reverse. A record written
+                        // before a write-back that then fails would vouch for bytes the
+                        // device does not have, and the reclaim pass would delete the
+                        // user's only copy on that word.
+                        uploadsDone++
+                        Logger.i(
+                            tag,
+                            "Writing the mirror of ${doc.relativePath} back: the provider " +
+                                "reports no time and the device copy is still the length " +
+                                "this app last wrote",
+                        )
+                        if (writeLocalToSaf(localPath, doc.uri)) {
+                            recordIdentity(recorded, doc.relativePath, localPath)
+                        }
                     } else if (doc.lastModified > 0L &&
                         localPath.lastModified() > doc.lastModified
                     ) {
@@ -269,9 +298,11 @@ class SafSyncEngine(private val context: Context) {
                         // not update needs this line to exist in a bug report.
                         Logger.i(
                             tag,
-                            "Kept ${doc.relativePath} and stopped tracking the device " +
-                                "copy: the provider reports no modification time and " +
-                                "this file no longer matches what the last sync wrote",
+                            "Kept ${doc.relativePath}: the provider reports no " +
+                                "modification time, and both sides have changed since " +
+                                "the last sync, so there is nothing that can say which " +
+                                "is newer. The mirror is kept and the device copy is " +
+                                "left alone.",
                         )
                     }
                     Logger.d(tag, "Kept local copy: ${doc.relativePath}")
@@ -842,7 +873,7 @@ class SafSyncEngine(private val context: Context) {
      * device copy. Permission loss is not retried: nothing about a revoked grant
      * gets better within a second.
      */
-    private fun writeLocalToSaf(localFile: File, safDocUri: Uri) {
+    private fun writeLocalToSaf(localFile: File, safDocUri: Uri): Boolean {
         markUploadInFlight(localFile.absolutePath)
         var attempts = 0
         while (true) {
@@ -856,13 +887,13 @@ class SafSyncEngine(private val context: Context) {
                     } ?: false
                 if (copied) {
                     clearUploadInFlight(localFile.absolutePath)
-                    return
+                    return true
                 }
                 attempts++
             } catch (e: SecurityException) {
                 Logger.e(tag, "Permission revoked while writing back: ${localFile.name}")
                 onWriteBackFailed(localFile)
-                return
+                return false
             } catch (e: Exception) {
                 attempts++
             }
@@ -873,7 +904,7 @@ class SafSyncEngine(private val context: Context) {
                         "is recorded as not to be trusted"
                 )
                 onWriteBackFailed(localFile)
-                return
+                return false
             }
         }
     }
@@ -1797,6 +1828,21 @@ class SafSyncEngine(private val context: Context) {
             unfetched: Set<String>,
         ): Boolean = deviceHoldsDocument && localPath in unfetched
 
+        /**
+         * The size the last sync recorded for [path], or null when it recorded none.
+         *
+         * The record's lines are `path`, `modification time` and `length`, tab
+         * separated, so this is a field read rather than new bookkeeping. A line
+         * that does not parse is dropped rather than repaired, the same as everywhere
+         * else that reads this file: a record we cannot read has to mean "no record",
+         * because the alternative is acting on a number we invented.
+         */
+        internal fun recordedSizeFor(path: String, record: Set<String>): Long? {
+            val prefix = "$path\t"
+            val line = record.firstOrNull { it.startsWith(prefix) } ?: return null
+            return line.substringAfterLast('\t').toLongOrNull()
+        }
+
         internal fun shouldOverwriteMirror(
             mirrorExists: Boolean,
             mirrorModified: Long,
@@ -1817,13 +1863,13 @@ class SafSyncEngine(private val context: Context) {
             // record behind it is not ours to overwrite either, which is the direction
             // reconcileDeletions already fails in.
             //
-            // ⚠️ What this costs, stated because it is permanent and the old behaviour
-            // did not have it. Once a file here answers false it can never answer true
-            // again: it is not copied, so `copyDocumentToLocal` never records it, and
-            // the equal-timestamp branch cannot record it either because a real file's
-            // mtime is never 0. Device-side changes to that file stop arriving, and no
-            // size comparison rescues it, because this clause returns before the size
-            // clause below is reached.
+            // ⚠️ What this costs, and it is narrower than it was. A file answering
+            // false here is kept, and the caller then asks a question this clause
+            // cannot: whether the device document is still the length the record says
+            // was written. If it is, the divergence is local only, the mirror is
+            // written back and re-recorded, and the next sync answers true again. If it
+            // is not, both sides moved and nothing here can say which is newer, so the
+            // mirror is kept and the device copy left alone until a human resolves it.
             //
             // Kept anyway, because the alternative is worse and is what shipped: with no
             // timestamp there is nothing to tell a device edit from a local one, and the
@@ -1833,11 +1879,11 @@ class SafSyncEngine(private val context: Context) {
             // itself in content if not in bookkeeping: the watcher writes the local edit
             // out on the next save, after which both sides hold the same bytes.
             //
-            // Tracked as #286. A real fix has to tell a device change from a local one
-            // without a clock, which means comparing content rather than metadata: a
-            // per-file digest beside the mtime and size [identityLine] already writes.
-            // That puts a hash over every mirrored file into each sync, so it wants
-            // measuring before it is taken.
+            // The recorded size is what makes that possible, and it is free: the
+            // cursor already carries the device document's length and the record
+            // already carries the length last written. Comparing content instead would
+            // have meant reading every device document over the provider on every sync,
+            // which is the copy this whole path exists to avoid.
             sourceModified == 0L -> mirrorIsOurCopy
             sourceModified > mirrorModified -> true
             // A newer local copy wins, whatever its size. Checking size before this

--- a/android/app/src/test/kotlin/com/vscodroid/storage/InitialSyncWiringTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/InitialSyncWiringTest.kt
@@ -12,6 +12,7 @@ import io.mockk.unmockkAll
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -182,26 +183,74 @@ class InitialSyncWiringTest {
     }
 
     /**
-     * The cost of the clause above, pinned so it is a decision rather than a surprise.
+     * The frozen case, now resolved by data the sync already has.
      *
-     * Once a file on a timestamp-less provider diverges from the record it can never be
-     * vouched for again: it is not copied, so nothing records it, and the equal-timestamp
-     * branch cannot record it because a real file's mtime is never 0. Device-side changes
-     * to that file stop arriving, and a size change does not rescue it, because the
-     * clause returns before the size comparison.
+     * With no clock there is nothing to say whether a difference came from the device
+     * or from the editor, and the old answer was to keep the mirror and stop looking.
+     * That was safe and permanent: the file never became vouched again, so device
+     * changes stopped arriving for the life of the mirror.
      *
-     * Kept because the alternative is what shipped: with nothing to compare, the old
-     * answer assumed the device always won and destroyed the local edit on every reopen.
+     * What separates the two cases is the size the record already carries. The cursor
+     * carries the device document's length for free, so when the two agree the device
+     * copy has not moved since the last sync and the divergence is local only. The
+     * mirror is written back, recorded, and the next sync treats it as its own again.
      *
-     * This test locks the limitation rather than the fix. When #286 lands it should go
-     * red, and the case that replaces it asserts the device change arriving.
+     * The two syncs are the point: the first leaves the file diverged, the second is
+     * where the old behaviour would have given up.
      */
     @Test
-    fun `a diverged file on a timestamp-less provider stops receiving device changes`() {
-        val local = mirrorHolding("notes.txt", "edited in the editor!", 1_700_000_060_000)
-        deviceFolderHolding("notes.txt", "a different length on the device", modified = 0)
-
+    fun `a local edit on a timestamp-less provider is written back and tracked again`() {
+        // The fake cursor is single use: `moveToNext` answers true once. So the device
+        // folder is re-armed before every sync, or the next one enumerates nothing and
+        // the assertions below would pass over an empty folder rather than a real one.
+        deviceFolderHolding("notes.txt", "from the device", modified = 0)
         sync()
+        val local = File(mirror, "notes.txt")
+        assertTrue(local.isFile, "setup failed: the first sync did not create the mirror")
+        val rec = File(mirror.path + ".synced")
+        assertTrue(rec.readText().contains("notes.txt"), "setup failed: nothing was recorded")
+
+        // The editor edits it, keeping the same length, so the device copy is still the
+        // length the record says this app wrote.
+        local.writeText("from the EDITOR")
+        local.setLastModified(1_700_000_060_000)
+        deviceFolderHolding("notes.txt", "from the device", modified = 0)
+        sync()
+
+        assertEquals(
+            listOf("notes.txt"), writtenDocuments,
+            "the local edit should have been written back: the device copy is still the " +
+                "length the record says this app wrote, so nothing of the user's is lost",
+        )
+
+        // And now it is tracked again: a device-side change reaches the mirror.
+        deviceFolderHolding("notes.txt", "changed on the device", modified = 0)
+        sync()
+
+        assertEquals(
+            "changed on the device", local.readText(),
+            "the file is still frozen: being written back should have re-recorded it, " +
+                "so this sync sees its own copy and takes the device change",
+        )
+    }
+
+    /**
+     * And the genuine conflict is still refused, which is what keeps the fix honest.
+     *
+     * When the device document's length no longer matches what the record says was
+     * written, both sides moved. Nothing here can say which is newer, so the mirror is
+     * kept and the device copy is left alone rather than overwritten.
+     */
+    @Test
+    fun `a timestamp-less file both sides changed is kept, and neither side is pushed`() {
+        deviceFolderHolding("notes.txt", "from the device", modified = 0)
+        sync()
+        val local = File(mirror, "notes.txt")
+        assertTrue(local.isFile, "setup failed: the first sync did not create the mirror")
+
+        local.writeText("edited in the editor!")
+        local.setLastModified(1_700_000_060_000)
+        deviceFolderHolding("notes.txt", "a different length on the device", modified = 0)
         sync()
 
         assertEquals(
@@ -209,9 +258,44 @@ class InitialSyncWiringTest {
             "the local edit survives, which is the point",
         )
         assertEquals(
-            emptyList<String>(), openedDocuments,
-            "and the device copy is never read again, even though its length differs: " +
-                "this is the permanent cost of having no clock to compare",
+            emptyList<String>(), writtenDocuments,
+            "and the device copy is not overwritten either: both sides changed, so " +
+                "pushing the mirror over it would destroy the device's version",
+        )
+    }
+
+    /**
+     * A write-back that fails must not leave the mirror vouched for.
+     *
+     * The record means "the device holds these bytes". Writing that line when the
+     * write-back did not land would claim the device has an edit it never received, and
+     * `holdsOnlyVouchedCopies` reads the record with exactly that meaning to decide a
+     * mirror is disposable. The reclaim pass would then be free to delete the only copy
+     * of the user's edit.
+     *
+     * So the record is gated on the write succeeding, and this is what proves the gate
+     * is load-bearing rather than decorative.
+     */
+    @Test
+    fun `a failed write-back on a timestamp-less provider vouches for nothing`() {
+        deviceFolderHolding("notes.txt", "from the device", modified = 0)
+        sync()
+        val local = File(mirror, "notes.txt")
+        assertTrue(local.isFile, "setup failed: the first sync did not create the mirror")
+        local.writeText("from the EDITOR")
+        local.setLastModified(1_700_000_060_000)
+        deviceFolderHolding("notes.txt", "from the device", modified = 0)
+        // The device refuses the write. Everything else about this sync is the case
+        // above, which does record.
+        every { resolver.openOutputStream(any(), "wt") } returns null
+        sync()
+
+        val after = File(mirror.path + ".synced").readText()
+        assertTrue(
+            "notes.txt\t${local.lastModified()}\t${local.length()}" !in after,
+            "the record now names the edit's own identity, so it claims the device holds " +
+                "bytes it never received and the reclaim pass is free to delete the only " +
+                "copy. The record holds:\n$after",
         )
     }
 


### PR DESCRIPTION
Closes #286.

A device folder whose provider omits `COLUMN_LAST_MODIFIED` has no clock to
compare, so a file that diverged from the record was kept and never looked at
again. Three things followed, and only the first was recorded:

- device changes stopped arriving for that file;
- the mirror could never be reclaimed, because `holdsOnlyVouchedCopies` requires
  every file to match the record and this one never would again;
- the sync-time write-back retry is gated on `doc.lastModified > 0L`, so the
  local edit had no second route to the device either.

## What changed

Keeping the mirror is still right when nothing can say which side is newer. What
was missing is that two different situations were collapsed into that one answer.
The recorded size tells them apart, and both halves are already in hand: the
cursor carries the device document's length, and the record's third field carries
the length last written.

| Device length vs record | Meaning | Now |
|---|---|---|
| same | the device copy has not moved | write the mirror back, re-record it, tracking resumes |
| different | both sides moved | keep the mirror, leave the device copy alone |

`writeLocalToSaf` now returns whether the write landed, and the record is written
only when it did. A record written for a failed write-back would claim the device
holds bytes it never received, and the reclaim pass reads it with exactly that
meaning, so it would be free to delete the only copy of the edit.

## Why not a content digest

That was the shape the issue proposed. It answers the same question and costs a
read of every device document over the provider on every sync, which is the copy
this path exists to avoid. The recorded size costs nothing and is already there.

## Verification

- 1223 unit tests across 191 suites pass.
- Three cases, each confirmed to fail against the defect it names: removing the
  new branch restores the freeze, ignoring the size makes the conflict case
  overwrite the device, and recording without checking the write-back result lets
  the record vouch for bytes the device never received.
- One existing case is replaced rather than edited. It asserted the freeze by
  running a second sync over a cursor that had already been consumed, so it
  enumerated no documents at all and was passing over an empty folder. The
  replacements re-arm the device folder before every sync.