### PR TITLE
build(gate): fail a build that packages assets without its checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A toolchain pack that ships a library its manifest does not list now fails the build, instead of redistributing it with no licence notice.
 - The zlib notice names the Java and Ruby toolchains, whose libraries link the copy the base app ships.
 - The weekly upstream patch check prints its verdict on the run summary, so a queued rebase is visible without opening the log.
+- A build that packages the app without the checks deciding whether its bundled tree may ship now fails, instead of producing an unchecked APK.
 - The three deprecated edge-to-edge APIs Play reports are gone. Bar colours, the display cutout and bar contrast move to theme attributes; edge-to-edge and bar icons stay in code.
 
 ### Fixed

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1017,6 +1017,68 @@ tasks.matching { it.name.startsWith("merge") && it.name.endsWith("Assets") }
         dependsOn(bundleNotices)
     }
 
+// The same eight, by name, so the graph can be asked whether they are in it.
+//
+// The wiring above is by name SHAPE, which is right: AGP has moved this family
+// between versions and matching two literal names would fail the build at
+// validation the first time a third appeared. What it cannot do is notice when
+// the shape stops matching. Rename merge*Assets upstream and every gate here
+// detaches at once, in silence, and an unchecked asset tree goes into an APK.
+//
+// So the shape is asserted against the graph that is about to run, not against
+// the task container. `tasks.matching { ... }.isEmpty()` would be the obvious
+// test and is the wrong one twice over: reading it realises every task in the
+// project, which defeats configuration avoidance for the whole build, and it is
+// vacuously true anyway, because mergeDebugAssets is registered in any Android
+// application project whether or not this build is going to run it.
+//
+// Quiet unless the graph really packages assets. `./gradlew testDebugUnitTest`
+// carries no *Assets merge at all (measured), and r8.yml's
+// `optimizeReleaseResources lintVitalRelease` carries none either, so neither
+// pays for this and neither can be failed by it.
+//
+// ⚠️ `gradle.taskGraph.whenReady` is not supported with Gradle's configuration
+// cache, which is off here: gradle.properties sets only jvmargs and the AGP
+// flags, and every build prints the "Consider enabling configuration cache"
+// hint. Whoever turns it on has to move this to a build service or flow action.
+// The question being asked is about the graph, so leaving that unexplained is
+// the failure mode, not the assertion itself.
+val packagingGateNames = listOf(
+    "checkPatchFingerprints", "verifyServerTree", "verifyBundledBinaries",
+    "verifyBundledShellPaths", "verifyRubyPackShellPaths", "verifyNativeAddons",
+    "checkPackOverlap", "verifyPythonPlatform",
+)
+
+gradle.taskGraph.whenReady {
+    // This project's tasks only. The gates named below are this project's, so a
+    // merge*Assets belonging to another module would be the wrong subject: it
+    // would demand :app:'s checks of a graph that never packages :app:'s tree.
+    // Nothing contributes one today (measured: the whole bundleRelease graph
+    // holds exactly one, :app:mergeReleaseAssets, and the asset packs bring
+    // generateAssetPackManifest instead), so this scopes the question rather
+    // than filtering anything out yet.
+    val prefix = "${project.path}:"
+    val here = allTasks.filter { it.path.startsWith(prefix) }
+    val packaging = here.map { it.name }
+        .filter { it.startsWith("merge") && it.endsWith("Assets") }
+    if (packaging.isEmpty()) return@whenReady
+
+    val present = here.map { it.name }.toSet()
+    val missing = packagingGateNames.filterNot { it in present }
+    if (missing.isNotEmpty()) {
+        throw GradleException(
+            "This build packages an asset tree (${packaging.joinToString(", ")}) " +
+                "without ${missing.size} of the ${packagingGateNames.size} checks " +
+                "that decide whether the tree may ship:\n" +
+                missing.joinToString("\n") { "  $it" } +
+                "\n\nThe checks are attached by name shape to tasks called " +
+                "merge*Assets. A task above matched that shape and carries none of " +
+                "them, so the attachment is no longer reaching this variant. Fix " +
+                "the tasks.matching predicate that wires them, not this message."
+        )
+    }
+}
+
 // The finished bundle is a Gradle product, so the edge is `finalizedBy` rather
 // than `dependsOn`: the file does not exist until bundleRelease has run. Writing
 // it the other way round would either check a file that is not there yet or, if


### PR DESCRIPTION
Eight gates decide whether the bundled asset tree may ship, and they are
attached by name shape:

```kotlin
tasks.matching { it.name.startsWith("merge") && it.name.endsWith("Assets") }
```

The shape is the right wiring. AGP has moved this family between versions, and
matching two literal names would fail the build the first time a third
appeared, which it since has: `mergeDebugAndroidTestAssets`.

What the shape cannot do is notice when it stops matching. Rename the family
upstream and all eight detach at once, in silence, and an unchecked tree goes
into an APK with a green build. Measured: breaking the predicate leaves
`mergeDebugAssets` in the graph, zero gates beside it, and `assembleDebug
--dry-run` exiting 0.

## What changed

- `gradle.taskGraph.whenReady` asserts the property that matters: if the graph
  about to run packages an asset tree, the same graph carries all eight checks.
- The failure names the missing ones and points at the predicate that wires
  them, not at itself.
- Not `tasks.matching { ... }.isEmpty()`, which is wrong twice: reading it
  realises every task in the project, defeating configuration avoidance, and it
  is vacuously true anyway, since `mergeDebugAssets` is registered in any
  Android application project whether or not this build runs it.
- Scoped to this project's tasks. The gates are this project's, so another
  module's merge would be the wrong subject. Nothing contributes one today, so
  that scopes the question rather than filtering anything out.

## Verification

The assertion has two failure modes, firing wrongly and never firing at all.
Both were measured, on every graph CI actually runs:

| Graph | `merge*Assets` | Gates in graph | Result |
|---|---|---|---|
| `assembleDebug` | `mergeDebugAssets` | 8 | checked, passes |
| `bundleRelease` | `mergeReleaseAssets` | 8 | checked, passes |
| `assemble` / `bundle` | both | 8 | checked, passes |
| `assembleDebugAndroidTest` | `mergeDebugAndroidTestAssets` | 8 | checked, passes |
| `testDebugUnitTest` | none | 0 | returns early |
| `lint` / `lintDebug` | none | 0 | returns early |
| `optimizeReleaseResources lintVitalRelease` | none | 0 | returns early |

The rows with 8 are what stop this from being a gate that guards nothing: the
early return is real, so an assertion that only ever met empty graphs would look
identical to one that works.

Negative control: with the family predicate broken to `mergeXX`, the same
`assembleDebug` graph fails, naming all eight. Restoring it makes the build
green again with no sentinel left in the file.

## Configuration cache

`whenReady` is unsupported with Gradle's configuration cache. It is off here:
`gradle.properties` sets only `jvmargs` and the AGP flags, and every build
prints the hint offering to enable it. The comment says so and says what moving
this would take, because leaving that as an unexplained blocker is the failure
mode.

Full suite 1241 tests, 0 failures. Lint holds at 52 warnings.
