### PR TITLE
build(gate): catch a pack library its manifest omits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The build moves to Android Gradle plugin 9.3.1 and Gradle 9.5.1, which turns on optimized resource shrinking. Play flagged the old configuration for memory and performance.
 - Kotlin now comes from the Android Gradle plugin rather than a separate plugin, so the compiler is 2.2.10 and the version catalog no longer names one.
 - 97 unused Material and AndroidX resources no longer ship: the date and time pickers, the navigation drawer, fragment transitions and the legacy notification templates.
+- A toolchain pack that ships a library its manifest does not list now fails the build, instead of redistributing it with no licence notice.
+- The zlib notice names the Java and Ruby toolchains, whose libraries link the copy the base app ships.
 - The three deprecated edge-to-edge APIs Play reports are gone. Bar colours, the display cutout and bar contrast move to theme attributes; edge-to-edge and bar icons stay in code.
 
 ### Fixed

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -118,7 +118,7 @@ component.
 | SQLite | Public Domain | Node.js, Python |
 | tmux | ISC | bundled tool in its own right |
 | xz / liblzma | LGPL-2.1, GPL-2.0, GPL-3.0 | Python |
-| zlib | Zlib | Git, Node.js, OpenSSH, Python, SQLite, libcurl, libssh2 |
+| zlib | Zlib | Git, Node.js, OpenSSH, Python, SQLite, libcurl, libssh2, and the on-demand Java and Ruby toolchains |
 | Zstandard | GPL-2.0 | Python |
 
 ## Toolchain Libraries

--- a/scripts/check-library-attribution.py
+++ b/scripts/check-library-attribution.py
@@ -372,6 +372,53 @@ def toolchain_libs():
     return sorted(set(libs)), read, unrecorded
 
 
