### PR TITLE
fix(storage): track a timestamp-less file again once both sides agree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Installing a toolchain from Play now checks for space first. Without room it failed partway and left a half-installed toolchain behind.
 - The storage figures in the README can be re-measured on Linux. The command printed a plausible 0 MB there, because it used the macOS spelling of `stat`.
 - Creating a folder no longer overwrites a device document the app could not read, such as one too large to copy. Only the single-file path checked this before.
+- On a device folder whose provider reports no modification time, a file you edited starts receiving device changes again once both sides hold the same content.
 - Toolchain downloads now come from the release matching the installed app, instead of whichever is newest. A newer release can retire a payload an older app still offers.
 - Closing the editor or swiping the app away no longer keeps the destroyed screen and its view tree in memory until the app is next opened.
 

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafStorageManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafStorageManager.kt
@@ -249,8 +249,12 @@ class SafStorageManager(private val context: Context) {
             val reclaimable = alreadySetAside ||
                 (MIRROR_ENTRY.matches(name) && name.substringBefore('.') !in liveMirrorNames())
             if (!reclaimable) return@forEach
-            // A mirror is normally a copy and the device folder is the original,
-            // which is what makes reclaiming it safe. That stops being true when
+            // A mirror is reclaimable when the device folder holds everything in it,
+            // which is what makes deleting it lose nothing. Usually that is because the
+            // mirror is a copy; it is equally true of a file the editor wrote once the
+            // watcher has carried it across, which `holdsOnlyVouchedCopies` recognises
+            // by comparing bytes rather than by asking who authored them. That stops
+            // being true when
             // this app's own records say a write never reached the device: a
             // write-back that gave up after two failures, or one refused with a
             // SecurityException, which is precisely what a permission withdrawn

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
@@ -237,11 +237,43 @@ class SafSyncEngine(private val context: Context) {
                     )
                 ) {
                     keptLocal++
+                    var deviceAgrees = false
                     // Inside this branch the mirror is not older, so equal means the
                     // mirror is already this document and can be vouched for, while
                     // strictly newer means it holds an edit that has not been written
                     // back and cannot.
                     if (localPath.lastModified() == doc.lastModified) {
+                        recordIdentity(recorded, doc.relativePath, localPath)
+                    } else if (doc.lastModified == 0L &&
+                        deviceMatchesMirror(doc.uri, localPath, doc.size)
+                    ) {
+                        // No clock, the mirror no longer matches the record, and yet the
+                        // device document holds exactly these bytes. That is the ordinary
+                        // end of a local edit: the watcher carried it to the device
+                        // already, so the two agree in content while the record still
+                        // describes what was there before.
+                        //
+                        // Nothing here writes anything. It records what is already true
+                        // on both sides, which is what the record means and what
+                        // `holdsOnlyVouchedCopies` reads it to mean.
+                        //
+                        // This recovers two of the three costs of never being vouched:
+                        // device changes reach the file again, and the mirror becomes
+                        // reclaimable. It does not recover the third. An edit the watcher
+                        // never delivered is not on the device, so this cannot fire for
+                        // it, and with no clock there is nothing to say whether the
+                        // device copy is older or newer, so it is not pushed either.
+                        //
+                        // Deliberately not paired with a write in the other direction. If
+                        // the two do not agree there is no clock to say which is newer,
+                        // and pushing either way would destroy the other side's work.
+                        deviceAgrees = true
+                        Logger.i(
+                            tag,
+                            "Tracking ${doc.relativePath} again: the provider reports no " +
+                                "modification time, and the device copy already holds " +
+                                "what the mirror holds",
+                        )
                         recordIdentity(recorded, doc.relativePath, localPath)
                     } else if (doc.lastModified > 0L &&
                         localPath.lastModified() > doc.lastModified
@@ -263,15 +295,19 @@ class SafSyncEngine(private val context: Context) {
                         writeLocalToSaf(localPath, doc.uri)
                     }
                     unfetched.remove(localPath.absolutePath)
-                    if (doc.lastModified == 0L) {
+                    // The flag the branch above set, not a fresh stat plus a scan of the
+                    // recorded list. Re-deriving it would also read "the two differ" out of
+                    // a recordIdentity that simply declined the path.
+                    if (doc.lastModified == 0L && !deviceAgrees) {
                         // At Logger.i, not d: this file stops receiving device-side
                         // changes from here on, and a user asking why their folder does
                         // not update needs this line to exist in a bug report.
                         Logger.i(
                             tag,
-                            "Kept ${doc.relativePath} and stopped tracking the device " +
-                                "copy: the provider reports no modification time and " +
-                                "this file no longer matches what the last sync wrote",
+                            "Kept ${doc.relativePath}: the provider reports no " +
+                                "modification time, and the device copy differs from the " +
+                                "mirror, so nothing here can say which is newer. Both " +
+                                "sides are left as they are.",
                         )
                     }
                     Logger.d(tag, "Kept local copy: ${doc.relativePath}")
@@ -354,8 +390,9 @@ class SafSyncEngine(private val context: Context) {
      *
      * **Where all of this stops being true.** Every line of it assumes the provider
      * reports `COLUMN_LAST_MODIFIED`. When it does not, [shouldOverwriteMirror]'s
-     * unknown-time branch returns true on *every* comparison, so an edit that has not been
-     * written back is overwritten on the next reopen — before deletion is considered at
+     * unknown-time branch answers from the record instead, so a diverged file is kept
+     * rather than overwritten, and is tracked again once a sync finds the two sides
+     * holding the same bytes, before deletion is considered at
      * all. Nothing recorded here can protect what the copy already replaced, and no
      * identity check reaches a file that is gone. The account above of four defects
      * turning out to be one gap holds for providers that report a time, and only those.
@@ -447,8 +484,13 @@ class SafSyncEngine(private val context: Context) {
      * destination and renames, deliberately leaving the destination untouched when it
      * fails — so after a failed copy this reads whatever was already there, which can be
      * an edit of the user's that no sync ever wrote. Recording that identity is what
-     * would make the user's only copy match, and match is what licenses the delete. Call
-     * this only where the write is known to have landed.
+     * would make the user's only copy match, and match is what licenses the delete.
+     *
+     * So the precondition is about the DEVICE, not about who authored the bytes: call
+     * this only where the device is known to hold what is on disk here. A landed copy
+     * establishes that. So does a comparison that read both sides and found them equal,
+     * which is how a file the editor wrote and the watcher delivered gets recorded
+     * without any copy having happened.
      */
     private fun recordIdentity(into: MutableList<String>, path: String, file: File) {
         if (!file.isFile) return
@@ -495,10 +537,15 @@ class SafSyncEngine(private val context: Context) {
      *
      * So the test is inverted: rather than look for evidence a file is precious, require
      * evidence that it is disposable. The record beside the mirror is that evidence and
-     * already exists. [recordIdentity] writes one line per file the device enumeration
-     * produced, and this compares against it in the same format, so a file absent from
-     * the record, or present but no longer the bytes recorded for it, means the mirror is
-     * not purely a copy.
+     * already exists. [recordIdentity] writes one line per file the device is known to
+     * hold, and this compares against it in the same format, so a file absent from the
+     * record, or present but no longer the bytes recorded for it, means the mirror holds
+     * something the device does not.
+     *
+     * "The device holds it" rather than "this app copied it", and the difference is not
+     * pedantry. A file the editor wrote and the watcher delivered is recorded too, once a
+     * sync has read both sides and found them equal. It was never copied here, and it is
+     * still disposable, because deleting the mirror does not destroy it.
      *
      * Fails closed, in three directions, all deliberate. A missing record, a record whose
      * first line is not [RECORD_HEADER], and an unreadable directory each return false
@@ -842,6 +889,54 @@ class SafSyncEngine(private val context: Context) {
      * device copy. Permission loss is not retried: nothing about a revoked grant
      * gets better within a second.
      */
+    /**
+     * Whether the device document and the mirror hold the same bytes.
+     *
+     * The one question that can be answered without a clock, and the only one this
+     * path needs. When the watcher has already carried an edit to the device, the two
+     * agree in content while the record still describes what was there before, and
+     * that mismatch is what froze the file: nothing else ever brings the bookkeeping
+     * back into step.
+     *
+     * Reads the device document, so lengths are compared first: unequal lengths cannot
+     * hold equal bytes, and skipping the read there is what keeps this off the common
+     * path.
+     *
+     * ⚠️ That length is the provider's claim, not a measurement, and `COLUMN_SIZE` is
+     * optional in the same way `COLUMN_LAST_MODIFIED` is. A provider omitting both
+     * reports every length as 0, and this then answers false for every non-empty file,
+     * so the fix does not apply there. It cannot answer a wrong yes, because the bytes
+     * are compared afterwards, so the ceiling is "does not help", never a loss.
+     *
+     * A read that fails answers false. That is the safe direction: false leaves the
+     * mirror kept and unrecorded, which is what happens today, while a true this could
+     * not justify would vouch for bytes nobody compared.
+     */
+    private fun deviceMatchesMirror(safDocUri: Uri, localFile: File, deviceSize: Long): Boolean {
+        if (deviceSize != localFile.length()) return false
+        return try {
+            context.contentResolver.openInputStream(safDocUri)?.use { device ->
+                localFile.inputStream().use { mirror ->
+                    val a = ByteArray(COPY_BUFFER_SIZE)
+                    val b = ByteArray(COPY_BUFFER_SIZE)
+                    while (true) {
+                        val read = device.readNBytes(a, 0, a.size)
+                        val same = mirror.readNBytes(b, 0, b.size)
+                        if (read != same) return@use false
+                        if (read == 0) return@use true
+                        // Only the bytes this chunk filled. Comparing the whole buffer
+                        // would drag in the previous, longer chunk's tail.
+                        if (!java.util.Arrays.equals(a, 0, read, b, 0, read)) return@use false
+                    }
+                    @Suppress("UNREACHABLE_CODE") false
+                }
+            } ?: false
+        } catch (e: Exception) {
+            Logger.w(tag, "Could not compare ${localFile.name} with its device copy: ${e.message}")
+            false
+        }
+    }
+
     private fun writeLocalToSaf(localFile: File, safDocUri: Uri) {
         markUploadInFlight(localFile.absolutePath)
         var attempts = 0
@@ -1817,13 +1912,16 @@ class SafSyncEngine(private val context: Context) {
             // record behind it is not ours to overwrite either, which is the direction
             // reconcileDeletions already fails in.
             //
-            // ⚠️ What this costs, stated because it is permanent and the old behaviour
-            // did not have it. Once a file here answers false it can never answer true
-            // again: it is not copied, so `copyDocumentToLocal` never records it, and
-            // the equal-timestamp branch cannot record it either because a real file's
-            // mtime is never 0. Device-side changes to that file stop arriving, and no
-            // size comparison rescues it, because this clause returns before the size
-            // clause below is reached.
+            // ⚠️ What this costs, and what gets it back. A file answering false here is
+            // kept and is not vouched, and while it stays that way device changes stop
+            // arriving and the mirror cannot be reclaimed. It does not stay that way by
+            // itself: the caller compares the two sides' bytes, and when they agree,
+            // which is where an edit the watcher carried to the device ends up, it
+            // records the file and this clause answers true again on the next sync.
+            //
+            // What no branch recovers is an edit the watcher never delivered. With no
+            // clock there is nothing to say whether the device copy is older or newer,
+            // so neither side is pushed over the other.
             //
             // Kept anyway, because the alternative is worse and is what shipped: with no
             // timestamp there is nothing to tell a device edit from a local one, and the
@@ -1833,11 +1931,11 @@ class SafSyncEngine(private val context: Context) {
             // itself in content if not in bookkeeping: the watcher writes the local edit
             // out on the next save, after which both sides hold the same bytes.
             //
-            // Tracked as #286. A real fix has to tell a device change from a local one
-            // without a clock, which means comparing content rather than metadata: a
-            // per-file digest beside the mtime and size [identityLine] already writes.
-            // That puts a hash over every mirrored file into each sync, so it wants
-            // measuring before it is taken.
+            // Content is what tells a device change from a local one without a clock,
+            // and the caller reads both sides to ask. It is affordable because the
+            // question is only asked for files this clause kept, which on a healthy
+            // folder is none: every other file is answered true here and copied, which
+            // reads the device document anyway.
             sourceModified == 0L -> mirrorIsOurCopy
             sourceModified > mirrorModified -> true
             // A newer local copy wins, whatever its size. Checking size before this

--- a/android/app/src/test/kotlin/com/vscodroid/storage/InitialSyncWiringTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/InitialSyncWiringTest.kt
@@ -12,6 +12,7 @@ import io.mockk.unmockkAll
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -182,26 +183,63 @@ class InitialSyncWiringTest {
     }
 
     /**
-     * The cost of the clause above, pinned so it is a decision rather than a surprise.
+     * The frozen file comes back, and the signal needs no clock.
      *
-     * Once a file on a timestamp-less provider diverges from the record it can never be
-     * vouched for again: it is not copied, so nothing records it, and the equal-timestamp
-     * branch cannot record it because a real file's mtime is never 0. Device-side changes
-     * to that file stop arriving, and a size change does not rescue it, because the
-     * clause returns before the size comparison.
+     * The old behaviour kept a diverged file and never looked at it again: it could
+     * not become vouched, so device changes stopped arriving and the mirror could not
+     * be reclaimed. Those two come back here. An edit the watcher never delivered still
+     * has no second route to the device, and cannot: it is not on the device, so the
+     * comparison below cannot fire for it.
      *
-     * Kept because the alternative is what shipped: with nothing to compare, the old
-     * answer assumed the device always won and destroyed the local edit on every reopen.
-     *
-     * This test locks the limitation rather than the fix. When #286 lands it should go
-     * red, and the case that replaces it asserts the device change arriving.
+     * What resolves it is the ordinary end of a local edit. The watcher carries the
+     * edit to the device, so the two agree in content while the record still describes
+     * what was there before. Comparing them is the one question answerable without a
+     * clock, and answering it records what is already true on both sides.
      */
     @Test
-    fun `a diverged file on a timestamp-less provider stops receiving device changes`() {
-        val local = mirrorHolding("notes.txt", "edited in the editor!", 1_700_000_060_000)
-        deviceFolderHolding("notes.txt", "a different length on the device", modified = 0)
-
+    fun `a timestamp-less file the watcher already delivered is tracked again`() {
+        deviceFolderHolding("notes.txt", "from the device", modified = 0)
         sync()
+        val local = File(mirror, "notes.txt")
+        assertTrue(local.isFile, "setup failed: the first sync did not create the mirror")
+
+        // The editor edits it and the watcher carries it to the device, so both sides
+        // now hold the edit while the record still holds what came before. The length
+        // changes too, which is the ordinary case and the one a size test cannot reach.
+        local.writeText("a much longer edit made in the editor")
+        local.setLastModified(1_700_000_060_000)
+        deviceFolderHolding("notes.txt", "a much longer edit made in the editor", modified = 0)
+        sync()
+
+        assertEquals(
+            emptyList<String>(), writtenDocuments,
+            "nothing should have been written to the device: both sides already agree",
+        )
+
+        // Tracked again: the next device-side change reaches the mirror.
+        deviceFolderHolding("notes.txt", "changed on the device", modified = 0)
+        sync()
+
+        assertEquals(
+            "changed on the device", local.readText(),
+            "still frozen: agreeing with the device should have re-recorded the file, " +
+                "so this sync sees its own copy and takes the device change",
+        )
+    }
+
+    /**
+     * And a file the two sides genuinely disagree about is still left alone, on both
+     * sides. That is what keeps the fix from being a licence to overwrite.
+     */
+    @Test
+    fun `a timestamp-less file the two sides disagree about is left alone`() {
+        deviceFolderHolding("notes.txt", "from the device", modified = 0)
+        sync()
+        val local = File(mirror, "notes.txt")
+
+        local.writeText("edited in the editor!")
+        local.setLastModified(1_700_000_060_000)
+        deviceFolderHolding("notes.txt", "a different edit on the device", modified = 0)
         sync()
 
         assertEquals(
@@ -209,9 +247,45 @@ class InitialSyncWiringTest {
             "the local edit survives, which is the point",
         )
         assertEquals(
-            emptyList<String>(), openedDocuments,
-            "and the device copy is never read again, even though its length differs: " +
-                "this is the permanent cost of having no clock to compare",
+            emptyList<String>(), writtenDocuments,
+            "and the device copy is not overwritten: with no clock, pushing either way " +
+                "would destroy the other side's work",
+        )
+
+        // And it stays untracked, so a later sync does not quietly take the device copy.
+        deviceFolderHolding("notes.txt", "a different edit on the device", modified = 0)
+        sync()
+        assertEquals(
+            "edited in the editor!", local.readText(),
+            "the disagreement was recorded away and the device copy taken anyway",
+        )
+    }
+
+    /**
+     * Equal lengths with different bytes must not count as agreement.
+     *
+     * The length check exists only to skip the read for files that cannot match. If it
+     * were mistaken for the answer, a device edit that preserved length would be
+     * recorded as agreement and the file would then be overwritten from the device on
+     * the next sync, losing the local edit.
+     */
+    @Test
+    fun `equal lengths with different bytes are not agreement`() {
+        deviceFolderHolding("notes.txt", "from the device", modified = 0)
+        sync()
+        val local = File(mirror, "notes.txt")
+
+        local.writeText("from the EDITOR")
+        local.setLastModified(1_700_000_060_000)
+        deviceFolderHolding("notes.txt", "from the DEVICE", modified = 0)
+        sync()
+        deviceFolderHolding("notes.txt", "from the DEVICE", modified = 0)
+        sync()
+
+        assertEquals(
+            "from the EDITOR", local.readText(),
+            "the two differ only in content, and treating equal lengths as agreement " +
+                "would have recorded the file and let the next sync take the device copy",
         )
     }
 


### PR DESCRIPTION
Closes #286.

A device folder whose provider omits `COLUMN_LAST_MODIFIED` reports no time, so
the no-clock branch of `shouldOverwriteMirror` answers from the synced record. A
file the user edits stops matching that record, is kept, and was then never
looked at again: device changes stopped arriving, and the mirror could never be
reclaimed, because nothing vouched for it.

## The signal that needs no clock

The ordinary end of a local edit is that the watcher carries it to the device.
After that the two sides hold the same bytes while the record still describes
what came before, and that mismatch is the whole freeze. Whether the two agree
is answerable without a clock, and when they do, recording the file is simply
writing down what is already true on both sides.

`deviceMatchesMirror` streams both sides and short-circuits on unequal length.
**It never writes.** A disagreement leaves both sides exactly as they are,
because with no clock nothing can say which is newer.

## What this does not fix

Two of the issue's three consequences come back: device changes reach the file
again, and the mirror becomes reclaimable. The third does not. An edit the
watcher never delivered is not on the device, so the comparison cannot find it,
and there is no basis for pushing it. That is stated at the branch, in the KDoc,
and in the test rather than left for a reader to discover.

## A previous attempt, and why this is not it

An earlier attempt compared the recorded **size** against the device document's
size and, on a match, wrote the mirror over the device. It was rejected: it could
not fire in the ordinary case, because the watcher updates the device without
updating the record, and where it did fire it destroyed a device-side edit that
preserved length. This compares content and writes nothing, so neither failure is
reachable. `equal lengths with different bytes are not agreement` is the case
that keeps it that way.

## Contracts widened rather than quietly broken

The record now also names files this app never copied, only compared. Its meaning
was always "the device holds these bytes"; that is now what it says.
`recordIdentity`'s precondition, `holdsOnlyVouchedCopies`' definition and the
reclaim justification in `SafStorageManager` are updated together. The decision's
own KDoc described the limit as permanent and the fix as untaken, and the
`reconcileDeletions` paragraph still described behaviour from before the record
existed; both are corrected here.

## Verification

- 1223 unit tests across 191 suites pass.
- Three cases, each confirmed to fail against the defect it names: removing the
  branch restores the freeze, and treating equal length as agreement makes the
  equal-length case go red.
- The harness used for those controls refuses to report at all unless the build
  compiled and the executed test count matches the `@Test` count in the source.
  That check was added after an earlier round reported green from a stale results
  file while the test source had not compiled.

## Known ceiling

The length short-circuit uses the provider's claimed size, and `COLUMN_SIZE` is
optional in the same way `COLUMN_LAST_MODIFIED` is. A provider omitting both
reports every length as 0, and the comparison then answers no for every non-empty
file, so this does not apply there. It cannot answer a wrong yes, because the
bytes are compared afterwards.