### PR TITLE
fix(storage): say when a folder opened without all of it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A save the sync refuses to write back now says so. It was silent, so an edit that never reached the device folder looked exactly like one that did.
 - Closing a device folder while a save is still going out no longer lets the next folder share its write-back queue, which could interleave two writes into one document.
 - A file two saves are writing at once stays marked as unfinished until the last one lands, so a crash between them can no longer leave a half-written device copy unrecorded.
+- Opening a device folder now says when files did not make it across. They were simply absent from the tree, and the first sign was a later save being refused.
 - The editor sees files changed outside it again. One source file was missing from the watcher build, so the addon could not load and nothing in a folder was watched.
 - Narrowing the platform-detection patch now fails the build. It could previously be narrowed with every check still green, leaving the marketplace asked for a binary that cannot start on Android.
 - First-run setup now shows progress while it extracts the editor, instead of holding at 5% for minutes and looking like it has hung.

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -389,6 +389,24 @@ class MainActivity : AppCompatActivity() {
             }
         }
 
+        // The other direction: documents the device holds that did not reach the editor.
+        // Its own wording, because "the only copy is inside VSCodroid" is the opposite of
+        // true for these, and would send the user looking for a file that is safe.
+        safManager.onDocumentsNotCopied { count, outOfRoom ->
+            runOnUiThread {
+                Toast.makeText(
+                    this@MainActivity,
+                    resources.getQuantityString(
+                        if (outOfRoom) R.plurals.saf_documents_not_copied_no_room
+                        else R.plurals.saf_documents_not_copied,
+                        count,
+                        count,
+                    ),
+                    Toast.LENGTH_LONG,
+                ).show()
+            }
+        }
+
         setupWebView()
         setupExtraKeyRow()
         setupBackNavigation()

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafStorageManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafStorageManager.kt
@@ -61,6 +61,17 @@ class SafStorageManager(private val context: Context) {
         }
     }
 
+    /**
+     * Told when a folder opened without every document reaching the mirror.
+     *
+     * Forwarded rather than set on the engine directly, for the reason
+     * [onWriteBackFailed] is, and unthrottled for the reason that one is throttled: this
+     * fires at most once per folder open and the count it carries is the whole burst.
+     */
+    fun onDocumentsNotCopied(announce: (Int, Boolean) -> Unit) {
+        syncEngine.onDocumentsNotCopied = announce
+    }
+
     private val lastFailureAnnouncedAt = AtomicLong(0)
 
     // -- Permission Management --

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
@@ -1,5 +1,6 @@
 package com.vscodroid.storage
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.net.Uri
 import android.os.FileObserver
@@ -161,6 +162,22 @@ class SafSyncEngine(private val context: Context) {
         val rootDocId = DocumentsContract.getTreeDocumentId(safUri)
         docIdCache[""] = rootDocId  // root entry
         val enumerationComplete = walkTree(safUri, rootDocId, "", documents)
+
+        // What phase 2 is about to fetch, against what there is room for. Nothing is
+        // refused on the strength of it: these are the sizes the provider reported, and a
+        // folder that opens is worth more than a prediction. It decides one thing, which
+        // notice the user gets if a copy does fail, and that is the difference between a
+        // message they can act on and one they cannot.
+        val toFetch = bytesToFetch(documents, mirrorDir)
+        val room = usableSpaceOf(mirrorDir)
+        val outOfRoom = toFetch > room
+        if (outOfRoom) {
+            Logger.w(
+                tag,
+                "Opening ${mirrorDir.name} needs ${toFetch / 1_048_576} MB and " +
+                    "${room / 1_048_576} MB is free; some documents will not be copied",
+            )
+        }
 
         val totalFiles = documents.count { !it.isDirectory }
         var filesDone = 0
@@ -405,6 +422,12 @@ class SafSyncEngine(private val context: Context) {
                 "$uploadsDone written back, ${recorded.size} vouched for, " +
                 "$removed removed) in ${elapsed}ms"
         )
+
+        // Only the copies that were attempted and failed. A document skipped for size is
+        // an expected, permanent condition that would toast on every open of the folder
+        // holding it, and the write-back guard already keeps a local file of that name
+        // from replacing it.
+        if (failedCopies > 0) onDocumentsNotCopied(failedCopies, outOfRoom)
     }
 
     /**
@@ -1086,6 +1109,35 @@ class SafSyncEngine(private val context: Context) {
      * is gone.
      */
     internal var onWriteBackFailed: (File) -> Unit = {}
