### PR TITLE
docs: correct where the ELF checker is cache-keyed

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -688,9 +688,13 @@ fun jniLibsHoldsRealBinary(): Boolean =
 // assets-cache hit restores jniLibs/arm64-v8a/ wholesale with every download step
 // skipped by `if: cache-hit != 'true'`, and a local `./gradlew assembleDebug`
 // after an old fetch never re-downloads anything. scripts/verify-android-elf.py
-// is also in neither CI cache key -- measured, 0 hits in both, against 1 for
-// verify-server-tree.py -- so tightening the checker does not invalidate a cached
-// binary that only ever passed the looser version of it.
+// is hashed into three CI cache keys: build.yml's `downloads-` and `assets-`,
+// and release.yml's `downloads-`. verify-server-tree.py is in the same three,
+// so the contrast this comment used to draw between them does not exist.
+// Tightening the checker therefore changes all three keys, the caches miss,
+// and every binary is fetched and examined again by the stricter version
+// rather than staying behind on the looser one. Re-measure with:
+//     grep -c 'verify-android-elf.py' .github/workflows/*.yml
 //
 // What that costs when it goes wrong is the quietest failure this project has:
 // a mis-built ripgrep installs perfectly and makes Search return no results,

--- a/scripts/verify-android-elf.py
+++ b/scripts/verify-android-elf.py
@@ -188,9 +188,12 @@ def main() -> int:
     # actually ships, and it exists because per-file checking left a gap: every
     # download script checks the binary it just installed, so a binary restored
     # from a build cache, or left by an earlier fetch, used to go unexamined from
-    # then on. This checker is also in neither CI cache key -- 0 hits in both,
-    # against 1 for verify-server-tree.py -- so tightening it does not by itself
-    # cause a cached binary to be looked at again.
+    # then on. This checker is hashed into three CI cache keys (build.yml's
+    # `downloads-` and `assets-`, release.yml's `downloads-`), the same three
+    # that carry verify-server-tree.py. So tightening it changes those keys,
+    # the caches miss, and every binary is fetched and examined again under
+    # the stricter rule. Re-measure with:
+    #     grep -c 'verify-android-elf.py' .github/workflows/*.yml
     ap.add_argument("--dir", type=pathlib.Path,
                     help="check every *.so in this directory instead of one file")
     ap.add_argument("--lib-dir", type=pathlib.Path, action="append", default=[],


### PR DESCRIPTION
Two comments, one on the packaging task in `android/app/build.gradle.kts` and one in `scripts/verify-android-elf.py`, said the ELF checker sits in neither CI cache key, reported that as measured at zero hits against one for `verify-server-tree.py`, and concluded that tightening the checker leaves a cached binary behind on the looser rule.

Both halves of the measurement are wrong today. The checker is hashed into three cache keys (`build.yml`'s `downloads-` and `assets-`, `release.yml`'s `downloads-`), and `verify-server-tree.py` is in the same three, so the contrast the comments drew does not exist either. The conclusion inverts with the count: editing the checker changes every key that names it, the caches miss, and each binary is fetched and examined again under the stricter rule. A reader who trusted the comments could add a second cache-busting mechanism for a problem that has none.

Both comments now name the three keys and carry the one-line command that re-measures them.

Comments only; no behavior changes and no CHANGELOG entry.
