### PR TITLE
fix(keyboard): make the extra key row usable without sight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The gesture trackpad now offers four accessibility actions to move the cursor. A drag was the only way to send an arrow, and a screen reader cannot drag.
+
 ### Changed
 
 - The design documents now describe the build that ships: two on-demand toolchains, terminals that spawn bash on a real PTY, and how the server is actually patched and built.
@@ -42,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A folder copied out that did not arrive whole now says how much is missing, once for the folder rather than once for every file in it.
 - A first run that fails now names the step and quotes the error, instead of only "Setup failed" and a Retry that walks into the same wall.
 - A link that no installed app can open now says so. The tap did nothing and said nothing, which reads as a broken link rather than a missing app.
+- Activating a key on the extra key row through a screen reader now types it. Every key offered activation and none of them did anything.
 - Dragging a finger inside an application menu now scrolls it instead of closing the submenu. A menu that cannot scroll still reported scrolling, and the submenu closed on it.
 - Tapping the editor now raises the keyboard, and what it types now arrives. The app never took Android input focus for its view, so keyboard input was silently discarded.
 - Brackets, quotes and other symbols on the extra key row now type into the editor. On recent WebViews they inserted nothing at all.

--- a/android/app/src/androidTest/kotlin/com/vscodroid/keyboard/KeyRowAccessibilityInstrumentedTest.kt
+++ b/android/app/src/androidTest/kotlin/com/vscodroid/keyboard/KeyRowAccessibilityInstrumentedTest.kt
@@ -1,0 +1,139 @@
+package com.vscodroid.keyboard
+
+import android.view.accessibility.AccessibilityNodeInfo
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * What an accessibility service can actually do with the extra key row.
+ *
+ * The JVM suite cannot answer this: both classes are `View` subclasses whose
+ * initialisers reach resources on the first line, so the unit tests next door
+ * assert the wiring by reading the source instead. These run on a device and
+ * take the same route a screen reader takes -- read the node, find the action,
+ * perform it by id -- so what they pin is the behaviour rather than the shape
+ * of the code that produces it.
+ *
+ * Not run by CI, which compiles the instrumented tests but has no emulator to
+ * run them on. They are here to be run against a device when this area changes,
+ * and to stop compiling if the API they use goes away.
+ */
+@RunWith(AndroidJUnit4::class)
+class KeyRowAccessibilityInstrumentedTest {
+
+    private val context get() = InstrumentationRegistry.getInstrumentation().targetContext
+
+    /**
+     * Runs on the main thread and waits.
+     *
+     * [ExtraKeyButton] builds a `GestureDetector` in its initialiser, which
+     * needs a Looper, and the instrumentation thread has none. A screen reader
+     * also reaches these views on the main thread, so this is the honest place
+     * to drive them from, not a workaround for the test's convenience.
+     */
+    private fun onMain(block: () -> Unit) =
+        InstrumentationRegistry.getInstrumentation().runOnMainSync(block)
+
+    @Test
+    fun activatingAKeyDeliversItsPress() {
+        var delivered: Pair<String, Boolean>? = null
+        var handled = false
+        lateinit var button: ExtraKeyButton
+        onMain {
+            button = ExtraKeyButton(context).apply {
+                keyValue = "Tab"
+                onKeyAction = { key, active -> delivered = key to active }
+            }
+            handled = button.performAccessibilityAction(AccessibilityNodeInfo.ACTION_CLICK, null)
+        }
+
+        assertTrue(
+            "the key advertises no click, so a service would never offer to activate it",
+            button.isClickable,
+        )
+
+        assertTrue("the click action was refused", handled)
+        assertEquals(
+            "activating the key through an accessibility service typed nothing",
+            "Tab" to true,
+            delivered,
+        )
+    }
+
+    @Test
+    fun activatingAModifierReportsTheFlippedState() {
+        var delivered: Pair<String, Boolean>? = null
+        lateinit var button: ExtraKeyButton
+        onMain {
+            button = ExtraKeyButton(context).apply {
+                keyValue = "Ctrl"
+                isToggle = true
+                onKeyAction = { key, active -> delivered = key to active }
+            }
+            button.performAccessibilityAction(AccessibilityNodeInfo.ACTION_CLICK, null)
+        }
+        assertEquals("first activation should switch the modifier on", "Ctrl" to true, delivered)
+
+        onMain { button.performAccessibilityAction(AccessibilityNodeInfo.ACTION_CLICK, null) }
+        assertEquals("second activation should switch it off again", "Ctrl" to false, delivered)
+    }
+
+    @Test
+    fun theTrackpadOffersOneActionPerArrow() {
+        lateinit var trackpad: GestureTrackpad
+        val node = AccessibilityNodeInfo.obtain()
+        onMain {
+            trackpad = GestureTrackpad(context)
+            trackpad.onInitializeAccessibilityNodeInfo(node)
+        }
+
+        val offered = node.actionList.mapNotNull { it.label?.toString() }
+        for ((label, _) in ARROW_ACTIONS) {
+            assertTrue(
+                "no accessibility action is labelled \"$label\"; the node offers $offered",
+                offered.contains(label),
+            )
+        }
+    }
+
+    @Test
+    fun performingAnArrowActionSendsThatArrowAndEndsTheDrag() {
+        val sent = mutableListOf<String>()
+        var dragsEnded = 0
+        lateinit var trackpad: GestureTrackpad
+        val node = AccessibilityNodeInfo.obtain()
+        onMain {
+            trackpad = GestureTrackpad(context).apply {
+                onArrowKey = { sent.add(it) }
+                onDragEnd = { dragsEnded++ }
+            }
+            trackpad.onInitializeAccessibilityNodeInfo(node)
+        }
+
+        for ((label, direction) in ARROW_ACTIONS) {
+            val action = node.actionList.firstOrNull { it.label?.toString() == label }
+            assertNotNull("no action labelled \"$label\"", action)
+
+            var handled = false
+            onMain { handled = trackpad.performAccessibilityAction(action!!.id, null) }
+            assertTrue("the action \"$label\" was refused", handled)
+            assertEquals(
+                "the action \"$label\" sent the wrong arrow",
+                direction,
+                sent.last(),
+            )
+        }
+
+        assertEquals("one arrow per action, no repeats", ARROW_ACTIONS.size, sent.size)
+        assertEquals(
+            "each action must end the drag, which is what clears a latched modifier",
+            ARROW_ACTIONS.size,
+            dragsEnded,
+        )
+    }
+}

