### PR TITLE
fix(menus): dismiss a submenu only on real scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - A first run that fails now names the step and quotes the error, instead of only "Setup failed" and a Retry that walks into the same wall.
 - A link that no installed app can open now says so. The tap did nothing and said nothing, which reads as a broken link rather than a missing app.
+- Dragging a finger inside an application menu now scrolls it instead of closing the submenu. A menu that cannot scroll still reported scrolling, and the submenu closed on it.
 - Tapping the editor now raises the keyboard, and what it types now arrives. The app never took Android input focus for its view, so keyboard input was silently discarded.
 - Brackets, quotes and other symbols on the extra key row now type into the editor. On recent WebViews they inserted nothing at all.
 - A save the sync refuses to write back now says so. It was silent, so an edit that never reached the device folder looked exactly like one that did.

--- a/patches/0014-menu-dismiss-submenu-only-on-real-scroll.patch
+++ b/patches/0014-menu-dismiss-submenu-only-on-real-scroll.patch
@@ -1,0 +1,50 @@
+Dismiss a submenu only when the parent menu actually scrolled.
+
+On a touch screen, opening the application menu and dragging a finger inside
+it closes the submenu instead of scrolling it. The chain: every menu item and
+the menu itself are gesture targets, and a gesture is dispatched to every
+registered target that contains the touch point, so one finger movement
+reaches the parent menu's own scroll handling. That handler calls
+setScrollPosition, and the scrollable's state change detection compares the
+raw, unclamped scroll position, so a menu that cannot scroll at all still
+emits onScroll events. The submenu entry subscribes to the parent's onScroll
+and dismisses itself unconditionally, so the first touch drag closes it, and
+a drag is the only way a touch user can scroll.
+
+The ScrollEvent already carries the discriminator: scrollTopChanged and
+scrollLeftChanged are computed from the clamped positions, so they are false
+for these phantom events and true whenever the menu genuinely moved. Gate the
+dismissal on them. A parent that really scrolls still dismisses its submenu,
+which is the behaviour this handler exists for: the submenu is anchored to an
+item that has moved away.
+
+Mouse users never see any of this, because a wheel over a menu that cannot
+scroll changes nothing and a menu that can scroll dismisses correctly either
+way. The visible change is touch only.
+
+Upstream: the same change is proposed against microsoft/vscode; this patch
+carries it until it lands in a version this build pins.
+
+diff --git a/src/vs/base/browser/ui/menu/menu.ts b/src/vs/base/browser/ui/menu/menu.ts
+index 7bb39f0..ca3b750 100644
+--- a/src/vs/base/browser/ui/menu/menu.ts
++++ b/src/vs/base/browser/ui/menu/menu.ts
+@@ -821,7 +821,17 @@ class SubmenuMenuActionViewItem extends BaseMenuActionViewItem {
+ 			}
+ 		}));
+ 
+-		this._register(this.parentData.parent.onScroll(() => {
++		this._register(this.parentData.parent.onScroll(e => {
++			if (!e.scrollTopChanged && !e.scrollLeftChanged) {
++				// A menu emits scroll events even when it cannot scroll: a state
++				// change is detected on the raw, unclamped scroll position, so a
++				// touch drag over a menu that fits its viewport fires onScroll
++				// with the clamped position unchanged. Dismissing the submenu on
++				// those events closes it on the first touch drag, and on a touch
++				// screen a drag is the only way to scroll. Real scrolling of the
++				// parent still dismisses below.
++				return;
++			}
+ 			if (this.parentData.submenu === this.mysubmenu) {
+ 				this.parentData.parent.focus(false);
+ 				this.cleanupExistingSubmenu(true);

--- a/patches/fingerprints.txt
+++ b/patches/fingerprints.txt
@@ -85,3 +85,9 @@
 0011 walkthrough brand|out/nls.messages.js|Get Started with VSCodroid
 0012 callback route|out/server-main.js|==="/callback"
 0013 level grace|out/server-main.js|while another client is connected
+# 0014 gates on the CLAMPED change flags. The pattern is the negated pair the
+# guard compiles to; measured in the pre-patch bundle it occurs zero times
+# (the positive control `scrollTopChanged` occurs 41 times), and an esbuild
+# minify of the new handler emits `!n.scrollTopChanged&&!n.scrollLeftChanged`,
+# so the token survives and only this patch introduces it.
+0014 menu submenu scroll dismiss|out/vs/workbench/workbench.web.main.internal.js|scrollTopChanged&&!


### PR DESCRIPTION
On a touch screen, opening the application menu and dragging a finger inside it closed the submenu instead of scrolling it. This is the report in issue #310. The chain, measured event by event on device: one finger movement is dispatched to every gesture target containing the touch point, so it reaches the parent menu's scroll handling; scroll state changes are detected on the raw, unclamped position, so a menu that cannot scroll still emits `onScroll`; and the submenu entry dismissed itself on every parent `onScroll`. On a touch screen a drag is the only way to scroll, so the gesture for scrolling was the gesture for dismissal.

- `patches/0014` gates the dismissal on the `ScrollEvent`'s clamped change flags, which are false for these phantom events and true whenever the menu genuinely moved. A parent that really scrolls still dismisses its submenu, which is what the handler exists for. That boundary is deliberate: in landscape, where the parent menu genuinely overflows, a drag that really scrolls the parent still closes the submenu.
- The fingerprint pattern was chosen by measurement: `scrollTopChanged&&!` occurs zero times in the pre-patch bundle (the bare property name occurs 41 times), and an esbuild minify of the new handler emits it, so the gate refuses any tree built without this patch.
- The `server-1.133.0` tarball was rebuilt from this branch before this PR was opened, so CI fetches a tree that carries the patch and the fingerprint gate passes. The same change is proposed upstream (microsoft/vscode#331839).

Verification: unit gates plus a device run driven by touch only, before and after the rebuilt server tree; results in the comments below.