+
+    /**
+     * Told, once per [initialSync], when documents the device holds did not reach the
+     * mirror: how many, and whether the sizes reported for them did not fit in the room
+     * that was left.
+     *
+     * Its own seam rather than a reuse of [onWriteBackFailed], because the two say
+     * opposite things. That one means the app holds the only copy; this one means the
+     * DEVICE does and the editor simply does not have the file, so a notice worded "the
+     * only copy is inside VSCodroid" would send the user looking after a file that is
+     * safe where it is. A no-op by default for the reason that one is: no screen here.
+     */
+    internal var onDocumentsNotCopied: (Int, Boolean) -> Unit = { _, _ -> }
+
+    /**
+     * How much room is left where the mirror lives.
+     *
+     * A seam because no JVM test can make a real filesystem answer that it is full, and
+     * the pre-flight that reads this is exactly the code that has to be right when it is.
+     *
+     * `usableSpace` rather than `StorageManager.getAllocatableBytes`, which lint asks for
+     * and which reports more, because it counts cache Android is willing to evict. The
+     * larger figure is the right one for deciding whether to attempt a write; this decides
+     * nothing of the kind. It runs after a copy has already failed and only picks which
+     * sentence explains it, so the question is not "could this have fit" but "was the disk
+     * visibly full when it did not", and free space is what answers that one.
+     */
+    @SuppressLint("UsableSpace")
+    internal var usableSpaceOf: (File) -> Long = { it.usableSpace }
 
     /**
      * Declines to write [localFile] out, because the device holds a document under that
@@ -2057,6 +2109,32 @@ class SafSyncEngine(private val context: Context) {
          * memory of what this sync could not read, and the document may have been deleted
          * on the device since, in which case the local file is an ordinary new file.
          */