--- a/android/app/src/main/kotlin/com/vscodroid/keyboard/ExtraKeyButton.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/keyboard/ExtraKeyButton.kt
@@ -108,6 +108,34 @@ class ExtraKeyButton @JvmOverloads constructor(
         onKeyAction?.invoke(keyValue, state)
     }
 
+    /**
+     * Delivers one press when an accessibility service activates this key.
+     *
+     * `isClickable` has been true on these buttons all along, so a screen
+     * reader has always offered "double tap to activate" on every one of them,
+     * and until this override the offer did nothing at all: the touch listener
+     * returns true, so `View.onTouchEvent` never runs and never calls
+     * `performClick`, the presses come out of a [GestureDetector] instead, and
+     * no `OnClickListener` was ever set for `performClick` to run. An offered
+     * action that silently does nothing is worse than an absent one, because
+     * the user cannot tell the key from a broken one.
+     *
+     * Nothing routes a finger through here, so this cannot double-fire: the
+     * listener consumes the event before the view's own click handling. That
+     * also means an ordinary tap and an assistive activation reach [emitPress]
+     * by different paths, which is why this calls it rather than duplicating
+     * what a press does.
+     *
+     * `super` still runs for the click sound and the TYPE_VIEW_CLICKED event a
+     * service listens for; the return is `true` because this handled the click
+     * regardless of what `super` reports with no listener attached.
+     */
+    override fun performClick(): Boolean {
+        emitPress()
+        super.performClick()
+        return true
+    }
+
     init {
         gravity = Gravity.CENTER
         setTextSize(TypedValue.COMPLEX_UNIT_SP, 13f)

--- a/android/app/src/main/kotlin/com/vscodroid/keyboard/GestureTrackpad.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/keyboard/GestureTrackpad.kt
@@ -10,6 +10,7 @@ import android.util.TypedValue
 import android.view.HapticFeedbackConstants
 import android.view.MotionEvent
 import android.view.View
+import androidx.core.view.ViewCompat
 import com.vscodroid.R
 
 /**
@@ -57,6 +58,28 @@ class GestureTrackpad @JvmOverloads constructor(
             setStroke(dpToPx(1f).toInt(), 0xFF555555.toInt())
         }
         contentDescription = "Arrow key trackpad. Drag to move cursor."
+
+        // A drag is the only way to earn an arrow from this view, and a screen
+        // reader user cannot drag: touch exploration takes the gesture stream
+        // first, so ACTION_MOVE never reaches onTouchEvent below. Every other
+        // key on this row is a view a screen reader can activate, which left
+        // the four arrows as the one thing on the row with no reachable route
+        // at all. There is no fallback elsewhere either: the arrow buttons
+        // that used to carry them were deleted when this pad replaced them,
+        // and no KeyPage has carried an arrow since.
+        //
+        // Each action ends the drag after emitting, because that call is what
+        // clears a latched modifier. Without it a Ctrl latched before the
+        // action would stay latched afterwards, while every ordinary key on
+        // the row clears it -- the same one-shot behaviour, reached a
+        // different way.
+        for ((label, direction) in ARROW_ACTIONS) {
+            ViewCompat.addAccessibilityAction(this, label) { _, _ ->
+                onArrowKey?.invoke(direction)
+                onDragEnd?.invoke()
+                true
+            }
+        }
     }
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
@@ -137,3 +160,23 @@ class GestureTrackpad @JvmOverloads constructor(
     private fun dpToPx(dp: Float): Float =
         TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, dp, resources.displayMetrics)
 }
+
+/**
+ * The four arrows reachable without a drag, and what each one is called.
+ *
+ * Top level rather than inside [GestureTrackpad] for the same reason
+ * `pressedState` sits outside [ExtraKeyButton]: that class is a `View` whose
+ * initialiser reaches resources and display metrics on its first line, so no
+ * JVM unit test can construct one. This is the half that is data, so it can be
+ * checked -- and the half worth checking, because a direction that [KeyMapping]
+ * does not know is dropped by [KeyInjector] with nothing said.
+ *
+ * The strings are DOM key names, not Android key codes; the whole arrow path in
+ * this app speaks the web client's language and never touches KEYCODE_DPAD.
+ */
+internal val ARROW_ACTIONS: List<Pair<String, String>> = listOf(
+    "Move cursor left" to "ArrowLeft",
+    "Move cursor right" to "ArrowRight",
+    "Move cursor up" to "ArrowUp",
+    "Move cursor down" to "ArrowDown",
+)

--- a/android/app/src/main/kotlin/com/vscodroid/keyboard/KeyPageConfig.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/keyboard/KeyPageConfig.kt
@@ -11,9 +11,12 @@ sealed class KeyItem {
         val alternates: List<AlternateKey> = emptyList()
     ) : KeyItem()
 
-    data class GesturePad(
-        val contentDescription: String = "Arrow key trackpad"
-    ) : KeyItem()
+    // No contentDescription here, deliberately. It used to carry one and
+    // nothing ever read it: KeyPageAdapter applies item.contentDescription in
+    // the Button branch only, so the description actually spoken is the one
+    // GestureTrackpad sets on itself. A field that looks like the place to
+    // change the label, and silently is not, is worse than no field.
+    data object GesturePad : KeyItem()
 }
 
 data class KeyPage(val items: List<KeyItem>)
