### PR TITLE
fix(ui): give two silent failures a cause the user can read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A first run that fails now names the step and quotes the error, instead of only "Setup failed" and a Retry that walks into the same wall.
+- A link that no installed app can open now says so. The tap did nothing and said nothing, which reads as a broken link rather than a missing app.
 - Tapping the editor now raises the keyboard, and what it types now arrives. The app never took Android input focus for its view, so keyboard input was silently discarded.
 - Brackets, quotes and other symbols on the extra key row now type into the editor. On recent WebViews they inserted nothing at all.
 - A save the sync refuses to write back now says so. It was silent, so an edit that never reached the device folder looked exactly like one that did.

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -1426,6 +1426,22 @@ class MainActivity : AppCompatActivity() {
             openFolder = { openWorkspaceFolder },
             connectionToken = { nodeService?.getConnectionToken() },
             onCrash = { recreateWebView() },
+            // A hand-off that no app accepted used to be indistinguishable from a
+            // dead link: the WebView does not navigate either, so the tap did
+            // nothing and said nothing. ActivityNotFoundException is separated
+            // out because it is the one the user can act on by installing
+            // something; everything else is quoted by type for a bug report.
+            onHandoffFailed = { uri, error ->
+                val scheme = uri.scheme ?: "external"
+                val message = if (error is android.content.ActivityNotFoundException) {
+                    getString(R.string.url_handoff_no_app, scheme)
+                } else {
+                    getString(R.string.url_handoff_failed, scheme, error.javaClass.simpleName)
+                }
+                runOnUiThread {
+                    Toast.makeText(this@MainActivity, message, Toast.LENGTH_LONG).show()
+                }
+            },
             onPageLoaded = { url ->
                 folderFromUrl(url)?.let {
                     openWorkspaceFolder = it

--- a/android/app/src/main/kotlin/com/vscodroid/SplashActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/SplashActivity.kt
@@ -205,7 +205,17 @@ class SplashActivity : AppCompatActivity() {
                     showSetupError(statusText, progressBar, message, setup)
                 }
                 FirstRunSetup.SetupResult.ERROR -> {
-                    showSetupError(statusText, progressBar, getString(R.string.error_setup_failed), setup)
+                    // The cause, when setup got far enough to know one. It reached
+                    // Logger.e and nothing else before this, so a release build
+                    // left the user with "Setup failed" and a Retry button that
+                    // walks into the same wall.
+                    val failure = setup.lastFailure
+                    val message = if (failure == null) {
+                        getString(R.string.error_setup_failed)
+                    } else {
+                        getString(R.string.error_setup_failed_at, failure.step, failure.detail)
+                    }
+                    showSetupError(statusText, progressBar, message, setup)
                 }
             }
         }

--- a/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
@@ -40,6 +40,30 @@ class FirstRunSetup(
 
     enum class SetupResult { SUCCESS, LOW_STORAGE, ERROR }
 
+    /** What the run was doing when it failed, and what the failure was. */
+    data class Failure(val step: String, val detail: String)
+
+    /**
+     * The cause of the last [SetupResult.ERROR], or null if setup has not failed.
+     *
+     * Read by whoever shows the failure. Until this existed the exception went to
+     * `Logger.e` and nowhere else, so a release build told the user "Setup failed"
+     * and kept the only useful sentence to itself. Retrying blind is the whole of
+     * what was left to them, and a device out of space retries into the same wall
+     * for ever.
+     *
+     * Set immediately before the ERROR is returned and never cleared: a stale
+     * value cannot be shown, because the only screen that reads it reads it in the
+     * same branch that just set it.
+     */
+    @Volatile
+    var lastFailure: Failure? = null
+        private set
+
+    /** The most recent [reportProgress] label, which names the step in flight. */
+    @Volatile
+    private var currentStep: String? = null
+
     fun isFirstRun(): Boolean = setupIsStale(
         prefs.getString(KEY_VERSION, null),
         prefs.getInt(KEY_VERSION_CODE, 0),
@@ -306,6 +330,7 @@ class FirstRunSetup(
             SetupResult.SUCCESS
         } catch (e: Exception) {
             Logger.e(tag, "First-run setup failed", e)
+            lastFailure = describeFailure(currentStep, e)
             SetupResult.ERROR
         }
     }
@@ -2171,10 +2196,45 @@ claude() {
 
     private fun reportProgress(message: String, percent: Int) {
         Logger.d(tag, "Progress: $percent% - $message")
+        // The single funnel every step already reports through, which is why the
+        // failing step can be named without threading a parameter through the
+        // twenty call sites below.
+        currentStep = message
         onProgress?.invoke(message, percent)
     }
 
     companion object {
+        /** How much of an exception message is worth putting on a splash screen. */
+        internal const val DETAIL_LIMIT = 120
+
+        /**
+         * The user-facing description of a failure: which step, and what went wrong.
+         *
+         * A pure function in the companion so it can be exercised without a
+         * `Context`, which the enclosing class needs and a JVM test cannot supply.
+         *
+         * The exception message is kept, not just its type. It is the half that
+         * says something actionable, "No space left on device" or "Permission
+         * denied", while the type alone says only that something threw. It is
+         * truncated because a message can carry a whole stack of causes, and a
+         * splash screen is not a log viewer; the untruncated one is already in
+         * `Logger.e` above the call site.
+         *
+         * Trailing ellipsis is stripped from the step because every progress label
+         * ends in one, and "failed while Extracting server files..." reads as if
+         * the sentence itself were unfinished.
+         */
+        internal fun describeFailure(step: String?, error: Throwable): Failure {
+            val type = error.javaClass.simpleName
+            val message = error.message?.trim().orEmpty()
+            val detail = when {
+                message.isEmpty() -> type
+                message.length <= DETAIL_LIMIT -> "$type: $message"
+                else -> "$type: " + message.take(DETAIL_LIMIT).trimEnd() + "\u2026"
+            }
+            return Failure(step?.trimEnd('.', ' ').orEmpty(), detail)
+        }
+
         /** The band the server extraction reports across; the next step opens at 60. */
         private const val SERVER_PROGRESS_START = 5
         private const val SERVER_PROGRESS_END = 60

--- a/android/app/src/main/kotlin/com/vscodroid/webview/VSCodroidWebViewClient.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/webview/VSCodroidWebViewClient.kt
@@ -270,6 +270,24 @@ class VSCodroidWebViewClient(
     private val onCrash: () -> Unit,
     private val onPageLoaded: (String?) -> Unit,
     private val onRetryServer: () -> Unit,
+    /**
+     * Told when a URL this app decided to hand away could not be handed away.
+     *
+     * A constructor parameter for the reason the three above are: this class has
+     * no screen and no context of its own beyond the one the request carries.
+     * Until it existed, `startActivity` throwing meant a `Logger.e` and nothing
+     * else, and `return true` below stops the WebView from navigating either, so
+     * the tap did nothing at all and said nothing at all. `ActivityNotFoundException`
+     * for `ssh:`, `git:` or `intent:`, `FileUriExposedException` for `file:` and
+     * `SecurityException` for a `content://` without a grant all land in the same
+     * catch and all looked identical to a broken link.
+     *
+     * Deliberately NOT a pre-flight. Detecting handlers with `<queries>` plus
+     * `resolveActivity` would answer null for handlers that do exist under
+     * package-visibility filtering, and enumerating schemes to make it work is a
+     * destination allowlist under another name. The exception is the signal.
+     */
+    private val onHandoffFailed: (Uri, Throwable) -> Unit = { _, _ -> },
 ) : WebViewClient() {
 
     private val tag = "WebViewClient"
@@ -340,6 +358,7 @@ class VSCodroidWebViewClient(
         } catch (e: Exception) {
             AuthTabWindow.disarm(armed)
             Logger.e(tag, "Failed to open external URL: ${redactToken(url.toString())}", e)
+            onHandoffFailed(url, e)
         }
         return true  // Don't navigate WebView to external URL
     }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -43,6 +43,23 @@
          failed in the same place. See FirstRunSetup.requiredStorageMb(). -->
     <string name="error_storage_full">Not enough storage space. Free at least %1$d MB and try again.</string>
     <string name="error_setup_failed">Setup failed. Tap Retry or reinstall the app.</string>
+    <!-- The same failure when setup knows which step it died on. Names the step
+         and quotes the exception, because the audience is developers and the
+         next thing they do is either free some space or file the message. The
+         version without a cause stays for a failure that happens before the
+         first progress report. -->
+    <string name="error_setup_failed_at">Setup failed while: %1$s\n\n%2$s\n\nTap Retry, or reinstall the app if it keeps failing.</string>
+
+    <!-- A tap on a link this app handed to Android that no app took. Names the
+         scheme rather than the whole address, which can be long and can carry a
+         token, and says the one thing the user can act on: nothing here is
+         broken, there is simply nothing installed that opens this kind of link. -->
+    <string name="url_handoff_no_app">No installed app opens %1$s links.</string>
+    <!-- The same tap failing for any other reason: a file:// URI Android refuses
+         to expose, a content:// without a grant, anything else. The exception
+         type is quoted because the audience is developers and it is the part
+         worth putting in a bug report. -->
+    <string name="url_handoff_failed">Could not open that %1$s link (%2$s).</string>
 
     <!-- Shown on the page itself, not in a toast, when the restart budget is
          spent. The screen behind it read "Starting server..." and went on

--- a/android/app/src/test/kotlin/com/vscodroid/setup/SetupAbortsOnIncompleteTreeTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/SetupAbortsOnIncompleteTreeTest.kt
@@ -15,6 +15,8 @@ import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -135,5 +137,47 @@ class SetupAbortsOnIncompleteTreeTest {
         runBlocking { FirstRunSetup(context).runSetup() }
 
         verify(exactly = 0) { editor.putString(any(), any()) }
+    }
+
+    /**
+     * And the failure has to be able to say what it was.
+     *
+     * The description itself is pinned by `SetupFailureCauseTest`, which drives
+     * the pure function directly. What that cannot show is whether the catch ever
+     * fills it in, and a describer nothing calls is the whole defect wearing a
+     * fix: the screen falls back to "Setup failed" and the user is exactly where
+     * they started. This drives the real run to a real failure and reads what was
+     * left behind.
+     */
+    @Test
+    fun `a failed setup leaves the cause behind for the screen to read`() {
+        blockTheServerWrite()
+        val setup = FirstRunSetup(context)
+
+        runBlocking { setup.runSetup() }
+
+        val failure = setup.lastFailure
+        assertNotNull(failure, "setup failed and left nothing for the screen to show")
+        assertTrue(
+            failure!!.step.isNotEmpty(),
+            "the failure names no step, so the screen can only say that something went wrong",
+        )
+        assertTrue(
+            failure.detail.isNotEmpty(),
+            "the failure carries no detail, so the exception still reaches only logcat",
+        )
+    }
+
+    /**
+     * The control. A run that succeeds must leave nothing behind, or the next
+     * failure screen would show a cause from a run that worked.
+     */
+    @Test
+    fun `a setup that succeeds leaves no cause behind`() {
+        val setup = FirstRunSetup(context)
+
+        runBlocking { setup.runSetup() }
+
+        assertNull(setup.lastFailure, "a successful run recorded a failure cause")
     }
 }

--- a/android/app/src/test/kotlin/com/vscodroid/setup/SetupFailureCauseTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/SetupFailureCauseTest.kt
@@ -1,0 +1,103 @@
+package com.vscodroid.setup
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.IOException
+
+/**
+ * What a failed first run is able to tell the user.
+ *
+ * Setup catches everything at one point and returns a bare `ERROR`. The exception
+ * went to `Logger.e` and nowhere else, and `Logger.e` is not readable on a release
+ * build without a cable, so the whole of what the user got was "Setup failed" and
+ * a Retry button. Retrying is the only move that string suggests, and it is the
+ * wrong one for the two failures most likely to be real: no space left, and a
+ * permission the app does not have. Both repeat for ever.
+ *
+ * These drive the pure half, which is the half that decides what appears on the
+ * screen. The wiring that carries it there is one branch in `SplashActivity`.
+ */
+class SetupFailureCauseTest {
+
+    /**
+     * The message is kept, not just the type. It is the half that names something
+     * the user can act on; `IOException` alone says only that something threw.
+     */
+    @Test
+    fun `the exception message survives into the description`() {
+        val failure = FirstRunSetup.describeFailure(
+            "Extracting server files...", IOException("No space left on device")
+        )
+
+        assertEquals("Extracting server files", failure.step)
+        assertEquals("IOException: No space left on device", failure.detail)
+    }
+
+    /**
+     * Every progress label ends in an ellipsis, and the screen reads
+     * "Setup failed while: <step>". Left in place the sentence looks unfinished.
+     */
+    @Test
+    fun `the step loses the trailing ellipsis of its progress label`() {
+        val failure = FirstRunSetup.describeFailure("Setting up git...", IOException("x"))
+
+        assertEquals("Setting up git", failure.step)
+        assertFalse(failure.step.endsWith("."), "the step still trails a progress ellipsis")
+    }
+
+    /**
+     * A failure before the first progress report has no step to name. The screen
+     * falls back to the plain string, so an empty step has to be distinguishable
+     * from a real one rather than rendering as "failed while: ".
+     */
+    @Test
+    fun `a failure with no step reported yet describes an empty step`() {
+        val failure = FirstRunSetup.describeFailure(null, IOException("early"))
+
+        assertEquals("", failure.step)
+        assertEquals("IOException: early", failure.detail)
+    }
+
+    /**
+     * Some exceptions carry no message at all. Appending an empty one would put a
+     * bare colon on the screen.
+     */
+    @Test
+    fun `an exception with no message contributes only its type`() {
+        val failure = FirstRunSetup.describeFailure("Creating directories...", IllegalStateException())
+
+        assertEquals("IllegalStateException", failure.detail)
+        assertFalse(failure.detail.endsWith(":"), "a bare colon reached the message")
+    }
+
+    /**
+     * A chained exception can carry a paragraph. The splash screen is not a log
+     * viewer, and the untruncated text is already in `Logger.e` at the call site.
+     */
+    @Test
+    fun `a very long message is truncated and marked as truncated`() {
+        val long = "x".repeat(FirstRunSetup.DETAIL_LIMIT * 3)
+        val failure = FirstRunSetup.describeFailure("Extracting tools...", IOException(long))
+
+        assertTrue(
+            failure.detail.length < long.length,
+            "a ${long.length} character message reached the screen whole",
+        )
+        assertTrue(failure.detail.endsWith("…"), "the truncation is not marked")
+    }
+
+    /**
+     * The control. Truncation must not eat a message that fits, or every ordinary
+     * failure would be reported as if something had been withheld.
+     */
+    @Test
+    fun `a message at the limit is not truncated`() {
+        val exact = "y".repeat(FirstRunSetup.DETAIL_LIMIT)
+        val failure = FirstRunSetup.describeFailure("Setting up tools...", IOException(exact))
+
+        assertEquals("IOException: $exact", failure.detail)
+        assertFalse(failure.detail.endsWith("…"), "a message that fits was marked truncated")
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/webview/ExternalUrlHandoffTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/ExternalUrlHandoffTest.kt
@@ -1,5 +1,6 @@
 package com.vscodroid.webview
 
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -19,6 +20,7 @@ import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.verify
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -154,8 +156,12 @@ class ExternalUrlHandoffTest {
         )
     }
 
+    /** Every hand-off failure the client announced, in order. */
+    private val announced = mutableListOf<Pair<String?, String>>()
+
     @BeforeEach
     fun setUp() {
+        announced.clear()
         mockkObject(Logger)
         every { Logger.i(any(), any()) } just Runs
         every { Logger.e(any(), any(), any()) } just Runs
@@ -183,6 +189,9 @@ class ExternalUrlHandoffTest {
             onCrash = {},
             onPageLoaded = {},
                     onRetryServer = { retried = true },
+            onHandoffFailed = { uri, error ->
+                announced += uri.scheme to error.javaClass.simpleName
+            },
         )
     }
 
@@ -397,5 +406,85 @@ class ExternalUrlHandoffTest {
                 "editor arrives here, so recording them all reopens the window an unsolicited " +
                 "vscodroid://callback is taken in.",
         )
+    }
+
+    /**
+     * The case this channel exists for. Nothing on the device answers `ssh:`, so
+     * `startActivity` throws, and `return true` below stops the WebView from
+     * navigating too. Before the channel existed the tap did nothing and said
+     * nothing, and the user's only reading was that the link was broken.
+     */
+    @Test
+    fun `a scheme no app answers is announced`() {
+        every { context.startActivity(any()) } throws ActivityNotFoundException("no handler")
+
+        val handled = client.shouldOverrideUrlLoading(
+            view, request("ssh", "git@example.com", -1, "ssh://git@example.com")
+        )
+
+        assertTrue(handled, "the WebView was left to navigate to a scheme it cannot load")
+        assertEquals(listOf("ssh" to "ActivityNotFoundException"), announced)
+    }
+
+    /**
+     * The three exception types the audit named land in one catch, and the user
+     * cannot tell them apart from the outside. Each still has to produce a
+     * notice, because a channel that only covers the easy one leaves the same
+     * silence for the other two.
+     */
+    @Test
+    fun `a file URI Android refuses to expose is announced`() {
+        every { context.startActivity(any()) } throws IllegalStateException("FileUriExposed")
+
+        client.shouldOverrideUrlLoading(
+            view, request("file", "/sdcard/x.txt", -1, "file:///sdcard/x.txt")
+        )
+
+        assertEquals(listOf("file" to "IllegalStateException"), announced)
+    }
+
+    @Test
+    fun `a content URI without a grant is announced`() {
+        every { context.startActivity(any()) } throws SecurityException("no grant")
+
+        client.shouldOverrideUrlLoading(
+            view, request("content", "doc/1", -1, "content://authority/doc/1")
+        )
+
+        assertEquals(listOf("content" to "SecurityException"), announced)
+    }
+
+    /**
+     * The control, and it is what stops the cases above from passing because the
+     * channel fires unconditionally. A hand-off that succeeded is not a failure,
+     * and a notice on every followed link would be worse than the silence it
+     * replaced.
+     */
+    @Test
+    fun `a hand-off that succeeds announces nothing`() {
+        every { context.startActivity(any()) } returns Unit
+
+        client.shouldOverrideUrlLoading(
+            view, request("https", "example.com", -1, "https://example.com/docs")
+        )
+
+        assertTrue(announced.isEmpty(), "announced $announced for a link that opened")
+    }
+
+    /**
+     * The retry navigation is answered on this side and never handed away, so it
+     * cannot fail as a hand-off. Without this the retry case and the failure
+     * cases could both be satisfied by a channel wired to the wrong branch.
+     */
+    @Test
+    fun `the retry navigation announces nothing`() {
+        retried = false
+
+        client.shouldOverrideUrlLoading(
+            view, request("vscodroid", "retry-server", -1, RETRY_URL)
+        )
+
+        assertTrue(retried, "the retry branch did not run")
+        assertTrue(announced.isEmpty(), "announced $announced for our own control")
     }
 }


### PR DESCRIPTION
Two failures reached `Logger` and nowhere else. `Logger.e` is not readable on a
release build without a cable, so what the user got was a screen that said
nothing useful and a control that could not help.

## First run

A run that throws returned a bare `ERROR`, and the screen said "Setup failed.
Tap Retry or reinstall the app." Retry is the only move that string suggests,
and it is the wrong one for the two failures most likely to be real: no space
left, and a permission the app does not have. Both repeat for ever.

- `reportProgress` is the single funnel every step already reports through, so
  the failing step can be named without threading a parameter through twenty
  call sites.
- `describeFailure` pairs the step with the exception and keeps the **message**,
  not just the type. "No space left on device" is the half that says what to do;
  `IOException` alone says only that something threw.
- Truncated at 120 characters. A splash screen is not a log viewer, and the
  whole text is already in `Logger.e` above the call site.
- The trailing ellipsis is stripped from the step, because every progress label
  ends in one and "failed while: Extracting server files..." reads as if the
  sentence itself were unfinished.

## URL hand-off

Worse, because `shouldOverrideUrlLoading` returns true and stops the WebView
navigating too, so the tap did nothing at all and said nothing at all.
`ActivityNotFoundException` for `ssh:`, `git:` or `intent:`,
`FileUriExposedException` for `file:` and `SecurityException` for a `content://`
without a grant all land in one catch, and all looked identical to a dead link.

- `onHandoffFailed` carries the URI and the throwable out to a screen.
  `AuthTabWindow.disarm` and the `return true` are unchanged.
- The notice separates "nothing installed opens this" from everything else,
  because only the first is something the user can act on.

**Deliberately not a pre-flight.** `<queries>` plus `resolveActivity()` would
answer null for handlers that do exist under package-visibility filtering, and
enumerating schemes to make it work is a destination allowlist under another
name. The exception is the signal.

## Verification

Eleven cases, each checked against the change it guards rather than assumed:

| Control | Turns red |
|---|---|
| Remove the hand-off announcement | the three failure paths, both controls stay green |
| Announce unconditionally | the succeeded-hand-off control |
| Drop the ellipsis strip | 2 cases |
| Drop the truncation | 1 case |
| Append an empty message anyway | 1 case |
| Stop filling in `lastFailure` | the real-run wiring case |

The last row is the one that matters most. The description is pinned by a pure
function, and a describer nothing calls is the whole defect wearing a fix, so
one case drives a real `runSetup()` to a real failure and reads what was left
behind. Its own control asserts a successful run leaves nothing behind, so a
later failure screen cannot show a cause from a run that worked.

Full suite 1268 tests, 0 failures. Lint holds at 52 warnings. All 11 gates in
`lint.yml` and `build.yml` pass, plus the patch parse, the device-suite
self-check and the eight Node self-checks.

## Not in this change

The third finding in the same group, the key row being unpressable under
TalkBack and having no discrete arrow keys, is being done separately by whoever
holds `keyboard/`.