+        /**
+         * How many bytes phase 2 would have to fetch for [documents] into [mirrorDir].
+         *
+         * Counts only what a copy would actually spend: a directory costs nothing, a
+         * document past [MAX_FILE_SIZE] is skipped rather than copied, and one the mirror
+         * already holds at the same length and no older is kept rather than fetched.
+         * Without those two exclusions, reopening a folder of large files reads as
+         * needing the whole folder again.
+         *
+         * A length the provider does not report arrives as 0 and is counted as 0, so a
+         * provider omitting `COLUMN_SIZE` makes the whole sync look free rather than made
+         * to fit a number nobody measured. That is the direction to fail in: the caller
+         * chooses the wording of a notice with this and refuses nothing, so a prediction
+         * that cannot be made must not become a claim.
+         */
+        internal fun bytesToFetch(documents: List<DocumentInfo>, mirrorDir: File): Long =
+            documents.asSequence()
+                .filterNot { it.isDirectory }
+                .filter { it.size in 1..MAX_FILE_SIZE }
+                .filterNot { doc ->
+                    val mirrored = File(mirrorDir, doc.relativePath)
+                    mirrored.isFile && mirrored.length() == doc.size &&
+                        mirrored.lastModified() >= doc.lastModified
+                }
+                .sumOf { it.size }
+
         internal fun writeWouldReplaceUnreadDocument(
             localPath: String,
             deviceHoldsDocument: Boolean,

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -116,4 +116,19 @@
          consequence rather than the error: the user's next decision is whether to
          copy the file out before uninstalling, not which exception was thrown. -->
     <string name="saf_write_back_failed">%1$s did not reach the device folder. The only copy is inside VSCodroid.</string>
+
+    <!-- Shown once after a folder opens when documents in it could not be copied into
+         the editor: a provider error, or no room left. The opposite of
+         saf_write_back_failed on purpose. There the app holds the only copy; here the
+         device does, and the file is simply absent from the editor. -->
+    <plurals name="saf_documents_not_copied">
+        <item quantity="one">A file could not be copied into the editor. It is unchanged in the device folder.</item>
+        <item quantity="other">%1$d files could not be copied into the editor. They are unchanged in the device folder.</item>
+    </plurals>
+    <!-- The same shortfall when the sizes the provider reported did not fit in the space
+         left. Named separately because it is the one the user can act on. -->
+    <plurals name="saf_documents_not_copied_no_room">
+        <item quantity="one">Not enough free space: a file could not be copied into the editor. It is unchanged in the device folder.</item>
+        <item quantity="other">Not enough free space: %1$d files could not be copied into the editor. They are unchanged in the device folder.</item>
+    </plurals>
 </resources>

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafOpenShortfallTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafOpenShortfallTest.kt
@@ -1,0 +1,295 @@
+package com.vscodroid.storage
+
+import android.content.ContentResolver
+import android.content.Context
+import android.database.Cursor
+import android.net.Uri
+import android.provider.DocumentsContract
+import com.vscodroid.util.Logger
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.io.IOException
+
+/**
+ * What the user is told when a folder opens without all of it arriving.
+ *
+ * A copy that fails is caught, its half-written mirror file deleted, and the run
+ * continues; the count reaches only the summary line at the end of [SafSyncEngine.initialSync],
+ * which is `Logger.i` and therefore gone from a release build. So the folder opens,
+ * the editor shows a tree with holes in it, and nothing distinguishes a file the
+ * device never had from one that did not make it across. The user's next move is
+ * to create the missing file, which is the write the unread-document guard then
+ * has to refuse, and that refusal is the first thing they ever hear about it.
+ *
+ * The notice carries whether the sizes the provider reported fit in the space that
+ * was left, because that is the difference between something the user can act on
+ * and something they cannot.
+ */
+class SafOpenShortfallTest {
+
+    @TempDir
+    lateinit var mirror: File
+
+    @TempDir
+    lateinit var filesDir: File
+
+    private lateinit var resolver: ContentResolver
+    private lateinit var engine: SafSyncEngine
+    private lateinit var treeUri: Uri
+    private val uris = mutableMapOf<String, Uri>()
+
+    /** Every notice the engine raised, in order. */
+    private val notices = mutableListOf<Pair<Int, Boolean>>()
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(Logger)
+        every { Logger.i(any(), any()) } just Runs
+        every { Logger.d(any(), any()) } just Runs
+        every { Logger.w(any(), any()) } just Runs
+        every { Logger.w(any(), any(), any()) } just Runs
+        every { Logger.e(any(), any()) } just Runs
+        every { Logger.e(any(), any(), any()) } just Runs
+
+        mockkStatic(DocumentsContract::class)
+        every { DocumentsContract.getTreeDocumentId(any()) } returns "root"
+        every { DocumentsContract.buildChildDocumentsUriUsingTree(any(), any()) } returns
+            mockk(relaxed = true)
+        every { DocumentsContract.buildDocumentUriUsingTree(any(), any()) } answers {
+            uris.getOrPut(secondArg()) { mockk(relaxed = true) }
+        }
+
+        resolver = mockk(relaxed = true)
+        val context = mockk<Context>(relaxed = true)
+        every { context.contentResolver } returns resolver
+        every { context.filesDir } returns filesDir
+        engine = SafSyncEngine(context)
+        engine.onDocumentsNotCopied = { count, outOfRoom -> notices += count to outOfRoom }
+        treeUri = mockk(relaxed = true)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        File(mirror.path + SafSyncEngine.SYNCED_RECORD_SUFFIX).delete()
+        unmockkAll()
+    }
+
+    /** One document in the device folder, as the sync will see it. */
+    private data class Doc(val name: String, val size: Long, val readable: Boolean = true)
+
+    /**
+     * Describes [docs] through a fake cursor, and reads back whatever a readable one
+     * holds. An unreadable one throws where the real provider would, which is the
+     * failure this notice counts.
+     */
+    private fun deviceHolding(vararg docs: Doc) {
+        val cursor = mockk<Cursor>(relaxed = true)
+        var row = -1
+        every { cursor.moveToNext() } answers { ++row < docs.size }
+        every { cursor.getColumnIndexOrThrow(any()) } answers {
+            when (firstArg<String>()) {
+                DocumentsContract.Document.COLUMN_DOCUMENT_ID -> 0
+                DocumentsContract.Document.COLUMN_DISPLAY_NAME -> 1
+                DocumentsContract.Document.COLUMN_MIME_TYPE -> 2
+                else -> 3
+            }
+        }
+        every { cursor.getColumnIndex(DocumentsContract.Document.COLUMN_LAST_MODIFIED) } returns 4
+        every { cursor.isNull(any()) } returns false
+        every { cursor.getString(0) } answers { "doc:" + docs[row].name }
+        every { cursor.getString(1) } answers { docs[row].name }
+        every { cursor.getString(2) } returns "text/plain"
+        every { cursor.getLong(3) } answers { docs[row].size }
+        every { cursor.getLong(4) } returns 1_700_000_000_000
+        every { resolver.query(any(), any(), any(), any(), any()) } answers {
+            row = -1
+            cursor
+        }
+        every { resolver.openInputStream(any()) } answers {
+            val name = uris.entries.first { it.value === firstArg<Uri>() }.key.removePrefix("doc:")
+            val doc = docs.first { it.name == name }
+            if (doc.readable) ByteArrayInputStream("device contents".toByteArray())
+            else throw IOException("the provider refused the read")
+        }
+    }
+
+    /** A folder with room to spare, so nothing here turns on the pre-flight. */
+    private fun withRoomToSpare() {
+        engine.usableSpaceOf = { Long.MAX_VALUE }
+    }
+
+    /**
+     * The case this exists for. One document could not be read, and the user is told
+     * that once, with the count.
+     */
+    @Test
+    fun `a document that could not be copied is announced`() {
+        withRoomToSpare()
+        deviceHolding(Doc("notes.md", 64, readable = false), Doc("readme.md", 64))
+
+        runBlocking { engine.initialSync(treeUri, mirror) { _, _ -> } }
+
+        assertEquals(listOf(1 to false), notices)
+    }
+
+    /**
+     * The control, and the one that keeps the case above from passing because the
+     * seam fires unconditionally. Everything arrived, so there is nothing to say,
+     * and a toast on every successful open would train the user to ignore it.
+     */
+    @Test
+    fun `a folder that opens whole announces nothing`() {
+        withRoomToSpare()
+        deviceHolding(Doc("notes.md", 64), Doc("readme.md", 64))
+
+        runBlocking { engine.initialSync(treeUri, mirror) { _, _ -> } }
+
+        assertTrue(notices.isEmpty(), "announced $notices for a folder that arrived whole")
+    }
+
+    /**
+     * A document past [SafSyncEngine.MAX_FILE_SIZE] is not a shortfall. It is a
+     * permanent, expected condition of that folder, so announcing it would fire on
+     * every open forever, and the unread-document guard already keeps a local file
+     * of that name from replacing it.
+     */
+    @Test
+    fun `a document skipped for size is not announced`() {
+        withRoomToSpare()
+        deviceHolding(Doc("big.zip", SafSyncEngine.MAX_FILE_SIZE + 1), Doc("readme.md", 64))
+
+        runBlocking { engine.initialSync(treeUri, mirror) { _, _ -> } }
+
+        assertTrue(notices.isEmpty(), "announced $notices for a document skipped by policy")
+    }
+
+    /**
+     * The same failure, when what the provider reported did not fit in what was left.
+     * Same count, different flag, and the flag is the whole reason the pre-flight runs:
+     * it is what turns "something went wrong" into a sentence naming free space.
+     */
+    @Test
+    fun `a shortfall with no room left says so`() {
+        engine.usableSpaceOf = { 8 }
+        deviceHolding(Doc("notes.md", 64, readable = false), Doc("readme.md", 64))
+
+        runBlocking { engine.initialSync(treeUri, mirror) { _, _ -> } }
+
+        assertEquals(listOf(1 to true), notices)
+    }
+
+    /**
+     * The pre-flight decides the wording, never whether the folder opens. A device
+     * that is genuinely out of room still gets its readable documents copied, because
+     * the reported sizes are a claim and a folder that opens beats a prediction.
+     */
+    @Test
+    fun `no room left does not stop the copy`() {
+        engine.usableSpaceOf = { 0 }
+        deviceHolding(Doc("readme.md", 64))
+
+        runBlocking { engine.initialSync(treeUri, mirror) { _, _ -> } }
+
+        assertEquals("device contents", File(mirror, "readme.md").readText())
+        assertTrue(notices.isEmpty(), "announced $notices when every copy succeeded")
+    }
+
+    /**
+     * `COLUMN_SIZE` is optional, and a provider that withholds it says so in two ways:
+     * a null, which `cursor.getLong` flattens to 0, or an explicit -1. The first is
+     * harmless because it adds nothing. The second is not: summed as given it would
+     * subtract from the estimate, so a folder of documents whose sizes are unknown
+     * would come out negative and read as more free space than there is.
+     */
+    @Test
+    fun `a size the provider says it does not know cannot shrink the estimate`() {
+        val docs = listOf(
+            DocumentInfo(mockk(), "doc:a", "a.md", isDirectory = false, size = -1),
+            DocumentInfo(mockk(), "doc:b", "b.md", isDirectory = false, size = 64),
+        )
+
+        assertEquals(64L, SafSyncEngine.bytesToFetch(docs, mirror))
+    }
+
+    /**
+     * Phase 2 refuses anything past [SafSyncEngine.MAX_FILE_SIZE] outright, so those
+     * bytes are never fetched and charging the estimate for them would predict a
+     * shortfall that cannot happen. One 60 MB archive in the folder would otherwise
+     * word every notice as an out-of-space problem the user cannot fix.
+     */
+    @Test
+    fun `a document too large to fetch is not counted`() {
+        val docs = listOf(
+            DocumentInfo(
+                mockk(), "doc:big", "big.zip", isDirectory = false,
+                size = SafSyncEngine.MAX_FILE_SIZE + 1,
+            ),
+            DocumentInfo(mockk(), "doc:b", "b.md", isDirectory = false, size = 64),
+        )
+
+        assertEquals(64L, SafSyncEngine.bytesToFetch(docs, mirror))
+    }
+
+    /**
+     * The same withholding seen from the engine, and the reason the notice can be
+     * trusted. A provider that reports nothing makes the estimate 0, which fits in any
+     * amount of room, so the shortfall is worded as the provider error it is rather
+     * than as a space problem that would send the user deleting files for nothing.
+     */
+    @Test
+    fun `a folder whose sizes were withheld is not blamed on free space`() {
+        engine.usableSpaceOf = { 0 }
+        deviceHolding(Doc("notes.md", 0, readable = false))
+
+        runBlocking { engine.initialSync(treeUri, mirror) { _, _ -> } }
+
+        assertEquals(listOf(1 to false), notices)
+    }
+
+    /**
+     * Phase 2 skips a mirror file that already matches the device document, so
+     * counting it would inflate the estimate on every reopen of a folder that is
+     * fully synced, which is the common case.
+     */
+    @Test
+    fun `a document already mirrored is not counted`() {
+        File(mirror, "a.md").writeText("0123456789")
+        File(mirror, "a.md").setLastModified(1_700_000_000_000)
+        val docs = listOf(
+            DocumentInfo(
+                mockk(), "doc:a", "a.md", isDirectory = false,
+                size = 10, lastModified = 1_700_000_000_000,
+            ),
+        )
+
+        assertEquals(0L, SafSyncEngine.bytesToFetch(docs, mirror))
+    }
+
+    /**
+     * A directory has no bytes to fetch and providers report sizes for them that mean
+     * nothing, so counting one would charge the estimate for something never copied.
+     */
+    @Test
+    fun `a directory is not counted`() {
+        val docs = listOf(
+            DocumentInfo(mockk(), "doc:d", "sub", isDirectory = true, size = 4096),
+        )
+
+        assertFalse(SafSyncEngine.bytesToFetch(docs, mirror) > 0)
+    }
+}