+def unlisted_toolchain_libs():
+    """Loose libraries in a built pack that its manifest does not name.
+
+    `toolchain_libs()` above reads the manifest, which is the list the app
+    installs from, and that is the right source for WHAT to attribute. It is the
+    wrong source for whether the list is complete: a download script that starts
+    copying one more `.so` into the pack and does not add the matching `libs`
+    entry ships a library this run never sees, so no component is demanded, no
+    notice is required, and nothing goes red.
+
+    Only the TOP LEVEL of the pack's `usr/lib` is swept, which is exactly what
+    `libs` means: the loose libraries the installer copies into the shared
+    `usr/lib` beside the base app's, and the ones an uninstall deletes from it.
+    A toolchain's own tree below that (`usr/lib/jvm/...`, `usr/lib/ruby/...`) is
+    attributed as the toolchain itself in NOTICE.md's On-Demand Toolchains
+    table; widening this to reach it would demand a per-file entry for every
+    object in a JDK.
+
+    Symlinks are skipped. A soname alias points at a file that is already
+    listed, so reporting it would report one library twice under a second name.
+
+    Empty on a tree whose packs were never downloaded: there is no `usr/lib` to
+    read. A pack that IS on disk with no manifest at all is a different failure
+    with a clearer message, which is why `unrecorded` is answered first in
+    `main()` and this never sees that pack.
+    """
+    out = []
+    for module in sorted(TOOLCHAINS.glob("toolchain_*")):
+        assets = module / "src/main/assets"
+        lib_dir = assets / "usr/lib"
+        if not lib_dir.is_dir():
+            continue
+        listed = set()
+        for manifest in sorted(assets.glob("*.json")):
+            try:
+                data = json.loads(manifest.read_text(encoding="utf-8"))
+            except (OSError, ValueError) as exc:
+                raise SystemExit(f"FAIL cannot read {manifest}: {exc}")
+            listed.update(data.get("libs", []))
+        for path in sorted(lib_dir.iterdir()):
+            if path.is_symlink() or not path.is_file() or ".so" not in path.name:
+                continue
+            if path.name not in listed:
+                out.append(f"{module.name}: usr/lib/{path.name}")
+    return out
+
+
 def shipped():
     """The redistributed binaries at the top level of the two flat directories,
     by file name.
@@ -642,6 +689,23 @@ def main():
             print(f"  {module}", file=sys.stderr)
         print("  -> its download script writes the manifest beside usr/; without it"
               " nothing knows what the pack ships", file=sys.stderr)
+        return 1
+
+    # After `unrecorded`, deliberately. A pack with a `usr/` payload and no
+    # manifest would come through here as every one of its libraries being
+    # unlisted, which is true and useless: the fix is to write the manifest, not
+    # to add forty entries to it.
+    unlisted = unlisted_toolchain_libs()
+    if unlisted:
+        print(f"FAIL {len(unlisted)} loose toolchain librar(ies) are in a pack that "
+              "its manifest does not list:", file=sys.stderr)
+        for entry in unlisted:
+            print(f"  {entry}", file=sys.stderr)
+        print("  -> the manifest is what this run reads to know what a pack ships,"
+              " so a file missing from `libs` is redistributed with nobody"
+              " attributing it. Add it to the `libs` array the download script"
+              " writes, and give it a row in TOOLCHAIN_LIBRARIES and in both"
+              " attribution documents", file=sys.stderr)
         return 1
 
     for name, entry in for_check:


### PR DESCRIPTION
`toolchain_libs()` reads the manifest, which is the right source for what to
attribute and the wrong one for whether the list is complete. A download script
that starts copying one more loose library into a pack and does not add the
matching `libs` entry ships a library this run never sees, so no component is
demanded and no notice is required.

Nothing is unattributed today: both packs' top-level libraries match their
manifests exactly. This fixes no present miss; it closes the one way a future
one arrives silently.

## What changed

- `unlisted_toolchain_libs()` sweeps the top level of each built pack's
  `usr/lib` and reports any `.so` that no manifest in that pack names.
- Only the top level, which is what `libs` means: the loose libraries the
  installer copies beside the base app's and an uninstall deletes. Widening it
  to a toolchain's own subtree would demand a per-file entry for every object in
  a JDK.
- Symlinks are skipped, since a soname alias points at a file already listed.
- It runs after the existing no-manifest check, not before it. A pack with a
  `usr/` payload and no manifest would otherwise come through here as every one
  of its libraries being unlisted, which is true and useless: the fix there is
  to write the manifest, not to add forty entries to it.
- The zlib row in NOTICE.md named neither toolchain, and both link it.

## Verification

With both packs downloaded, the reported line is unchanged: `ok: 64 shipped
binaries + 195 nested + 6 toolchain libraries from 2 manifest(s), 63
components`.

| Tree | Before | After |
|---|---|---|
| An extra `.so` in `toolchain_ruby/usr/lib` | `ok`, exit 0 | `FAIL`, names the file, exit 1 |
| A symlink alias of a listed library | `ok` | `ok` |
| A non-library file in `usr/lib` | `ok` | `ok` |
| The `jvm` directory | `ok` | `ok` |
| A pack with `usr/` and no manifest | no-manifest message | no-manifest message, unchanged |

The zlib claim was read from DT_NEEDED with the repository's own ELF reader,
not by searching the files for the string. Java's `libzip.so` and `libjli.so`
and Ruby's `libruby.so` and `zlib.so` all carry `libz.so.1`; neither pack ships
a copy, so all four resolve to the base app's. A library with no zlib linkage
was read as a control and came back without it.

## Left open

Whether zlib belongs in the base-app table with toolchains named in its
Linked-by column, or should be duplicated into the On-Demand Toolchains
section, is a documentation-shape question for a maintainer. The measurement is
not in doubt; the table layout is the open part.

The reverse check, a manifest naming a library that is not on disk, is not
here. A fresh checkout has `toolchain_ruby.json` committed with no `usr/`
beside it, so that rule needs a guard measured on a runner mid-download before
it could be trusted not to go red on a clean tree.
