### PR TITLE
ci(patch-drift): put the verdict on the run summary

### DIFF
--- a/.github/workflows/patch-drift.yml
+++ b/.github/workflows/patch-drift.yml
@@ -72,4 +72,26 @@ jobs:
         # consistency: check-build-steps.py recognises a shell script CI runs by
         # that exact form, so a bare `scripts/...` invocation is invisible to it
         # and the script would count as one CI never runs.
-        run: bash scripts/check-patches-apply.sh "$INPUT_TAG"
+        #
+        # The verdict goes on the run's summary page, not only into the log.
+        # Nothing watches a scheduled job, so its whole output is one mark in a
+        # list, and the mark here does not mean what a red mark usually means:
+        # it means rebase work is queued for the next bump. A reader who has to
+        # open the log to learn WHICH patch stops opening it.
+        #
+        # `|| status=$?` rather than a pipeline, both halves measured. The step
+        # shell is `bash -e`, so without it the script's non-zero exit ends the
+        # step before the summary is written and the page stays empty. And
+        # `tee` would report 0 for a script that exited 1 or 2, losing the
+        # distinction between "a patch failed" and "the check could not run"
+        # that this script's header defines and a reader depends on.
+        run: |
+          status=0
+          bash scripts/check-patches-apply.sh "$INPUT_TAG" > drift.txt 2>&1 || status=$?
+          cat drift.txt
+          {
+            echo '```text'
+            cat drift.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit "$status"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 97 unused Material and AndroidX resources no longer ship: the date and time pickers, the navigation drawer, fragment transitions and the legacy notification templates.
 - A toolchain pack that ships a library its manifest does not list now fails the build, instead of redistributing it with no licence notice.
 - The zlib notice names the Java and Ruby toolchains, whose libraries link the copy the base app ships.
+- The weekly upstream patch check prints its verdict on the run summary, so a queued rebase is visible without opening the log.
 - The three deprecated edge-to-edge APIs Play reports are gone. Bar colours, the display cutout and bar contrast move to theme attributes; edge-to-edge and bar icons stay in code.
 
 ### Fixed


### PR DESCRIPTION
The workflow has never executed. It landed on 2026-08-19 and its only automatic
trigger is a Monday 04:00 UTC cron, so nothing has shown that the job runs at
all.

Its entire product for a reader is one mark in a run list, and a red mark here
does not mean what a red mark usually means: it means a patch needs rebasing
before the next bump, and the pinned tree is unaffected. A reader who has to
open the log to learn which patch stops opening it.

## What changed

- The step writes the script's full output into the run summary inside a fenced
  block, then re-raises the script's own exit status.
- `|| status=$?` rather than a pipeline, both halves measured rather than
  argued. The step shell is `bash -e`, so without it the non-zero exit ends the
  step before the summary is written and the page stays empty. And `tee` reports
  0 for a script that exited 1 or 2, losing the distinction between "a patch
  failed" and "the check could not run" that this script's header defines.
- The `bash scripts/...` form stays on its own line: `check-build-steps.py`
  recognises a shell script CI runs by exactly that pattern.

## Verification

Exit codes were driven through the fragment with a stub, apart from the
twenty-minute clone:

| Stub exits | Step reports | Summary written |
|---|---|---|
| 0 | 0 | yes |
| 1 | 1 | yes |
| 2 | 2 | yes |
| 1, via `tee` | 0 | yes, verdict lost |
| 1, no `\|\| status=$?` | 1 | no |

`scripts/check-patches-apply.sh` was also run locally against upstream: eleven
patches apply, the twelfth does not, exit 1. That is the expected answer while
the pin sits below the newest upstream stable, and it is what the first
dispatched run should show.

## Note for whoever merges

This workflow must not be added to branch protection. A red run is queued
rebase work, not a broken build, and the pinned tree still builds.

Nothing here records which patch currently fails: that answer changes with
every upstream release and a comment stating it would be stale within the
month.