### PR DESCRIPTION
A document `initialSync` cannot copy is caught, its half-written mirror file
deleted, and the run continues. The count reaches only the summary line at the
end of the sync, which is `Logger.i` and so absent from a release build.

The folder opens, the tree has holes in it, and nothing distinguishes a file
the device never held from one that did not make it across. The user's next
move is to create the missing file, which is the write the unread-document
guard then has to refuse, and that refusal is the first thing they hear about
any of it.

## What changed

- `onDocumentsNotCopied` carries the count to `MainActivity`, which toasts it
  once per open. A separate seam from `onWriteBackFailed`, because the two say
  opposite things: that one means the app holds the only copy, this one means
  the device does and the file is simply absent from the editor. Its wording
  would send the user looking after a file that is safe where it is.
- The notice also carries whether the reported sizes fit in the room that was
  left, which is the difference between a message the user can act on and one
  they cannot.
- `bytesToFetch` sums only what phase 2 would spend: directories cost nothing,
  a document past `MAX_FILE_SIZE` is skipped rather than copied, and one the
  mirror already holds unchanged is kept rather than fetched.
- A document skipped for size is deliberately not a shortfall. It is a
  permanent condition of that folder that would toast on every open, and the
  write-back guard already keeps a local file of that name from replacing it.

## Failing open on the estimate

`COLUMN_SIZE` is optional. A provider that withholds it makes the estimate 0,
so the folder reads as fitting and the shortfall is worded as the provider
error it is, rather than sending the user deleting files for nothing. One that
reports -1 cannot drag the estimate below zero and invent free space.

Nothing is refused on the strength of any of this. The pre-flight picks a
sentence and decides nothing else, because these are the sizes a provider
claimed and a folder that opens beats a prediction.

`usableSpace` rather than `StorageManager.getAllocatableBytes`, which lint asks
for. The larger figure is right for deciding whether to attempt a write; this
decides nothing of the kind, and runs only after a copy has already failed.

## Verification

`SafOpenShortfallTest` adds ten cases, each checked against the change it
guards rather than assumed:

- Removing the announcement turns three red.
- Announcing unconditionally turns a different three red.
- Each exclusion in `bytesToFetch` has a case that goes red when only that
  exclusion is dropped: the lower size bound, the upper one, the already-mirrored
  check, and the directory check.

Full suite 1239 tests, 0 failures, up from 1229. Lint holds at 52 warnings:
the notice is a `<plurals>`, so no `PluralsCandidate` is added.
