### PR TITLE
fix(saf): tell the user when work never reached the device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A file the device folder refuses to create now says so. It stayed inside the app looking synced, and the difference only showed after an uninstall.
+- A folder copied out that did not arrive whole now says how much is missing, once for the folder rather than once for every file in it.
 - A first run that fails now names the step and quotes the error, instead of only "Setup failed" and a Retry that walks into the same wall.
 - A link that no installed app can open now says so. The tap did nothing and said nothing, which reads as a broken link rather than a missing app.
 - Dragging a finger inside an application menu now scrolls it instead of closing the submenu. A menu that cannot scroll still reported scrolling, and the submenu closed on it.

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -392,6 +392,21 @@ class MainActivity : AppCompatActivity() {
         // The other direction: documents the device holds that did not reach the editor.
         // Its own wording, because "the only copy is inside VSCodroid" is the opposite of
         // true for these, and would send the user looking for a file that is safe.
+        // The outbound direction of the same silence: a folder created in the editor
+        // that did not arrive whole on the device. One notice per folder, and the cap
+        // gets its own wording because it is a limit this app chose rather than the
+        // device refusing.
+        safManager.onUploadIncomplete { dir, lost, capped ->
+            val message = if (capped) {
+                getString(R.string.saf_upload_capped, dir.name)
+            } else {
+                resources.getQuantityString(R.plurals.saf_upload_incomplete, lost, lost, dir.name)
+            }
+            runOnUiThread {
+                Toast.makeText(this@MainActivity, message, Toast.LENGTH_LONG).show()
+            }
+        }
+
         safManager.onDocumentsNotCopied { count, outOfRoom ->
             runOnUiThread {
                 Toast.makeText(

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafStorageManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafStorageManager.kt
@@ -72,6 +72,18 @@ class SafStorageManager(private val context: Context) {
         syncEngine.onDocumentsNotCopied = announce
     }
 
+    /**
+     * Told when a directory copied out to the device arrived incomplete.
+     *
+     * Forwarded rather than set on the engine directly, for the reason the two above
+     * are. Unthrottled, like [onDocumentsNotCopied] and unlike [onWriteBackFailed]:
+     * this fires once per directory copy and the count it carries is the whole burst,
+     * so there is nothing for a throttle to collapse.
+     */
+    fun onUploadIncomplete(announce: (File, Int, Boolean) -> Unit) {
+        syncEngine.onUploadIncomplete = announce
+    }
+
     private val lastFailureAnnouncedAt = AtomicLong(0)
 
     // -- Permission Management --

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
@@ -1124,6 +1124,20 @@ class SafSyncEngine(private val context: Context) {
     internal var onDocumentsNotCopied: (Int, Boolean) -> Unit = { _, _ -> }
 
     /**
+     * Told when a directory being copied out to the device arrived incomplete: which
+     * directory, how many entries did not make it, and whether the enumeration cap was
+     * the reason rather than a provider refusal.
+     *
+     * The outbound twin of [onDocumentsNotCopied], and a separate seam from
+     * [onWriteBackFailed] for a reason of accuracy rather than symmetry. That one says
+     * the app holds the only copy, which is true of a single file that never arrived
+     * and false of a directory where most entries did: announcing forty failures with
+     * it would overstate forty times, and announcing them one by one is another way of
+     * not telling the user anything.
+     */
+    internal var onUploadIncomplete: (File, Int, Boolean) -> Unit = { _, _, _ -> }
+
+    /**
      * How much room is left where the mirror lives.
      *
      * A seam because no JVM test can make a real filesystem answer that it is full, and
@@ -1159,6 +1173,18 @@ class SafSyncEngine(private val context: Context) {
             "Not writing $describedAs back: the device holds a document there " +
                 "that this sync never read, and writing would replace it",
         )
+        announceLost(localFile)
+    }
+
+    /**
+     * Says once that [localFile] exists only inside the app.
+     *
+     * The throttle is per path and lives here rather than at each site, so a file the
+     * watcher retries on every save is announced once instead of on every keystroke.
+     * [startWatching] clears the set for a folder when it is reopened, which is the one
+     * moment the user could act on the notice again.
+     */
+    private fun announceLost(localFile: File) {
         if (refusalsAnnounced.add(localFile.absolutePath)) onWriteBackFailed(localFile)
     }
 
@@ -1303,7 +1329,16 @@ class SafSyncEngine(private val context: Context) {
      * safe to keep.
      */
     private fun createInSaf(localFile: File, parentSafUri: Uri, treeUri: Uri) {
-        val docUri = createOneInSaf(localFile, parentSafUri, treeUri) ?: return
+        val docUri = createOneInSaf(localFile, parentSafUri, treeUri)
+        if (docUri == null) {
+            // The provider refused, and the file exists only inside the app. Exactly
+            // what onWriteBackFailed already means, so it says it rather than a second
+            // wording of the same fact. Until this line the caller returned on the null
+            // and the user was never told: a file they created in the editor simply was
+            // not on the device, and the difference only shows after an uninstall.
+            announceLost(localFile)
+            return
+        }
         if (localFile.isDirectory) {
             // A directory that just appeared brings whatever is inside it; without
             // this it landed on the device empty and its files stayed in the mirror.
@@ -1414,14 +1449,24 @@ class SafSyncEngine(private val context: Context) {
                 made++
             }
         }
-        if (entries.size >= MAX_UPLOAD_ENTRIES) {
-            // Said out loud rather than silently truncated: the user's copy on the
-            // device is then genuinely incomplete, and a log line is the only place
-            // that can say so.
+        val capped = entries.size >= MAX_UPLOAD_ENTRIES
+        if (capped) {
             Logger.w(tag, "Stopped at $MAX_UPLOAD_ENTRIES entries under ${localDir.name}; " +
                 "the rest were not copied to the device")
         }
         Logger.i(tag, "Created $made of ${entries.size} entries under ${localDir.name}")
+
+        // One notice for the directory, not one per entry. `made` already counts both
+        // ways an entry can be lost: a creation the provider refused, and a child
+        // skipped because its own parent was never created. Reading the shortfall off
+        // that count is what keeps a new silent branch from appearing here later, the
+        // way one did when this reported only to the log.
+        //
+        // The comment above the cap used to say a log line was the only place that
+        // could say so. That was true when it was written and stopped being true when
+        // the notice channel arrived, which is the shape a reason comment rots in.
+        val lost = entries.size - made
+        if (lost > 0 || capped) onUploadIncomplete(localDir, lost, capped)
     }
 
     /**

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -148,4 +148,18 @@
         <item quantity="one">Not enough free space: a file could not be copied into the editor. It is unchanged in the device folder.</item>
         <item quantity="other">Not enough free space: %1$d files could not be copied into the editor. They are unchanged in the device folder.</item>
     </plurals>
+
+    <!-- A folder copied out to the device that did not arrive whole. Counts entries
+         rather than naming them, because the failure is usually folder-wide and forty
+         separate notices is another way of telling the user nothing. Deliberately not
+         worded like saf_write_back_failed: most of the folder did arrive, so "the only
+         copy is inside VSCodroid" would overstate. -->
+    <plurals name="saf_upload_incomplete">
+        <item quantity="one">%2$s: one item did not reach the device folder.</item>
+        <item quantity="other">%2$s: %1$d items did not reach the device folder.</item>
+    </plurals>
+    <!-- The same folder stopped by the enumeration cap rather than by a refusal. Named
+         separately because the cause is a limit this app chose, not the device saying
+         no, and the user's next move is to copy the rest out by hand. -->
+    <string name="saf_upload_capped">%1$s is too large to copy out whole. The rest of it stayed inside VSCodroid.</string>
 </resources>

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafUploadSilenceTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafUploadSilenceTest.kt
@@ -1,0 +1,264 @@
+package com.vscodroid.storage
+
+import android.content.ContentResolver
+import android.content.Context
+import android.database.Cursor
+import android.net.Uri
+import android.os.FileObserver
+import android.provider.DocumentsContract
+import com.vscodroid.util.Logger
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.ByteArrayOutputStream
+import java.io.File
+
+/**
+ * What the user is told when work created in the editor does not reach the device.
+ *
+ * Three announcement channels already existed and all three face the same way: a
+ * write-back that failed, a write refused because the device holds a document this
+ * sync never read, and documents that did not arrive when a folder was opened. What
+ * none of them covered is the plainest loss of all, a file created in the editor
+ * that the provider refuses to create. `createOneInSaf` returned null, the caller
+ * returned on it, and the only trace was a `Logger.w` no release build shows anyone.
+ *
+ * A file in that state is not merely unsynced. It exists in one place, inside the
+ * app's private storage, and the user has no reason to suspect it: the editor shows
+ * it, the folder is open, everything looks synced. The difference appears when the
+ * app is uninstalled and the work is gone with it.
+ */
+class SafUploadSilenceTest {
+
+    @TempDir
+    lateinit var mirror: File
+
+    @TempDir
+    lateinit var filesDir: File
+
+    private lateinit var resolver: ContentResolver
+    private lateinit var engine: SafSyncEngine
+    private lateinit var treeUri: Uri
+
+    /** Files announced as existing only inside the app. */
+    private val lost = mutableListOf<String>()
+
+    /** Directories announced as arrived incomplete: name, count, capped. */
+    private val incomplete = mutableListOf<Triple<String, Int, Boolean>>()
+
+    /** Whether the provider will accept a create of a file. */
+    private var filesAccepted = true
+
+    /** Whether the provider will accept a create of a directory. */
+    private var directoriesAccepted = true
+
+    @BeforeEach
+    fun setUp() {
+        lost.clear()
+        incomplete.clear()
+        filesAccepted = true
+        directoriesAccepted = true
+
+        mockkObject(Logger)
+        every { Logger.i(any(), any()) } just Runs
+        every { Logger.d(any(), any()) } just Runs
+        every { Logger.w(any(), any()) } just Runs
+        every { Logger.w(any(), any(), any()) } just Runs
+        every { Logger.e(any(), any()) } just Runs
+        every { Logger.e(any(), any(), any()) } just Runs
+
+        mockkStatic(DocumentsContract::class)
+        every { DocumentsContract.getTreeDocumentId(any()) } returns "root"
+        every { DocumentsContract.buildChildDocumentsUriUsingTree(any(), any()) } returns
+            mockk(relaxed = true)
+        every { DocumentsContract.buildDocumentUriUsingTree(any(), any()) } returns
+            mockk(relaxed = true)
+        every { DocumentsContract.getDocumentId(any()) } returns "root"
+        // The whole of what these cases turn on. A provider that refuses a create
+        // answers null here, which is the documented contract, not an exception.
+        every { DocumentsContract.createDocument(any(), any(), any(), any()) } answers {
+            val isDir = thirdArg<String>() == DocumentsContract.Document.MIME_TYPE_DIR
+            val accepted = if (isDir) directoriesAccepted else filesAccepted
+            if (accepted) mockk<Uri>(relaxed = true) else null
+        }
+
+        resolver = mockk(relaxed = true)
+        // An empty device folder: every local file is a create, never a write into an
+        // existing document.
+        val empty = mockk<Cursor>(relaxed = true)
+        every { empty.moveToNext() } returns false
+        every { resolver.query(any(), any(), any(), any(), any()) } returns empty
+        every { resolver.openOutputStream(any(), any()) } returns ByteArrayOutputStream()
+
+        val context = mockk<Context>(relaxed = true)
+        every { context.contentResolver } returns resolver
+        every { context.filesDir } returns filesDir
+
+        engine = SafSyncEngine(context)
+        engine.onWriteBackFailed = { lost += it.name }
+        engine.onUploadIncomplete = { dir, count, capped ->
+            incomplete += Triple(dir.name, count, capped)
+        }
+        treeUri = mockk(relaxed = true)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        File(mirror.path + SafSyncEngine.SYNCED_RECORD_SUFFIX).delete()
+        unmockkAll()
+    }
+
+    /** The event alone, without the write-back thread's pass over it. */
+    private fun observe(entry: String) {
+        engine.handleMirrorEvent(FileObserver.CREATE, File(mirror, entry), mirror, treeUri)
+    }
+
+    /** The write-back thread's pass over whatever the events queued. */
+    private fun drain() = engine.runWriteBackLoop { false }
+
+    /** One event and its drain, for the cases that need no gap between them. */
+    private fun deliver(entry: String) {
+        observe(entry)
+        drain()
+    }
+
+    /**
+     * A directory event, delivered the only way a JVM test can.
+     *
+     * `watchTree` registers a watch for a directory that exists when the event
+     * arrives, and building a `FileObserver` runs a static initializer that reaches
+     * native code. So the directory is absent at event time and appears before the
+     * drain, which is also the order the watcher's own thread sees in production:
+     * inotify reports the create, and the tree fills in while the queue is drained.
+     */
+    private fun deliverDirectory(name: String, fill: (File) -> Unit) {
+        observe(name)
+        File(mirror, name).apply { mkdirs() }.also(fill)
+        drain()
+    }
+
+    /**
+     * The case this exists for. A file created in the editor, a provider that refuses
+     * it, and until now nothing said so.
+     */
+    @Test
+    fun `a file the provider refuses to create is announced`() {
+        filesAccepted = false
+        File(mirror, "notes.md").writeText("work the user just did")
+
+        deliver("notes.md")
+
+        assertEquals(listOf("notes.md"), lost)
+    }
+
+    /**
+     * The control, and it is what stops the case above from passing because the channel
+     * fires on every create. A file that reached the device is not lost, and a notice
+     * on every save would be worse than the silence it replaced.
+     */
+    @Test
+    fun `a file the provider accepts announces nothing`() {
+        File(mirror, "notes.md").writeText("work the user just did")
+
+        deliver("notes.md")
+
+        assertTrue(lost.isEmpty(), "announced $lost for a file that reached the device")
+    }
+
+    /**
+     * The watcher re-queues a file on every save, so an unthrottled notice would fire
+     * on every keystroke that triggers a write. Once per path is the whole point of
+     * the set the refusal path already used.
+     */
+    @Test
+    fun `a file that keeps failing is announced once`() {
+        filesAccepted = false
+        File(mirror, "notes.md").writeText("first")
+
+        deliver("notes.md")
+        File(mirror, "notes.md").writeText("second")
+        deliver("notes.md")
+        File(mirror, "notes.md").writeText("third")
+        deliver("notes.md")
+
+        assertEquals(listOf("notes.md"), lost, "the same file was announced repeatedly")
+    }
+
+    /**
+     * A folder is the case where per-file notices stop being help. Forty refusals means
+     * forty toasts, which is another way of telling the user nothing, so the directory
+     * is announced once with the count.
+     */
+    @Test
+    fun `a directory whose children are all refused is announced once with the count`() {
+        deliverDirectory("project") { dir ->
+            repeat(3) { File(dir, "file$it.txt").writeText("x") }
+            filesAccepted = false
+        }
+
+        assertTrue(lost.isEmpty(), "a directory-wide failure produced per-file notices: $lost")
+        assertEquals(1, incomplete.size, "expected one notice for the directory, got $incomplete")
+        assertEquals("project", incomplete[0].first)
+        assertTrue(incomplete[0].second > 0, "the notice carries no count")
+        assertTrue(!incomplete[0].third, "a refusal was reported as the enumeration cap")
+    }
+
+    /**
+     * When the folder itself is refused, nothing under it was even attempted, so the
+     * folder is the thing that exists only inside the app and the per-file wording is
+     * the accurate one. This is the boundary between the two channels, and getting it
+     * backwards would either under-report a whole subtree or overstate a partial one.
+     */
+    @Test
+    fun `a directory the provider refuses is announced as lost, not as incomplete`() {
+        deliverDirectory("project") { dir ->
+            repeat(3) { File(dir, "file$it.txt").writeText("x") }
+            directoriesAccepted = false
+        }
+
+        assertEquals(listOf("project"), lost)
+        assertTrue(incomplete.isEmpty(), "a folder that never existed was reported as partial")
+    }
+
+    /**
+     * The other way a folder arrives incomplete, and the one no provider is at fault
+     * for: the enumeration stops at a cap this app chose. Every entry that was reached
+     * succeeded, so the shortfall count is zero and only the flag distinguishes it. A
+     * notice that reported this as a refusal would send the user looking at the device.
+     */
+    @Test
+    fun `a directory stopped by the enumeration cap is announced as capped`() {
+        deliverDirectory("huge") { dir ->
+            repeat(SafSyncEngine.MAX_UPLOAD_ENTRIES + 5) { File(dir, "f$it.txt").writeText("x") }
+        }
+
+        assertEquals(1, incomplete.size, "expected one notice, got $incomplete")
+        assertEquals("huge", incomplete[0].first)
+        assertTrue(incomplete[0].third, "the cap was reported as an ordinary failure")
+    }
+
+    /**
+     * The control for the directory path. Everything arrived, so there is nothing to
+     * say. Without this the case above would pass for an announcement that fires on
+     * every folder copied out.
+     */
+    @Test
+    fun `a directory that arrives whole announces nothing`() {
+        deliverDirectory("project") { dir ->
+            repeat(3) { File(dir, "file$it.txt").writeText("x") }
+        }
+
+        assertTrue(incomplete.isEmpty(), "announced $incomplete for a folder that arrived whole")
+        assertTrue(lost.isEmpty(), "announced $lost for a folder that arrived whole")
+    }
+}


### PR DESCRIPTION
Three announcement channels existed and all three faced the same way: a write-back
that failed, a write refused because the device holds a document this sync never
read, and documents that did not arrive when a folder was opened.

The plainest loss of all had none. `createOneInSaf` returned null, `createInSaf`
returned on it, and the only trace was a `Logger.w` that no release build shows
anyone.

A file in that state is not merely unsynced. It exists in one place, inside the
app's private storage, and nothing gives the user a reason to suspect it: the
editor shows it, the folder is open, everything looks synced. The difference
appears when the app is uninstalled and the work is gone with it.

## Two granularities, because the population is two

| Situation | Channel | Why |
|---|---|---|
| One file never arrived | `onWriteBackFailed` | Already means exactly that, already throttled per path |
| A folder arrived incomplete | `onUploadIncomplete` | Once for the folder, with the count |
| A folder the provider refused outright | `onWriteBackFailed` | Nothing under it was attempted, so the folder is what exists only in the app |

The second seam is about accuracy, not symmetry. `onWriteBackFailed` says the app
holds the only copy, which is true of a file that never arrived and false of a
directory where most entries did. Announcing forty refusals with it would
overstate forty times, and announcing them one by one is another way of telling
the user nothing.

## What keeps a new silent branch from appearing here

The shortfall is read off `made`, which already counts both ways an entry can be
lost: a creation the provider refused, and a child skipped because its own parent
was never created. Deriving the notice from that count rather than from a list of
known failure sites is what stops the next branch added here from being silent by
default, which is how this one got that way.

The enumeration cap keeps its own wording, because it is a limit this app chose
rather than the device refusing, and the user's next move is different. The
comment above it claiming a log line was the only place that could say so is
gone: it was true when written and stopped being true when the notice channel
arrived, without the code around it changing at all.

## Verification

Seven cases, each checked against the change it guards:

| Control | Turns red |
|---|---|
| Remove the file announcement | 3 |
| Remove the directory announcement | 2 |
| Drop the per-path throttle | the repeat case |
| Report the cap as an ordinary failure | the cap case |

The four subsets are disjoint where they should be, so no case is passing on
another's mechanism. One case pins the boundary between the two channels: a
directory the provider refuses outright is announced as lost, not as incomplete.
Getting that backwards would either under-report a whole subtree or overstate a
partial one.

Full suite 1275 tests, 0 failures, up from 1268. Lint holds at 52 warnings, with
no new plurals finding. All 11 gates pass, plus the patch parse, the device-suite
self-check and the eight Node self-checks.

## Scope

This closes the upload direction of the same silence. It does not touch the
remaining data-integrity gap in the same file: two writers can still hold
`openOutputStream(uri, "wt")` on one document, and `"wt"` truncates at open. That
is a separate change with a different risk profile.
