### PR TITLE
fix(keyboard): type row characters as key presses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Tapping the editor now raises the keyboard, and what it types now arrives. The app never took Android input focus for its view, so keyboard input was silently discarded.
+- Brackets, quotes and other symbols on the extra key row now type into the editor. On recent WebViews they inserted nothing at all.
 - A save the sync refuses to write back now says so. It was silent, so an edit that never reached the device folder looked exactly like one that did.
 - Closing a device folder while a save is still going out no longer lets the next folder share its write-back queue, which could interleave two writes into one document.
 - A file two saves are writing at once stays marked as unfinished until the last one lands, so a crash between them can no longer leave a half-written device copy unrecorded.

--- a/android/app/src/main/kotlin/com/vscodroid/keyboard/ExtraKeyRow.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/keyboard/ExtraKeyRow.kt
@@ -208,16 +208,6 @@ class ExtraKeyRow @JvmOverloads constructor(
                 startModifierSync()
                 Logger.d(tag, "Shift toggled: $shiftActive")
             }
-            "{" -> {
-                // Only inject opening brace — Monaco auto-closes and positions cursor inside
-                keyInjector?.injectKey("{", ctrlKey = ctrlActive, altKey = altActive, shiftKey = shiftActive)
-                resetModifiersIfNeeded()
-            }
-            "(" -> {
-                // Only inject opening paren — Monaco auto-closes and positions cursor inside
-                keyInjector?.injectKey("(", ctrlKey = ctrlActive, altKey = altActive, shiftKey = shiftActive)
-                resetModifiersIfNeeded()
-            }
             else -> {
                 keyInjector?.injectKey(key, ctrlKey = ctrlActive, altKey = altActive, shiftKey = shiftActive)
                 resetModifiersIfNeeded()

--- a/android/app/src/main/kotlin/com/vscodroid/keyboard/KeyInjector.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/keyboard/KeyInjector.kt
@@ -1,11 +1,29 @@
 package com.vscodroid.keyboard
 
+import android.view.KeyEvent
 import android.webkit.WebView
 import com.vscodroid.util.Logger
 
-class KeyInjector(private val webView: WebView) {
+/**
+ * @param keyEventsFor how a character becomes key presses. Defaulted rather than
+ * called directly so the routing can be exercised on the JVM: `KeyCharacterMap`
+ * and `KeyEvent` are android.jar stubs that throw off a device.
+ */
+class KeyInjector(
+    private val webView: WebView,
+    private val keyEventsFor: (String) -> List<KeyEvent>? = ::virtualKeyboardEvents
+) {
     private val tag = "KeyInjector"
 
+    /**
+     * Delivers one press of [key], by whichever of the two routes it needs.
+     *
+     * See [isTextEntry] for which is which and why there have to be two. In
+     * short: a character is typed as a real key press, because a synthetic DOM
+     * event performs no default action and inserts nothing; everything else,
+     * and anything held with Ctrl, Alt or Meta, is announced as a DOM event,
+     * because that is what the workbench resolves its bindings from.
+     */
     fun injectKey(
         key: String,
         ctrlKey: Boolean = false,
@@ -13,20 +31,73 @@ class KeyInjector(private val webView: WebView) {
         shiftKey: Boolean = false,
         metaKey: Boolean = false
     ) {
+        // A latched Shift changes WHICH character is typed, not whether it is
+        // typed. The row offers no other route to `?`, `+`, `}` and the rest,
+        // so resolving it here is what makes those reachable at all.
+        val typed = if (shiftKey) KeyMapping.shiftedForm(key) ?: key else key
+        if (isTextEntry(typed, ctrlKey, altKey, metaKey) && typeCharacter(typed)) return
+        announceKeystroke(key, ctrlKey, altKey, shiftKey, metaKey)
+    }
+
+    /**
+     * Types [key] through the WebView's own key handling. False when the layout
+     * has no press for it, which leaves the caller to fall back.
+     *
+     * Read that fallback for what it is. The path it falls back to is the one
+     * that inserts nothing, which is the whole defect this routing exists to
+     * fix, so for such a character nothing is recovered: the press is preserved
+     * as a keystroke the page can see and the text still does not arrive.
+     * Swallowing the key would be worse, which is why it stays, but "fell back"
+     * must not be read as "handled".
+     *
+     * The [Logger.w] below is the only signal that a key on the row cannot type
+     * on the layout in force, and it is deliberately a warning rather than a
+     * debug line: `Logger.d` is gated on a debuggable build, so on the builds
+     * users run it would say nothing at all. On the US layout this is expected
+     * to be no keys, and "expected to be none" on a layout nobody here chose is
+     * exactly the claim worth instrumenting rather than assuming.
+     */
+    private fun typeCharacter(key: String): Boolean {
+        val events = keyEventsFor(key)
+        if (events.isNullOrEmpty()) {
+            Logger.w(tag, "no press types '$key' on the virtual keyboard layout")
+            return false
+        }
+        var handled = true
+        for (event in events) handled = webView.dispatchKeyEvent(event) && handled
+        if (!handled) {
+            // The view refused the press: the renderer is being rebuilt after a
+            // crash, or the WebView is detached mid folder switch. Reporting
+            // success here would swallow the key entirely, so say so and let the
+            // caller fall back to the path that at least reaches the page.
+            Logger.w(tag, "the WebView refused the press for '$key'")
+            return false
+        }
+        Logger.d(tag, "typed key=$key presses=${events.size}")
+        return true
+    }
+
+    private fun announceKeystroke(
+        key: String,
+        ctrlKey: Boolean,
+        altKey: Boolean,
+        shiftKey: Boolean,
+        metaKey: Boolean
+    ) {
         val keyDef = KeyMapping.getKeyDefOrLetter(key)
         // Quoted by [KeyMapping.jsQuote], which is the table's own escaper and
         // the only one in this package that is correct.
         //
         // What was here escaped `'` and `"` and left `\` alone, which is exactly
         // the character the table holds as a key. For the `\` entry it rendered
-        // `key: '\',` -- the backslash escapes the closing quote, the string
+        // `key: '\',` : the backslash escapes the closing quote, the string
         // runs on into the rest of the object, and the whole injected IIFE is a
         // SyntaxError. `evaluateJavascript` reports a parse failure to a null
         // callback, so the key did nothing at all and did it silently. It is
         // reachable: the `/` key offers `\` as its long-press alternate.
         //
         // jsQuote emits a double-quoted literal, so these are no longer wrapped
-        // in quotes here -- doing both would produce a quoted quote.
+        // in quotes here; doing both would produce a quoted quote.
         val jsKey = KeyMapping.jsQuote(keyDef.key)
         val jsCode = KeyMapping.jsQuote(keyDef.code)
         // Force shiftKey=true for characters that require Shift on a physical keyboard
@@ -50,12 +121,22 @@ class KeyInjector(private val webView: WebView) {
                 };
                 target.dispatchEvent(new KeyboardEvent('keydown', eventInit));
                 target.dispatchEvent(new KeyboardEvent('keyup', eventInit));
+                return target === document.body ? 'body' : (target.tagName || 'unknown');
             })();
         """.trimIndent()
 
-        webView.evaluateJavascript(js, null)
-        Logger.d(tag, "Injected key=$key ctrl=$ctrlKey alt=$altKey shift=$shiftKey")
+        webView.evaluateJavascript(js) { target ->
+            // What this can honestly report is where the event went, not what
+            // the page did with it: a synthetic KeyboardEvent runs the
+            // workbench's bindings and performs no default action, so "it was
+            // delivered" and "something happened" are different claims and only
+            // the first is observable from here. The line this replaced said
+            // "Injected key={" for a press that inserted nothing, on every tap,
+            // for as long as that key had been broken.
+            Logger.d(tag, "sent key=$key to $target ctrl=$ctrlKey alt=$altKey shift=$effectiveShift")
+        }
     }
+
 
     /**
      * Installs a JS `beforeinput` listener that intercepts soft keyboard text input

--- a/android/app/src/main/kotlin/com/vscodroid/keyboard/KeyMapping.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/keyboard/KeyMapping.kt
@@ -84,6 +84,29 @@ object KeyMapping {
      */
     fun getKeyDef(key: String): KeyDef? = mappings[key]
 
+    /**
+     * The character a latched Shift produces for [key] on the US layout this
+     * table describes, or null when Shift produces nothing different.
+     *
+     * The table already carries both halves of every pair: `/` and `?` are both
+     * Slash with keyCode 191 and differ only in [KeyDef.requiresShift], as are
+     * `;` and `:`, `=` and `+`, `[` and `{`. Reading the pair back out of it
+     * keeps one description of the layout instead of a second opinion, which is
+     * the same reason [virtualKeyboardEvents] asks the layout rather than
+     * carrying a table of its own.
+     *
+     * This matters because the row has no `?`, `+`, `*`, `%`, `^`, `$`, `}` or
+     * `)` on any page, so a latched Shift is the only route the row offers to
+     * them. Dropping it types the base character, which is worse than typing
+     * nothing: it is confidently wrong output.
+     */
+    fun shiftedForm(key: String): String? {
+        if (key.length == 1 && key[0].isLetter()) return key.uppercase()
+        val base = mappings[key] ?: return null
+        if (base.requiresShift) return key
+        return mappings.values.firstOrNull { it.keyCode == base.keyCode && it.requiresShift }?.key
+    }
+
     fun getKeyDefOrLetter(key: String): KeyDef {
         return mappings[key] ?: run {
             val char = key.firstOrNull() ?: ' '

--- a/android/app/src/main/kotlin/com/vscodroid/keyboard/LongPressPopup.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/keyboard/LongPressPopup.kt
@@ -53,8 +53,15 @@ class LongPressPopup(
 
                 setOnClickListener {
                     performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
-                    onKeySelected(alt.value)
+                    // Dismiss BEFORE emitting. This popup is focusable (the
+                    // fourth argument to PopupWindow below), so while it is up
+                    // the activity window does not hold input focus, and an
+                    // alternate is now delivered as a real key press rather than
+                    // as JavaScript. A key press aimed at a window that is not
+                    // focused is at best fragile, and `\`, `~` and `'` reach the
+                    // editor through no other route.
                     dismiss()
+                    onKeySelected(alt.value)
                 }
             }
             val lp = LinearLayout.LayoutParams(

--- a/android/app/src/main/kotlin/com/vscodroid/keyboard/TextEntry.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/keyboard/TextEntry.kt
@@ -1,0 +1,66 @@
+package com.vscodroid.keyboard
+
+import android.os.SystemClock
+import android.view.InputDevice
+import android.view.KeyCharacterMap
+import android.view.KeyEvent
+
+/**
+ * Whether [key] is a character to be typed rather than a keystroke to be
+ * announced. They are two different operations and only one of them can be done
+ * from JavaScript.
+ *
+ * A `KeyboardEvent` built in the page is untrusted, so the browser runs the
+ * listeners and performs no default action. The workbench's key bindings fire,
+ * which is why Tab indents and Ctrl+P opens Quick Open, and no text is
+ * inserted, which is why `{` produced nothing at all. Text has to enter through
+ * the browser's own text input path, and the only way into that path from
+ * Kotlin is a real Android [KeyEvent] delivered to the WebView.
+ *
+ * That distinction, rather than the edit widget, is what makes this survive
+ * both DOM shapes. Old WebViews put a hidden `textarea.inputarea` behind the
+ * editor; WebView 121 and later use `EditContext` over `div.native-edit-context`
+ * and have no textarea at all. A key press is above both.
+ *
+ * [KeyMapping]'s own names separate the two cases: a key that types is one
+ * character (`{`, `;`, `"`), a key that commands is spelled out (`Tab`,
+ * `Escape`, `F7`, `PageDown`). Ctrl, Alt or Meta makes any key a chord, and a
+ * chord is a command however it is spelled. Shift does not: the layout below
+ * presses Shift itself for the characters that need it.
+ *
+ * ASCII only, because [virtualKeyboardEvents] resolves through a US layout and
+ * anything outside it has no key to press there.
+ */
+internal fun isTextEntry(key: String, ctrlKey: Boolean, altKey: Boolean, metaKey: Boolean): Boolean {
+    if (ctrlKey || altKey || metaKey) return false
+    if (key.length != 1) return false
+    return key[0].code in 0x20..0x7E
+}
+
+/**
+ * The presses that type [text] on the virtual keyboard layout, or null when the
+ * layout cannot produce one of its characters.
+ *
+ * Shift is not applied by hand. `getEvents` returns whatever the layout needs,
+ * which for `{` is Shift down, `[` down, `[` up, Shift up, with the meta state
+ * already set on each event. A table written here would be a second opinion
+ * about a layout that is available to ask.
+ *
+ * The events come back stamped at time zero and are re-stamped: a press that
+ * claims to have happened at boot is one whose repeat and long-press timing
+ * cannot be read downstream. The device id stays [KeyCharacterMap.VIRTUAL_KEYBOARD]
+ * because that is the map whose characters these key codes were resolved from,
+ * and it is the map `KeyEvent.getUnicodeChar` will consult again on the way in.
+ */
+internal fun virtualKeyboardEvents(text: String): List<KeyEvent>? {
+    val events = KeyCharacterMap.load(KeyCharacterMap.VIRTUAL_KEYBOARD)
+        .getEvents(text.toCharArray()) ?: return null
+    val now = SystemClock.uptimeMillis()
+    return events.map { event ->
+        KeyEvent(
+            now, now, event.action, event.keyCode, event.repeatCount, event.metaState,
+            KeyCharacterMap.VIRTUAL_KEYBOARD, event.scanCode, event.flags,
+            InputDevice.SOURCE_KEYBOARD,
+        )
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/keyboard/KeyInjectorEscapingTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/keyboard/KeyInjectorEscapingTest.kt
@@ -43,7 +43,12 @@ class KeyInjectorEscapingTest {
     }
 
     private fun inject(key: String): String {
-        KeyInjector(webView).injectKey(key)
+        // Ctrl, and it is load-bearing rather than incidental. A bare character
+        // is now typed as a real key press and never reaches the page as
+        // JavaScript, so there would be no script to capture. A modifier makes
+        // any key a chord, and a chord is what this generated source is for; the
+        // escaping it checks is identical either way.
+        KeyInjector(webView).injectKey(key, ctrlKey = true)
         return script.captured
     }
 

--- a/android/app/src/test/kotlin/com/vscodroid/keyboard/KeyInjectorShiftTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/keyboard/KeyInjectorShiftTest.kt
@@ -19,11 +19,15 @@ import org.junit.jupiter.api.Test
  * the injector leaves every one of those green, and leaves the extra key row
  * sending `shiftKey: false` for `{`, `(`, `:` and the rest.
  *
- * What that costs is the whole point of those keys. Monaco decides how to handle
- * a keystroke from the modifiers on the event, not from the character, so a `{`
- * arriving without Shift is not the same keystroke — auto-closing brackets and
- * the bindings that watch for shifted punctuation stop matching. The character
- * still appears, which is why nothing would look broken.
+ * What that costs is which chord the workbench resolves. Monaco decides how to
+ * handle a keystroke from the modifiers on the event, so Ctrl with an unshifted
+ * `{` is a different binding from Ctrl with a shifted one, and neither is the
+ * one the user asked for. It does not cost the character. This paragraph said
+ * "The character still appears, which is why nothing would look broken" until it
+ * was measured on a device: a synthetic KeyboardEvent is untrusted, the browser
+ * performs no default action for it, and tapping `{` inserted nothing whatever
+ * the modifiers said. Characters now go through a real key press instead, which
+ * is why every case here holds Ctrl.
  *
  * The injector already takes its WebView through the constructor, so the script
  * it hands over can be captured without touching production code.
@@ -50,7 +54,9 @@ class KeyInjectorShiftTest {
     }
 
     private fun inject(key: String, shiftKey: Boolean = false): String {
-        KeyInjector(webView).injectKey(key, shiftKey = shiftKey)
+        // Ctrl for the reason given in the class comment: it is what keeps a
+        // character on the path that generates this script.
+        KeyInjector(webView).injectKey(key, ctrlKey = true, shiftKey = shiftKey)
         return script.captured
     }
 

--- a/android/app/src/test/kotlin/com/vscodroid/keyboard/KeyInjectorTextEntryTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/keyboard/KeyInjectorTextEntryTest.kt
@@ -1,0 +1,164 @@
+package com.vscodroid.keyboard
+
+import android.view.KeyEvent
+import android.webkit.WebView
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Which presses are typed and which are announced.
+ *
+ * Measured on a device before this split existed: tapping `{}` or `()` on the
+ * key row logged a press and inserted nothing, while Tab indented and the soft
+ * keyboard typed normally. A synthetic `KeyboardEvent` is untrusted, so the
+ * browser runs the page's listeners and performs no default action for it. That
+ * is exactly right for a command (Tab, Escape, Ctrl+P) and useless for a
+ * character, which needs the browser's own text input path.
+ *
+ * The two edit paths are why this cannot be patched in JavaScript. On API 33 /
+ * WebView 109 the workbench has one `textarea.inputarea` and nothing else; on
+ * API 37 / WebView 150 `EditContext` is supported, there is no textarea in the
+ * DOM at all, and two `div.native-edit-context` elements instead. A real key
+ * press enters above both.
+ *
+ * The layout lookup arrives through the constructor so these run on the JVM:
+ * `KeyCharacterMap` and `KeyEvent` are android.jar stubs that throw when called.
+ */
+class KeyInjectorTextEntryTest {
+
+    private val webView = mockk<WebView>(relaxed = true)
+    private val down = mockk<KeyEvent>(relaxed = true)
+    private val up = mockk<KeyEvent>(relaxed = true)
+
+    /** Every string the injector asked the layout to type. */
+    private val asked = mutableListOf<String>()
+
+    @BeforeEach
+    fun setUp() {
+        // Logger.w is not gated on debugEnabled, and the fallback case below
+        // reaches it. Log is an android.jar stub that throws otherwise.
+        mockkStatic(android.util.Log::class)
+        every { android.util.Log.w(any(), any<String>()) } returns 0
+        every { android.util.Log.d(any(), any()) } returns 0
+        every { webView.dispatchKeyEvent(any()) } returns true
+    }
+
+    private fun injector(events: List<KeyEvent>? = listOf(down, up)) =
+        KeyInjector(webView) { text -> asked.add(text); events }
+
+    @Test
+    fun `a bracket is typed as a key press, not announced as a DOM event`() {
+        injector().injectKey("{")
+
+        assertEquals(listOf("{"), asked, "the layout was never asked what to press for '{'")
+        verify(exactly = 1) { webView.dispatchKeyEvent(down) }
+        verify(exactly = 1) { webView.dispatchKeyEvent(up) }
+        verify(exactly = 0) { webView.evaluateJavascript(any(), any()) }
+    }
+
+    @Test
+    fun `Tab is still announced as a DOM event`() {
+        injector().injectKey("Tab")
+
+        assertTrue(asked.isEmpty(), "Tab is a command, not a character; the layout must not be asked to type it")
+        verify(exactly = 0) { webView.dispatchKeyEvent(any()) }
+        verify(exactly = 1) { webView.evaluateJavascript(any(), any()) }
+    }
+
+    @Test
+    fun `a modifier latched on the row keeps a character on the DOM path`() {
+        injector().injectKey("p", ctrlKey = true)
+
+        assertTrue(asked.isEmpty(), "Ctrl+P is a chord, and a chord is resolved by the workbench, not typed")
+        verify(exactly = 0) { webView.dispatchKeyEvent(any()) }
+        verify(exactly = 1) { webView.evaluateJavascript(any(), any()) }
+    }
+
+    @Test
+    fun `a latched Shift types the shifted character, not the base one`() {
+        // The row has no `?` on any page, so Shift plus `/` is its only route to
+        // one. Typing `/` here would be worse than the defect this class exists
+        // to fix: before, a latched Shift inserted nothing; getting the
+        // unshifted character back is confidently wrong output.
+        injector().injectKey("/", shiftKey = true)
+
+        assertEquals(listOf("?"), asked, "Shift plus / must ask the layout for ?, not /")
+        verify(exactly = 2) { webView.dispatchKeyEvent(any()) }
+        verify(exactly = 0) { webView.evaluateJavascript(any(), any()) }
+    }
+
+    @Test
+    fun `a latched Shift on an already shifted character types that character`() {
+        // `{` is itself the shifted form of `[`, so a latched Shift must not
+        // resolve it a second time into something else.
+        injector().injectKey("{", shiftKey = true)
+
+        assertEquals(listOf("{"), asked, "the shifted form of { is { itself")
+        verify(exactly = 2) { webView.dispatchKeyEvent(any()) }
+        verify(exactly = 0) { webView.evaluateJavascript(any(), any()) }
+    }
+
+    @Test
+    fun `a latched Shift on a key with no shifted form still announces the chord`() {
+        // Shift+Tab is a real chord the workbench resolves; it is not text.
+        injector().injectKey("Tab", shiftKey = true)
+
+        assertTrue(asked.isEmpty(), "Tab is a command; the layout must not be asked to type it")
+        verify(exactly = 0) { webView.dispatchKeyEvent(any()) }
+        verify(exactly = 1) { webView.evaluateJavascript(any(), any()) }
+    }
+
+    @Test
+    fun `a character the layout cannot press falls back to the DOM event`() {
+        // This pins the fallback, not a cure. The DOM path inserts no text, so
+        // such a character still does not type; what the fallback buys is that
+        // the page sees the keystroke instead of the key vanishing. The warning
+        // logged on this path is the only way to find out it happened.
+        injector(events = null).injectKey(";")
+
+        assertEquals(listOf(";"), asked, "the layout was asked, so this is the fallback and not a routing regression")
+        verify(exactly = 0) { webView.dispatchKeyEvent(any()) }
+        verify(exactly = 1) { webView.evaluateJavascript(any(), any()) }
+    }
+
+    @Test
+    fun `a press the WebView refuses falls back instead of vanishing`() {
+        // dispatchKeyEvent returns false when the view cannot consume the event,
+        // for instance while the renderer is being rebuilt after a crash or the
+        // WebView is detached during a folder switch. Reporting that as typed
+        // swallows the key with nothing on screen and nothing in a release log.
+        every { webView.dispatchKeyEvent(any()) } returns false
+
+        injector().injectKey("{")
+
+        assertEquals(listOf("{"), asked, "the layout was asked, so this is the refusal path")
+        verify(exactly = 1) { webView.evaluateJavascript(any(), any()) }
+    }
+
+    @Test
+    fun `every key on the row is routed by whether it is a character`() {
+        // Driven from the row itself, so a key added to KeyPages later is
+        // covered without anyone remembering this file. The three modifiers
+        // never reach the injector: ExtraKeyRow.handleKeyAction consumes them.
+        val modifiers = setOf("Ctrl", "Alt", "Shift")
+        val values = KeyPages.defaults.flatMap { it.items }
+            .filterIsInstance<KeyItem.Button>()
+            .flatMap { button -> listOf(button.value) + button.alternates.map { it.value } }
+            .filterNot { it in modifiers }
+        check(values.size > 30) { "the key row came back nearly empty; this test would prove nothing" }
+
+        for (value in values) {
+            assertEquals(
+                value.length == 1,
+                isTextEntry(value, ctrlKey = false, altKey = false, metaKey = false),
+                "'$value' is routed the wrong way: a single character is typed, a named key is announced",
+            )
+        }
+    }
+}

--- a/docs/DEVICE_TEST_CHECKLIST.md
+++ b/docs/DEVICE_TEST_CHECKLIST.md
@@ -47,7 +47,8 @@
 | KB-7 | Extra Key Row — Ctrl+S | Press Ctrl on EKR then S on keyboard | File saves (no error) | | |
 | KB-8 | Extra Key Row — Ctrl+P | Press Ctrl on EKR then P | Quick Open dialog appears | | |
 | KB-9 | Extra Key Row trackpad | Drag on the trackpad: slowly first, then keep going without lifting, then diagonally | Cursor steps character by character at first and speeds up the longer the drag gets; a diagonal drag moves on both axes. There are no arrow buttons to press: the trackpad replaced them, so it is the only way a touch user moves the cursor | | |
-| KB-10 | Extra Key Row — brackets | Press {, }, (, ) on EKR | Characters inserted in editor | | |
+| KB-10 | Extra Key Row, brackets on the textarea edit path | On a device whose WebView is older than 121, open a file and press {, }, (, ) on the key row. Confirm the path first in remote debugging: `document.querySelectorAll("textarea.inputarea").length` is 1 | Each character is inserted, and Monaco auto-closes the pair | | |
+| KB-11 | Extra Key Row, brackets on the EditContext edit path | On a device whose WebView is 121 or newer, same presses. Confirm the path first: `document.querySelectorAll("textarea.inputarea").length` is 0 and `document.querySelectorAll("div.native-edit-context").length` is 2 | Each character is inserted. This is the path where anything written to a textarea is inert, so a pass here and a fail on KB-10 means the fix went to the wrong layer | | |
 
 ## 4. Screen & Orientation
 
@@ -207,7 +208,7 @@ first launch of a build that has this line, so the row to run instead is TC-8.
 |----------|-------|------|------|------|
 | Device Matrix | 4 | | | |
 | Android Versions | 4 | | | |
-| Keyboard Input | 10 | | | |
+| Keyboard Input | 11 | | | |
 | Screen & Orientation | 6 | | | |
 | Editor Operations | 8 | | | |
 | Extensions | 6 | | | |
@@ -217,7 +218,7 @@ first launch of a build that has this line, so the row to run instead is TC-8.
 | Toolchains | 6 | | | |
 | Terminal & Tools | 11 | | | |
 | SAF & Files | 8 | | | |
-| **Total** | **85** | | | |
+| **Total** | **86** | | | |
 
 **Overall Result**: [ ] PASS / [ ] FAIL
 


### PR DESCRIPTION
Character keys on the extra key row inserted nothing in the editor. The row delivered every key as a synthetic DOM `KeyboardEvent` built in JavaScript; an untrusted event runs the workbench's key bindings but performs no default action, so command keys such as Tab worked while `{`, `(`, `;` and every other printing character silently did nothing, with a debug log line claiming the key had been injected.

Characters now go through a real Android `KeyEvent` dispatched to the WebView, which is the browser's own text input path and works on both editor input paths (the hidden textarea on older WebViews, `EditContext` on 121+, which has no textarea in the DOM at all). Commands and chords keep the existing DOM path, because that is what resolves the bindings.

- A latched Shift resolves to the shifted character before routing, read back out of `KeyMapping`'s own table (`/` and `?` are one `Slash` keyCode apart only in `requiresShift`). The row offers no other route to `?`, `+`, `}`, `)` and friends, so dropping the modifier would type the base character, which is worse than typing nothing.
- A press the WebView refuses (renderer being rebuilt, view detached mid folder-switch) is reported as refused and falls back instead of being swallowed, with a warning that survives release builds.
- The long-press popup dismisses before it emits, because it is focusable and a key press aimed at an unfocused window is fragile; `\`, `` ` `` and `~` reach the editor through no other route.
- The duplicated `{`/`(` branches in `ExtraKeyRow` are gone; their comment claimed Monaco auto-closes, which cannot happen when nothing is inserted.

Verified on devices against both editor paths, with the path confirmed first via remote debugging in each case:

- WebView 109 (`textarea.inputarea` = 1): pressing `{}` then `()` on the row produces `{()}` with Monaco auto-closing each pair.
- WebView 150 (`textarea.inputarea` = 0, `native-edit-context` = 2): same presses, same result. This is the path where anything written to a textarea is inert, so a pass here shows the fix is at the right layer.

Nine JVM cases cover the routing, driven from `KeyPages.defaults` so a key added later is covered automatically. Each fix was checked by removing it and confirming exactly the expected cases go red. `docs/DEVICE_TEST_CHECKLIST.md` splits the bracket row into one row per edit path, and its summary counts move with it. Suite: 1255 tests, 0 failures.
