### PR TITLE
docs: correct three claims the code stopped supporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The security document no longer calls the extension host a sandbox. It is a fault boundary, and an extension reaches app-private storage exactly as the app does.
+- The landing page quotes the storage figure the app computes and says extraction repeats after an update, which every other document already said.
 - The design documents now describe the build that ships: two on-demand toolchains, terminals that spawn bash on a real PTY, and how the server is actually patched and built.
 - Seven documents named a "Settings > Toolchains" screen the app has never had. They now name the real route, the launcher icon's **Manage toolchains** shortcut.
 - Three documents no longer list file-type "Open with" intent filters as shipped. A `content://` URI has no POSIX path, so every save would reach a copy.

--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -281,7 +281,7 @@ M6 (Release)   → Play Store release
    - [x] Symlink: `make` → `libmake.so` via `setupToolSymlinks()`
 
 3. **npm integration** (`FirstRunSetup.createNpmWrappers`)
-   - [x] npm/npx defined as bash functions in `.bashrc` (not script wrappers — Android noexec restriction)
+   - [x] npm/npx defined as bash functions in `.bashrc` (not script wrappers; SELinux denies `execute_no_trans` under `filesDir`, while `dlopen` of a `.node` addon there still works)
    - [x] Functions invoke Node.js with `npm-cli.js` entry point from `usr/lib/node_modules/npm/`
    - [x] `.npmrc` created with `script-shell` pointing to `libbash.so`
 

