### PR TITLE
fix(storage): keep a path recorded until its last writer lands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - A save the sync refuses to write back now says so. It was silent, so an edit that never reached the device folder looked exactly like one that did.
 - Closing a device folder while a save is still going out no longer lets the next folder share its write-back queue, which could interleave two writes into one document.
+- A file two saves are writing at once stays marked as unfinished until the last one lands, so a crash between them can no longer leave a half-written device copy unrecorded.
 - The editor sees files changed outside it again. One source file was missing from the watcher build, so the addon could not load and nothing in a folder was watched.
 - Narrowing the platform-detection patch now fails the build. It could previously be narrowed with every check still green, leaving the marketplace asked for a binary that cannot start on Android.
 - First-run setup now shows progress while it extracts the editor, instead of holding at 5% for minutes and looking like it has hung.

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
@@ -237,7 +237,7 @@ class SafSyncEngine(private val context: Context) {
                 // owns this moment; it is on the IO dispatcher and mid-copy.
                 if (localPath.exists() && localPath.absolutePath in unfinishedUploads) {
                     unfinishedUploads.remove(localPath.absolutePath)
-                    clearUploadInFlight(localPath.absolutePath)
+                    consumeStaleUploadRecord(localPath.absolutePath)
                     keptLocal++
                     Logger.i(
                         tag,
@@ -1112,7 +1112,9 @@ class SafSyncEngine(private val context: Context) {
 
     private fun uploadJournal(): File = File(context.filesDir, UPLOADS_IN_FLIGHT_FILE)
 
+    /** Takes this writer's claim on [absolutePath] and records that a write began. */
     private fun markUploadInFlight(absolutePath: String) = synchronized(uploadJournalLock) {
+        uploadWriters[absolutePath] = (uploadWriters[absolutePath] ?: 0) + 1
         try {
             val journal = uploadJournal()
             val lines = if (journal.isFile) journal.readLines() else emptyList()
@@ -1124,7 +1126,44 @@ class SafSyncEngine(private val context: Context) {
         }
     }
 
+    /**
+     * Releases this writer's claim on [absolutePath], and removes the journal line only
+     * when it was the last claim.
+     *
+     * Paired with [markUploadInFlight] and called by writers alone. A second writer of
+     * the same path is reachable whenever a folder is reopened while a drain of the
+     * previous session is still streaming: the mirror is named by a hash of the folder,
+     * so both writers address one file, and before the count the first to finish removed
+     * the line the other was still inside.
+     */
     private fun clearUploadInFlight(absolutePath: String) = synchronized(uploadJournalLock) {
+        val stillWriting = (uploadWriters[absolutePath] ?: 0) - 1
+        if (stillWriting > 0) {
+            uploadWriters[absolutePath] = stillWriting
+            return@synchronized
+        }
+        uploadWriters.remove(absolutePath)
+        removeJournalLine(absolutePath)
+    }
+
+    /**
+     * Drops a journal line this sync has already acted on, without touching any claim.
+     *
+     * Not the same operation as [clearUploadInFlight] and deliberately not spelled as
+     * one. [initialSync] consumes a record left by a process that died, and it does that
+     * for a path it is about to write itself; treating that as releasing a claim would
+     * decrement a live writer to zero and remove the line while that writer was still
+     * streaming, which is the defect the count exists to prevent, arriving through a
+     * different door. A path somebody is writing right now is left alone, and that
+     * writer's own clear removes the line when it lands.
+     */
+    private fun consumeStaleUploadRecord(absolutePath: String) = synchronized(uploadJournalLock) {
+        if (uploadWriters.containsKey(absolutePath)) return@synchronized
+        removeJournalLine(absolutePath)
+    }
+
+    /** Caller must hold [uploadJournalLock]. */
+    private fun removeJournalLine(absolutePath: String) {
         try {
             val journal = uploadJournal()
             if (journal.isFile) {
@@ -1837,6 +1876,25 @@ class SafSyncEngine(private val context: Context) {
          * one file on its own monitor otherwise.
          */
         private val uploadJournalLock = Any()
+
+        /**
+         * How many write-backs are streaming into each mirror path right now, across
+         * engine instances and guarded by [uploadJournalLock].
+         *
+         * The journal line means "an upload of this path did not finish", and one line
+         * cannot carry two writers: [initialSync] writes a newer mirror copy back on the
+         * IO dispatcher while a drain that outlived its folder is still streaming the
+         * same file, and whichever landed first used to remove the line for both. The
+         * next sync then read a device copy another writer was still part way through as
+         * a finished one, and copied it over the mirror. Reopening the same folder is
+         * what makes the two paths identical, because the mirror is named by a hash of
+         * the folder rather than by the session.
+         *
+         * In memory rather than in the file, because the writers are threads of one
+         * process. A process that dies mid-write leaves the line behind, which is exactly
+         * what the journal is for.
+         */
+        private val uploadWriters = mutableMapOf<String, Int>()
 
         /**
          * Suffix of the sibling file recording what the last complete sync found.

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafUploadInterruptionTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafUploadInterruptionTest.kt
@@ -4,6 +4,7 @@ import android.content.ContentResolver
 import android.content.Context
 import android.database.Cursor
 import android.net.Uri
+import android.os.FileObserver
 import android.provider.DocumentsContract
 import com.vscodroid.util.Logger
 import io.mockk.Runs
@@ -18,9 +19,16 @@ import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import java.io.ByteArrayOutputStream
+import java.io.OutputStream
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.thread
 import java.io.ByteArrayInputStream
 import java.io.File
 
@@ -52,6 +60,7 @@ class SafUploadInterruptionTest {
     lateinit var filesDir: File
 
     private lateinit var resolver: ContentResolver
+    private lateinit var context: Context
     private lateinit var engine: SafSyncEngine
     private lateinit var treeUri: Uri
     private val uris = mutableMapOf<String, Uri>()
@@ -81,7 +90,7 @@ class SafUploadInterruptionTest {
         }
 
         resolver = mockk(relaxed = true)
-        val context = mockk<Context>(relaxed = true)
+        context = mockk<Context>(relaxed = true)
         every { context.contentResolver } returns resolver
         every { context.filesDir } returns filesDir
         engine = SafSyncEngine(context)
@@ -220,5 +229,116 @@ class SafUploadInterruptionTest {
                 "and a surviving entry would throw away the device edits that " +
                 "followed"
         )
+    }
+
+    /**
+     * Two write-backs of one file overlap: a drain that outlived the folder it belongs
+     * to is still streaming when the next sync writes the same path. Both bracket the
+     * copy with the journal, and the journal has one line per path, so the writer that
+     * finished first removed the bracket the other was still inside. A death in that
+     * window then left a device copy that is newer, shorter and unrecorded, which the
+     * next sync reads as an edit made on the device and copies over the mirror.
+     */
+    @Test
+    fun `a path stays recorded while another write to it is still in flight`() {
+        deviceHolding("notes.txt")
+        val file = File(mirror, "notes.txt").apply { writeText("the whole edit") }
+        val released = AtomicBoolean(false)
+        val firstWriteStarted = CountDownLatch(1)
+        var opens = 0
+        every { resolver.openOutputStream(any(), any()) } answers {
+            if (opens++ == 0) {
+                object : OutputStream() {
+                    override fun write(b: Int) = write(byteArrayOf(b.toByte()), 0, 1)
+                    override fun write(b: ByteArray, off: Int, len: Int) {
+                        firstWriteStarted.countDown()
+                        // Uninterruptible: the point is a write still in flight.
+                        while (!released.get()) {
+                            try { Thread.sleep(10) } catch (_: InterruptedException) { }
+                        }
+                    }
+                }
+            } else {
+                ByteArrayOutputStream()
+            }
+        }
+
+        // The first writer: this engine's drain, still streaming.
+        engine.handleMirrorEvent(FileObserver.MODIFY, file, mirror, treeUri)
+        val drain = thread(isDaemon = true) { engine.runWriteBackLoop { false } }
+        assertTrue(
+            firstWriteStarted.await(5, TimeUnit.SECONDS),
+            "setup failed: the first write never reached the provider",
+        )
+
+        // The second: a different engine over the same journal, which is what a
+        // recreated Activity builds, writing the same file and finishing at once.
+        val second = SafSyncEngine(context)
+        second.handleMirrorEvent(FileObserver.MODIFY, file, mirror, treeUri)
+        second.runWriteBackLoop { false }
+
+        assertEquals(
+            listOf(file.absolutePath), engine.uploadsInFlight().toList(),
+            "the writer that landed first cleared the record the other one is inside",
+        )
+
+        released.set(true)
+        drain.join(5_000)
+        assertFalse(journal.isFile, "the record outlived the last writer")
+    }
+
+    /**
+     * The record a dead process left is consumed without touching a live writer's claim.
+     *
+     * `initialSync` clears the record for a path it is about to write itself, and that is
+     * a different operation from a writer releasing its own claim. Spelling it as one
+     * would decrement a live writer to zero and drop the line while that writer was still
+     * streaming, which is the defect the count exists to prevent, reached by another door.
+     * Reopening the same folder is what puts a live writer and a stale record on one path,
+     * because the mirror is named by a hash of the folder rather than by the session.
+     */
+    @Test
+    fun `consuming a stale record leaves a live writer's claim alone`() {
+        deviceHolding("notes.txt")
+        val file = File(mirror, "notes.txt").apply { writeText("the whole edit") }
+        val released = AtomicBoolean(false)
+        val firstWriteStarted = CountDownLatch(1)
+        // Only the drain's write blocks. The sync writes the same file itself right
+        // after consuming the record, and blocking that one would hang the test on the
+        // very call it is here to observe.
+        var opens = 0
+        every { resolver.openOutputStream(any(), any()) } answers {
+            if (opens++ == 0) {
+                object : OutputStream() {
+                    override fun write(b: Int) = write(byteArrayOf(b.toByte()), 0, 1)
+                    override fun write(b: ByteArray, off: Int, len: Int) {
+                        firstWriteStarted.countDown()
+                        while (!released.get()) {
+                            try { Thread.sleep(10) } catch (_: InterruptedException) { }
+                        }
+                    }
+                }
+            } else {
+                ByteArrayOutputStream()
+            }
+        }
+
+        engine.handleMirrorEvent(FileObserver.MODIFY, file, mirror, treeUri)
+        val drain = thread(isDaemon = true) { engine.runWriteBackLoop { false } }
+        assertTrue(
+            firstWriteStarted.await(5, TimeUnit.SECONDS),
+            "setup failed: the write never reached the provider",
+        )
+
+        // What initialSync does when it finds that path in the journal it read at start.
+        runBlocking { engine.initialSync(treeUri, mirror) { _, _ -> } }
+
+        assertEquals(
+            listOf(file.absolutePath), engine.uploadsInFlight().toList(),
+            "the sync consumed a record belonging to a writer that is still streaming",
+        )
+
+        released.set(true)
+        drain.join(5_000)
     }
 }


### PR DESCRIPTION
`writeLocalToSaf` brackets its copy with a journal line, and the journal holds one line
per path, so whichever writer finished first removed the bracket the other was still
inside.

Two writers of one path are reachable. The mirror is named by a hash of the folder rather
than by the session, so reopening a folder while a drain of the previous one is still
streaming puts `initialSync` on the IO dispatcher and that drain on the same file. A
process death in that window left a device copy that is newer, shorter and unrecorded,
which the next sync reads as an edit made on the device and copies over the mirror.

## What changed

- `markUploadInFlight` takes a reference and `clearUploadInFlight` releases one. The line
  goes when the last writer is done, not the first.
- The count lives in memory rather than in the file, because the writers are threads of
  one process. A process that dies mid-write leaves the line behind, which is exactly what
  the journal is for.
- Consuming a stale record is a separate operation and now has a separate name.
  `initialSync` clears the record of an upload a dead process left, for a path it is about
  to write itself. Spelling that as releasing a claim would decrement a live writer to zero
  and drop the line while that writer was still streaming, which is the defect the count
  exists to prevent, arriving through another door. `consumeStaleUploadRecord` leaves a
  path somebody is writing right now alone, and that writer's own clear removes the line
  when it lands.

The on-disk format, the signatures and every call site are unchanged, so `uploadsInFlight`,
`clearUploadsUnder` and `SafStorageManager.mayReclaim` keep their present shapes.

## Risk

The journal can now outlive a write by as long as a second writer takes, which costs a
mirror being kept slightly longer than before. That is the direction the reclaim gates
already fail in, and the opposite direction is the data loss this closes.

## Verification

`SafUploadInterruptionTest` gains two cases, each checked against the change it guards
rather than assumed:

- Removing the reference count turns **both** new cases red.
- Routing the sync's consumption back through the writer's clear turns **only** the
  stale-record case red, which is what makes the separate seam load-bearing rather than
  decorative.

Both drive a provider stream that holds the first write open until the test releases it,
which is the only way to keep one writer in flight while the other lands.

Full suite 1231 tests, 0 failures, up from 1229.
