### PR TITLE
fix(saf): tell the user when a write-back is refused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A save the sync refuses to write back now says so. It was silent, so an edit that never reached the device folder looked exactly like one that did.
 - The editor sees files changed outside it again. One source file was missing from the watcher build, so the addon could not load and nothing in a folder was watched.
 - Narrowing the platform-detection patch now fails the build. It could previously be narrowed with every check still green, leaving the marketplace asked for a binary that cannot start on Android.
 - First-run setup now shows progress while it extracts the editor, instead of holding at 5% for minutes and looking like it has hung.

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
@@ -83,6 +83,21 @@ class SafSyncEngine(private val context: Context) {
     private val unfetched = ConcurrentHashMap.newKeySet<String>()
 
     /**
+     * Mirror paths a refusal has already been announced for.
+     *
+     * The refusal fires on every inotify MODIFY, so an editor autosaving a file whose
+     * device document this sync could not read reaches it on every save. Announcing each
+     * one would be a wall of the same notice, and worse: the manager's throttle is one
+     * timer for the whole folder, so the wall would swallow an unrelated write-back
+     * failure for as long as it lasted. One notice per path carries the whole fact,
+     * which is that this file is not reaching the device folder.
+     *
+     * Absolute paths and scoped per mirror in [initialSync], next to [unfetched] and for
+     * the same reason: one engine serves every folder in turn.
+     */
+    private val refusalsAnnounced = ConcurrentHashMap.newKeySet<String>()
+
+    /**
      * The tree [docIdCache]'s entries were resolved against. The cache is cleared
      * and refilled per folder, and a write-back drain can outlive its folder, so
      * anything resolving at processing time has to know whether the cache still
@@ -129,6 +144,7 @@ class SafSyncEngine(private val context: Context) {
         // a switch that fails partway must not drop the protection the previous
         // folder's mirror is still relying on.
         unfetched.removeAll { it.startsWith(mirrorDir.absolutePath + File.separator) }
+        refusalsAnnounced.removeAll { it.startsWith(mirrorDir.absolutePath + File.separator) }
         cacheTree = safUri
 
         // Phase 1: Enumerate all documents in the tree
@@ -1021,13 +1037,44 @@ class SafSyncEngine(private val context: Context) {
      * class has no screen and should not reach for one. The layer that owns a screen
      * decides how to say it.
      *
-     * Both exits leave the file's journal entry in place, so the data is already safe:
-     * the reclaim pass reads that journal and refuses to delete the mirror. What was
-     * missing is the user knowing, and the two are not the same fact. A save that never
-     * reached the device folder looks exactly like one that did, and the difference only
-     * shows when the app is uninstalled and the work is gone.
+     * Three callers reach this, and the mirror is protected on all three, by two gates
+     * rather than the one this comment used to name. The two exits inside
+     * [writeLocalToSaf] leave the file's journal entry in place, which
+     * `SafStorageManager.mayReclaim` reads. [refuseUnreadDocument] writes no journal
+     * entry at all, because it declines before the write begins; what covers it is the
+     * second gate, [holdsOnlyVouchedCopies], which refuses to reclaim a mirror holding
+     * any file the `.synced` record cannot vouch for, and a file that was never written
+     * back never is.
+     *
+     * What was missing is the user knowing, and that is a different fact from the data
+     * being safe. A save that never reached the device folder looks exactly like one
+     * that did, and the difference only shows when the app is uninstalled and the work
+     * is gone.
      */
     internal var onWriteBackFailed: (File) -> Unit = {}
+
+    /**
+     * Declines to write [localFile] out, because the device holds a document under that
+     * name this sync never read, and says so once per file.
+     *
+     * Both refusal sites come through here, and the message living in one place is what
+     * keeps them saying the same thing: [createOneInSaf] asks the same question while
+     * walking into a directory, and no JVM test can reach it, because delivering a
+     * directory event builds a `FileObserver` and its static initializer needs native
+     * code. One of them is the only thing holding the two together.
+     *
+     * The notice is [onWriteBackFailed]'s and it fits: the file did not reach the device
+     * folder, and the copy inside the app is the only one of it that exists. What the
+     * device holds under that name is a different document, which is why this refuses.
+     */
+    private fun refuseUnreadDocument(localFile: File, describedAs: String) {
+        Logger.w(
+            tag,
+            "Not writing $describedAs back: the device holds a document there " +
+                "that this sync never read, and writing would replace it",
+        )
+        if (refusalsAnnounced.add(localFile.absolutePath)) onWriteBackFailed(localFile)
+    }
 
     private fun uploadJournal(): File = File(context.filesDir, UPLOADS_IN_FLIGHT_FILE)
 
@@ -1186,11 +1233,7 @@ class SafSyncEngine(private val context: Context) {
                         localFile.absolutePath, existingDocId != null, unfetched,
                     )
                 ) {
-                    Logger.w(
-                        tag,
-                        "Not writing ${localFile.name} back: the device holds a document " +
-                            "there that this sync never read, and writing would replace it",
-                    )
+                    refuseUnreadDocument(localFile, localFile.name)
                 } else {
                     writeLocalToSaf(localFile, docUri)
                 }