--- a/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
@@ -216,8 +216,8 @@ class FirstRunSetup(
             // prefix everything on PATH resolves through. Losing one silently
             // left an install that reached the editor and could never serve it,
             // with markSetupComplete() certifying the result and isFirstRun()
-            // keyed on versionName, so nothing tried again until the app
-            // updated. Nothing on device checks these trees are complete --
+            // keyed on versionName or versionCode, so nothing tried again until
+            // the app updated. Nothing on device checks these trees are complete --
             // verify-server-tree.py checks the build, not the install.
             //
             // Aborting was held back on the argument that a single lost file
@@ -383,8 +383,8 @@ class FirstRunSetup(
      * reach them, so they only ever need creating. This one needs repairing.
      *
      * Creating it once per version was not enough. isFirstRun() gates on
-     * versionName, so a folder deleted after setup stayed missing through every
-     * relaunch and force-stop: the explorer was empty, new files could not be
+     * versionName or versionCode, so a folder deleted after setup stayed missing
+     * through every relaunch and force-stop: the explorer was empty, new files could not be
      * saved, and terminals started in a directory that was not there. The only
      * ways back were clearing app data or installing a new version.
      *
@@ -499,9 +499,10 @@ class FirstRunSetup(
      *
      * The interpreter ships in the APK and every install replaces it. Its
      * runtime library and stdlib travel in assets and reach filesDir only
-     * through first-run extraction, which [isFirstRun] gates on versionName. An
-     * install that changes the bundled Python without changing versionName --
-     * `adb install -r` of a rebuilt debug APK is the everyday case -- therefore
+     * through first-run extraction, which [isFirstRun] gates on versionName or
+     * versionCode. An install that changes the bundled Python without moving
+     * either -- `adb install -r` of a rebuilt debug APK is the everyday case --
+     * therefore
      * leaves a new interpreter next to the previous runtime. Python then dies
      * with `CANNOT LINK EXECUTABLE ... library "libpython3.X.so" not found`,
      * naming a missing file rather than the install that removed it.
@@ -1548,8 +1549,8 @@ claude() {
             // Thrown, not logged. This runs only from runSetupLocked, whose
             // markSetupComplete() is the last statement of the same try block --
             // so swallowing the failure certifies an install that has no
-            // .bashrc, and isFirstRun() is keyed on versionName, so nothing
-            // writes one until the app updates. The every-launch repairs cannot
+            // .bashrc, and isFirstRun() is keyed on versionName or versionCode,
+            // so nothing writes one until the app updates. The every-launch repairs cannot
             // cover it either: createNpmWrappers, ensureToolchainEnvSourcing
             // and ensurePromptFix all open with `if (bashrc.exists())`.
             //

--- a/docs/06-SECURITY.md
+++ b/docs/06-SECURITY.md
@@ -45,7 +45,7 @@ flowchart TD
 | ----------------------------------------------------- | -------------------------- | ------ | ---------- | ----------------------------------------------------------------------------------- |
 | Other app connects to localhost server                | **Spoofing**               | Medium | Low        | localhost-only binding, plus a connection token required on all but three routes           |
 | Malicious extension impersonates trusted extension    | **Spoofing**               | Medium | Low        | Open VSX publisher verification, user review                                        |
-| Malicious extension steals files                      | **Tampering**              | High   | Medium     | Extension sandbox (Extension Host only), user awareness                             |
+| Malicious extension steals files                      | **Tampering**              | High   | Medium     | **Not mitigated.** The extension host is a fault boundary, not a security one: an extension reaches app-private storage and the network exactly as the app does. What bounds it is the Android app sandbox and the SAF grants the user gave |
 | Man-in-middle on Open VSX downloads                   | **Tampering**              | High   | Low        | HTTPS only, certificate pinning (future)                                            |
 | No audit trail for file changes by extensions         | **Repudiation**            | Low    | Medium     | VS Code timeline/git history, extension activity logging (future)                   |
 | User denies executing destructive terminal command    | **Repudiation**            | Low    | Low        | Accepted, no audit trail. Each terminal spawns bash directly on a PTY through node-pty, and the only record is bash's own history file in app-private storage, which the user can edit or clear |
@@ -55,7 +55,7 @@ flowchart TD
 | Malicious extension consuming all memory/CPU          | **Denial of Service**      | Medium | Low        | Extension Host resource limits, idle-kill for LS                                    |
 | WebView XSS via malicious file content                | **Elevation of Privilege** | Medium | Low        | VS Code CSP, WebView sandboxing                                                     |
 | Extension/webview script abuses AndroidBridge methods | **Elevation of Privilege** | High   | Medium     | Per-session capability token on every bridge method, pinned by a reflection test    |
-| Extension escapes sandbox to access system files      | **Elevation of Privilege** | High   | Low        | Android app sandbox, Extension Host isolation (a worker_thread inside the server process) |
+| Extension reads files outside the app                 | **Elevation of Privilege** | High   | Low        | Android app sandbox, and SAF grants for anything outside it. The worker_thread the extension host runs in is not part of this: it exists so the host does not spend a phantom process slot |
 
 ---
 
@@ -88,7 +88,7 @@ flowchart TD
 | Control                        | Implementation                                                                                           |
 | ------------------------------ | -------------------------------------------------------------------------------------------------------- |
 | Extension Host isolation       | Runs as a worker_thread inside the server process, applied by `patches/0004-exthost-as-worker-thread.patch`, so it does not spend one of Android's 32 phantom process slots |
-| VS Code Extension API sandbox  | Extensions can only access vscode.\* APIs                                                                |
+| Extension reach                | **No sandbox.** The extension host is Node, so an extension can `require('fs')` and reach whatever the app can. The `vscode.*` API is a convenience, not a boundary |
 | AndroidBridge capability model | All bridge APIs require the valid per-session token; no origin component                                 |
 | File system scoping            | Extensions see workspace folder by default                                                               |
 | Open VSX moderation            | Open VSX has publisher verification and abuse reporting                                                  |

--- a/docs/10-RELEASE_PLAN.md
+++ b/docs/10-RELEASE_PLAN.md
@@ -50,7 +50,7 @@ flowchart TD
   REPO --> B2["Same events, only when one of seven build-configuration paths changes<br/>r8.yml: R8, the resource shrinker and lintVitalRelease"]
   REPO --> B3["Tag v*<br/>release.yml: signed AAB and APK, toolchain ZIPs, GitHub Release"]
   REPO --> B4["Push to main touching docs/site, the user guide or the privacy policy<br/>pages.yml: publishes the usage site"]
-  REPO --> B5["Monday cron, or dispatched by hand<br/>r8.yml at 03:00 UTC, patch-drift.yml at 04:00 UTC"]
+  REPO --> B5["r8.yml: Monday 03:00 UTC, pushes to main, pull requests, or by hand<br/>patch-drift.yml: Monday 04:00 UTC, or by hand"]
   REPO --> B6["Dispatched by hand on a VS Code bump, arm64 runner<br/>build-vscode-oss.yml: builds the server once per version"]
 ```
 
@@ -101,7 +101,7 @@ jobs:
 | Workflow | Schedule | Purpose | Failure Action |
 |----------|----------|---------|----------------|
 | `patch-drift.yml` | Monday 04:00 UTC, or dispatched with a tag | Applies `patches/` against an upstream VS Code tag with `git apply --check` | Rebase the patch set before the next version bump |
-| `r8.yml` | Monday 03:00 UTC, or dispatched | Runs R8, the resource shrinker and `lintVitalRelease`, so a dependency that arrives without its consumer rules is caught before a tag | Fix the keep rules, or the shrinker configuration, before tagging |
+| `r8.yml` | Monday 03:00 UTC, pushes to main, pull requests, or dispatched. The three event triggers are filtered to the files that configure the shrinkers, so a change to Kotlin alone still waits for the cron | Runs R8, the resource shrinker and `lintVitalRelease`, so a dependency that arrives without its consumer rules is caught before a tag | Fix the keep rules, or the shrinker configuration, before tagging |
 
 ### 2.3 Caching Strategy
 

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -52,8 +52,8 @@
           </a>
         </div>
         <p class="hero-note">
-          Android 13 or newer, 64-bit. Around 875 MB free space for the first
-          launch.
+          Android 13 or newer, 64-bit. Around 873 MB free space for the first
+          launch, and again after each update.
         </p>
       </div>
       <div class="device">
@@ -147,8 +147,10 @@
             <h3>Let it unpack</h3>
             <p>
               The first launch extracts the editor and the bundled tools behind
-              a progress bar. It happens once, and it needs the space before it
-              starts rather than partway through.
+              a progress bar, and it needs the space before it starts rather than
+              partway through. It repeats after each app update, though an update
+              needs far less room because what is already unpacked counts toward
+              it.
             </p>
           </div>
         </li>


### PR DESCRIPTION
Five stale claims, of which one is a security claim pointing the wrong way.

## The extension host is not a sandbox

`docs/06-SECURITY.md` called it one in three places. The root `SECURITY.md` says
the opposite in as many words:

> It is a fault boundary, not a security sandbox: an extension has the same reach
> over app-private storage and the network as the app itself

A threat model asserting a boundary the project says does not exist is the
direction that gets a reader to **under**-protect, which is why this is first
rather than filed with the rest.

- The mitigation for "malicious extension steals files" said "Extension sandbox
  (Extension Host only)". It now says the threat is not mitigated, and names what
  does bound an extension: the Android app sandbox and the SAF grants the user
  gave.
- "Extension escapes sandbox to access system files" is now "Extension reads
  files outside the app", and the worker_thread is no longer offered as a
  security control. It exists so the host does not spend a phantom process slot.
- "VS Code Extension API sandbox: extensions can only access vscode.* APIs" is
  now "no sandbox": the host is Node, an extension can `require('fs')`, and the
  `vscode.*` API is a convenience rather than a boundary.

## The landing page

The last surface quoting 875 MB and promising a one-time unpack. Both were
corrected everywhere else, and the page a prospective user reads first kept them.
Now 873 MB, which is what the storage gate asks for, and extraction repeats after
an update.

## Three smaller ones

- Four comments in `FirstRunSetup.kt` said setup is keyed on versionName alone.
  It is versionName **or** versionCode, and the difference is expensive: a
  versionCode bump on its own re-runs the whole extraction, which a reader
  trusting these comments would conclude it does not.
- Two rows of the release plan described `r8.yml` as cron or dispatch only. It
  also runs on pushes to main and on pull requests, filtered to the files that
  configure the shrinkers, which is why a Kotlin-only change still waits for the
  cron.
- One line in `MILESTONES.md` blamed a `noexec` mount for npm being a bash
  function. It is SELinux denying `execute_no_trans` under `filesDir`, and the
  distinction is load-bearing: a `noexec` mount would also block the `.node`
  addons loaded from the same directory.

## Two candidates left alone

Checked and not defects, recorded so the next sweep does not re-open them:

- The file-tree annotations in the implementation plan reading "(settings screen
  for toolchain management)" describe what `ToolchainActivity.kt` is. That is
  accurate; the finding was about a route in the app, and the line directly under
  them already says the route does not exist.
- The remaining `noexec` mentions are inside dated records, where the wording is
  part of what was recorded at the time.

## Not in this change

Nothing guards the storage figure. It is quoted in six documents plus the landing
page, and it drifted here without CI noticing. A cross-document consistency check
would have caught it, but adding a seventeenth `check-*.py` means wiring it into
`lint.yml` and `CONTRIBUTING.md`, which is a change of its own rather than a
rider on a text correction.

Full suite 1275 tests, 0 failures. All 11 gates pass.