@@ -27,7 +30,7 @@ object KeyPages {
             KeyItem.Button("Ctrl", "Ctrl", isToggle = true, contentDescription = "Control modifier"),
             KeyItem.Button("Alt", "Alt", isToggle = true, contentDescription = "Alt modifier"),
             KeyItem.Button("Shift", "Shift", isToggle = true, contentDescription = "Shift modifier"),
-            KeyItem.GesturePad(),
+            KeyItem.GesturePad,
             KeyItem.Button("{}", "{", contentDescription = "Curly braces",
                 alternates = listOf(AlternateKey("[", "["), AlternateKey("<", "<"))),
             KeyItem.Button("()", "(", contentDescription = "Parentheses",

--- a/android/app/src/test/kotlin/com/vscodroid/keyboard/KeyRowAccessibilityTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/keyboard/KeyRowAccessibilityTest.kt
@@ -1,0 +1,215 @@
+package com.vscodroid.keyboard
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * What a user who cannot see the screen can reach on the extra key row.
+ *
+ * Two routes, and neither existed before. A screen reader activates a view
+ * through ACTION_CLICK, which lands on `View.performClick`; the row's keys are
+ * `isClickable` and so have always advertised that action, but the presses came
+ * out of a [GestureDetector] and nothing ever called `performClick`, so the
+ * offer did nothing. The trackpad was worse: its arrows are earned only by a
+ * drag, touch exploration consumes the gesture stream before onTouchEvent sees
+ * it, and the arrow buttons that would have been the fallback were deleted when
+ * the pad replaced them. So there was no route to a left or right cursor move
+ * anywhere in the app.
+ *
+ * Both fixes live in `View` subclasses whose initialisers reach resources on
+ * their first line, so no test here can construct one. The split follows what
+ * this package already does with `pressedState`: the data half is asserted
+ * directly, and the wiring half is asserted by reading the source, with a
+ * control first so that a scan which has stopped matching cannot pass by
+ * finding nothing.
+ */
+class KeyRowAccessibilityTest {
+
+    private val mainSources = File("src/main/kotlin/com/vscodroid/keyboard")
+
+    private fun source(name: String): String {
+        val file = File(mainSources, name)
+        assertTrue(
+            file.isFile,
+            "$name is not at ${file.absolutePath}; this test would otherwise pass " +
+                "by reading nothing",
+        )
+        return file.readText()
+    }
+
+    /** Source with comment lines dropped, so prose naming a call is not a call. */
+    private fun code(name: String): List<String> =
+        source(name).lines().filterNot {
+            val start = it.trimStart()
+            start.startsWith("//") || start.startsWith("*") || start.startsWith("/*")
+        }
+
+    @Nested
+    inner class TrackpadArrowActions {
+
+        @Test
+        fun `offers exactly the four arrows, each named once`() {
+            assertEquals(4, ARROW_ACTIONS.size, "one action per arrow, no more")
+            assertEquals(
+                4,
+                ARROW_ACTIONS.map { it.second }.toSet().size,
+                "two actions send the same arrow: $ARROW_ACTIONS",
+            )
+            assertEquals(
+                4,
+                ARROW_ACTIONS.map { it.first }.toSet().size,
+                "two actions share a label, so a screen reader would read the same " +
+                    "entry twice: $ARROW_ACTIONS",
+            )
+        }
+
+        @Test
+        fun `sends only arrows the key table knows`() {
+            // The failure this catches is silent. KeyInjector routes anything
+            // that is not a single character through announceKeystroke, which
+            // asks KeyMapping for the key code; a direction the table does not
+            // hold would be dispatched with a code derived from its first
+            // letter, so "ArrowLef" would arrive in the page as the letter A.
+            for ((label, direction) in ARROW_ACTIONS) {
+                val def = KeyMapping.getKeyDef(direction)
+                assertNotNull(
+                    def,
+                    "the action \"$label\" sends \"$direction\", which KeyMapping does " +
+                        "not hold; it would reach the page as a letter instead of an arrow",
+                )
+                assertEquals(
+                    direction,
+                    def!!.key,
+                    "KeyMapping resolves \"$direction\" to a different key",
+                )
+            }
+        }
+
+        @Test
+        fun `covers every arrow a drag can produce`() {
+            // The two routes have to stay in step. A drag earns its arrows from
+            // string literals in TrackpadGesture; if a fifth direction is ever
+            // added there, this fails rather than leaving the assistive route
+            // quietly one short. Read from the producer rather than restated
+            // here, because a restated list is only as good as its last edit.
+            val fromDrag = Regex("\"(Arrow[A-Za-z]+)\"")
+                .findAll(code("TrackpadGesture.kt").joinToString("\n"))
+                .map { it.groupValues[1] }
+                .toSet()
+
+            assertEquals(
+                4,
+                fromDrag.size,
+                "the scan found ${fromDrag.size} arrow literals in TrackpadGesture.kt, " +
+                    "not the four a drag emits, so it is not reading that file and its " +
+                    "verdict below is worth nothing. It found: $fromDrag",
+            )
+            assertEquals(
+                fromDrag,
+                ARROW_ACTIONS.map { it.second }.toSet(),
+                "a drag and the accessibility actions no longer send the same set of " +
+                    "arrows, so one route can do something the other cannot",
+            )
+        }
+
+        @Test
+        fun `every action is registered on the view, and ends the drag`() {
+            val lines = code("GestureTrackpad.kt")
+            val body = lines.joinToString("\n")
+
+            assertTrue(
+                body.contains("ViewCompat.addAccessibilityAction"),
+                "GestureTrackpad no longer registers accessibility actions, so the " +
+                    "list in ARROW_ACTIONS is data nothing reads and the arrows are " +
+                    "again reachable only by a drag",
+            )
+            val registration = lines.indexOfFirst {
+                it.contains("for ((label, direction) in ARROW_ACTIONS)")
+            }
+            assertTrue(
+                registration >= 0,
+                "the registration no longer walks ARROW_ACTIONS, so the list and what " +
+                    "the view offers can disagree while every assertion above stays green",
+            )
+
+            // Scoped to the loop body, not the file. `onDragEnd?.invoke()` also
+            // appears in onTouchEvent's ACTION_UP branch, and a whole-file
+            // search for it passes on that copy alone: measured, deleting the
+            // call from the action left this test green. What is guarded is
+            // what the action does, so the window is what the action is.
+            val actionBody = lines.drop(registration).take(6).joinToString("\n")
+            assertTrue(
+                actionBody.contains("onArrowKey?.invoke(direction)"),
+                "the action no longer sends its arrow, so activating it does nothing. " +
+                    "It reads: $actionBody",
+            )
+            assertTrue(
+                actionBody.contains("onDragEnd?.invoke()"),
+                "the action no longer ends the drag, so a modifier latched before it " +
+                    "stays latched afterwards, unlike every ordinary key on the row. " +
+                    "It reads: $actionBody",
+            )
+        }
+    }
+
+    @Nested
+    inner class ButtonActivation {
+
+        @Test
+        fun `a key press is what an assistive activation produces`() {
+            val lines = code("ExtraKeyButton.kt")
+
+            // The control: this scan drops comment lines, and the class carries
+            // long prose about presses. If the drop is ever widened, or the file
+            // moved, the assertion below would pass by reading nothing.
+            assertTrue(
+                lines.any { it.contains("private fun emitPress()") },
+                "the scan cannot see emitPress in ExtraKeyButton.kt, so it is not " +
+                    "reading the source and cannot judge what performClick does",
+            )
+
+            val performClick = lines.indexOfFirst {
+                it.contains("override fun performClick()")
+            }
+            assertTrue(
+                performClick >= 0,
+                "ExtraKeyButton no longer overrides performClick. isClickable is true " +
+                    "on these keys, so a screen reader still offers to activate them, " +
+                    "and without this override the offer does nothing at all",
+            )
+
+            val bodyAfter = lines.drop(performClick).take(5).joinToString("\n")
+            assertTrue(
+                bodyAfter.contains("emitPress()"),
+                "performClick no longer delivers a press, so activating a key through " +
+                    "an accessibility service types nothing. It reads: $bodyAfter",
+            )
+        }
+
+        @Test
+        fun `the touch path still consumes, so a press cannot double-fire`() {
+            // performClick is safe to emit from only because a finger never
+            // reaches it: the touch listener returns true, so View.onTouchEvent
+            // never runs and never calls performClick itself. If that return
+            // ever becomes false, one tap would deliver two presses.
+            val listener = code("ExtraKeyButton.kt")
+                .dropWhile { !it.contains("setOnTouchListener") }
+                .takeWhile { !it.contains("private fun updateToggleAppearance") }
+
+            assertTrue(
+                listener.isNotEmpty(),
+                "the touch listener is no longer where this test looks for it",
+            )
+            assertTrue(
+                listener.any { it.trim() == "true" },
+                "the touch listener no longer returns true unconditionally. If it can " +
+                    "return false, View.onTouchEvent runs and calls performClick, and " +
+                    "one tap delivers two presses. It reads: ${listener.joinToString("\n")}",
+            )
+        }
+    }
+}

--- a/docs/DEVICE_TEST_CHECKLIST.md
+++ b/docs/DEVICE_TEST_CHECKLIST.md
@@ -49,6 +49,8 @@
 | KB-9 | Extra Key Row trackpad | Drag on the trackpad: slowly first, then keep going without lifting, then diagonally | Cursor steps character by character at first and speeds up the longer the drag gets; a diagonal drag moves on both axes. There are no arrow buttons to press: the trackpad replaced them, so it is the only way a touch user moves the cursor | | |
 | KB-10 | Extra Key Row, brackets on the textarea edit path | On a device whose WebView is older than 121, open a file and press {, }, (, ) on the key row. Confirm the path first in remote debugging: `document.querySelectorAll("textarea.inputarea").length` is 1 | Each character is inserted, and Monaco auto-closes the pair | | |
 | KB-11 | Extra Key Row, brackets on the EditContext edit path | On a device whose WebView is 121 or newer, same presses. Confirm the path first: `document.querySelectorAll("textarea.inputarea").length` is 0 and `document.querySelectorAll("div.native-edit-context").length` is 2 | Each character is inserted. This is the path where anything written to a textarea is inert, so a pass here and a fail on KB-10 means the fix went to the wrong layer | | |
+| KB-12 | Extra Key Row keys under a screen reader | Turn TalkBack on, open a file, swipe to a key on the row until it is announced, then double tap to activate it. **`adb shell input tap` cannot answer this row**: it injects below touch exploration, so a single tap types the character and the run looks like a pass whatever the code does. Drive it by hand, or from a test that performs ACTION_CLICK on the node | The character is inserted, exactly once. A modifier announces and latches, and the next key carries it | | |
+| KB-13 | Trackpad arrows under a screen reader | With TalkBack on, swipe to the trackpad, open its actions menu and choose each of Move cursor left, right, up and down. Same caveat as KB-12: an injected tap or swipe proves nothing here, because a drag is what touch exploration consumes | The caret moves one step in the chosen direction. A drag is the only other route and a screen reader cannot perform one, so a failure here leaves no way to move the caret at all | | |
 
 ## 4. Screen & Orientation
 
@@ -208,7 +210,7 @@ first launch of a build that has this line, so the row to run instead is TC-8.
 |----------|-------|------|------|------|
 | Device Matrix | 4 | | | |
 | Android Versions | 4 | | | |
-| Keyboard Input | 11 | | | |
+| Keyboard Input | 13 | | | |
 | Screen & Orientation | 6 | | | |
 | Editor Operations | 8 | | | |
 | Extensions | 6 | | | |
@@ -218,7 +220,7 @@ first launch of a build that has this line, so the row to run instead is TC-8.
 | Toolchains | 6 | | | |
 | Terminal & Tools | 11 | | | |
 | SAF & Files | 8 | | | |
-| **Total** | **86** | | | |
+| **Total** | **88** | | | |
 
 **Overall Result**: [ ] PASS / [ ] FAIL
 


### PR DESCRIPTION
A user who cannot see the screen could not use the extra key row, in two separate ways.

Every key on the row sets `isClickable`, so a screen reader has always offered to activate all of them, and the offer did nothing. `ExtraKeyButton` installs an `OnTouchListener` that returns true, so `View.onTouchEvent` never runs and never calls `performClick`; the presses come out of a `GestureDetector`, and no `OnClickListener` was ever set for `performClick` to run. An offered action that silently does nothing is worse than an absent one, because the key is indistinguishable from a broken one.

The trackpad was worse. Its four arrows are earned only by a drag, touch exploration takes the gesture stream before `onTouchEvent` sees it, and the arrow buttons that would have been the fallback were deleted when the pad replaced them. No `KeyPage` has carried an arrow since, so there was no route to a cursor move anywhere in the app for someone who cannot drag.

## What changed

- `ExtraKeyButton` overrides `performClick` to deliver one press. A finger never reaches it, because the touch listener consumes the event first, so an ordinary tap and an assistive activation cannot both fire.
- `GestureTrackpad` registers one accessibility action per arrow, named in a top-level `ARROW_ACTIONS` list. Each action ends the drag after emitting, because that call is what clears a latched modifier, so a `Ctrl` latched beforehand behaves here exactly as it does on every other key of the row.
- `KeyItem.GesturePad` loses a `contentDescription` field nothing ever read. `KeyPageAdapter` applies that field in the `Button` branch only, so the description actually spoken is the one the view sets on itself; a field that looks like the place to change it, and silently is not, is a trap.

No new dependency: `androidx.core` 1.16.0 is already a direct dependency and carries `ViewCompat.addAccessibilityAction`.

## Risk

Behaviour for a sighted user is unchanged. The one path that could regress is a double press, if a finger were ever to reach `performClick` as well as the gesture detector. It cannot today, and a test pins the reason: the touch listener returns true unconditionally, which is what keeps `View.onTouchEvent` from running.

## Verification

Measured on two emulators, API 33 and API 37:

- With the code as it stood, all four instrumented cases fail on both devices; with the change they pass on both.
- A running app's node tree shows all seven keys with their spoken descriptions and `clickable=true`, and the pad with its own description.
- On the device, one ordinary tap on `{}` in an empty field still types exactly one pair.

Ten cases cover this. The four instrumented ones take the same route a screen reader takes: read the node, find the action, perform it by id. CI compiles them but has no emulator to run them on, which is why the JVM half exists as well. Those six assert the data directly and read the source for the wiring, because both classes are `View`s whose initialisers reach resources on their first line.

Each case was checked against a mutation that should redden it. One stayed green: the assertion that an action ends the drag searched the whole file, and the identical call in `onTouchEvent` satisfied it, so it now reads only the action's own body.