@@ -1543,11 +1586,7 @@ class SafSyncEngine(private val context: Context) {
                 unfetched,
             )
         ) {
-            Logger.w(
-                tag,
-                "Not writing $relativePath back: the device holds a document there " +
-                    "that this sync never read, and writing would replace it",
-            )
+            refuseUnreadDocument(localFile, relativePath)
             return
         }
 

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafUnfetchedDocumentTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafUnfetchedDocumentTest.kt
@@ -17,6 +17,8 @@ import io.mockk.unmockkAll
 import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -203,5 +205,116 @@ class SafUnfetchedDocumentTest {
         // A name the device does not hold is created and then written, so the
         // write happening at all is what separates this from the guarded cases.
         verify(atLeast = 1) { resolver.openOutputStream(any(), "wt") }
+    }
+
+    /**
+     * The four cases above pin that the device document survives. These pin the other
+     * half, which was missing: that the user is told their edit did not travel.
+     *
+     * Refusing the write is correct and it is also invisible. The mirror holds the
+     * edit, the editor reports the save, the tab goes clean, and the device folder
+     * still holds a different document. That is the shape the project's own rule
+     * forbids, a save that looks identical to one that worked, and the engine's KDoc
+     * names this group as "the user's only copy" while announcing nothing about it.
+     *
+     * Asserted on the seam rather than on a Toast: the engine has no screen, and
+     * `WriteBackNoticeWiringTest` covers the Activity end of the same channel.
+     */
+    @Test
+    fun `a refused write-back tells the user their edit stayed in the app`() {
+        val announced = mutableListOf<String>()
+        engine.onWriteBackFailed = { announced.add(it.name) }
+
+        deviceHolding("big.zip", size = SafSyncEngine.MAX_FILE_SIZE + 1)
+        runBlocking { engine.initialSync(treeUri, mirror) { _, _ -> } }
+
+        File(mirror, "big.zip").writeText("stub")
+        deliver(FileObserver.CREATE, "big.zip")
+
+        assertEquals(
+            listOf("big.zip"),
+            announced,
+            "the write was refused and nothing said so, which is the silence this " +
+                "guard was supposed to end rather than create",
+        )
+    }
+
+    /** The same, for a document the sync tried to read and could not. */
+    @Test
+    fun `a copy that failed is announced too`() {
+        val announced = mutableListOf<String>()
+        engine.onWriteBackFailed = { announced.add(it.name) }
+
+        deviceHolding("notes.md", size = 64, readable = false)
+        runBlocking { engine.initialSync(treeUri, mirror) { _, _ -> } }
+
+        File(mirror, "notes.md").writeText("stub")
+        deliver(FileObserver.MODIFY, "notes.md")
+
+        assertEquals(listOf("notes.md"), announced, "a failed copy refused the write silently")
+    }
+
+    /**
+     * The negative control, and the one that stops the two above from passing for the
+     * wrong reason. A write that actually lands must announce nothing: an app that
+     * warns on every successful save teaches the user to ignore the warning, which
+     * costs more than the silence did.
+     */
+    @Test
+    fun `a write-back that lands announces nothing`() {
+        val announced = mutableListOf<String>()
+        engine.onWriteBackFailed = { announced.add(it.name) }
+
+        deviceHolding("notes.md", size = 64)
+        runBlocking { engine.initialSync(treeUri, mirror) { _, _ -> } }
+
+        File(mirror, "notes.md").writeText("edited in the editor")
+        deliver(FileObserver.MODIFY, "notes.md")
+
+        verify(atLeast = 1) { resolver.openOutputStream(any(), "wt") }
+        assertTrue(
+            announced.isEmpty(),
+            "a save that reached the device folder still warned the user: $announced",
+        )
+    }
+
+    /**
+     * Once per file, not once per save. The refusal fires on every inotify MODIFY, so an
+     * editor autosaving reaches it every few seconds, and the notice is throttled by one
+     * timer for the whole folder: a wall of the same message would also swallow an
+     * unrelated write-back failure for as long as it lasted.
+     */
+    @Test
+    fun `an editor saving the same file again is not announced again`() {
+        val announced = mutableListOf<String>()
+        engine.onWriteBackFailed = { announced.add(it.name) }
+
+        deviceHolding("big.zip", size = SafSyncEngine.MAX_FILE_SIZE + 1)
+        runBlocking { engine.initialSync(treeUri, mirror) { _, _ -> } }
+        File(mirror, "big.zip").writeText("stub")
+
+        repeat(3) { deliver(FileObserver.MODIFY, "big.zip") }
+
+        assertEquals(listOf("big.zip"), announced, "one notice per file, not one per save")
+    }
+
+    /**
+     * The other refusal site cannot be driven from here at all: reaching it means walking
+     * into a directory, and delivering a directory event builds a `FileObserver`, whose
+     * static initializer needs native code. What holds it to the behaviour above is that
+     * there is one refusal in the file, so this reads the source and pins that.
+     */
+    @Test
+    fun `the refusal message has one home, so both sites announce`() {
+        val engineSource =
+            File("../../android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt")
+        assertTrue(engineSource.isFile, "SafSyncEngine.kt is not where this test expects it")
+
+        assertEquals(
+            1,
+            Regex("sync never read, and writing would replace it")
+                .findAll(engineSource.readText()).count(),
+            "a second copy of the refusal means a site that refuses without saying so",
+        )
     }
 }


