### PR TITLE
fix(release): resolve outstanding defects and bump to 1.2.0

### DIFF
--- a/.github/workflows/patch-drift.yml
+++ b/.github/workflows/patch-drift.yml
@@ -40,8 +40,16 @@ permissions:
   contents: read
 
 concurrency:
-  group: patch-drift-${{ github.ref }}
-  cancel-in-progress: true
+  group: patch-drift-${{ github.event_name }}-${{ github.ref }}
+  # Both triggers resolve to the default branch ref, so keying on the ref alone
+  # put the weekly run and a manual dispatch in one group with cancellation on:
+  # asking for an answer by hand cancelled the scheduled run mid-fetch, and that
+  # week recorded a cancellation instead of a verdict. The same shape and the same
+  # reasoning as r8.yml, which has the same pair of triggers.
+  #
+  # Nothing here is worth cancelling: there is no pull_request trigger, and the
+  # job is a 20-minute clone-and-apply whose result is the point.
+  cancel-in-progress: false
 
 jobs:
   apply:
@@ -59,7 +67,8 @@ jobs:
         # after the splice and so cannot be what protects this.
         env:
           INPUT_TAG: ${{ inputs.tag }}
-        #  prefix to match every other workflow here, and not only for
+        # A `bash ` prefix, to match every other workflow here, and not only for
         # consistency: check-build-steps.py recognises a shell script CI runs by
-        # that exact form, so a bare invocation is invisible to it.
+        # that exact form, so a bare `scripts/...` invocation is invisible to it
+        # and the script would count as one CI never runs.
         run: bash scripts/check-patches-apply.sh "$INPUT_TAG"

--- a/.github/workflows/r8.yml
+++ b/.github/workflows/r8.yml
@@ -42,6 +42,13 @@ on:
       - "android/app/proguard-rules.pro"
       - "android/gradle/libs.versions.toml"
       - "android/gradle.properties"
+      # The Gradle distribution is part of the configuration, not a detail below
+      # it: AGP declares a minimum Gradle and refuses to apply on an older one,
+      # so a wrapper bump and an AGP bump are one change that can arrive as two
+      # files. Without this line a pull request moving only the wrapper skipped
+      # the one job that compiles a release build, and the pairing was checked
+      # for the first time at tag time.
+      - "android/gradle/wrapper/gradle-wrapper.properties"
       - ".github/workflows/r8.yml"
 
 concurrency:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The build moves to Android Gradle plugin 9.3.1 and Gradle 9.5.1, which turns on optimized resource shrinking. Play flagged the old configuration for memory and performance.
 - Kotlin now comes from the Android Gradle plugin rather than a separate plugin, so the compiler is 2.2.10 and the version catalog no longer names one.
 - 97 unused Material and AndroidX resources no longer ship: the date and time pickers, the navigation drawer, fragment transitions and the legacy notification templates.
-- The three deprecated edge-to-edge APIs Play reports are gone. Edge-to-edge, bar icons, cutout and bar contrast are now set by theme attributes instead.
+- The three deprecated edge-to-edge APIs Play reports are gone. Bar colours, the display cutout and bar contrast move to theme attributes; edge-to-edge and bar icons stay in code.
 
 ### Fixed
 
@@ -29,7 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A toolchain Play finished downloading after its screen closed is now installed on the next launch, instead of being paid for and never appearing.
 - Refusing a toolchain install for lack of space now hands Play's copy back, instead of leaving it on the device that just ran out.
 - A toolchain whose release publishes no checksum for it now says so, instead of reporting a connection problem that retrying cannot fix.
-- The navigation and status bars are transparent again on Android 13 and 14, instead of picking up a system scrim behind them.
 - On a device provider that reports no modification time, reopening a folder no longer replaces edits made in the editor. It refreshes only files identical to the last sync.
 - Reopening a device folder now writes back an edit the watcher never carried out, instead of leaving it in the app forever.
 - A save that cannot reach the device folder now says so, once per burst, instead of failing silently and looking like a save that worked.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The build moves to Android Gradle plugin 9.3.1 and Gradle 9.5.1, which turns on optimized resource shrinking. Play flagged the old configuration for memory and performance.
+- Kotlin now comes from the Android Gradle plugin rather than a separate plugin, so the compiler is 2.2.10 and the version catalog no longer names one.
+- 97 unused Material and AndroidX resources no longer ship: the date and time pickers, the navigation drawer, fragment transitions and the legacy notification templates.
+- The three deprecated edge-to-edge APIs Play reports are gone. Edge-to-edge, bar icons, cutout and bar contrast are now set by theme attributes instead.
+
 ### Fixed
 
 - First-run setup now shows progress while it extracts the editor, instead of holding at 5% for minutes and looking like it has hung.
@@ -16,26 +23,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - On a device folder whose provider reports no modification time, a file you edited starts receiving device changes again once both sides hold the same content.
 - Toolchain downloads now come from the release matching the installed app, instead of whichever is newest. A newer release can retire a payload an older app still offers.
 - Closing the editor or swiping the app away no longer keeps the destroyed screen and its view tree in memory until the app is next opened.
+- A toolchain install started from Play no longer keeps that screen in memory for as long as the download runs.
+- A toolchain Play finished downloading after its screen closed is now installed on the next launch, instead of being paid for and never appearing.
+- Refusing a toolchain install for lack of space now hands Play's copy back, instead of leaving it on the device that just ran out.
+- A toolchain whose release publishes no checksum for it now says so, instead of reporting a connection problem that retrying cannot fix.
+- The navigation and status bars are transparent again on Android 13 and 14, instead of picking up a system scrim behind them.
+- On a device provider that reports no modification time, reopening a folder no longer replaces edits made in the editor. It refreshes only files identical to the last sync.
+- Reopening a device folder now writes back an edit the watcher never carried out, instead of leaving it in the app forever.
+- A save that cannot reach the device folder now says so, once per burst, instead of failing silently and looking like a save that worked.
+- A device folder's local copy is no longer deleted when it falls off the recent list. Anything written there but never sent, a cloned repository included, was the only copy.
 
 ### Security
 
 - Content rendered in the editor can no longer read workspace files across origins. Served files are readable by anyone, and a page in the built-in browser could fetch one.
 - A webview can no longer name an arbitrary file and have the app read it with the editor's own credential. The route that did was reachable but unused.
 - The editor can no longer make the app fetch an arbitrary web address on its behalf. The route reached any host, including addresses only this device can see.
-
-### Fixed
-
-- On a device provider that reports no modification time, reopening a folder no longer replaces edits made in the editor. It refreshes only files still identical to what the last sync wrote.
-- Reopening a device folder now writes back an edit the watcher never carried out, instead of leaving it in the app forever.
-- A save that cannot reach the device folder now says so, once per burst, instead of failing silently and looking like a save that worked.
-- A device folder's local copy is no longer deleted when it falls off the recent list. Anything written there that never reached the device, a cloned repository included, was the only copy.
-
-### Changed
-
-- The build moves to Android Gradle plugin 9.3.1 and Gradle 9.5.1, which turns on optimized resource shrinking. Play flagged the old configuration for memory and performance.
-- Kotlin now comes from the Android Gradle plugin rather than a separate plugin, so the compiler is 2.2.10 and the version catalog no longer names one.
-- 97 unused Material and AndroidX resources no longer ship: the date and time pickers, the navigation drawer, fragment transitions and the legacy notification templates.
-- The three deprecated edge-to-edge APIs Play reports are gone from the app. Edge-to-edge, light bar icons and the display cutout are now set directly rather than through a library call that carried them.
 
 ## [1.1.0] - 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-08-20
+
 ### Changed
 
 - The build moves to Android Gradle plugin 9.3.1 and Gradle 9.5.1, which turns on optimized resource shrinking. Play flagged the old configuration for memory and performance.
@@ -551,7 +553,8 @@ This release represents the cumulative work across milestones M0 through M5, bri
 - Health check polling for server readiness
 - Android intent handling for "Open with VSCodroid"
 
-[Unreleased]: https://github.com/rmyndharis/VSCodroid/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/rmyndharis/VSCodroid/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/rmyndharis/VSCodroid/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/rmyndharis/VSCodroid/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/rmyndharis/VSCodroid/compare/v0.2.9...v1.0.0
 [0.2.9]: https://github.com/rmyndharis/VSCodroid/compare/v0.2.8...v0.2.9

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,6 +203,7 @@ VSCodroid/
 │   ├── deploy.sh                     # Build + install + launch on device
 │   ├── device-test.sh                # Run device tests
 │   ├── device-launch.sh              # Launch on device, dismissing first-run dialogs
+│   ├── build-aab.sh                  # Build a signed AAB outside CI
 │   └── generate-branding-icons.py    # Regenerate the web client's PWA icons
 ├── toolchains/                    # Work dir for the download scripts — gitignored,
 │                                  #   cached by CI, safe to delete (costs a re-download)
@@ -256,6 +257,7 @@ checkouts differed.
 | `build-vscode-oss.sh` | Builds that tree from the MIT source with `patches/` and `branding/` applied. Run by the build-vscode-oss workflow on an arm64 runner, or locally in Docker; not needed for a normal build | a `.tar.gz` published as a release asset |
 | `generate-branding-icons.py` | Renders the web client's PWA icon set from the Android launcher icon. Run **by hand** when the launcher icon changes, never by CI, and its outputs are committed: `build-vscode-oss.sh` copies them into the server tree, so the build consumes the committed files and not this script. Load-bearing rather than cosmetic, because upstream ships Microsoft's VS Code icon there and that cannot travel with this app. Needs Pillow | `branding/server/{code-192.png,code-512.png,favicon.ico}` |
 | `device-launch.sh` | Launches the app on a connected device and clears what blocks a first run, matching the POST_NOTIFICATIONS prompt and the toolchain picker by their on-screen text through `uiautomator` rather than by fixed coordinates. Worth knowing why it exists: both dialogs take focus, so the app is backgrounded and its process is gone, which through `ps` and `logcat` reads exactly like a crash. Run by hand, not by CI | the app running on the device |
+| `build-aab.sh` | Builds a signed release bundle outside CI, reading the keystore from the gitignored `android/signing.properties` or the `VSCODROID_*` environment variables. Run by hand; `release.yml` builds the published bundle itself and does not call this. Useful for checking what a release build actually produces, which is also the only build that runs R8 | `app/build/outputs/bundle/release/app-release.aab` |
 | `verify-server-tree.py` | Checks a server tree: required paths, no vsda, no bundled GNU/Linux node, every native binary aarch64, branding applied. Run by both scripts above on the tree they produce, and again by the `verifyServerTree` Gradle task on the copy in `assets/` that is actually packaged — which on a warm-cache build is the only run that happens | exit status |
 | `download-termux-tools.sh` | Downloads bash, git, tmux, make, openssh and every shared library the bundled binaries link against, including Node's | `jniLibs/arm64-v8a/`, `assets/usr/` |
 | `download-node.sh` | Installs Termux's `nodejs-lts` as `libnode.so`. Run after `download-termux-tools.sh`, which places the libraries it links against | `jniLibs/arm64-v8a/libnode.so` |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,7 +201,9 @@ VSCodroid/
 │   ├── download-java.sh              # Download Java (OpenJDK 17) toolchain
 │   ├── build-all.sh                  # Run all download/build scripts
 │   ├── deploy.sh                     # Build + install + launch on device
-│   └── device-test.sh                # Run device tests
+│   ├── device-test.sh                # Run device tests
+│   ├── device-launch.sh              # Launch on device, dismissing first-run dialogs
+│   └── generate-branding-icons.py    # Regenerate the web client's PWA icons
 ├── toolchains/                    # Work dir for the download scripts — gitignored,
 │                                  #   cached by CI, safe to delete (costs a re-download)
 ├── patches/                       # Unified diffs applied to the VS Code source
@@ -252,6 +254,8 @@ checkouts differed.
 | ------ | ------------ | --------------- |
 | `fetch-vscode-oss.sh` | Downloads the Code - OSS server tree from the `server-<version>` release, verifies it, and installs ripgrep as `libripgrep.so` | `server/vscode-reh/`, `jniLibs/arm64-v8a/libripgrep.so` |
 | `build-vscode-oss.sh` | Builds that tree from the MIT source with `patches/` and `branding/` applied. Run by the build-vscode-oss workflow on an arm64 runner, or locally in Docker; not needed for a normal build | a `.tar.gz` published as a release asset |
