### PR TITLE
fix(webview): take view focus so typing arrives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Tapping the editor now raises the keyboard, and what it types now arrives. The app never took Android input focus for its view, so keyboard input was silently discarded.
 - A save the sync refuses to write back now says so. It was silent, so an edit that never reached the device folder looked exactly like one that did.
 - Closing a device folder while a save is still going out no longer lets the next folder share its write-back queue, which could interleave two writes into one document.
 - A file two saves are writing at once stays marked as unfinished until the last one lands, so a crash between them can no longer leave a half-written device copy unrecorded.

--- a/android/app/src/main/kotlin/com/vscodroid/webview/VSCodroidWebView.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/webview/VSCodroidWebView.kt
@@ -1,6 +1,7 @@
 package com.vscodroid.webview
 
 import android.annotation.SuppressLint
+import android.view.MotionEvent
 import android.webkit.WebSettings
 import android.webkit.WebView
 import com.vscodroid.util.Logger
@@ -8,7 +9,7 @@ import com.vscodroid.util.Logger
 object VSCodroidWebView {
     private const val TAG = "WebView"
 
-    @SuppressLint("SetJavaScriptEnabled")
+    @SuppressLint("SetJavaScriptEnabled", "ClickableViewAccessibility")
     fun configure(webView: WebView) {
         webView.settings.apply {
             javaScriptEnabled = true
@@ -26,6 +27,30 @@ object VSCodroidWebView {
             mediaPlaybackRequiresUserGesture = false
             javaScriptCanOpenWindowsAutomatically = true
             setSupportMultipleWindows(false)
+        }
+
+        // The editor cannot be typed into unless this view holds Android focus.
+        // Measured on WebView 109 and 150 and reported from a device: without
+        // it the input method serves the DecorView through a fallback
+        // connection, everything the keyboard produces is discarded, and the
+        // keyboard never rises because the show request comes from an
+        // unfocused view. A real tap moves the caret (Blink-side focus works)
+        // but never grants the Android view focus, so both halves are done
+        // here: once up front, and again on every touch-down. The listener
+        // returns false so scrolling and taps are untouched, which is also why
+        // suppressing ClickableViewAccessibility is honest: performClick still
+        // runs, nothing is consumed.
+        //
+        // setOnTouchListener is a single setter. A second caller anywhere would
+        // replace this listener and kill the fix with every test still green,
+        // which is why WebViewFocusTest pins the set of files allowed to call
+        // it. If you need to observe touches too, extend THIS listener.
+        webView.isFocusable = true
+        webView.isFocusableInTouchMode = true
+        webView.requestFocus()
+        webView.setOnTouchListener { v, event ->
+            if (event.actionMasked == MotionEvent.ACTION_DOWN && !v.isFocused) v.requestFocus()
+            false
         }
 
         webView.isScrollbarFadingEnabled = true

--- a/android/app/src/test/kotlin/com/vscodroid/webview/WebViewFocusTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/WebViewFocusTest.kt
@@ -1,0 +1,150 @@
+package com.vscodroid.webview
+
+import android.view.MotionEvent
+import android.view.View
+import android.webkit.WebView
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * The editor cannot be typed into unless the WebView holds Android view focus.
+ *
+ * Measured on two emulators (WebView 109 and 150) and reported from a real
+ * device: after launch the input method serves the DecorView through a fallback
+ * connection, so everything the keyboard produces is discarded, and the
+ * keyboard itself never rises because the show request comes from a view that
+ * is not focused. A real tap moves the caret (Blink-side focus works) but
+ * never grants the Android view focus, and nothing in this app requested it.
+ * Chromium's own DevTools click path and a d-pad key both granted it, and with
+ * focus held, the same keyboard committed text immediately.
+ *
+ * So [VSCodroidWebView.configure] owns two duties beyond settings: request
+ * focus once up front, and keep granting it on every touch-down thereafter,
+ * without consuming the touch. `configure` is the right home because both the
+ * launch path and the post-crash `recreateWebView` path go through it.
+ */
+class WebViewFocusTest {
+
+    private val webView = mockk<WebView>(relaxed = true)
+
+    @BeforeEach
+    fun setUp() {
+        // configure() logs through android.util.Log, an android.jar stub that
+        // throws on the JVM.
+        mockkStatic(android.util.Log::class)
+        every { android.util.Log.i(any(), any<String>()) } returns 0
+        every { android.util.Log.d(any(), any()) } returns 0
+    }
+
+    @AfterEach
+    fun tearDown() = unmockkAll()
+
+    @Test
+    fun `configure makes the WebView focusable in touch mode and requests focus`() {
+        VSCodroidWebView.configure(webView)
+
+        verify { webView.isFocusable = true }
+        verify { webView.isFocusableInTouchMode = true }
+        verify(exactly = 1) { webView.requestFocus() }
+    }
+
+    @Test
+    fun `a touch-down on an unfocused WebView requests focus and is not consumed`() {
+        val listener = slot<View.OnTouchListener>()
+        VSCodroidWebView.configure(webView)
+        verify { webView.setOnTouchListener(capture(listener)) }
+
+        val down = mockk<MotionEvent> { every { actionMasked } returns MotionEvent.ACTION_DOWN }
+        every { webView.isFocused } returns false
+
+        val consumed = listener.captured.onTouch(webView, down)
+
+        assertFalse(consumed, "consuming the touch would break scrolling and taps")
+        verify(exactly = 2) { webView.requestFocus() }
+    }
+
+    @Test
+    fun `a touch-down on an already focused WebView does not re-request focus`() {
+        val listener = slot<View.OnTouchListener>()
+        VSCodroidWebView.configure(webView)
+        verify { webView.setOnTouchListener(capture(listener)) }
+
+        val down = mockk<MotionEvent> { every { actionMasked } returns MotionEvent.ACTION_DOWN }
+        every { webView.isFocused } returns true
+
+        val consumed = listener.captured.onTouch(webView, down)
+
+        assertFalse(consumed)
+        // Once from configure itself, none from the listener.
+        verify(exactly = 1) { webView.requestFocus() }
+    }
+
+    @Test
+    fun `the WebView touch listener has exactly one owner`() {
+        // setOnTouchListener is a single setter: a second caller anywhere would
+        // replace the focus-granting listener and kill this fix with every
+        // other test still green, because the replacement looks harmless to its
+        // author. ExtraKeyButton installs one too, on its own Button view, which
+        // is a different view and cannot displace this one.
+        // A count per file, not a set of file names: a set stays unchanged when
+        // a SECOND call is added inside an already-listed file, and that is the
+        // likeliest edit of all, because whoever adds gesture handling will put
+        // it in the file that already has a touch listener. The count is the
+        // quantity actually guarded: how many listeners are installed.
+        //
+        // What this cannot see, stated rather than closed: Java sources, XML
+        // android:onTouch, a listener installed through some other API, a
+        // single-line block comment naming the method (only `//` and `*`
+        // prefixed lines are dropped; KDoc bodies are `*` lines, so today the
+        // only surviving mentions are the two real calls), and a string
+        // literal, which counts. Closing any of these needs a parser and is
+        // not worth it; a false red here reads as "look at this scan", which
+        // is the safe direction.
+        // Comment lines are dropped before counting, because the call site's
+        // own comment names the method in prose; the guarded quantity is
+        // installed listeners, not mentions.
+        val owners = File("src/main/kotlin")
+            .walkTopDown()
+            .filter { it.extension == "kt" }
+            .associate { file ->
+                file.name to file.readLines()
+                    .filterNot { it.trimStart().startsWith("//") || it.trimStart().startsWith("*") }
+                    .count { Regex("\\bsetOnTouchListener\\b").containsMatchIn(it) }
+            }
+            .filterValues { it > 0 }
+            .toSortedMap()
+
+        assertEquals(
+            sortedMapOf("ExtraKeyButton.kt" to 1, "VSCodroidWebView.kt" to 1),
+            owners,
+            "a setOnTouchListener call appeared or multiplied; a second call on " +
+                "the WebView silently replaces the focus listener, so extend the " +
+                "one in VSCodroidWebView.configure instead, then update this map",
+        )
+    }
+
+    @Test
+    fun `a move event does not touch focus at all`() {
+        val listener = slot<View.OnTouchListener>()
+        VSCodroidWebView.configure(webView)
+        verify { webView.setOnTouchListener(capture(listener)) }
+
+        val move = mockk<MotionEvent> { every { actionMasked } returns MotionEvent.ACTION_MOVE }
+        every { webView.isFocused } returns false
+
+        val consumed = listener.captured.onTouch(webView, move)
+
+        assertFalse(consumed)
+        verify(exactly = 1) { webView.requestFocus() }
+    }
+}


### PR DESCRIPTION
Typing did not work. Tapping the editor did not raise the keyboard, and text typed on the soft keyboard accumulated in the IME's composing strip without ever reaching the document. Reproduced on WebView 109 and 150 and on a physical device, on the shipped 1.1.0 as well as this tree.

The WebView never held Android view focus. Initial focus stays on the DecorView, and a touch moves Blink's internal focus (the caret follows taps, so everything looks alive) without granting the Android view focus. The input method then serves the DecorView through a fallback connection that discards everything, and the keyboard never shows because the show request comes from an unfocused view. Nothing in the app ever called `requestFocus`; `ExtraKeyButton` even sets `isFocusable = false` on the row's own buttons, assuming some other view holds focus, and none ever did.

- `VSCodroidWebView.configure` now requests focus once up front and re-requests it on every touch-down, through a listener that returns false so scrolling and taps are untouched. Both the launch path and the post-crash `recreateWebView` path go through `configure`.
- `setOnTouchListener` is a single-slot setter, so a second caller anywhere would silently replace the focus listener. A source-scanning test therefore counts calls per file over the main sources (comments stripped) and fails when one appears or multiplies; its stated blind spots are Java, XML `onTouch`, and other install APIs.

Verified on a device end to end with plain touches only: a fresh install serves the WebView from launch, tapping an input raises the keyboard, and typed characters land in the document, with auto-closing pairs working. Granting focus by any other means (a d-pad key press) cures the unpatched build the same way, which is what isolated the cause.

Suite: 1246 tests, 0 failures. `mServedView` in `dumpsys input_method` flips from `DecorView` to the WebView from launch onward.