### PR DESCRIPTION
A device folder can hold a document this app never read: one past the 50 MiB mirror
limit, or one whose copy failed. `writeWouldReplaceUnreadDocument` stops a later local
file of that name from being written over it, which is right, because the mirror holds a
placeholder rather than the document.

Refusing was silent. From the editor the save looks like every other save: the file is in
the mirror, the tab goes clean, and the device folder still holds something else. The
engine's own KDoc names this group as the user's only copy and announced nothing about it.

## What changed

- Both refusal sites now route through one `refuseUnreadDocument`, which logs and then
  announces through `onWriteBackFailed`. That seam already exists for a write-back that
  gives up, is wired to a toast in `MainActivity`, and is throttled in
  `SafStorageManager`. The existing wording fits: the edit did not reach the device
  folder, and the app holds the only copy of it.
- Announced once per path, not once per save. The refusal fires on every inotify MODIFY,
  so an autosaving editor reaches it every few seconds, and the throttle is one timer for
  the whole folder: a wall of the same notice would swallow an unrelated write-back
  failure for as long as it lasted. A per-mirror set carries that, scoped in
  `initialSync` beside `unfetched`.
- The seam's KDoc named one reclaim gate as though the other did not exist. It now names
  both and says which covers which caller: the refusal path writes no journal entry,
  because it declines before the write begins, so `holdsOnlyVouchedCopies` is what keeps
  its mirror rather than `mayReclaim`.

## Risk

The behaviour that protects the device document is unchanged; only the silence is. The
one new failure mode would be over-warning, which the per-path set and the existing
throttle bound, and which the third test below pins.

## Verification

`SafUnfetchedDocumentTest` gains five cases: both refusal paths announce, a repeated save
announces once, a write-back that lands announces nothing, and the refusal message has
exactly one home in the file.

Each was checked against the change it guards rather than assumed:

- Removing the production change turns the two announcement cases red and leaves the four
  pre-existing cases green.
- Removing only the per-path set turns exactly one case red, the repeated-save one.
- The write-back that lands is the negative control. An app that warns on every
  successful save teaches the user to ignore the warning.

Full suite 1226 tests, 0 failures, up from 1221.

Only the event path is driven by a test. The directory walk cannot be reached from a JVM
test, because delivering a directory event builds a `FileObserver` whose static
initializer needs native code. The one-home assertion is what holds the two sites
together instead.