+| `generate-branding-icons.py` | Renders the web client's PWA icon set from the Android launcher icon. Run **by hand** when the launcher icon changes, never by CI, and its outputs are committed: `build-vscode-oss.sh` copies them into the server tree, so the build consumes the committed files and not this script. Load-bearing rather than cosmetic, because upstream ships Microsoft's VS Code icon there and that cannot travel with this app. Needs Pillow | `branding/server/{code-192.png,code-512.png,favicon.ico}` |
+| `device-launch.sh` | Launches the app on a connected device and clears what blocks a first run, matching the POST_NOTIFICATIONS prompt and the toolchain picker by their on-screen text through `uiautomator` rather than by fixed coordinates. Worth knowing why it exists: both dialogs take focus, so the app is backgrounded and its process is gone, which through `ps` and `logcat` reads exactly like a crash. Run by hand, not by CI | the app running on the device |
 | `verify-server-tree.py` | Checks a server tree: required paths, no vsda, no bundled GNU/Linux node, every native binary aarch64, branding applied. Run by both scripts above on the tree they produce, and again by the `verifyServerTree` Gradle task on the copy in `assets/` that is actually packaged — which on a warm-cache build is the only run that happens | exit status |
 | `download-termux-tools.sh` | Downloads bash, git, tmux, make, openssh and every shared library the bundled binaries link against, including Node's | `jniLibs/arm64-v8a/`, `assets/usr/` |
 | `download-node.sh` | Installs Termux's `nodejs-lts` as `libnode.so`. Run after `download-termux-tools.sh`, which places the libraries it links against | `jniLibs/arm64-v8a/libnode.so` |

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -236,7 +236,7 @@ android {
     sourceSets["main"].assets.srcDir(bundleNotices)
 
     lint {
-        // The baseline is what makes this affordable: the 17 issues recorded in
+        // The baseline is what makes this affordable: the 16 issues recorded in
         // lint-baseline.xml are filtered out of every report, so what remains is
         // what arrived after it was taken.
         //

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -84,8 +84,8 @@ android {
         applicationId = "com.vscodroid"
         minSdk = 33
         targetSdk = 36
-        versionCode = 12
-        versionName = "1.1.0"
+        versionCode = 13
+        versionName = "1.2.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/android/app/lint-baseline.xml
+++ b/android/app/lint-baseline.xml
@@ -41,16 +41,6 @@
             column="5"/>
     </issue>
 
-    <issue
-        id="UnusedResources"
-        message="The resource `R.color.colorNotificationBg` appears to be unused"
-        errorLine1="    &lt;color name=&quot;colorNotificationBg&quot;>#1E1E1E&lt;/color>"
-        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values/colors.xml"
-            line="19"
-            column="12"/>
-    </issue>
 
     <issue
         id="IconLauncherShape"

--- a/android/app/src/androidTest/README.md
+++ b/android/app/src/androidTest/README.md
@@ -107,7 +107,7 @@ That accounted for 21 tests and roughly 52 s of test time. This paragraph claime
 three minutes for a long time; the recorded run says otherwise, which is what
 reading the XML is for.
 
-**At HEAD there are 27 tests across seven classes**, counted from the sources rather
+**At HEAD there are 26 tests across seven classes**, counted from the sources rather
 than from any run: `SafWatchWiringTest` arrived with the per-directory watch work
 and adds five, `ExtractionOnDeviceTest` arrived with the first-run setup work and
 adds four, and the classes have moved since besides. No recorded run covers

--- a/android/app/src/androidTest/kotlin/com/vscodroid/SplashActivityTest.kt
+++ b/android/app/src/androidTest/kotlin/com/vscodroid/SplashActivityTest.kt
@@ -1,7 +1,6 @@
 package com.vscodroid
 
 import android.content.Context
-import android.content.Intent
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -79,7 +79,6 @@ class MainActivity : AppCompatActivity() {
     private var webView: WebView? = null
     private var extraKeyRow: ExtraKeyRow? = null
     private var nodeService: NodeService? = null
-    private var serviceBound = false
     private var serviceBindingInitiated = false
     private var serverPort = 0
     private var backgroundedAt = 0L
@@ -360,14 +359,12 @@ class MainActivity : AppCompatActivity() {
         override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
             val binder = service as NodeService.LocalBinder
             nodeService = binder.getService()
-            serviceBound = true
             Logger.i(tag, "Bound to NodeService")
             setupServiceCallbacks()
         }
 
         override fun onServiceDisconnected(name: ComponentName?) {
             nodeService = null
-            serviceBound = false
             Logger.w(tag, "Disconnected from NodeService")
         }
     }
@@ -551,7 +548,6 @@ class MainActivity : AppCompatActivity() {
                 // Already unbound — safe to ignore
             }
             serviceBindingInitiated = false
-            serviceBound = false
         }
         webView?.destroy()
         webView = null

--- a/android/app/src/main/kotlin/com/vscodroid/SplashActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/SplashActivity.kt
@@ -109,6 +109,13 @@ class SplashActivity : AppCompatActivity() {
         // I/O thread, because the trees involved have thousands of files
         // and this block is on the main thread.
         repair("the toolchain repair pass") { ToolchainManager(this).repairInstalledToolchains() }
+        // A Play pack that finished downloading after its screen went away was
+        // never installed: the COMPLETED callback is the only thing that installs
+        // one, and both screens drop their listener at teardown. This is the
+        // reconcile that was missing, and launch is where it belongs, because the
+        // alternative is a listener outliving the Activity that registered it.
+        // Returns immediately; the copy runs on the toolchain I/O thread.
+        repair("the delivered toolchain reconcile") { ToolchainManager(this).reconcileDeliveredPacks() }
         // A folder whose permission the user withdrew in system settings never
         // comes back through the app, so its mirror is disk nothing can reach.
         // Here because it is the one point that is guaranteed to have no folder

--- a/android/app/src/main/kotlin/com/vscodroid/bridge/AndroidBridge.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/bridge/AndroidBridge.kt
@@ -20,6 +20,7 @@ import com.vscodroid.webview.redactToken
 import org.json.JSONArray
 import org.json.JSONObject
 import java.io.File
+import java.lang.ref.WeakReference
 
 /**
  * How long generateSshKey waits for ssh-keygen before killing it.
@@ -595,7 +596,7 @@ class AndroidBridge(
         // that lives in that library and outlives every Activity here. The
         // listener holds this manager, so a manager built with the Activity keeps
         // the Activity, its Context and its view tree reachable for as long as
-        // the registration stands. `AndroidBridge.onToolchainState` removes the
+        // the registration stands. The state callback below removes the
         // registration only on COMPLETED, FAILED or CANCELED, and
         // REQUIRES_USER_CONFIRMATION waiting on a dialog the user walked away
         // from reaches none of them.
@@ -608,34 +609,53 @@ class AndroidBridge(
         // registers afterwards. Dropping it mid-download would leave the pack
         // downloaded and never installed, with no error anywhere.
         //
-        // So the reference goes, not the registration. `ToolchainManager` reads
+        // So the references go, not the registration. `ToolchainManager` reads
         // only `filesDir`, `cacheDir`, `assets`, `packageManager` and
         // `packageName` from this, all identical on the application context, and
         // `showConfirmationDialog` takes the Activity as a parameter from
         // [confirmLargeDownload] rather than from the manager's own field.
-        ToolchainManager(context.applicationContext).apply {
-            onStateChange = { packName, status, _, _ -> onToolchainState(packName, status) }
-        }
-    }
-
-    /**
-     * Resolves what a Play install needs from a foreground component, and
-     * balances the registration [ToolchainManager.install] makes on our behalf.
-     *
-     * The unregister is the other half of a pair that had no other half:
-     * `install()` calls `registerListener()` before every Play fetch and nothing
-     * here ever undid it, so this instance stayed subscribed to Play Core for
-     * the life of the process. Terminal states are where the pair closes --
-     * after COMPLETED, FAILED or CANCELED there is nothing further to hear, and
-     * the next `install()` subscribes again. Harmless on the HTTP path, which
-     * never registers: the unregister is guarded and does nothing.
-     */
-    private fun onToolchainState(packName: String, status: Int) {
-        when (status) {
-            AssetPackStatus.REQUIRES_USER_CONFIRMATION -> confirmLargeDownload(packName)
-            AssetPackStatus.COMPLETED,
-            AssetPackStatus.FAILED,
-            AssetPackStatus.CANCELED -> toolchainManager.unregisterListener()
+        //
+        // Plural, and that is the correction. Changing only the constructor
+        // argument left the leak intact one link along: `onStateChange` was
+        // `{ ... -> onToolchainState(...) }`, an unqualified call to a member of
+        // this class, which captures the bridge exactly as completely as naming a
+        // field would, and the bridge holds the Activity. Confirmed in bytecode:
+        // the lambda compiled to a method taking `AndroidBridge` as its first
+        // parameter. It is the same shape `ServiceWorkerRetentionTest` refuses in
+        // `MainActivity`, and it reached here because the fix was written as "use
+        // the application context" rather than "hold nothing that holds a screen".
+        //
+        // So the two things this has to do are split by what they need:
+        //  - closing the registration is the manager's own business, is reached
+        //    through the manager, and still happens with no screen left.
+        //  - the confirmation dialog needs an Activity, so it reads through a weak
+        //    reference and correctly does nothing when there is none. A dialog for
+        //    a destroyed Activity was never showable; what changes is that the
+        //    Activity is now collectable while the download runs.
+        val bridge = WeakReference(this)
+        ToolchainManager(context.applicationContext).also { manager ->
+            manager.onStateChange = { packName, status, _, _ ->
+                when (status) {
+                    // The other half of a pair that had no other half: `install()`
+                    // calls `registerListener()` before every Play fetch and nothing
+                    // undid it, so this instance stayed subscribed for the life of
+                    // the process. After COMPLETED, FAILED or CANCELED there is
+                    // nothing further to hear, and the next `install()` subscribes
+                    // again. Harmless on the HTTP path, which never registers: the
+                    // unregister is guarded and does nothing.
+                    //
+                    // Spelled out rather than delegated to `isTerminalPackStatus`,
+                    // which answers a different question. That predicate defaults an
+                    // unknown status to true so the first-run queue advances rather
+                    // than stalls; here an unknown status is one still to come, and
+                    // unregistering on it would drop the install that finishes it.
+                    AssetPackStatus.COMPLETED,
+                    AssetPackStatus.FAILED,
+                    AssetPackStatus.CANCELED -> manager.unregisterListener()
+                    AssetPackStatus.REQUIRES_USER_CONFIRMATION ->
+                        bridge.get()?.confirmLargeDownload(packName)
+                }
+            }
         }
     }
 

--- a/android/app/src/main/kotlin/com/vscodroid/bridge/AndroidBridge.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/bridge/AndroidBridge.kt
@@ -222,6 +222,44 @@ object AuthTabWindow {
     fun armedReadings(): List<Long> = launches.values.toList()
 }
 
+/**
+ * The `AndroidBridge` object the workbench sees, one `@JavascriptInterface` method
+ * per call an extension may make.
+ *
+ * ⚠️ **Several methods have no PRODUCTION caller, and that is not dead code.**
+ * A sweep for unused declarations flags `minimizeApp`, `getDeviceInfo`, `getThemeMode`,
+ * `logToNative` and `cancelToolchainInstall`, because their callers are extensions
+ * nobody here wrote. Read that as "nothing in `main` calls them", not as "nothing calls
+ * them": some are exercised by tests, `logToNative` among them. Three things make
+ * removing one a breaking change rather than a cleanup, and all three were checked
+ * before this note was written:
+ *
+ *  1. Every one is published in `docs/05-API_SPEC.md`, which is what an extension
+ *     author writes against, and `check-bridge-api-spec.py` holds the bridge and that
+ *     document to each other in BOTH directions. A method deleted here fails the gate
+ *     until the spec drops it too, which is the gate correctly refusing a silent API
+ *     break.
+ *  2. `proguard-rules.pro` keeps every `@JavascriptInterface` member, so all of them
+ *     ship live and callable in the release build. "Not called here" and "not callable"
+ *     are different facts.
+ *  3. Two of them are load-bearing for code that is NOT obviously related.
+ *     `getDeviceInfo` is the only caller of the private `getVersionName()`, so removing
+ *     it strands a second declaration. `minimizeApp` is the only consumer of the
+ *     `onMinimize` constructor parameter, which every test that builds a bridge has to
+ *     pass; note that minimise-on-back does not depend on it, since `MainActivity`
+ *     calls `moveTaskToBack(true)` natively.
+ *
+ * Retiring one is therefore a deliberate API decision: drop the spec row in the same
+ * change, and expect the cascade above. It is not something a dead-code pass should do.
+ *
+ * Keeping them costs little. Every method validates the session token first, so the
+ * surface is bounded by whoever holds it, which is the workbench itself.
+ *
+ * One caveat worth knowing before an extension trusts it: `getThemeMode` reports the
+ * DEVICE's night mode, not the editor's theme. This app is always dark and ships no
+ * `values-night`, so on a device in light mode it answers "light" for an editor that
+ * is not.
+ */
 class AndroidBridge(
     private val context: Context,
     private val security: SecurityManager,
@@ -602,12 +640,16 @@ class AndroidBridge(
         // from reaches none of them.
         //
         // Releasing the registration at teardown instead would be worse than the
-        // leak. `installFromDirectory` is reachable only from
-        // `handleStateUpdate`'s COMPLETED branch, so the listener is what
-        // finishes an install; nothing reconciles pack state at launch, and
-        // Play Core does not promise to re-emit a state to a listener that
-        // registers afterwards. Dropping it mid-download would leave the pack
-        // downloaded and never installed, with no error anywhere.
+        // leak. The COMPLETED branch of `handleStateUpdate` is what finishes an
+        // install, and Play Core does not promise to re-emit a state to a listener
+        // that registers afterwards, so dropping it mid-download leaves the pack
+        // downloaded and never installed.
+        //
+        // That used to be unrecoverable, and this said so. It no longer is:
+        // `ToolchainManager.reconcileDeliveredPacks` runs at launch and installs a
+        // pack Play has already delivered, without needing any listener. The
+        // registration is still not the thing to drop, because reconcile repairs
+        // the next launch rather than this download, but the loss is now bounded.
         //
         // So the references go, not the registration. `ToolchainManager` reads
         // only `filesDir`, `cacheDir`, `assets`, `packageManager` and
@@ -654,6 +696,19 @@ class AndroidBridge(
                     AssetPackStatus.CANCELED -> manager.unregisterListener()
                     AssetPackStatus.REQUIRES_USER_CONFIRMATION ->
                         bridge.get()?.confirmLargeDownload(packName)
+                            // A literal, NOT the `tag` property. That property belongs
+                            // to AndroidBridge, so naming it here reads a member of the
+                            // very object this lambda must not hold, and the capture is
+                            // complete whether or not the read looks like one.
+                            // ToolchainManagerContextTest caught exactly that when this
+                            // line was first written with `tag`.
+                            ?: Logger.w(
+                                "AndroidBridge",
+                                "Pack $packName needs confirmation and the bridge that " +
+                                    "started it is gone, so nothing can show the dialog. " +
+                                    "The download waits until it is asked again from the " +
+                                    "toolchain screen.",
+                            )
                 }
             }
         }

--- a/android/app/src/main/kotlin/com/vscodroid/keyboard/ExtraKeyRow.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/keyboard/ExtraKeyRow.kt
@@ -5,7 +5,6 @@ import android.graphics.drawable.GradientDrawable
 import android.util.AttributeSet
 import android.view.Gravity
 import android.view.View
-import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.LinearLayout
 import androidx.core.view.ViewCompat

--- a/android/app/src/main/kotlin/com/vscodroid/keyboard/KeyMapping.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/keyboard/KeyMapping.kt
@@ -73,6 +73,15 @@ object KeyMapping {
         " " to KeyDef(" ", "Space", 32),
     )
 
+    /**
+     * The mapping for [key], or null when there is none.
+     *
+     * ⚠️ No production caller, and that is by design rather than neglect, so a sweep
+     * for unused code should leave it. Production goes through [getKeyDefOrLetter],
+     * which never returns null because the key row must produce something for any
+     * character. This is the nullable half the tests use to assert what IS and is NOT
+     * in the table, which is the only way to state that a key is absent.
+     */
     fun getKeyDef(key: String): KeyDef? = mappings[key]
 
     fun getKeyDefOrLetter(key: String): KeyDef {

--- a/android/app/src/main/kotlin/com/vscodroid/keyboard/KeyPageAdapter.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/keyboard/KeyPageAdapter.kt
@@ -1,6 +1,5 @@
 package com.vscodroid.keyboard
 
-import android.graphics.drawable.GradientDrawable
 import android.view.Gravity
 import android.view.ViewGroup
 import android.widget.LinearLayout

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
@@ -793,6 +793,19 @@ class ToolchainManager(private val context: Context) {
             // first-run queue moves on, and the card reads "Install" again after
             // the next launch with nothing said.
             if (!writeState(state)) {
+                // ⚠️ The tree copied into `usr/` above is left where it is, and
+                // nothing removes it later. Uninstall works off this manifest, so a
+                // manifest that was never written leaves the files with no record
+                // naming them: roughly the unpacked size, 146 MB for Java 17, that
+                // only clearing app data reclaims.
+                //
+                // Not repaired here on purpose. The copy shares `usr/` with the base
+                // install and with other toolchains, so removing it means the
+                // uninstall path's own library bookkeeping rather than a
+                // deleteRecursively, and getting that wrong takes out a library the
+                // app itself loads. Pre-existing, but worth naming now that
+                // [reconcileDeliveredPacks] can reach this line at launch with no
+                // screen watching.
                 fail(packName, ToolchainFailure.STORAGE)
                 return
             }

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
@@ -84,6 +84,14 @@ class ToolchainManager(private val context: Context) {
      * same. Counting them here would only rot; the compiler does the counting.
      */
     private fun fail(packName: String, why: ToolchainFailure) {
+        // Logged before the callback, and unconditionally, because the callback is
+        // optional and this used to be the whole method. A manager built without an
+        // `onStateChange` reported its failures into a null and left nothing at all,
+        // not even a line: `reconcileDeliveredPacks` runs on exactly such an instance
+        // at launch, so a manifest it could not read or a state file it could not
+        // write vanished without trace. Every screen that installs does set the
+        // callback, which is why this was invisible.
+        Logger.e(tag, "Toolchain $packName failed: $why")
         onStateChange?.invoke(packName, AssetPackStatus.FAILED, 0, why)
     }
 
@@ -291,6 +299,15 @@ class ToolchainManager(private val context: Context) {
         // cancelling it must not reach a download that is running for another.
         httpDownloads[info.packName]?.cancelled = true
         assetPackManager.cancel(listOf(info.packName))
+        // Play's cancel is a request to the download service and does nothing to a
+        // pack it has already finished delivering, so without this a cancel could
+        // leave a complete pack sitting in `filesDir/assetpacks`. That was merely
+        // wasted disk until [reconcileDeliveredPacks] existed; now it is a delivered
+        // pack that the next launch would find and install, which is the opposite of
+        // what the user just asked for. Releasing it here is what makes "cancelled"
+        // and "not delivered" the same state, which is the only reading of Play's
+        // records that reconcile can make.
+        releasePack(info.packName)
         Logger.i(tag, "Cancelled download of ${info.packName}")
     }
 
@@ -551,12 +568,23 @@ class ToolchainManager(private val context: Context) {
                         "${available / 1_000_000} MB available, " +
                         "${required / 1_000_000} MB required",
                 )
-                // Before the return, and that ordering is the fix. This branch fires
-                // only when the device is out of room, and it used to be the one path
-                // that skipped the release, so the delivered pack stayed on the device
-                // that had just reported having no space for it. Play's copy is of no
-                // use now: the install did not happen and a retry fetches again.
-                releasePack(packName)
+                // Play's copy is deliberately KEPT here, and an earlier version of
+                // this branch released it on the reasoning that a refused install has
+                // no use for it. That reasoning was wrong twice over.
+                //
+                // Play delivers into `filesDir/assetpacks`, verified from
+                // asset-delivery 2.2.2's bytecode: `bh` builds
+                // `new File(context.getFilesDir(), "assetpacks")`. So the pack sits on
+                // the very filesystem `StatFs(filesDir)` above just measured. Deleting
+                // it frees `unpacked` bytes and the retry re-downloads and re-extracts
+                // `unpacked` bytes into the same directory, arriving back at the free
+                // space that failed the gate. The delete buys the next attempt nothing
+                // and charges it a full download, 55 MB for Java 17.
+                //
+                // Keeping it is also what makes the repair work. The user frees space,
+                // and the next launch's [reconcileDeliveredPacks] finds this same
+                // delivered pack still in place and installs it with no download at
+                // all. Releasing it here would remove the one thing that path needs.
                 fail(packName, ToolchainFailure.STORAGE)
                 return
             }
@@ -568,8 +596,9 @@ class ToolchainManager(private val context: Context) {
     /**
      * Finishes any Play delivery that completed while nothing was listening for it.
      *
-     * `installFromDirectory` is reachable only from the COMPLETED callback, and that
-     * callback only arrives while a listener is registered. Both screens that install
+     * Until this existed, `installFromDirectory` was reachable only from the
+     * COMPLETED callback, and that callback only arrives while a listener is
+     * registered. This is the second route, and the one that needs no listener. Both screens that install
      * toolchains drop their registration at teardown -- `ToolchainActivity.onStop` and
      * `SplashActivity.onDestroy` -- so backgrounding the app mid-download left the pack
      * downloaded, paid for, and never installed. Nothing retried it: the picker reads
@@ -587,11 +616,18 @@ class ToolchainManager(private val context: Context) {
      * meaning rather than a cheap no.
      */
     fun reconcileDeliveredPacks() {
-        if (shouldUseHttpFallback()) return
         ioExecutor.execute {
+            // Inside the executor, not before it. `shouldUseHttpFallback` asks the
+            // package manager who installed this app, which is a synchronous binder
+            // call, and the one caller is `SplashActivity.onCreate` on the main
+            // thread. Every other launch repair hands its work off for the same
+            // reason; this one used to do its first piece of work before it did.
+            if (shouldUseHttpFallback()) return@execute
             try {
-                // Read once, ahead of the loop: `installFromDirectory` rewrites the
-                // state, and re-reading per pack would let one install hide the next.
+                // Read once, and nothing in the loop invalidates it: each pack is
+                // visited at most once, so an install performed here can only affect
+                // an entry already passed. Re-reading per pack would be equally
+                // correct and would cost a file parse per toolchain.
                 val installed = getInstalledToolchains()
                 ToolchainRegistry.available.forEach { info ->
                     if (info.packName.removePrefix("toolchain_") in installed) return@forEach
@@ -1873,12 +1909,23 @@ internal fun packUnpackedBytes(packName: String): Long? =
 /**
  * What a Play Asset Delivery install needs free, given its unpacked size.
  *
- * One tree rather than two, and the difference is where the first copy already
- * sits. Play writes the pack outside `filesDir` before this app is told about
- * it, so the only allocation the install makes is the copy into `usr/`, and
- * `removePack` frees Play's copy afterwards. Charging for both would refuse
- * devices for room they never need at once, which is the mistake the HTTP
- * figure above was corrected for in the other direction.
+ * One tree rather than two, because by the time this is asked the first copy is
+ * already written and already counted. The figure is right; the reason given for
+ * it was not, and the wrong reason is worth naming because a later change rested
+ * on it.
+ *
+ * ⚠️ Play does NOT write the pack outside `filesDir`, which this used to claim.
+ * Verified from asset-delivery 2.2.2's bytecode: `bh` builds
+ * `new File(context.getFilesDir(), "assetpacks")`. The delivered tree therefore
+ * sits on exactly the filesystem `StatFs(context.filesDir)` measures, and it is
+ * already occupying space when the caller takes that reading. So the only NEW
+ * allocation the install makes is the copy into `usr/`, which is what this
+ * charges for; peak usage is two trees, and `removePack` frees Play's afterwards.
+ *
+ * The consequence that matters is elsewhere: deleting Play's copy when an install
+ * is refused for space does not improve the next attempt, because the retry
+ * re-extracts the same bytes into the same place. See the refusal branch in
+ * [ToolchainManager.installDeliveredPack], which keeps it for that reason.
  */
 internal fun packInstallBytes(unpackedBytes: Long): Long =
     unpackedBytes + SPACE_BUFFER

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
@@ -484,30 +484,7 @@ class ToolchainManager(private val context: Context) {
                         val location = assetPackManager.getPackLocation(packName)
                         val assetsPath = location?.assetsPath()
                         if (assetsPath != null) {
-                            // The same pre-flight downloadViaHttp does, for the same
-                            // reason and with a smaller figure. installFromDirectory
-                            // copies the whole tree into usr/, and without this the
-                            // copy fails partway on a full device: an IOException
-                            // reported as INTERNAL, and half a toolchain left in usr/
-                            // under no manifest, which is what made every retry start
-                            // from less space than the last.
-                            val required = packInstallBytes(
-                                ToolchainRegistry.find(packName)?.estimatedSize ?: 0L
-                            )
-                            val available = StatFs(context.filesDir.absolutePath).availableBytes
-                            if (available < required) {
-                                Logger.e(
-                                    tag,
-                                    "Not enough disk space for $packName: " +
-                                        "${available / 1_000_000} MB available, " +
-                                        "${required / 1_000_000} MB required",
-                                )
-                                fail(packName, ToolchainFailure.STORAGE)
-                                return@execute
-                            }
-                            installFromDirectory(packName, File(assetsPath))
-                            assetPackManager.removePack(packName)
-                            Logger.i(tag, "Removed asset pack $packName (freed duplicate storage)")
+                            installDeliveredPack(packName, File(assetsPath))
                         } else {
                             Logger.e(tag, "No assetsPath for completed pack $packName")
                             fail(packName, ToolchainFailure.INTERNAL)
@@ -530,6 +507,130 @@ class ToolchainManager(private val context: Context) {
                 Logger.w(tag, "Pack $packName requires user confirmation")
             }
             else -> { /* DOWNLOADING, PENDING, WAITING_FOR_WIFI, etc. — just report progress */ }
+        }
+    }
+
+    /**
+     * Copies a pack Play has delivered into `usr/`, then hands Play's copy back.
+     *
+     * One method rather than the same sequence at each site, because two now reach it:
+     * the COMPLETED callback, and [reconcileDeliveredPacks] at launch. Both have to
+     * apply the same pre-flight and neither may forget the release, and the way the
+     * second site came to exist is that the first was the only one.
+     *
+     * The pre-flight is the one [downloadViaHttp] does, with a smaller figure.
+     * `installFromDirectory` copies the whole tree, and without this the copy fails
+     * partway on a full device: an IOException reported as INTERNAL, and half a
+     * toolchain left in `usr/` under no manifest, which is what made every retry start
+     * from less space than the last.
+     */
+    private fun installDeliveredPack(packName: String, assetsDir: File) {
+        // [packUnpackedBytes], not `ToolchainRegistry.find(...)?.estimatedSize ?: 0L`.
+        // A retired pack answers null from the registry -- that pass-through is
+        // deliberate and keeps uninstalling one working -- and the elvis then made the
+        // whole reservation the 50 MB buffer. A gate that asks for 50 MB before copying
+        // 146 MB is worse than no gate: it passes exactly the devices it exists to
+        // refuse, and reports success while doing it.
+        val unpacked = packUnpackedBytes(packName)
+        if (unpacked == null) {
+            // Unknown size, so there is no honest reservation to make. Said out loud
+            // rather than gated on a guess, because a wrong figure here is
+            // indistinguishable from a check that ran.
+            Logger.w(
+                tag,
+                "No recorded size for $packName, so the space pre-flight is skipped; " +
+                    "a full device will fail during the copy instead of before it",
+            )
+        } else {
+            val required = packInstallBytes(unpacked)
+            val available = StatFs(context.filesDir.absolutePath).availableBytes
+            if (available < required) {
+                Logger.e(
+                    tag,
+                    "Not enough disk space for $packName: " +
+                        "${available / 1_000_000} MB available, " +
+                        "${required / 1_000_000} MB required",
+                )
+                // Before the return, and that ordering is the fix. This branch fires
+                // only when the device is out of room, and it used to be the one path
+                // that skipped the release, so the delivered pack stayed on the device
+                // that had just reported having no space for it. Play's copy is of no
+                // use now: the install did not happen and a retry fetches again.
+                releasePack(packName)
+                fail(packName, ToolchainFailure.STORAGE)
+                return
+            }
+        }
+        installFromDirectory(packName, assetsDir)
+        releasePack(packName)
+    }
+
+    /**
+     * Finishes any Play delivery that completed while nothing was listening for it.
+     *
+     * `installFromDirectory` is reachable only from the COMPLETED callback, and that
+     * callback only arrives while a listener is registered. Both screens that install
+     * toolchains drop their registration at teardown -- `ToolchainActivity.onStop` and
+     * `SplashActivity.onDestroy` -- so backgrounding the app mid-download left the pack
+     * downloaded, paid for, and never installed. Nothing retried it: the picker reads
+     * `toolchains.json`, sees the toolchain absent, and offers the same download again.
+     *
+     * Holding the registration open instead is the wrong repair, and the reason is
+     * the retention this class was just corrected for: a listener that outlives its
+     * screen is what kept an Activity alive in Play Core's registry. Reconciling at
+     * launch needs no listener at all. Play is asked what it has already delivered,
+     * which is a question with an answer whether or not anyone was listening when it
+     * became true.
+     *
+     * Play installs only. On the HTTP path there is no pack to ask about, and
+     * `getPackLocation` on an install Play does not recognise is a question with no
+     * meaning rather than a cheap no.
+     */
+    fun reconcileDeliveredPacks() {
+        if (shouldUseHttpFallback()) return
+        ioExecutor.execute {
+            try {
+                // Read once, ahead of the loop: `installFromDirectory` rewrites the
+                // state, and re-reading per pack would let one install hide the next.
+                val installed = getInstalledToolchains()
+                ToolchainRegistry.available.forEach { info ->
+                    if (info.packName.removePrefix("toolchain_") in installed) return@forEach
+                    val assetsPath = try {
+                        assetPackManager.getPackLocation(info.packName)?.assetsPath()
+                    } catch (e: Exception) {
+                        Logger.w(tag, "Could not ask Play about ${info.packName}: ${e.message}")
+                        null
+                    } ?: return@forEach
+                    Logger.i(
+                        tag,
+                        "Finishing a delivery nothing was listening for: ${info.packName}",
+                    )
+                    installDeliveredPack(info.packName, File(assetsPath))
+                }
+            } catch (e: Exception) {
+                Logger.w(tag, "Could not reconcile delivered packs: ${e.message}")
+            }
+        }
+    }
+
+    /**
+     * Hands Play's copy of [packName] back, whether or not the install used it.
+     *
+     * Called on both exits from the COMPLETED branch, which is the point. Play writes
+     * the pack outside `filesDir` and keeps it until asked; leaving it there after a
+     * refusal charged the user for a delivery nothing consumed, on the one path that
+     * fires only when the device is already out of room.
+     *
+     * Guarded, because this now runs on a failure path. `removePack` is a Play Core
+     * call and the HTTP delivery path never registered one; an exception here must not
+     * replace the failure the caller is on its way to report.
+     */
+    private fun releasePack(packName: String) {
+        try {
+            assetPackManager.removePack(packName)
+            Logger.i(tag, "Removed asset pack $packName (freed duplicate storage)")
+        } catch (e: Exception) {
+            Logger.w(tag, "Could not remove asset pack $packName: ${e.message}")
         }
     }
 
@@ -1130,7 +1231,19 @@ class ToolchainManager(private val context: Context) {
             fetchManifest(manifestUrlFor(zipUrl))
         }
         return digestFromManifest(manifest, zipName)
-            ?: throw IOException(
+            // [MissingFromRelease], not the plain IOException it extends. The two are
+            // caught in that order and mean different things to the user, and this
+            // case was landing in the wrong one: the manifest was fetched, so nothing
+            // about the network is at fault, yet `catch (e: IOException)` reported
+            // "Download failed. Check your connection and try again." A better
+            // connection cannot produce a manifest entry that is not there.
+            //
+            // The release is incomplete, which is exactly what NOT_PUBLISHED already
+            // says: "not in the current release, try again after the next app update."
+            // `digestFromManifest` also answers null for two conflicting entries, and
+            // that is the same answer for the same reason -- nothing here can say
+            // which one vouches for the payload.
+            ?: throw MissingFromRelease(
                 "The release's digest manifest does not name $zipName; refusing to install a " +
                     "payload nothing vouches for"
             )
@@ -1737,6 +1850,27 @@ internal fun toolchainInstallBytes(unpackedBytes: Long): Long =
     unpackedBytes * 2 + SPACE_BUFFER
 
 /**
+ * The unpacked size recorded for [packName], or null when none is.
+ *
+ * Null rather than zero, and the distinction is the whole reason this exists.
+ * `ToolchainRegistry.find` answers null for a retired pack, by design: that
+ * pass-through is what keeps uninstalling one working after its row is dropped.
+ * A caller that spells the lookup as `find(...)?.estimatedSize ?: 0L` therefore
+ * turns "I do not know" into "it needs nothing", and a space gate built on that
+ * reserves the bare buffer for a tree of any size. Zero is a real answer here
+ * only for a pack that genuinely occupies nothing, which none do.
+ *
+ * [RETIRED_TOOLCHAINS] is consulted second for the same reason `toolchainBytesFor`
+ * consults it: the packs most likely to be on a device right now are the ones
+ * installed before a withdrawal, and the registry is exactly where they are not.
+ * The prefix is stripped here rather than through `toolchainShortName`, which
+ * resolves through the registry and returns a retired name unchanged.
+ */
+internal fun packUnpackedBytes(packName: String): Long? =
+    ToolchainRegistry.find(packName)?.estimatedSize
+        ?: RETIRED_TOOLCHAINS[packName.removePrefix("toolchain_")]
+
+/**
  * What a Play Asset Delivery install needs free, given its unpacked size.
  *
  * One tree rather than two, and the difference is where the first copy already
@@ -1900,7 +2034,10 @@ internal fun isCompleteTransfer(declaredBytes: Long, receivedBytes: Long): Boole
  * release does not contain, and telling someone to check their connection when
  * that is the problem sends them to look in the wrong place.
  */
-enum class ToolchainFailure(@StringRes val message: Int) {
+// `@param:` rather than a bare `@StringRes`, which Kotlin warns will start
+// applying to the backing field as well. Naming the target pins today's meaning
+// instead of letting a compiler upgrade choose a different one.
+enum class ToolchainFailure(@param:StringRes val message: Int) {
     NETWORK(R.string.toolchain_failed_network),
     STORAGE(R.string.toolchain_failed_storage),
     NOT_PUBLISHED(R.string.toolchain_failed_not_published),

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafStorageManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafStorageManager.kt
@@ -1,6 +1,5 @@
 package com.vscodroid.storage
 
-import android.content.ContentResolver
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -9,6 +8,7 @@ import com.vscodroid.util.Logger
 import org.json.JSONArray
 import org.json.JSONObject
 import java.io.File
+import java.util.concurrent.atomic.AtomicLong
 import kotlin.concurrent.thread
 
 /**
@@ -45,15 +45,23 @@ class SafStorageManager(private val context: Context) {
     fun onWriteBackFailed(announce: (File) -> Unit) {
         syncEngine.onWriteBackFailed = { file ->
             val now = System.currentTimeMillis()
-            if (shouldAnnounce(now, lastFailureAnnouncedAt)) {
-                lastFailureAnnouncedAt = now
+            val last = lastFailureAnnouncedAt.get()
+            // `compareAndSet`, not read-then-write. Two threads genuinely arrive here:
+            // the `saf-writeback` daemon draining the queue, and `Dispatchers.IO`
+            // running the write-backs `initialSync` issues itself. `@Volatile` gave
+            // visibility but not atomicity, so both could read the same stale `last`,
+            // both find the interval elapsed, and both announce for one burst, which
+            // is the wall of toasts the throttle exists to prevent.
+            //
+            // The loser does not retry, deliberately. Losing means another thread has
+            // just announced this same burst, which is the answer the user needed.
+            if (shouldAnnounce(now, last) && lastFailureAnnouncedAt.compareAndSet(last, now)) {
                 announce(file)
             }
         }
     }
 
-    @Volatile
-    private var lastFailureAnnouncedAt = 0L
+    private val lastFailureAnnouncedAt = AtomicLong(0)
 
     // -- Permission Management --
 
@@ -471,12 +479,6 @@ class SafStorageManager(private val context: Context) {
         }
     }
 
-    private fun removeFromRecentFolders(uri: Uri) {
-        val folders = getPersistedFolders().toMutableList()
-        folders.removeAll { it.uri == uri }
-        saveRecentFolders(folders)
-    }
-
     private fun updateLastOpened(uri: Uri) {
         val folders = getPersistedFolders().toMutableList()
         val index = folders.indexOfFirst { it.uri == uri }
@@ -496,22 +498,6 @@ class SafStorageManager(private val context: Context) {
             })
         }
         prefs.edit().putString(KEY_RECENT_FOLDERS, array.toString()).apply()
-    }
-
-    private fun cleanupMirror(safUri: Uri) {
-        val mirrorDir = getMirrorDir(safUri)
-        if (mirrorDir.exists()) {
-            try {
-                mirrorDir.deleteRecursively()
-                Logger.i(tag, "Cleaned up mirror: ${mirrorDir.absolutePath}")
-            } catch (e: Exception) {
-                Logger.w(tag, "Failed to clean up mirror: ${e.message}")
-            }
-        }
-        // The sync engine keeps its record of the folder beside the mirror rather than
-        // inside it, so removing the mirror alone leaves the record orphaned.
-        File(mirrorDir.path + SafSyncEngine.SYNCED_RECORD_SUFFIX).delete()
-        syncEngine.clearUploadsUnder(mirrorDir)
     }
 
     companion object {

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
@@ -171,21 +171,14 @@ class SafSyncEngine(private val context: Context) {
         // once here rather than per document; [reconcileDeletions] reads the same file
         // again in phase 3, after phase 2 may have changed what is on disk.
         //
-        // ⚠️ `by lazy`, and be clear about how little that defers, because this comment
-        // claimed the opposite and the claim reads plausibly. The membership test is an
-        // ARGUMENT to [shouldOverwriteMirror], and Kotlin evaluates arguments before the
-        // call, so the first ordinary file in the loop forces this whether or not its
-        // provider reports a time. It is not "only the no-timestamp branch reads it":
-        // every branch pays for it. What the laziness actually saves is a sync that
-        // reaches the call for no file at all -- an empty folder, one of only
-        // directories, or one where every entry is too large -- which is worth the two
-        // words it costs and nothing more.
-        //
-        // Making it genuinely lazy means either repeating `doc.lastModified == 0L` at
-        // the call site, which puts the callee's branch condition in the caller, or
-        // taking the argument as a lambda, which rewrites eleven assertions in
-        // SafSyncEngineTest to buy one HashSet on a path that is already correct.
-        // Neither is worth it; stating the real cost is.
+        // `by lazy`, and it takes both halves to make that true. This was passed to
+        // [shouldOverwriteMirror] by value, and Kotlin evaluates arguments before the
+        // call, so the first ordinary file forced the read whether or not its provider
+        // reported a time: the deferral the word promised never happened on any folder
+        // with a file in it. The parameter is a function now, invoked only by the
+        // unknown-time branch, so a provider that reports times never reads the record
+        // and a large folder does not hold one string per mirrored file for a sync that
+        // will not look at any of them.
         val previouslyRecorded: Set<String> by lazy {
             readSyncedRecord(File(mirrorDir.path + SYNCED_RECORD_SUFFIX))
                 .let { if (it.firstOrNull() == RECORD_HEADER) it.drop(1).toHashSet() else emptySet() }
@@ -244,8 +237,9 @@ class SafSyncEngine(private val context: Context) {
                 if (!shouldOverwriteMirror(
                         localPath.exists(), localPath.lastModified(), localPath.length(),
                         doc.lastModified, doc.size,
-                        mirrorIsOurCopy = identityLine(doc.relativePath, localPath)
-                            in previouslyRecorded,
+                        mirrorIsOurCopy = {
+                            identityLine(doc.relativePath, localPath) in previouslyRecorded
+                        },
                     )
                 ) {
                     keptLocal++
@@ -303,21 +297,32 @@ class SafSyncEngine(private val context: Context) {
                         // without this guard every file in such a folder would look
                         // newer and be pushed over the device document on every reopen.
                         //
-                        // Deliberately NOT capped at [MAX_FILE_SIZE], which the same
-                        // loop applies a few lines up. The asymmetry is real and it is
-                        // the right way round: that cap keeps a large DEVICE document
-                        // out of `filesDir`, which is the app's own storage and the
-                        // thing that runs out. Writing back spends the device folder's
-                        // space, not ours, and the bytes are an edit the user made in
-                        // the editor. Refusing it because it grew past 50 MB would
-                        // discard their work silently, which is the failure this whole
-                        // branch exists to end. The other three write-back sites do not
-                        // cap either, so a cap added here alone would also make the
-                        // engine disagree with itself about the same question.
+                        // Deliberately NOT capped at [MAX_FILE_SIZE], which the same loop
+                        // applies a few lines up, and the asymmetry is the right way
+                        // round. That cap keeps a large DEVICE document out of
+                        // `filesDir`, which is this app's own storage and the thing that
+                        // runs out; writing back spends the device folder's space
+                        // instead, so the reason for the cap does not apply in this
+                        // direction.
+                        //
+                        // The decisive argument is consistency, not data loss. Capping
+                        // costs nothing permanent -- an uncapped file simply stays in
+                        // the mirror, where [holdsOnlyVouchedCopies] keeps it because
+                        // the record cannot vouch for it -- but none of the other three
+                        // `writeLocalToSaf` sites cap, so a cap here alone would upload
+                        // a file when the watcher saves it and refuse the same file on
+                        // reopen. One engine, two answers to one question, is worse
+                        // than either answer.
+                        //
+                        // Note also how narrow the case is: reaching here needs the
+                        // DEVICE document under the cap, since a larger one is skipped
+                        // above, so only a file the user grew past 50 MB locally
+                        // qualifies.
                         //
                         // What it costs is honest: a large file makes the folder-open
-                        // dialog sit on this one entry. Progress is per file, so the
-                        // bar does not move until the copy finishes.
+                        // dialog sit on this one entry. Progress is per file, so the bar
+                        // does not move until the copy finishes. This runs on
+                        // Dispatchers.IO, so it is a slow dialog and not an ANR.
                         uploadsDone++
                         Logger.i(tag, "Writing back a newer mirror copy: ${doc.relativePath}")
                         writeLocalToSaf(localPath, doc.uri)
@@ -1931,8 +1936,17 @@ class SafSyncEngine(private val context: Context) {
              * recorded for it. No default: there is one production caller and it has the
              * record in hand, and a default here would let a future caller answer the
              * question by not thinking about it.
+             *
+             * A function, not a value, and the laziness belongs here rather than at the
+             * call site. Only the unknown-time branch below asks, and answering costs
+             * the caller a read of the whole synced record; passed by value, that read
+             * happened for every file on every provider, including the ones that report
+             * a time and never reach the branch. The alternative was for the caller to
+             * repeat `sourceModified == 0L` before computing it, which puts this
+             * function's branch condition in the caller and goes stale the moment a
+             * second branch here wants the same answer.
              */
-            mirrorIsOurCopy: Boolean,
+            mirrorIsOurCopy: () -> Boolean,
         ): Boolean = when {
             !mirrorExists -> true
             // The provider did not report a time, so the record answers instead: our
@@ -1964,7 +1978,7 @@ class SafSyncEngine(private val context: Context) {
             // question is only asked for files this clause kept, which on a healthy
             // folder is none: every other file is answered true here and copied, which
             // reads the device document anyway.
-            sourceModified == 0L -> mirrorIsOurCopy
+            sourceModified == 0L -> mirrorIsOurCopy()
             sourceModified > mirrorModified -> true
             // A newer local copy wins, whatever its size. Checking size before this
             // was the defect: almost every edit changes a file's length, so almost

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
@@ -176,9 +176,14 @@ class SafSyncEngine(private val context: Context) {
         // call, so the first ordinary file forced the read whether or not its provider
         // reported a time: the deferral the word promised never happened on any folder
         // with a file in it. The parameter is a function now, invoked only by the
-        // unknown-time branch, so a provider that reports times never reads the record
-        // and a large folder does not hold one string per mirrored file for a sync that
-        // will not look at any of them.
+        // unknown-time branch, so THIS read no longer happens for a provider that
+        // reports times, and a large folder does not hold one string per mirrored file
+        // through phase 2 for a sync that will not look at any of them.
+        //
+        // Note the scope carefully: it is this binding that is deferred, not the file.
+        // [reconcileDeletions] opens the same record again in phase 3 on every sync
+        // that enumerates anything, whatever the provider reports, so the saving is one
+        // parse and one live Set across phase 2, never "the record is not read".
         val previouslyRecorded: Set<String> by lazy {
             readSyncedRecord(File(mirrorDir.path + SYNCED_RECORD_SUFFIX))
                 .let { if (it.firstOrNull() == RECORD_HEADER) it.drop(1).toHashSet() else emptySet() }

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
@@ -165,15 +165,27 @@ class SafSyncEngine(private val context: Context) {
         val unfinishedUploads = uploadsInFlight().toMutableSet()
 
         // Loaded for the same reason and read the same way: what the last sync wrote,
-        // as (path, mtime, size) lines. Phase 2 needs it only for providers that omit
+        // as (path, mtime, size) lines. Phase 2 consults it only for providers that omit
         // COLUMN_LAST_MODIFIED, where there is no clock to compare and the record is the
         // only thing that can tell this app's own copy from an edit made since. Read
         // once here rather than per document; [reconcileDeletions] reads the same file
         // again in phase 3, after phase 2 may have changed what is on disk.
-        // `by lazy` rather than eagerly: only the no-timestamp branch reads it, and a
-        // provider that reports times never asks. Building it eagerly meant one string
-        // per mirrored file held for the length of a sync that would not look at any of
-        // them, which on a large folder is real memory for nothing.
+        //
+        // ⚠️ `by lazy`, and be clear about how little that defers, because this comment
+        // claimed the opposite and the claim reads plausibly. The membership test is an
+        // ARGUMENT to [shouldOverwriteMirror], and Kotlin evaluates arguments before the
+        // call, so the first ordinary file in the loop forces this whether or not its
+        // provider reports a time. It is not "only the no-timestamp branch reads it":
+        // every branch pays for it. What the laziness actually saves is a sync that
+        // reaches the call for no file at all -- an empty folder, one of only
+        // directories, or one where every entry is too large -- which is worth the two
+        // words it costs and nothing more.
+        //
+        // Making it genuinely lazy means either repeating `doc.lastModified == 0L` at
+        // the call site, which puts the callee's branch condition in the caller, or
+        // taking the argument as a lambda, which rewrites eleven assertions in
+        // SafSyncEngineTest to buy one HashSet on a path that is already correct.
+        // Neither is worth it; stating the real cost is.
         val previouslyRecorded: Set<String> by lazy {
             readSyncedRecord(File(mirrorDir.path + SYNCED_RECORD_SUFFIX))
                 .let { if (it.firstOrNull() == RECORD_HEADER) it.drop(1).toHashSet() else emptySet() }
@@ -290,6 +302,22 @@ class SafSyncEngine(private val context: Context) {
                         // as 0, and every real mirror timestamp is greater than 0, so
                         // without this guard every file in such a folder would look
                         // newer and be pushed over the device document on every reopen.
+                        //
+                        // Deliberately NOT capped at [MAX_FILE_SIZE], which the same
+                        // loop applies a few lines up. The asymmetry is real and it is
+                        // the right way round: that cap keeps a large DEVICE document
+                        // out of `filesDir`, which is the app's own storage and the
+                        // thing that runs out. Writing back spends the device folder's
+                        // space, not ours, and the bytes are an edit the user made in
+                        // the editor. Refusing it because it grew past 50 MB would
+                        // discard their work silently, which is the failure this whole
+                        // branch exists to end. The other three write-back sites do not
+                        // cap either, so a cap added here alone would also make the
+                        // engine disagree with itself about the same question.
+                        //
+                        // What it costs is honest: a large file makes the folder-open
+                        // dialog sit on this one entry. Progress is per file, so the
+                        // bar does not move until the copy finishes.
                         uploadsDone++
                         Logger.i(tag, "Writing back a newer mirror copy: ${doc.relativePath}")
                         writeLocalToSaf(localPath, doc.uri)

--- a/android/app/src/main/kotlin/com/vscodroid/util/CrashReporter.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/util/CrashReporter.kt
@@ -193,7 +193,16 @@ object CrashReporter {
  * "no crashes".
  *
  * `Thread.getId()` has been there since API 1 and is not deprecated in the
- * android-36 stub, so this needs no suppression and no desugaring.
+ * android-36 stub, so this needs no suppression and no desugaring. Verified by
+ * dumping `java/lang/Thread.class` out of `platforms/android-36/android.jar`:
+ * `getId()` carries no deprecation attribute, and `threadId()` is absent from
+ * the android-33 jar entirely.
+ *
+ * ⚠️ The Kotlin compiler warns here anyway, "'val id: Long' is deprecated.
+ * Deprecated in Java", and that warning is about the JDK's own `Thread`, not
+ * about the platform this ships against. Do not silence it by switching to
+ * `threadId()`. That is the exact call this function exists to avoid, and the
+ * paragraph above is what it costs on 33, 34 and 35.
  */
 internal fun threadIdentity(thread: Thread): String =
     "Thread: ${thread.name} (id=${thread.id})"

--- a/android/app/src/main/kotlin/com/vscodroid/util/Environment.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/util/Environment.kt
@@ -243,6 +243,18 @@ object Environment {
     fun getServerDir(context: Context): String =
         "${context.filesDir}/server"
 
+    /**
+     * The bash binary itself, under `nativeLibraryDir`.
+     *
+     * ⚠️ Has no production caller, and that is the point rather than an oversight,
+     * so a sweep for unused code should leave it here. It is the wrong answer for
+     * the terminal profile and [getTerminalShellPath] below is the right one; the
+     * two exist side by side so the difference is visible at the place someone
+     * would reach for either. `TerminalShellPathTest` is built on that contrast.
+     *
+     * Production that genuinely wants the binary spells it out at the point of use
+     * (`FirstRunSetup.createNpmWrappers`), because it wants the `.so` knowingly.
+     */
     fun getBashPath(context: Context): String =
         "${context.applicationInfo.nativeLibraryDir}/libbash.so"
 

--- a/android/app/src/main/kotlin/com/vscodroid/util/ViewInsets.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/util/ViewInsets.kt
@@ -72,9 +72,10 @@ fun View.padForSystemBars(basePx: Int = 0) {
  *    `setStatusBarContrastEnforced(false)` unconditionally and
  *    `setNavigationBarContrastEnforced(nightMode == 0)`, and every call site
  *    passed `SystemBarStyle.dark()`, whose nightMode is `MODE_NIGHT_YES`, so
- *    both arrived as false. Both platform defaults are **true**, so omitting
- *    them let the system paint a scrim behind the bars the theme had just made
- *    transparent.
+ *    both arrived as false. The defaults differ, and calling them both true was
+ *    wrong: `PhoneWindow.generateLayout` defaults `enforceStatusBarContrast` to
+ *    false and `enforceNavigationBarContrast` to **true**, so the omission cost
+ *    the navigation bar a scrim and the status line restates the default.
  *
  * What is kept is the part the call sites actually needed: light icons pinned
  * regardless of the device theme. This app is always dark and has no

--- a/android/app/src/main/kotlin/com/vscodroid/util/ViewInsets.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/util/ViewInsets.kt
@@ -39,11 +39,20 @@ fun View.padForSystemBars(basePx: Int = 0) {
  * rather than the behaviour. Play Console reports three deprecated edge-to-edge
  * APIs, and all three are inside that one call: `Window.setStatusBarColor` and
  * `Window.setNavigationBarColor` from `EdgeToEdgeApi26`, `Api29` and `Api35`,
- * and `LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES` from `Api28` and `Api30`.
- * Measured from the release dex with `dexdump`, de-obfuscated through this
- * build's own mapping. Note `Api35`: the references are not confined to the
- * pre-35 compat half, so trimming the old implementations by minSdk would not
- * have cleared them. Dropping the call is what removes the classes.
+ * and the display-cutout write from `Api28` and `Api30`. Measured from the
+ * release dex with `dexdump`, de-obfuscated through this build's own mapping.
+ * Note `Api35`: the references are not confined to the pre-35 compat half, so
+ * trimming the old implementations by minSdk would not have cleared them.
+ * Dropping the call is what removes the classes.
+ *
+ * ⚠️ The two cutout implementations write **different** values, and this said
+ * `SHORT_EDGES` for both until it was read from the bytecode.
+ * `Api28.adjustLayoutInDisplayCutoutMode` stores `1` (`SHORT_EDGES`);
+ * `Api30` stores `3` (`ALWAYS`), and `Api35` extends `Api30` without overriding
+ * it. minSdk is 33, so the only implementation that ever ran here wrote
+ * `ALWAYS`. That is why the theme names `always`: it is what this app already
+ * had, not a new choice, and changing it to `shortEdges` to match the old
+ * comment would be a real behaviour change.
  *
  * Nothing is lost by dropping it, because `targetSdk` is 36:
  *
@@ -57,11 +66,24 @@ fun View.padForSystemBars(basePx: Int = 0) {
  *  - The display cutout moves to `android:windowLayoutInDisplayCutoutMode` in
  *    the theme, which is declarative and names `always`, the value API 35+
  *    forces anyway.
+ *  - Contrast enforcement moves to `android:enforceStatusBarContrast` and
+ *    `android:enforceNavigationBarContrast`, both `false`. This is the piece
+ *    the first version of this migration dropped: `Api29.setUp` calls
+ *    `setStatusBarContrastEnforced(false)` unconditionally and
+ *    `setNavigationBarContrastEnforced(nightMode == 0)`, and every call site
+ *    passed `SystemBarStyle.dark()`, whose nightMode is `MODE_NIGHT_YES`, so
+ *    both arrived as false. Both platform defaults are **true**, so omitting
+ *    them let the system paint a scrim behind the bars the theme had just made
+ *    transparent.
  *
  * What is kept is the part the call sites actually needed: light icons pinned
  * regardless of the device theme. This app is always dark and has no
  * `values-night`, so the `auto` default drew dark icons on a dark background
  * whenever the device was in light mode.
+ *
+ * Everything else this replaces is an attribute, so nothing about the window is
+ * set from code here beyond the two lines below. [ThemeEdgeToEdgeTest] holds the
+ * attributes in place, because a theme value has no compiler to lose it.
  */
 fun Activity.drawBehindSystemBars() {
     WindowCompat.setDecorFitsSystemWindows(window, false)

--- a/android/app/src/main/kotlin/com/vscodroid/webview/VSCodroidWebViewClient.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/webview/VSCodroidWebViewClient.kt
@@ -777,14 +777,20 @@ class VSCodroidWebViewClient(
          * answers 403 and the asset silently fails to load.
          *
          * Deliberately not folded into proxyToLocalhost(), despite the name of
-         * that function: one of its callers proxies http/https resources to
-         * whatever host an extension's webview references, and putting the token
-         * there would hand our credential to that host.
+         * that function, and the reason is now a historical one rather than a
+         * present hazard. `proxyToLocalhost` has exactly one caller today, the
+         * CDN rewrite, which always names 127.0.0.1 and always comes through
+         * here. It used to have three: one proxied http/https resources to
+         * whatever host an extension's webview referenced, where the token would
+         * have been handed to that host, and one appended the token to a
+         * page-controlled path against our own server. Both are gone.
          *
-         * The reason that separation is load-bearing rather than tidy: a third
-         * caller once did append the token to a page-controlled path, which is
-         * the defect removed from interceptResourceRequest. Keeping the token an
-         * explicit step is what makes such a call visible in a diff.
+         * ⚠️ Do not read "one caller, always local" as licence to fold the token
+         * into `proxyToLocalhost`. The separation is what made both of those
+         * callers visible as defects, and a token applied inside the proxy is
+         * applied to whatever a future caller passes, silently. Keeping it an
+         * explicit step at the call site is the property worth having, not the
+         * current caller count.
          */
         private fun withToken(url: String, token: String?): String {
             if (token.isNullOrEmpty()) return url

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -22,7 +22,6 @@
     <color name="colorPopupBg">#3C3C3C</color>
 
     <!-- Notification -->
-    <color name="colorNotificationBg">#1E1E1E</color>
 
     <!-- Toolchain picker -->
     <color name="colorCardSelected">#1A007ACC</color>

--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -25,6 +25,23 @@
              only decides API 33 and 34; naming the value the platform settles
              on keeps the two the same. See util/ViewInsets.drawBehindSystemBars. -->
         <item name="android:windowLayoutInDisplayCutoutMode">always</item>
+
+        <!-- The bars stay transparent rather than having the platform paint a scrim
+             behind them. Both default to true, so leaving them out is not neutral:
+             it turns the two transparent colours above back into translucent ones.
+
+             This is the fifth thing enableEdgeToEdge() did and the one the move to
+             attributes first missed. Read from androidx.activity 1.13.0's bytecode:
+             EdgeToEdgeApi29.setUp calls setStatusBarContrastEnforced(false)
+             unconditionally, and setNavigationBarContrastEnforced(nightMode == 0).
+             Every call site here passed SystemBarStyle.dark(), whose nightMode is
+             MODE_NIGHT_YES, so both arrived as false.
+
+             Attributes rather than the setters for the same reason as the colours:
+             Play scans bytecode and an attribute is not a call. API 29+ honours
+             both, and minSdk is 33, so no version-qualified copy is needed. -->
+        <item name="android:enforceStatusBarContrast">false</item>
+        <item name="android:enforceNavigationBarContrast">false</item>
     </style>
 
 </resources>

--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -27,19 +27,25 @@
         <item name="android:windowLayoutInDisplayCutoutMode">always</item>
 
         <!-- The bars stay transparent rather than having the platform paint a scrim
-             behind them. Both default to true, so leaving them out is not neutral:
-             it turns the two transparent colours above back into translucent ones.
-
-             This is the fifth thing enableEdgeToEdge() did and the one the move to
-             attributes first missed. Read from androidx.activity 1.13.0's bytecode:
+             behind them. This is the fifth thing enableEdgeToEdge() did and the one
+             the move to attributes first missed: androidx.activity 1.13.0's
              EdgeToEdgeApi29.setUp calls setStatusBarContrastEnforced(false)
-             unconditionally, and setNavigationBarContrastEnforced(nightMode == 0).
-             Every call site here passed SystemBarStyle.dark(), whose nightMode is
-             MODE_NIGHT_YES, so both arrived as false.
+             unconditionally and setNavigationBarContrastEnforced(nightMode == 0),
+             and every call site here passed SystemBarStyle.dark(), whose nightMode
+             is MODE_NIGHT_YES, so both arrived as false. Read from its bytecode.
+
+             ⚠️ The two defaults are NOT the same, and this comment said they were.
+             PhoneWindow.generateLayout reads Window_enforceStatusBarContrast with a
+             default of FALSE and Window_enforceNavigationBarContrast with a default
+             of TRUE. So only the navigation line changes behaviour; the status line
+             restates the default. It is kept anyway, because the pair is what the
+             call this replaced set, and a reader finding one without the other would
+             reasonably wonder which bar was left out and why.
 
              Attributes rather than the setters for the same reason as the colours:
-             Play scans bytecode and an attribute is not a call. API 29+ honours
-             both, and minSdk is 33, so no version-qualified copy is needed. -->
+             Play scans bytecode and an attribute is not a call. Both exist in the
+             android-33 SDK's attrs.xml, verified, and minSdk is 33, so no
+             version-qualified copy is needed. -->
         <item name="android:enforceStatusBarContrast">false</item>
         <item name="android:enforceNavigationBarContrast">false</item>
     </style>

--- a/android/app/src/test/kotlin/com/vscodroid/ServiceWorkerRetentionTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/ServiceWorkerRetentionTest.kt
@@ -160,6 +160,12 @@ class ServiceWorkerRetentionTest {
             "filesDir.absolutePath" to "a member inherited from Context",
             "folderSupplier" to "a supplier hoisted into a local first",
             "self.get()?.openWorkspaceFolder ?: fallbackFolder()" to "a weak read plus a capture",
+            "self.get()?.resolveFolder(openWorkspaceFolder)" to
+                "a weak read whose ARGUMENT is an unqualified member, which captures " +
+                "the Activity just as completely. The first version of readsWeakly " +
+                "allowed anything inside the parentheses and accepted this",
+            "self.get()?.resolveFolder(recreateWebView())" to
+                "the same, with a member function rather than a property",
         ).forEach { (body, why) ->
             assertTrue(!readsWeakly(body), "`$body` was accepted, but it captures: $why")
         }
@@ -209,8 +215,23 @@ class ServiceWorkerRetentionTest {
     private companion object {
         const val CALL = "setupServiceWorkerInterception("
 
-        /** Whether a lambda body is a read through `self` and nothing else. */
+        /**
+         * Whether a lambda body is a read through `self` and nothing else.
+         *
+         * A chain of member reads and NO-ARGUMENT calls. The argument list is the part
+         * worth spelling out, because the first version of this allowed one: its
+         * character class held `(`, `)` and letters, so everything between a call's
+         * parentheses was unconstrained and `self.get()?.f(recreateWebView())` matched.
+         * That body reads through the weak reference and still captures the Activity,
+         * through the unqualified call it passes as an argument, which is the exact
+         * shape the control list below refuses everywhere else.
+         *
+         * Nothing legitimate is lost. Both real suppliers are plain chains, and a
+         * supplier that genuinely needs an argument needs something from the Activity
+         * to build it, which is the case worth stopping at rather than widening for.
+         */
         fun readsWeakly(body: String): Boolean =
-            Regex("""^self\.get\(\)\?\.[A-Za-z0-9_.?()]*$""").matches(body.trim())
+            Regex("""^self\.get\(\)(\?\.|\.)[A-Za-z0-9_]+(\(\))?((\?\.|\.)[A-Za-z0-9_]+(\(\))?)*$""")
+                .matches(body.trim())
     }
 }

--- a/android/app/src/test/kotlin/com/vscodroid/bridge/OpenExternalUrlRefusalTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/bridge/OpenExternalUrlRefusalTest.kt
@@ -3,9 +3,7 @@ package com.vscodroid.bridge
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import android.os.Bundle
 import android.os.SystemClock
-import androidx.core.content.ContextCompat
 import com.vscodroid.storage.SafStorageManager
 import com.vscodroid.util.Logger
 import io.mockk.Runs

--- a/android/app/src/test/kotlin/com/vscodroid/bridge/SecurityManagerTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/bridge/SecurityManagerTest.kt
@@ -14,8 +14,6 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.ValueSource
 
 /**
  * Tests for [SecurityManager] — token generation/validation and the URL allowlist.

--- a/android/app/src/test/kotlin/com/vscodroid/bridge/ToolchainManagerContextTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/bridge/ToolchainManagerContextTest.kt
@@ -13,22 +13,28 @@ import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotSame
 import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.io.File
 
 /**
- * Which Context the bridge's `ToolchainManager` is built with.
+ * What the bridge's `ToolchainManager` is allowed to hold.
  *
  * `install()` hands a listener to Play Core, which keeps it in a registry that
  * lives in that library and outlives every Activity here. The listener holds the
- * manager, so a manager built with the Activity keeps the Activity, its Context
- * and its view tree reachable for as long as the registration stands.
- * `AndroidBridge.onToolchainState` removes the registration only on COMPLETED,
- * FAILED or CANCELED, and a REQUIRES_USER_CONFIRMATION waiting on a dialog the
- * user walked away from reaches none of them.
+ * manager, so anything the manager holds keeps the Activity, its Context and its
+ * view tree reachable for as long as the registration stands. The state callback
+ * removes the registration only on COMPLETED, FAILED or CANCELED, and a
+ * REQUIRES_USER_CONFIRMATION waiting on a dialog the user walked away from
+ * reaches none of them.
+ *
+ * Two tests, and the second exists because the first is not enough. Naming the
+ * constructor argument binds one link; the leak had two, and the one this file
+ * originally missed was a lambda. Read them in order.
  *
  * **The reference is the defect, not the registration**, and that distinction is
  * why this file asserts what it does. Releasing the registration at teardown
@@ -99,6 +105,108 @@ class ToolchainManagerContextTest {
 
         verify { AssetPackManagerFactory.getInstance(application) }
         verify(exactly = 0) { AssetPackManagerFactory.getInstance(activity) }
+    }
+
+    /**
+     * Nothing reachable from the manager is the Activity, by any route.
+     *
+     * The test above binds one link, the constructor argument, and that is exactly as
+     * far as it goes. It passed while the leak was intact: `onStateChange` was
+     * `{ ... -> onToolchainState(...) }`, an unqualified call to a member of
+     * `AndroidBridge`, so the lambda captured the bridge and the bridge holds the
+     * Activity. Measured in bytecode, the lambda compiled to a method whose first
+     * parameter is `AndroidBridge`.
+     *
+     * So the question is asked of the object graph rather than of one argument. This is
+     * the same lesson `ServiceWorkerRetentionTest` records in `MainActivity` and states
+     * outright: a supplier that only calls a method captures just as completely as one
+     * that names a field. A whitelist of field names would have missed this too.
+     *
+     * `WeakReference` and friends are not walked through, which is the point rather than
+     * an exemption: a weak reference is not retention, and the fix is precisely to hold
+     * the bridge through one.
+     *
+     * ⚠️ Its ceiling. This walks declared fields, so it sees what the JVM sees and not
+     * what a native or `ThreadLocal` route might hold, and it stops at [NODE_CAP]. The
+     * negative control below is what keeps a walk that quietly reached nothing from
+     * reading as a pass.
+     */
+    @Test
+    fun `no route from the manager reaches the Activity`() {
+        val b = bridge()
+        b.getInstalledToolchains("")
+
+        val manager = AndroidBridge::class.java
+            .getDeclaredMethod("getToolchainManager")
+            .apply { isAccessible = true }
+            .invoke(b)!!
+
+        // The control, and it runs first. The bridge legitimately holds the Activity
+        // for `confirmLargeDownload`, so a walk that cannot find it from there is
+        // broken, and every assertion after it would pass by seeing nothing.
+        assertTrue(
+            reaches(b, activity),
+            "the walk cannot find the Activity even from the bridge, which holds it " +
+                "directly, so it proves nothing about the manager",
+        )
+
+        assertFalse(
+            reaches(manager, activity),
+            "the Activity is reachable from the ToolchainManager. Play Core keeps the " +
+                "listener, the listener keeps the manager, so this keeps the Activity " +
+                "and its view tree alive for the life of the process. Anything the " +
+                "manager holds must reach a screen weakly or not at all.",
+        )
+    }
+
+    /** Whether [target] is reachable from [root] by strong references alone. */
+    private fun reaches(root: Any, target: Any): Boolean {
+        val seen = java.util.Collections.newSetFromMap(java.util.IdentityHashMap<Any, Boolean>())
+        val queue = ArrayDeque<Any>()
+        queue.add(root)
+        seen.add(root)
+        var visited = 0
+
+        while (queue.isNotEmpty() && visited < NODE_CAP) {
+            val node = queue.removeFirst()
+            visited++
+            if (node === target) return true
+
+            // A weak reference does not retain, so following it would report the very
+            // shape this test exists to accept.
+            if (node is java.lang.ref.Reference<*>) continue
+
+            if (node is Array<*>) {
+                node.filterNotNull().forEach { if (seen.add(it)) queue.add(it) }
+                continue
+            }
+
+            var cls: Class<*>? = node.javaClass
+            while (cls != null && cls != Any::class.java) {
+                for (f in cls.declaredFields) {
+                    if (java.lang.reflect.Modifier.isStatic(f.modifiers)) continue
+                    if (f.type.isPrimitive) continue
+                    val v = try {
+                        f.isAccessible = true
+                        f.get(node)
+                    } catch (e: Throwable) {
+                        // A field the JDK refuses to open is one this cannot speak for.
+                        // Skipped rather than failed: the control above is what says
+                        // whether enough of the graph was reachable to mean anything.
+                        null
+                    } ?: continue
+                    if (v === target) return true
+                    if (seen.add(v)) queue.add(v)
+                }
+                cls = cls.superclass
+            }
+        }
+        return false
+    }
+
+    private companion object {
+        /** Enough for this graph; a bound so a cycle cannot hang the suite. */
+        const val NODE_CAP = 20_000
     }
 
     @Test

--- a/android/app/src/test/kotlin/com/vscodroid/bridge/ToolchainManagerContextTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/bridge/ToolchainManagerContextTest.kt
@@ -38,14 +38,17 @@ import java.io.File
  *
  * **The reference is the defect, not the registration**, and that distinction is
  * why this file asserts what it does. Releasing the registration at teardown
- * looks like the obvious fix and is worse than the leak: `installFromDirectory`
- * is reachable only from `handleStateUpdate`'s COMPLETED branch, nothing
- * reconciles pack state at launch (`getPackStates` appears nowhere in main), and
- * Play Core does not promise to re-emit a state to a listener that registers
- * afterwards. Unregistering mid-download would leave the pack downloaded and
- * never installed, with no error anywhere the user could see. Such a call would
- * also have had to survive `recreateWebView()`, which builds a second bridge
- * after a renderer crash and would orphan the first one's registration.
+ * looks like the obvious fix and is worse than the leak: the COMPLETED branch of
+ * `handleStateUpdate` is what finishes an install, and Play Core does not promise
+ * to re-emit a state to a listener that registers afterwards.
+ * Unregistering mid-download would therefore leave the pack downloaded and never
+ * installed, with no error anywhere the user could see. Such a call would also
+ * have had to survive `recreateWebView()`, which builds a second bridge after a
+ * renderer crash and would orphan the first one's registration.
+ *
+ * `ToolchainManager.reconcileDeliveredPacks` now repairs such a pack at the NEXT
+ * launch, so the loss is bounded rather than permanent. It does not rescue the
+ * download in flight, which is why the registration still stays.
  *
  * So the assertion is about the Context handed over, which is what decides
  * retention, and it is made at the call Play Core actually receives rather than

--- a/android/app/src/test/kotlin/com/vscodroid/setup/LaunchRepairWiringTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/LaunchRepairWiringTest.kt
@@ -82,6 +82,7 @@ class LaunchRepairWiringTest {
         "updateSettingsNativeLibPaths",
         "ensureProjectsDir",
         "repairInstalledToolchains",
+        "reconcileDeliveredPacks",
         "reclaimRevokedMirrors",
     )
 

--- a/android/app/src/test/kotlin/com/vscodroid/setup/LaunchRepairWiringTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/LaunchRepairWiringTest.kt
@@ -276,10 +276,14 @@ class LaunchRepairWiringTest {
     }
 
     /**
-     * The other direction, and the order with it. Without this, a fifteenth
-     * repair could be added inside the shared `try` this class exists to keep
-     * dismantled and every assertion above would still pass, because they name
-     * only the fourteen they know.
+     * The other direction, and the order with it. Without this, one more repair
+     * could be added inside the shared `try` this class exists to keep dismantled
+     * and every assertion above would still pass, because they name only the
+     * repairs they already know.
+     *
+     * Deliberately not phrased as a count. The prose here said "the fourteen" and
+     * went stale the moment a fifteenth was added, while the assertion below kept
+     * working because it compares the whole list rather than its length.
      *
      * Order is checked because the list above says "in call order" and because
      * one pair genuinely depends on it: `repairTruncatedSetupFiles` clears a
@@ -301,8 +305,8 @@ class LaunchRepairWiringTest {
     private companion object {
         /**
          * `repair("...") { <receiver>.<name>() }` and nothing else. The receiver
-         * is optional and may be a constructor call, which is how two of the
-         * fourteen are written.
+         * is optional and may be a constructor call, which is how the ones built
+         * on a fresh `ToolchainManager` or `SafStorageManager` are written.
          */
         val BARE_REPAIR_CALL =
             Regex("""^repair\("[^"]*"\)\s*\{\s*(?:[A-Za-z_]\w*(?:\([^()]*\))?\.)?([A-Za-z_]\w*)\(\)\s*}$""")

--- a/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainDigestTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainDigestTest.kt
@@ -395,8 +395,10 @@ class LatestReleasePinningTest {
         //
         // The release variant has no unit test task to run this under: AGP builds
         // test components for `testBuildType` only, which is debug. So this runs
-        // against the debug value, "1.1.0-debug", and the suffix stripping is the
-        // half it can prove. The release value differs from it only by that suffix.
+        // against the debug value, which is the release versionName plus "-debug",
+        // and the suffix stripping is the half it can prove. The release value
+        // differs from it only by that suffix. Not quoted here: the literal went
+        // stale at the first version bump, while the property it describes did not.
         val tag = appReleaseTag(BuildConfig.VERSION_NAME)
 
         assertNotNull(

--- a/android/app/src/test/kotlin/com/vscodroid/setup/WalkthroughCompletionEventTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/WalkthroughCompletionEventTest.kt
@@ -81,7 +81,7 @@ class WalkthroughCompletionEventTest {
                     val step = steps.getJSONObject(s)
                     val events = step.optJSONArray("completionEvents")
                     found += Step(
-                        where = "${manifest.parentFile.name} step '${step.optString("id", "?")}'",
+                        where = "${manifest.parentFile?.name} step '${step.optString("id", "?")}'",
                         commandLinks = COMMAND_LINK
                             .findAll(step.optString("description", ""))
                             .map { it.groupValues[1] }

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafMirrorReclamationTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafMirrorReclamationTest.kt
@@ -9,8 +9,10 @@ import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkConstructor
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
+import io.mockk.verify
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -195,23 +197,58 @@ class SafMirrorReclamationTest {
      * promises no order: ext4 and APFS disagree, which is how this shipped green on one
      * and red on the other. With the record visited first it was deleted, and the
      * directory behind it was then judged with its record already gone, answered
-     * "nothing vouches for this", and was kept.
+     * "nothing vouches for this", and was kept -- leaving a mixed state the pass can
+     * never reach again, because the evidence that would license the delete is what the
+     * delete removed.
      *
-     * Driven by asking the pass twice with the record removed in between, which is the
-     * state that ordering produces, rather than by trying to control `listFiles()`.
+     * Asserted as **one verdict per mirror**, not as an outcome, and that is deliberate.
+     * The outcome depends on the order `listFiles()` happens to return, so an
+     * outcome-only test passes on the filesystem whose order is favourable and says
+     * nothing on the other. This repository's own history is exactly that. Counting the
+     * calls is the property the memo actually provides and is the same on every
+     * filesystem: two entries, one question.
+     *
+     * The previous version of this test was named for the reclaim and asserted the
+     * keep, drove the pass once while its prose described twice, and deleted the record
+     * before the pass so the two-entries-present state it exists for never arose. It
+     * duplicated `a mirror with no record at all is kept`, which is the case it was
+     * really testing.
      */
     @Test
-    fun `a mirror is still reclaimed when its record is gone`() {
+    fun `one mirror is one verdict, however its two entries are ordered`() {
+        // The fixture is built first, on purpose. `mirrorFor` validates the record it
+        // writes by asking the engine to accept it, so arming the constructor mock
+        // before this point counts those calls too and "exactly one" then fails against
+        // a correct implementation. Measured: six engine calls land before the pass
+        // begins.
         val (staleDir, staleRecord) = mirrorFor(revokedUri)
         mirrorFor(liveUri)
         every { resolver.persistedUriPermissions } returns listOf(permissionFor(liveUri))
 
-        check(staleRecord.delete()) { "could not remove the record for the fixture" }
-        manager.reclaimRevokedMirrorsSync()
+        // The fixture's own control: both entries have to be there, or "one call" is
+        // just the one entry that existed.
+        assertTrue(staleDir.isDirectory, "fixture did not create the mirror directory")
+        assertTrue(staleRecord.isFile, "fixture did not create the mirror's record")
 
-        assertTrue(
-            staleDir.isDirectory,
-            "with no record at all the mirror cannot be vouched for, so it has to be kept",
+        mockkConstructor(SafSyncEngine::class)
+        // callOriginal, so the pass still behaves; only the count is observed. A stub
+        // returning a constant would decide the outcome and prove nothing about it.
+        every { anyConstructed<SafSyncEngine>().holdsOnlyVouchedCopies(any()) } answers { callOriginal() }
+
+        // Built after the constructor is armed, or this manager's engine predates it.
+        val watched = SafStorageManager(context)
+
+        watched.reclaimRevokedMirrorsSync()
+
+        verify(exactly = 1) { anyConstructed<SafSyncEngine>().holdsOnlyVouchedCopies(staleDir) }
+
+        // And the consequence, which is what the count is for: the pair moved together.
+        // The state this refuses is the mixed one, so both are named.
+        assertFalse(
+            staleDir.exists() || staleRecord.exists(),
+            "the mirror and its record did not go together: dir=${staleDir.exists()} " +
+                "record=${staleRecord.exists()}. A directory left behind with its record " +
+                "deleted can never be reclaimed again.",
         )
     }
 

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafSyncEngineTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafSyncEngineTest.kt
@@ -155,7 +155,7 @@ class SafSyncEngineTest {
             assertTrue(
                 SafSyncEngine.shouldOverwriteMirror(
                     mirrorExists = false, mirrorModified = 0, mirrorSize = 0,
-                    sourceModified = 1_700_000_000_000, sourceSize = 4096, mirrorIsOurCopy = false
+                    sourceModified = 1_700_000_000_000, sourceSize = 4096, mirrorIsOurCopy = { false }
                 ),
                 "First sync must copy: there is nothing to lose"
             )
@@ -166,7 +166,7 @@ class SafSyncEngineTest {
             assertTrue(
                 SafSyncEngine.shouldOverwriteMirror(
                     mirrorExists = true, mirrorModified = 1_700_000_000_000, mirrorSize = 4096,
-                    sourceModified = 1_700_000_060_000, sourceSize = 4096, mirrorIsOurCopy = false
+                    sourceModified = 1_700_000_060_000, sourceSize = 4096, mirrorIsOurCopy = { false }
                 ),
                 "An edit made outside the app should reach the mirror"
             )
@@ -179,7 +179,7 @@ class SafSyncEngineTest {
             assertFalse(
                 SafSyncEngine.shouldOverwriteMirror(
                     mirrorExists = true, mirrorModified = 1_700_000_060_000, mirrorSize = 4096,
-                    sourceModified = 1_700_000_000_000, sourceSize = 4096, mirrorIsOurCopy = false
+                    sourceModified = 1_700_000_000_000, sourceSize = 4096, mirrorIsOurCopy = { false }
                 ),
                 "A newer local edit must survive reopening the folder"
             )
@@ -190,7 +190,7 @@ class SafSyncEngineTest {
             assertFalse(
                 SafSyncEngine.shouldOverwriteMirror(
                     mirrorExists = true, mirrorModified = 1_700_000_000_000, mirrorSize = 4096,
-                    sourceModified = 1_700_000_000_000, sourceSize = 4096, mirrorIsOurCopy = false
+                    sourceModified = 1_700_000_000_000, sourceSize = 4096, mirrorIsOurCopy = { false }
                 ),
                 "Same timestamp and same size means the copy is current"
             )
@@ -209,7 +209,7 @@ class SafSyncEngineTest {
             assertFalse(
                 SafSyncEngine.shouldOverwriteMirror(
                     mirrorExists = true, mirrorModified = 1_700_000_060_000, mirrorSize = 700_000,
-                    sourceModified = 1_700_000_000_000, sourceSize = 2_000_000, mirrorIsOurCopy = false
+                    sourceModified = 1_700_000_000_000, sourceSize = 2_000_000, mirrorIsOurCopy = { false }
                 ),
                 "A newer local edit must survive regardless of how its length changed"
             )
@@ -222,7 +222,7 @@ class SafSyncEngineTest {
             assertTrue(
                 SafSyncEngine.shouldOverwriteMirror(
                     mirrorExists = true, mirrorModified = 1_700_000_000_000, mirrorSize = 4096,
-                    sourceModified = 1_700_000_000_000, sourceSize = 8192, mirrorIsOurCopy = false
+                    sourceModified = 1_700_000_000_000, sourceSize = 8192, mirrorIsOurCopy = { false }
                 ),
                 "Equal timestamps with different lengths means the device copy changed"
             )
@@ -242,7 +242,7 @@ class SafSyncEngineTest {
             assertTrue(
                 SafSyncEngine.shouldOverwriteMirror(
                     mirrorExists = true, mirrorModified = 1_700_000_000_000, mirrorSize = 4096,
-                    sourceModified = 0, sourceSize = 4096, mirrorIsOurCopy = true
+                    sourceModified = 0, sourceSize = 4096, mirrorIsOurCopy = { true }
                 ),
                 "the mirror is this app's own copy, so the folder must not freeze"
             )
@@ -253,7 +253,7 @@ class SafSyncEngineTest {
             assertFalse(
                 SafSyncEngine.shouldOverwriteMirror(
                     mirrorExists = true, mirrorModified = 1_700_000_000_000, mirrorSize = 4096,
-                    sourceModified = 0, sourceSize = 4096, mirrorIsOurCopy = false
+                    sourceModified = 0, sourceSize = 4096, mirrorIsOurCopy = { false }
                 ),
                 "the mirror no longer matches what was recorded for it, so it holds an " +
                     "edit that was never written back and is the only copy"
@@ -265,7 +265,7 @@ class SafSyncEngineTest {
             assertTrue(
                 SafSyncEngine.shouldOverwriteMirror(
                     mirrorExists = false, mirrorModified = 0, mirrorSize = 0,
-                    sourceModified = 0, sourceSize = 4096, mirrorIsOurCopy = false
+                    sourceModified = 0, sourceSize = 4096, mirrorIsOurCopy = { false }
                 ),
                 "A missing mirror file must still be fetched even without timestamps"
             )
@@ -295,7 +295,7 @@ class SafSyncEngineTest {
                     mirrorModified = 1_700_000_000_000L,
                     mirrorSize = 1024,
                     sourceModified = doc.lastModified,
-                    sourceSize = doc.size, mirrorIsOurCopy = true
+                    sourceSize = doc.size, mirrorIsOurCopy = { true }
                 ),
                 "a document with no reported time must reach the unknown-time branch " +
                     "rather than falling through to the clock comparison"

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafUploadInterruptionTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafUploadInterruptionTest.kt
@@ -18,7 +18,6 @@ import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafWriteBackFilterTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafWriteBackFilterTest.kt
@@ -118,24 +118,56 @@ class SafWriteBackFilterTest {
 
     // ── the two filters, side by side ────────────────────────────────────
 
-    @ParameterizedTest(name = "agree on: {0}")
-    @ValueSource(
-        strings = ["node_modules", ".git", "__pycache__", ".gradle", ".idea", "venv", ".env",
-            "src", "build", ".vscode", "lib", "docs"]
-    )
-    fun `both filters reach the same verdict on a top-level entry`(name: String) {
-        // The two rules are one rule seen from either side. Stated as an equality so
-        // that changing SKIP_DIRECTORIES moves both together or fails here: a name
-        // added to the set that the write-back still allows means edits pushed to a
-        // device folder the mirror does not have, and a name removed that the
-        // write-back still blocks is the .vscode defect again under another name.
-        for (isDir in listOf(true, false)) {
-            assertEquals(
-                !SafSyncEngine.shouldSkip(name, isDir),
-                SafSyncEngine.shouldWriteBack(name, isDir),
-                "'$name' (isDir=$isDir) is filtered on one side only"
+    /**
+     * The write-back filter answers to [SafSyncEngine.SKIP_DIRECTORIES] itself.
+     *
+     * This used to assert `!shouldSkip(name, isDir) == shouldWriteBack(name, isDir)`,
+     * which cannot fail: for a single-segment, non-machine-temporary path
+     * `shouldWriteBack` **is** `!shouldSkip`, so the equality restates the
+     * implementation. A test that cannot go red is worse than no test, because its
+     * comment claimed it would catch a name added to the set that the write-back still
+     * allows, and someone reading the list of green tests would believe that.
+     *
+     * Asked of the data instead. The set is the single source of what the walk keeps
+     * out of the mirror, so reading it here is what would catch `shouldWriteBack` being
+     * reimplemented against a second, drifting list of its own, which is the shape the
+     * `.vscode` defect took: two filters, one of them written out by hand.
+     */
+    @Test
+    fun `every skipped directory is refused by the write-back filter`() {
+        val skipped = SafSyncEngine.SKIP_DIRECTORIES
+        // The set is the fixture, so an empty one would make the loop vacuous and the
+        // whole file agreeable.
+        assertTrue(skipped.size >= 5, "SKIP_DIRECTORIES has ${skipped.size} entries; too few to mean anything")
+
+        skipped.forEach { name ->
+            assertFalse(
+                SafSyncEngine.shouldWriteBack(name, isDirectory = true),
+                "'$name' is in SKIP_DIRECTORIES, so it was never mirrored in and there " +
+                    "is nothing on the device for a write-back to update",
+            )
+            assertFalse(
+                SafSyncEngine.shouldWriteBack("$name/child.txt", isDirectory = false),
+                "'$name/child.txt' lives under a skipped directory, so the walk never " +
+                    "copied it in",
             )
         }
+    }
+
+    @ParameterizedTest(name = "written back: {0}")
+    @ValueSource(strings = ["src", "build", ".vscode", "lib", "docs", "app"])
+    fun `a directory the walk mirrors in is written back`(name: String) {
+        // The other direction, and the one the `.vscode` defect was. Named literals
+        // rather than "everything not in the set", because the interesting cases are
+        // the dot-directories the walk deliberately does NOT skip.
+        assertFalse(
+            name in SafSyncEngine.SKIP_DIRECTORIES,
+            "'$name' is in SKIP_DIRECTORIES, so this case is asserting the wrong thing",
+        )
+        assertTrue(
+            SafSyncEngine.shouldWriteBack(name, isDirectory = true),
+            "'$name' is mirrored in, so an edit under it has to reach the device",
+        )
     }
 
     /**

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafWriteBackFilterTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafWriteBackFilterTest.kt
@@ -1,6 +1,5 @@
 package com.vscodroid.storage
 
-import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test

--- a/android/app/src/test/kotlin/com/vscodroid/util/ThemeEdgeToEdgeTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/util/ThemeEdgeToEdgeTest.kt
@@ -1,0 +1,153 @@
+package com.vscodroid.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * The window attributes that replaced `androidx.activity.enableEdgeToEdge()`.
+ *
+ * [drawBehindSystemBars] sets two things from code and leaves the other four to
+ * `values/themes.xml`, because Play's scan reads bytecode and an attribute is not a
+ * call. That trade is what cleared the three deprecated APIs Play reported, and it
+ * moves the cost here: a theme item has no compiler. Deleting one is a silent,
+ * device-only regression, and one of the four was in fact missing when the migration
+ * first landed.
+ *
+ * ⚠️ What this cannot see. It reads the XML, so it proves the attribute is written,
+ * not that the platform honours it, and not that the value looks right on a screen.
+ * The API 33 emulator is still the instrument for that, and
+ * `docs/PLAY_EDGE_TO_EDGE.md` says so: API 35+ ignores every attribute checked here
+ * and paints the bars from the window background, so a current image cannot see this
+ * class of defect at all.
+ *
+ * Values are asserted, not just presence. `enforceNavigationBarContrast` defaulting
+ * to `true` is exactly the state this exists to refuse, and an item naming `true`
+ * would satisfy a presence check while restoring the scrim.
+ */
+class ThemeEdgeToEdgeTest {
+
+    private val themes = File("src/main/res/values/themes.xml")
+
+    /** `name` to literal value, for every `<item>` in the app's theme. */
+    private fun themeItems(): Map<String, String> {
+        assertTrue(
+            themes.isFile,
+            "themes.xml is not at ${themes.absolutePath}; this test would otherwise " +
+                "pass by reading nothing",
+        )
+        val text = themes.readText()
+        // The one style this app declares. Bounded to it rather than scanning the file,
+        // so a second style added later cannot answer for this one.
+        val style = Regex("""<style\s+name="Theme\.VSCodroid".*?</style>""", RegexOption.DOT_MATCHES_ALL)
+            .find(text)
+        assertTrue(style != null, "Theme.VSCodroid is not declared in themes.xml")
+        return Regex("""<item\s+name="([^"]+)"\s*>([^<]*)</item>""")
+            .findAll(style!!.value)
+            .associate { it.groupValues[1] to it.groupValues[2].trim() }
+    }
+
+    @Test
+    fun `the theme carries every window attribute drawBehindSystemBars does not set`() {
+        val items = themeItems()
+
+        // The control: if the parse silently matched nothing, every assertion below
+        // would fail with "expected X but was null", which reads like a deleted
+        // attribute rather than a broken parser. This says which it is.
+        assertTrue(
+            items.size >= 5,
+            "only ${items.size} items were parsed out of Theme.VSCodroid, so the " +
+                "pattern is not matching the file. Parsed: $items",
+        )
+
+        mapOf(
+            // Transparent rather than the Material3 default, which is blue against
+            // this app's dark editor on API 33 and 34.
+            "android:statusBarColor" to "@android:color/transparent",
+            "android:navigationBarColor" to "@android:color/transparent",
+            // `always`, which is what Api30 wrote and what API 35+ forces. Not
+            // `shortEdges`: Api28 wrote that and minSdk 33 never reached it.
+            "android:windowLayoutInDisplayCutoutMode" to "always",
+            // Both default to true. Leaving either out puts a platform scrim behind
+            // a bar the two colours above just made transparent.
+            "android:enforceStatusBarContrast" to "false",
+            "android:enforceNavigationBarContrast" to "false",
+        ).forEach { (name, expected) ->
+            assertEquals(
+                expected, items[name],
+                "Theme.VSCodroid no longer sets $name to $expected. " +
+                    "drawBehindSystemBars() deliberately does not set it from code, " +
+                    "because Play flags the setter, so the theme is the only thing " +
+                    "holding it and there is nothing else to catch this.",
+            )
+        }
+    }
+
+    /**
+     * [text] with every comment blanked to spaces, newlines and offsets preserved.
+     *
+     * Blanking rather than deleting so a line number still points where it did.
+     *
+     * Not optional, and the first version of this test proved it: the KDoc on
+     * [drawBehindSystemBars] names all three deprecated APIs, because explaining why
+     * they are gone requires saying what they were. Scanning raw text found those four
+     * lines and reported the documentation as the defect. A guard that fires on the
+     * prose describing it is one someone silences by deleting the prose.
+     */
+    private fun codeOnly(text: String): String {
+        val out = StringBuilder(text.length)
+        var i = 0
+        while (i < text.length) {
+            when {
+                text.startsWith("//", i) ->
+                    while (i < text.length && text[i] != '\n') { out.append(' '); i++ }
+                text.startsWith("/*", i) -> {
+                    while (i < text.length && !text.startsWith("*/", i)) {
+                        out.append(if (text[i] == '\n') '\n' else ' '); i++
+                    }
+                    repeat(minOf(2, text.length - i)) { out.append(' '); i++ }
+                }
+                else -> { out.append(text[i]); i++ }
+            }
+        }
+        return out.toString()
+    }
+
+    @Test
+    fun `the window setters Play reports are not called from app code`() {
+        // The other half of the trade, and the reason the attributes exist at all.
+        // Source-level, so it speaks only for this repository's own code; the release
+        // dex is what settles the bundle, and r8.yml is where that runs.
+        val sources = File("src/main/kotlin").walkTopDown()
+            .filter { it.isFile && it.extension == "kt" }
+            .toList()
+        assertTrue(sources.size > 10, "only ${sources.size} sources walked; the walk is wrong")
+
+        val banned = listOf(
+            "setStatusBarColor", "statusBarColor =",
+            "setNavigationBarColor", "navigationBarColor =",
+            "enableEdgeToEdge",
+        )
+
+        // The negative control, run against a literal rather than the tree: the
+        // blanking has to remove a commented occurrence and keep a real one, or an
+        // empty offender list means nothing.
+        val probe = codeOnly("/** enableEdgeToEdge */\nwindow.setStatusBarColor(0)\n")
+        assertTrue("enableEdgeToEdge" !in probe, "codeOnly did not blank a KDoc mention")
+        assertTrue("setStatusBarColor" in probe, "codeOnly blanked a real call")
+
+        val offenders = sources.flatMap { f ->
+            codeOnly(f.readText()).lines().withIndex()
+                .filter { (_, line) -> banned.any { it in line } }
+                .map { (i, _) -> "${f.name}:${i + 1}" }
+        }
+
+        assertEquals(
+            emptyList<String>(), offenders,
+            "these call an edge-to-edge API Play reports as deprecated. The theme " +
+                "attributes replace them; adding one back puts the class into the " +
+                "bundle again and the Play Console warning with it.",
+        )
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/util/ThemeEdgeToEdgeTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/util/ThemeEdgeToEdgeTest.kt
@@ -8,22 +8,25 @@ import java.io.File
 /**
  * The window attributes that replaced `androidx.activity.enableEdgeToEdge()`.
  *
- * [drawBehindSystemBars] sets two things from code and leaves the other four to
+ * [drawBehindSystemBars] sets two things from code and leaves the rest to
  * `values/themes.xml`, because Play's scan reads bytecode and an attribute is not a
  * call. That trade is what cleared the three deprecated APIs Play reported, and it
  * moves the cost here: a theme item has no compiler. Deleting one is a silent,
- * device-only regression, and one of the four was in fact missing when the migration
+ * device-only regression, and one of them was in fact missing when the migration
  * first landed.
  *
  * ⚠️ What this cannot see. It reads the XML, so it proves the attribute is written,
  * not that the platform honours it, and not that the value looks right on a screen.
- * The API 33 emulator is still the instrument for that, and
- * `docs/PLAY_EDGE_TO_EDGE.md` says so: API 35+ ignores every attribute checked here
- * and paints the bars from the window background, so a current image cannot see this
- * class of defect at all.
+ * The API 33 emulator is the instrument for that.
  *
- * Values are asserted, not just presence. `enforceNavigationBarContrast` defaulting
- * to `true` is exactly the state this exists to refuse, and an item naming `true`
+ * Not every attribute here is a pre-35 concern, and saying so loosely was wrong. API
+ * 35+ does ignore the two bar COLOURS and paints from the window background, and it
+ * forces the cutout mode. It does NOT ignore `enforceNavigationBarContrast`, which
+ * still decides whether the platform draws a scrim behind a 3-button navigation bar,
+ * so that one is worth looking at on a current image as well as on API 33.
+ *
+ * Values are asserted, not just presence. `enforceNavigationBarContrast` defaults to
+ * `true`, which is exactly the state this exists to refuse, and an item naming `true`
  * would satisfy a presence check while restoring the scrim.
  */
 class ThemeEdgeToEdgeTest {
@@ -69,8 +72,9 @@ class ThemeEdgeToEdgeTest {
             // `always`, which is what Api30 wrote and what API 35+ forces. Not
             // `shortEdges`: Api28 wrote that and minSdk 33 never reached it.
             "android:windowLayoutInDisplayCutoutMode" to "always",
-            // Both default to true. Leaving either out puts a platform scrim behind
-            // a bar the two colours above just made transparent.
+            // Only the navigation default is `true`; the status one is already
+            // `false`. Both are pinned so the pair stays visible as one decision, and
+            // so a later edit to `true` is refused rather than merely unnoticed.
             "android:enforceStatusBarContrast" to "false",
             "android:enforceNavigationBarContrast" to "false",
         ).forEach { (name, expected) ->

--- a/docs/10-RELEASE_PLAN.md
+++ b/docs/10-RELEASE_PLAN.md
@@ -166,8 +166,8 @@ unrelated to the versionName. 1.0.0 shipped as 10; 1.1.0 ships as 12, because 11
 was uploaded and burned.
 
 ```kotlin
-versionCode = 12
-versionName = "1.1.0"
+versionCode = 13
+versionName = "1.2.0"
 ```
 
 This document described an encoded scheme, `major * 1_000_000 + minor * 10_000 +

--- a/docs/PLAY_EDGE_TO_EDGE.md
+++ b/docs/PLAY_EDGE_TO_EDGE.md
@@ -44,7 +44,7 @@ through setters the platform had already turned into no-ops.
 
 ## What replaced it
 
-`util/ViewInsets.drawBehindSystemBars()`, plus three attributes in
+`util/ViewInsets.drawBehindSystemBars()`, plus five attributes in
 `values/themes.xml`. Each piece maps to something the old call did:
 
 | `enableEdgeToEdge()` did | Now |
@@ -53,12 +53,26 @@ through setters the platform had already turned into no-ops.
 | pin light system bar icons | `WindowInsetsControllerCompat.isAppearanceLight*Bars = false` |
 | set both bars transparent | `android:statusBarColor` / `android:navigationBarColor` in the theme |
 | set the cutout mode | `android:windowLayoutInDisplayCutoutMode` in the theme |
+| stop the platform enforcing bar contrast | `android:enforceStatusBarContrast` / `android:enforceNavigationBarContrast` in the theme |
 
-The bar colours and the cutout mode move to attributes rather than disappearing,
-and that is the point: Play's scan reads bytecode, and an attribute is not a
-method call. It is also honest about scope, because API 35+ ignores all three
-attributes and paints the bars from the window background anyway. They decide
-API 33 and 34 and nothing else.
+The last row was missing when this migration first landed, and its absence was
+the one behaviour change the move actually caused. `EdgeToEdgeApi29.setUp` calls
+`setStatusBarContrastEnforced(false)` and
+`setNavigationBarContrastEnforced(nightMode == 0)`, and every call site passed
+`SystemBarStyle.dark()`, so both arrived false. The platform defaults are not
+symmetric: `PhoneWindow.generateLayout` defaults the status one to false and the
+navigation one to **true**, so omitting them put a scrim behind the navigation
+bar the theme had just made transparent.
+
+The bar colours, the cutout mode and the contrast flags move to attributes rather
+than disappearing, and that is the point: Play's scan reads bytecode, and an
+attribute is not a method call.
+
+Their scope is not uniform, and an earlier version of this section flattened it.
+API 35+ ignores the two bar COLOURS and paints from the window background, and it
+forces the cutout mode, so those three decide API 33 and 34 and nothing else. It
+does **not** ignore `enforceNavigationBarContrast`, which still decides whether a
+scrim is drawn behind a 3-button navigation bar on a current image.
 
 `setDecorFitsSystemWindows` stays in the bundle and that is fine. It is not one
 of the three Play named, and Play Core's asset pack code puts it there

--- a/scripts/build-vscode-oss.sh
+++ b/scripts/build-vscode-oss.sh
@@ -31,12 +31,19 @@ set -euo pipefail
 #       -v "$PWD/patches:/patches:ro" \
 #       vscodroid-codeoss-build:24.18.0 bash /scripts/build-vscode-oss.sh
 #
-# The tag's version is the Dockerfile's ARG NODE_VERSION, which is .nvmrc at the
-# VS Code tag being built, and it is written out by hand in both places with
-# nothing checking they agree. Read it from the Dockerfile when bumping rather
-# than copying this line, and note its own warning: the Node this build HOST runs
-# and the Node that ends up on the DEVICE are different numbers that merely
-# coincide at 1.133.0.
+# ⚠️ The version in that tag is the Dockerfile's ARG NODE_VERSION, written out by
+# hand in both places with NOTHING checking they agree, and nothing here reads the
+# Dockerfile either. A stale tag builds against a Node the image does not have, or
+# silently reuses an image built for an older one. Read the value out of
+# docker/codeoss-build.Dockerfile when bumping rather than copying this line.
+#
+# Left ungated deliberately, and it is the one loose end in this block: the check
+# would have to parse a Dockerfile that CI never builds, since the workflow installs
+# the same toolchain directly on an arm64 runner. Worth a gate the day a second
+# person builds locally.
+#
+# Note also the Dockerfile's own warning: the Node this build HOST runs and the Node
+# that ends up on the DEVICE are different numbers that merely coincide at 1.133.0.
 #
 # Run it on an arm64 host. Every native module in the tree is built for the build
 # host, and only two of them are overlaid afterwards by build-native-addons.sh —

--- a/scripts/build-vscode-oss.sh
+++ b/scripts/build-vscode-oss.sh
@@ -18,6 +18,8 @@ set -euo pipefail
 # order of 100k files, and a Docker Desktop bind mount makes that pathologically
 # slow:
 #
+#   docker build -f docker/codeoss-build.Dockerfile \
+#       -t vscodroid-codeoss-build:24.18.0 docker/
 #   docker volume create vscodroid-codeoss
 #   docker volume create vscodroid-npm-cache
 #   docker run --rm -v vscodroid-codeoss:/work \
@@ -28,6 +30,13 @@ set -euo pipefail
 #       -v "$PWD/branding:/branding" \
 #       -v "$PWD/patches:/patches:ro" \
 #       vscodroid-codeoss-build:24.18.0 bash /scripts/build-vscode-oss.sh
+#
+# The tag's version is the Dockerfile's ARG NODE_VERSION, which is .nvmrc at the
+# VS Code tag being built, and it is written out by hand in both places with
+# nothing checking they agree. Read it from the Dockerfile when bumping rather
+# than copying this line, and note its own warning: the Node this build HOST runs
+# and the Node that ends up on the DEVICE are different numbers that merely
+# coincide at 1.133.0.
 #
 # Run it on an arm64 host. Every native module in the tree is built for the build
 # host, and only two of them are overlaid afterwards by build-native-addons.sh —

--- a/scripts/check-patches-apply.sh
+++ b/scripts/check-patches-apply.sh
@@ -72,16 +72,25 @@ if [ "$TAG" = "$PINNED" ]; then
     exit 0
 fi
 
-SRC=$(mktemp -d)
+# Every step below is guarded with `fail`, which exits 2, and that is the whole
+# point of guarding them. Left bare, `set -e` ends the script with the failing
+# command's own status, which for git and mktemp is 1, and 1 is the code this
+# file's header assigns to "a patch failed". A runner out of temp space, or with
+# no network to reach github.com, would then report the one thing it had proved
+# nothing about: that the Android adaptations no longer apply upstream. The
+# distinction is the reason the workflow can be read at a glance, and it is worth
+# nothing if only some of the ways to fail respect it.
+SRC=$(mktemp -d) || fail "could not create a work directory"
 trap 'rm -rf "$SRC"' EXIT
 
 echo
 echo "Fetching $TAG (shallow)"
-git -C "$SRC" init -q
-git -C "$SRC" remote add origin "$UPSTREAM"
+git -C "$SRC" init -q || fail "could not init a git repository in $SRC"
+git -C "$SRC" remote add origin "$UPSTREAM" || fail "could not add the upstream remote"
 git -C "$SRC" fetch -q --depth 1 origin "refs/tags/$TAG" || fail "could not fetch tag $TAG"
-git -C "$SRC" checkout -q FETCH_HEAD
-echo "  HEAD    : $(git -C "$SRC" rev-parse --short HEAD)"
+git -C "$SRC" checkout -q FETCH_HEAD || fail "could not check out $TAG"
+head=$(git -C "$SRC" rev-parse --short HEAD) || fail "could not resolve the fetched commit"
+echo "  HEAD    : $head"
 
 echo
 echo "Applying"


### PR DESCRIPTION
Closes the defects standing between `main` and a 1.2.0 tag, and cuts the release. Fourteen commits, each self-contained.

## Fixed

- **System bars lost their transparency below API 35.** The move from `enableEdgeToEdge()` to theme attributes reproduced four of the five things that call did. Contrast enforcement had no replacement, and `PhoneWindow.generateLayout` defaults `enforceNavigationBarContrast` to true, so the platform painted a scrim behind a bar the theme had just made transparent. Two theme attributes replace it; `ThemeEdgeToEdgeTest` pins all five by value, since a theme item has no compiler.
- **The bridge kept a destroyed screen alive.** `ToolchainManager` was given the application context, but the state callback beside it was an unqualified call to a bridge member, which captures the bridge, and the bridge holds the Activity. Play Core's registry outlives every Activity, so the whole view tree stayed reachable. The callback is split by what each branch needs: closing the registration goes through the manager, the confirmation dialog reads a weak reference.
- **A Play pack delivered after its screen closed was never installed.** `installFromDirectory` was reachable only from the COMPLETED callback, and both screens drop their listener at teardown, so backgrounding the app mid-download left the pack downloaded, paid for and invisible. `reconcileDeliveredPacks` asks Play at launch what it has already delivered, which needs no listener.
- **The Play space gate reserved 50 MB for a 146 MB tree.** It sized itself with `find(...)?.estimatedSize ?: 0L`, and the registry answers null for a retired pack by design, so the elvis turned the whole reservation into the buffer. A gate that passes exactly the devices it exists to refuse is worse than no gate.
- **A refused install deleted Play's copy.** Play delivers into `filesDir/assetpacks`, the filesystem the gate had just measured, so the delete freed the unpacked size and the retry re-extracted the same bytes, costing a full download for nothing. It also removed what the launch reconcile needs to finish the install once space is freed.
- **A cancelled toolchain could still install.** Play's cancel does not touch a pack it has already delivered, so `cancel()` now releases it and "cancelled" means "not delivered".
- **A missing checksum was reported as a connection problem.** The manifest was fetched successfully and simply did not name the ZIP, which no retry can change; it now reports that the release does not carry it.
- **Failures on a manager with no listener vanished.** `fail()` was only a callback invocation, so an instance built without one reported nothing at all, not even a log line.
- **The write-back failure notice could fire twice for one burst.** `@Volatile` gave visibility but not atomicity, and two threads reach that callback.
- **The synced-record read was never actually deferred.** It was passed to `shouldOverwriteMirror` by value, so the first ordinary file forced it whatever the provider reported.

## Changed

- Version moves to 1.2.0 / versionCode 13, and the changelog closes. Minor rather than patch: the range adds behaviour and carries three security entries. Both fields move together because `isFirstRun` gates on the name and `runMigrations` thresholds on the code.
- Nine unused imports, one write-only field and one unreferenced colour are removed, with its lint-baseline entry and the count the build file states.
- `check-patches-apply.sh` separates infrastructure failures from a failed patch: `mktemp`, `git init`, `remote add` and `checkout` were bare under `set -e`, so a runner with no network reported the one thing it had proved nothing about.
- `patch-drift.yml` no longer lets a manual run cancel the weekly one, and `r8.yml` now triggers on the Gradle wrapper, which is part of the shrinker's configuration since AGP declares a minimum Gradle.

## Known gaps, deliberately shipped

- A Play confirmation prompt can still be lost if the renderer crashes while one is pending: `recreateWebView()` drops the only strong reference to the bridge while the Activity lives. Now logged rather than silent. Reaching it needs a Play install, cellular, a pack over Play's threshold, a renderer crash and a collection.
- `installFromDirectory` leaves the copied tree in `usr/` when `writeState` fails, with no manifest naming it. Pre-existing, and not repaired here because that tree shares `usr/` with the base install and other toolchains, so removing it is the uninstall path's library bookkeeping rather than a recursive delete.

Both are recorded at their sites.

## Verification

- 1221 unit tests, 0 failures.
- Instrumented suite on API 33 and API 37: 26/26 each, 0 skipped. API 33 matters here because API 35+ ignores the bar colours entirely.
- Cold first run on API 33 driven by `scripts/device-launch.sh` with no manual input: 793 MB server plus 126 MB usr extracted, editor reached, bars transparent.
- R8, resource shrinking, `lintVitalRelease` and `checkPatchFingerprints` green; all thirteen repository checks pass.
- The release gate's own tag and versionCode logic was run against this bump before committing.
- The retention fix is confirmed in bytecode: the lambda took `AndroidBridge` before and takes `ToolchainManager` and a `WeakReference` after. The guarding test was measured against the defect restored, and it goes red.
