### PR TITLE
docs(changelog): reopen the section until the tag is cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.2.0] - 2026-08-20
-
 ### Changed
 
 - The build moves to Android Gradle plugin 9.3.1 and Gradle 9.5.1, which turns on optimized resource shrinking. Play flagged the old configuration for memory and performance.
@@ -552,8 +550,7 @@ This release represents the cumulative work across milestones M0 through M5, bri
 - Health check polling for server readiness
 - Android intent handling for "Open with VSCodroid"
 
-[Unreleased]: https://github.com/rmyndharis/VSCodroid/compare/v1.2.0...HEAD
-[1.2.0]: https://github.com/rmyndharis/VSCodroid/compare/v1.1.0...v1.2.0
+[Unreleased]: https://github.com/rmyndharis/VSCodroid/compare/v1.1.0...HEAD
 [1.1.0]: https://github.com/rmyndharis/VSCodroid/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/rmyndharis/VSCodroid/compare/v0.2.9...v1.0.0
 [0.2.9]: https://github.com/rmyndharis/VSCodroid/compare/v0.2.8...v0.2.9


### PR DESCRIPTION
The 1.2.0 heading and its compare link landed alongside the version bump in #302, which put the changelog in its released form while no such tag exists. Closing the section is a separate step taken at tag time, as it was for 1.1.0.

- `## [1.2.0] - 2026-08-20` is removed and its entries move back under `## [Unreleased]` unchanged.
- The compare link returns to `v1.1.0...HEAD` and the `[1.2.0]` line is dropped.

`versionCode` and `versionName` are deliberately left at 13 and 1.2.0. A build may carry the next version before the tag exists, and `release.yml` compares the tag against both at the point that matters.

Verified: 22 entries before, 22 after, compared as sets, none lost or reworded. One file, one line added, four removed.