### PR TITLE
fix(storage): give each folder its own write-back queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - A save the sync refuses to write back now says so. It was silent, so an edit that never reached the device folder looked exactly like one that did.
+- Closing a device folder while a save is still going out no longer lets the next folder share its write-back queue, which could interleave two writes into one document.
 - The editor sees files changed outside it again. One source file was missing from the watcher build, so the addon could not load and nothing in a folder was watched.
 - Narrowing the platform-detection patch now fails the build. It could previously be narrowed with every check still green, leaving the marketplace asked for a binary that cannot start on Android.
 - First-run setup now shows progress while it extracts the editor, instead of holding at 5% for minutes and looking like it has hung.

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
@@ -41,8 +41,17 @@ import kotlin.concurrent.thread
 class SafSyncEngine(private val context: Context) {
 
     private val tag = "SafSyncEngine"
-    private val writeBackQueue = ConcurrentLinkedQueue<SyncJob>()
-    private var writeBackThread: Thread? = null
+    /**
+     * The write-back of the folder being watched: its queue of jobs and its thread.
+     *
+     * Replaced, never mutated, by [startWatching] and [stopWatching]. A drain that
+     * outlives its stop keeps the object it was started with, so the folder opened next
+     * hands its jobs to a different queue and no two threads ever poll one.
+     */
+    @Volatile
+    internal var session = WatchSession()
+        private set
+
     @Volatile private var isWatching = false
 
     /**
@@ -652,13 +661,21 @@ class SafSyncEngine(private val context: Context) {
     fun startWatching(mirrorDir: File, safUri: Uri) {
         stopWatching()
 
+        // Published before any observer exists, because an observer fires into whatever
+        // session is current and this is the one its jobs belong to.
+        val opening = WatchSession()
+        session = opening
         isWatching = true
         watchTree(mirrorDir, mirrorDir, safUri)
 
-        // Background thread to process write-back queue
-        writeBackThread = thread(name = "saf-writeback", isDaemon = true) {
-            runWriteBackLoop { isWatching }
+        // Background thread to process this session's write-back queue. Handed over
+        // before it starts, so a stop arriving at once cannot find a null worker for a
+        // thread that is already running.
+        val worker = thread(start = false, name = "saf-writeback", isDaemon = true) {
+            runWriteBackLoop(opening) { opening.running }
         }
+        opening.worker = worker
+        worker.start()
 
         val watched = synchronized(watchersLock) { watchers.size }
         Logger.i(tag, "File watcher started for ${mirrorDir.absolutePath} ($watched directories)")
@@ -668,16 +685,24 @@ class SafSyncEngine(private val context: Context) {
      * Processes queued write-backs until [isRunning] goes false or the thread is
      * interrupted, then sends out whatever is still queued.
      *
-     * Takes its termination condition as a parameter so a test can drive the loop
-     * without a live watcher; the caller passes the watcher's own flag.
+     * Drives whichever session is current, which is what a test without a live watcher
+     * needs: no JVM test can call [startWatching], because registering a watch builds a
+     * [FileObserver] and its static initializer reaches native code.
      */
-    internal fun runWriteBackLoop(isRunning: () -> Boolean) {
+    internal fun runWriteBackLoop(isRunning: () -> Boolean) = runWriteBackLoop(session, isRunning)
+
+    /**
+     * The same loop bound to one folder's [session], which is the form the watcher's own
+     * thread runs: a drain that outlives [stopWatching] goes on polling the queue it was
+     * started with, and the folder opened next has a different one.
+     */
+    internal fun runWriteBackLoop(session: WatchSession, isRunning: () -> Boolean) {
         var interrupted = false
         try {
             while (isRunning()) {
-                val job = writeBackQueue.poll()
+                val job = session.queue.poll()
                 if (job != null) {
-                    processWriteBack(job)
+                    processWriteBack(session, job)
                 } else {
                     Thread.sleep(WRITEBACK_POLL_MS)
                 }
@@ -696,10 +721,10 @@ class SafSyncEngine(private val context: Context) {
         // carrying the flag, losing exactly what this drain exists to save.
         if (Thread.interrupted()) interrupted = true
 
-        var remaining = writeBackQueue.poll()
+        var remaining = session.queue.poll()
         while (remaining != null) {
-            processWriteBack(remaining)
-            remaining = writeBackQueue.poll()
+            processWriteBack(session, remaining)
+            remaining = session.queue.poll()
         }
         if (interrupted) Thread.currentThread().interrupt()
     }
@@ -713,10 +738,16 @@ class SafSyncEngine(private val context: Context) {
             watchers.values.forEach { it.stopWatching() }
             watchers.clear()
         }
+        // The folder being closed keeps the queue its jobs are in, and the folder opened
+        // next gets an empty one, whether or not the drain below finishes in time.
+        val closing = session
+        session = WatchSession()
+        closing.running = false
+
         // Wake the thread out of its sleep, then wait for it to drain remaining writes.
         // An idle queue drains in microseconds, so this costs only what there is to lose.
-        val worker = writeBackThread
-        writeBackThread = null
+        val worker = closing.worker
+        closing.worker = null
         worker?.interrupt()
         try { worker?.join(DRAIN_GRACE_MS) } catch (_: InterruptedException) {}
 
@@ -724,11 +755,14 @@ class SafSyncEngine(private val context: Context) {
             // Still draining. Emptying the queue from here would throw away exactly the
             // writes the drain exists to save, and would do it in the case where there
             // are the most of them — a burst of saves, or one slow provider. The thread
-            // owns the queue until it finishes; jobs carry the URIs they belong to, so a
-            // later lifecycle sharing the queue cannot misdirect them.
+            // owns this session's queue until it finishes, and nothing else can reach
+            // it: the queue went with the session, so the folder opened next offers its
+            // jobs somewhere this drain never polls. Addressing was never the question.
+            // Two threads polling one queue was: each write opens its document with
+            // "wt", which truncates at open, so the two interleave inside one document.
             Logger.w(tag, "Write-back still draining after ${DRAIN_GRACE_MS}ms; leaving it to finish")
         } else {
-            writeBackQueue.clear()
+            closing.queue.clear()
         }
         // docIdCache is deliberately not cleared here. A drain that outlived the wait
         // still needs the mappings of the folder it is finishing, and [initialSync]
@@ -1391,9 +1425,11 @@ class SafSyncEngine(private val context: Context) {
 
     // -- Internal: Write-back Processing --
 
-    private fun processWriteBack(job: SyncJob) {
-        // Small debounce: skip if more recent job for same path exists
-        if (writeBackQueue.any { it.localPath == job.localPath && it.timestamp > job.timestamp }) {
+    private fun processWriteBack(session: WatchSession, job: SyncJob) {
+        // Small debounce: skip if more recent job for same path exists. Scoped to the
+        // session the job came off, so it cannot see, or be blinded by, the jobs of a
+        // folder that is closing or one that has just opened.
+        if (session.queue.any { it.localPath == job.localPath && it.timestamp > job.timestamp }) {
             return
         }
 
@@ -1673,7 +1709,7 @@ class SafSyncEngine(private val context: Context) {
                 parentPathOf(renamedFrom) != parentPathOf(relativePath)
             ) resolveDocumentUri(safTreeUri, parentPathOf(renamedFrom)) else null
 
-        writeBackQueue.offer(
+        session.queue.offer(
             SyncJob(
                 type = if (renamedFromUri != null) SyncType.RENAME else type,
                 localPath = localFile.absolutePath,
@@ -2315,3 +2351,22 @@ internal data class VanishedDirectory(
     val relativePath: String,
     val atMillis: Long
 )
+
+/**
+ * One folder's write-back: the jobs its observers produced, and the thread sending them.
+ *
+ * Per folder rather than per engine, and that is what keeps two writers off one
+ * document. [SafSyncEngine.stopWatching] leaves a drain that outran its grace period
+ * holding this object and installs a fresh one, so the jobs of the folder opened next go
+ * somewhere the departing thread cannot reach, and the thread started for that folder
+ * polls a queue nothing else polls.
+ */
+internal class WatchSession {
+    val queue = ConcurrentLinkedQueue<SyncJob>()
+
+    /** Cleared by [SafSyncEngine.stopWatching]; the loop's own termination condition. */
+    @Volatile var running = true
+
+    /** The thread draining [queue], or null before one is started and once it is joined. */
+    @Volatile var worker: Thread? = null
+}

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafWatchSessionTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafWatchSessionTest.kt
@@ -1,0 +1,189 @@
+package com.vscodroid.storage
+
+import android.content.ContentResolver
+import android.content.Context
+import android.net.Uri
+import com.vscodroid.util.Logger
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.io.OutputStream
+import java.util.Collections
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.thread
+
+/**
+ * Who may write into a device document, and how many of them there can be.
+ *
+ * `stopWatching()` waits DRAIN_GRACE_MS for the write-back thread and then, rather than
+ * throw away queued saves, leaves it running. Everything the engine started afterwards
+ * shared one queue object with that survivor: the thread the next folder started polled
+ * it too, so two threads took jobs off one queue and opened one provider stream at once,
+ * with `"wt"` truncating the document at open.
+ *
+ * The queue and the thread belong to a [WatchSession] now, so a drain that outlived its
+ * stop keeps the queue it was started with and the folder opened next gets an empty one.
+ */
+class SafWatchSessionTest {
+
+    @TempDir
+    lateinit var mirror: File
+
+    @TempDir
+    lateinit var filesDir: File
+
+    private lateinit var resolver: ContentResolver
+    private lateinit var engine: SafSyncEngine
+
+    /** Held closed until the test lets the provider finish accepting a write. */
+    private val released = AtomicBoolean(false)
+
+    /** Documents the engine opened for writing, in order, from any thread. */
+    private val openedForWrite: MutableList<String> =
+        Collections.synchronizedList(mutableListOf())
+
+    private val documentNames = mutableMapOf<Uri, String>()
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(Logger)
+        every { Logger.i(any(), any()) } just Runs
+        every { Logger.d(any(), any()) } just Runs
+        every { Logger.w(any(), any()) } just Runs
+        every { Logger.w(any(), any(), any()) } just Runs
+        every { Logger.e(any(), any()) } just Runs
+        every { Logger.e(any(), any(), any()) } just Runs
+
+        resolver = mockk(relaxed = true)
+        val context = mockk<Context>(relaxed = true)
+        every { context.contentResolver } returns resolver
+        every { context.filesDir } returns filesDir
+        engine = SafSyncEngine(context)
+
+        every { resolver.openOutputStream(any(), "wt") } answers {
+            openedForWrite.add(documentNames[firstArg<Uri>()] ?: "unknown")
+            blockingStream()
+        }
+    }
+
+    @AfterEach
+    fun tearDown() {
+        // However the assertions ended, no test may leave a thread parked in a write.
+        released.set(true)
+        unmockkAll()
+    }
+
+    /**
+     * A provider stream that accepts the bytes only once the test says so.
+     *
+     * Uninterruptible on purpose: `stopWatching()` interrupts the drain, and a wait that
+     * gave up on the interrupt would end the very write this has to keep in flight while
+     * the grace period expires.
+     */
+    private fun blockingStream(): OutputStream = object : OutputStream() {
+        override fun write(b: Int) = write(byteArrayOf(b.toByte()), 0, 1)
+
+        override fun write(b: ByteArray, off: Int, len: Int) {
+            while (!released.get()) {
+                try {
+                    Thread.sleep(10)
+                } catch (_: InterruptedException) {
+                    // Keep waiting: the interrupt is the stop ending the loop, not the
+                    // provider refusing the bytes.
+                }
+            }
+        }
+    }
+
+    /** A save of [name] in the mirror, addressed to its own device document. */
+    private fun saveOf(name: String): SyncJob {
+        val local = File(mirror, name).apply { writeText("a save the provider is slow to accept") }
+        val docUri = mockk<Uri>(relaxed = true)
+        documentNames[docUri] = name
+        return SyncJob(
+            type = SyncType.MODIFY,
+            localPath = local.absolutePath,
+            safDocUri = docUri,
+            safParentUri = null,
+            safTreeUri = null,
+            timestamp = 1_700_000_000_000,
+        )
+    }
+
+    private fun waitUntil(what: String, condition: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + 5_000
+        while (System.currentTimeMillis() < deadline) {
+            if (condition()) return
+            Thread.sleep(10)
+        }
+        throw AssertionError("timed out waiting until $what")
+    }
+
+    @Test
+    fun `a drain that outlives its stop never takes the next folder's jobs`() {
+        val closing = engine.session
+        closing.queue.offer(saveOf("slow.txt"))
+        val worker = thread(isDaemon = true) { engine.runWriteBackLoop(closing) { closing.running } }
+        closing.worker = worker
+
+        // The write has to be in flight before the folder closes: that is the case where
+        // stopWatching() cannot end the thread and lets it finish on its own.
+        waitUntil("the first write reaches the provider") { openedForWrite.isNotEmpty() }
+
+        val startedAt = System.currentTimeMillis()
+        engine.stopWatching()
+        val waited = System.currentTimeMillis() - startedAt
+
+        assertTrue(waited >= 2_000, "stopWatching returned without waiting for the drain")
+        assertTrue(worker.isAlive, "setup failed: the drain was meant to outlive the stop")
+
+        val opened = engine.session
+        assertNotSame(closing, opened, "the next folder was handed the closed folder's queue")
+
+        // The next folder's first save, queued while the previous drain is still going.
+        opened.queue.offer(saveOf("next.txt"))
+        released.set(true)
+        worker.join(5_000)
+
+        assertEquals(
+            listOf("slow.txt"), openedForWrite.toList(),
+            "the departing drain opened a document of the folder opened after it",
+        )
+        assertEquals(1, opened.queue.size, "the departing drain took the next folder's job")
+    }
+
+    @Test
+    fun `the stop ends the drain rather than leaving it polling`() {
+        val closing = engine.session
+        val worker = thread(isDaemon = true) { engine.runWriteBackLoop(closing) { closing.running } }
+        closing.worker = worker
+
+        engine.stopWatching()
+
+        assertFalse(worker.isAlive, "the drain kept polling after its folder was closed")
+    }
+
+    @Test
+    fun `a stop with no drain running leaves nothing behind for the next folder`() {
+        val closing = engine.session
+        closing.queue.offer(saveOf("slow.txt"))
+
+        engine.stopWatching()
+
+        assertTrue(closing.queue.isEmpty(), "a stop with nothing draining has to clear the queue")
+        assertNotSame(closing, engine.session, "the next folder reuses the closed folder's session")
+        assertTrue(engine.session.queue.isEmpty(), "the next folder starts holding old jobs")
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafWriteBackLoopTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafWriteBackLoopTest.kt
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 
@@ -61,12 +60,9 @@ class SafWriteBackLoopTest {
         unmockkAll()
     }
 
-    /** Puts [job] on the engine's queue without a live watcher to produce it. */
-    @Suppress("UNCHECKED_CAST")
+    /** Puts [job] on the current session's queue without a live watcher to produce it. */
     private fun enqueue(job: SyncJob) {
-        val field = SafSyncEngine::class.java.getDeclaredField("writeBackQueue")
-            .apply { isAccessible = true }
-        (field.get(engine) as ConcurrentLinkedQueue<SyncJob>).offer(job)
+        engine.session.queue.offer(job)
     }
 
     @Test


### PR DESCRIPTION
> Stacked on #307. The base is `fix/saf-write-back-notice`, so this diff shows only the
> queue change. Retarget to `main` once #307 lands.

`stopWatching()` waits 2000 ms for the write-back thread and, rather than throw away the
saves still queued, leaves the thread running when the wait expires. That was the right
call. What made it unsafe is that the queue and the thread were fields of the engine, so
everything started afterwards shared one queue with that survivor: the thread
`startWatching()` created polled it too.

Two threads then took jobs off one queue, and both write with
`openOutputStream(uri, "wt")`, which truncates at open. Reopening a folder while a slow
provider was still accepting bytes could interleave two writes inside one device
document, and the upload journal could not detect it, because whichever thread finished
second cleared the entry the other was relying on.

## What changed

- The queue, the thread and the loop's termination flag move into a `WatchSession`, which
  `startWatching` and `stopWatching` **replace** rather than mutate. A drain that outran
  its grace period keeps the object it was started with, so the folder opened next offers
  its jobs somewhere that thread never polls, and its own thread polls a queue nothing
  else does.
- The debounce in `processWriteBack` moves with them, so it can neither see nor be
  blinded by the jobs of a folder that is closing or one that has just opened.
- `runWriteBackLoop` gains an overload bound to one session. The existing one-argument
  form stays and binds the current session, which is what a test without a live watcher
  needs: no JVM test can call `startWatching`, because registering a watch builds a
  `FileObserver` whose static initializer reaches native code.

The comment that justified the old arrangement said jobs carry the URIs they belong to,
so a later lifecycle sharing the queue could not misdirect them. That is true, and it
answered the wrong question: addressing was never at risk, concurrency was. The comment
now says which.

## Risk

`stopWatching` still lets a slow drain finish, and still clears the queue when nothing is
draining, so no save is thrown away that was not thrown away before. The behaviour that
changes is only which queue each thread can reach.

## Verification

`SafWatchSessionTest` drives it with a provider stream that holds the write open until the
test releases it, which is the only way to keep a write in flight while the grace period
expires:

- a drain that outlives its stop opens only its own document and leaves the next folder's
  job on the next folder's queue
- a stop with nothing in flight ends the thread rather than leaving it polling
- a stop with nothing draining clears the queue and still hands the next folder a fresh one

Checked against the defect rather than assumed: simulating the old behaviour, by keeping
the session across the stop, turns exactly the two session cases red and leaves the third
green, since that one guards a different property.

`SafWriteBackLoopTest` reached the queue through reflection on the private field. It asks
the session for it now, and its three cases pass unchanged.

Full suite 1229 tests, 0 failures, up from 1226 on the base branch.
