### PR TITLE
fix(a11y): make six faint texts readable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Six texts on the setup and toolchain screens were too faint to read, including the Continue button and the word that says a download failed.
 - Two write-backs of one device file can no longer interleave. Each opened the document with truncation, so the copy on the device could end up neither version.
 - A file the device folder refuses to create now says so. It stayed inside the app looking synced, and the difference only showed after an uninstall.
 - A folder copied out that did not arrive whole now says how much is missing, once for the folder rather than once for every file in it.

--- a/android/app/src/main/kotlin/com/vscodroid/SplashActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/SplashActivity.kt
@@ -401,7 +401,10 @@ class SplashActivity : AppCompatActivity() {
         val statusText = TextView(ctx).apply {
             text = getString(R.string.progress_waiting)
             setTextColor(getColor(R.color.colorOnSurface))
-            alpha = 0.6f
+            // 0.7 rather than 0.6: this text is 12sp, so WCAG AA asks 4.5:1 and
+            // dimming #CCCCCC to 0.6 on this window measures 3.62:1. At 0.7 it is
+            // 5.78:1 and still reads as secondary beside the pack name.
+            alpha = 0.7f
             textSize = 12f
         }
 
@@ -423,6 +426,24 @@ class SplashActivity : AppCompatActivity() {
         val packName = downloadQueue[currentDownloadIndex]
         progressRows[packName]?.statusText?.text = getString(R.string.progress_installing)
         toolchainManager?.install(packName)
+    }
+
+    /**
+     * Paints a terminal result on a progress row, at full opacity.
+     *
+     * The row's status text is dimmed while it counts percentages, which is right
+     * for a number that changes every second and wrong for the one word the user
+     * has to read at the end. Setting only the colour left the dimming in place:
+     * "Failed" measured 3.28:1 and "Done" 3.81:1 against this window, both under
+     * the 4.5:1 AA asks for 12sp text. At full opacity they are 6.79:1 and 8.18:1.
+     *
+     * A helper rather than two lines twice, because the pairing is the point: a
+     * result colour without the opacity is the defect, and the next result added
+     * here should not be able to reintroduce it by copying one half.
+     */
+    private fun showResult(view: android.widget.TextView, colorRes: Int) {
+        view.setTextColor(getColor(colorRes))
+        view.alpha = 1f
     }
 
     private fun handleDownloadState(packName: String, status: Int, percent: Int) {
@@ -456,7 +477,7 @@ class SplashActivity : AppCompatActivity() {
             AssetPackStatus.COMPLETED -> {
                 row.progressBar.progress = 100
                 row.statusText.text = getString(R.string.progress_done)
-                row.statusText.setTextColor(getColor(R.color.colorSuccess))
+                showResult(row.statusText, R.color.colorSuccess)
             }
             AssetPackStatus.PENDING, AssetPackStatus.WAITING_FOR_WIFI -> {
                 row.statusText.text = getString(R.string.progress_waiting)
@@ -477,7 +498,7 @@ class SplashActivity : AppCompatActivity() {
                     Logger.w(tag, "Pack $packName ended at status $status")
                 }
                 row.statusText.text = getString(R.string.progress_failed)
-                row.statusText.setTextColor(getColor(R.color.colorError))
+                showResult(row.statusText, R.color.colorError)
             }
         }
 

--- a/android/app/src/main/res/layout/item_toolchain_card.xml
+++ b/android/app/src/main/res/layout/item_toolchain_card.xml
@@ -61,7 +61,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="2dp"
-            android:alpha="0.5"
+            android:alpha="0.7"
             android:textColor="@color/colorOnSurface"
             android:textSize="12sp"
             app:layout_constraintEnd_toEndOf="parent"
@@ -85,6 +85,7 @@
         <Button
             android:id="@+id/actionButton"
             style="@style/Widget.Material3.Button.TextButton"
+            android:textColor="@color/colorPrimaryText"
             android:layout_width="wrap_content"
             android:layout_height="36dp"
             android:layout_marginTop="4dp"

--- a/android/app/src/main/res/layout/layout_toolchain_picker.xml
+++ b/android/app/src/main/res/layout/layout_toolchain_picker.xml
@@ -61,7 +61,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginBottom="24dp"
-        android:alpha="0.5"
+        android:alpha="0.7"
         android:gravity="center"
         android:text="@string/picker_included"
         android:textColor="@color/colorOnSurface"

--- a/android/app/src/main/res/layout/layout_toolchain_progress.xml
+++ b/android/app/src/main/res/layout/layout_toolchain_progress.xml
@@ -45,6 +45,7 @@
         android:layout_marginTop="32dp"
         android:text="@string/progress_cancel"
         android:textAllCaps="false"
+        android:textColor="@color/colorPrimaryText"
         android:textSize="14sp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -4,6 +4,12 @@
     <color name="colorPrimary">#007ACC</color>
     <color name="colorPrimaryDark">#005A9E</color>
     <color name="colorAccent">#007ACC</color>
+    <!-- The same brand blue is unreadable as TEXT on this app's dark grounds:
+         #007ACC measures 3.70:1 on the window and 3.40:1 on a card, and WCAG AA
+         asks 4.5:1 for text this size. It stays as a button GROUND, where white
+         sits on it; this lighter tone is for text buttons and links, and measures
+         5.43:1 and 4.99:1 on the same two grounds. -->
+    <color name="colorPrimaryText">#3794FF</color>
 
     <!-- Editor surface colors -->
     <color name="colorBackground">#1E1E1E</color>

--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -6,6 +6,16 @@
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
+        <!-- Overriding colorPrimary without this left Material3 supplying its own
+             onPrimary, which in the dark palette is a dark violet. On this app's
+             blue that measured 2.92:1, so the label of the picker's Continue
+             button, the control the whole screen exists to reach, failed even the
+             3:1 floor for large text. White on the same blue is 4.51:1.
+             ⚠️ That margin is 0.01. It clears AA and nothing more. Moving the
+             button ground to colorPrimaryDark would give 7.10:1, but that is a
+             visual-design decision rather than an accessibility fix, so it is
+             raised rather than taken here. -->
+        <item name="colorOnPrimary">@android:color/white</item>
 
         <!-- Window background: VS Code dark editor -->
         <item name="android:windowBackground">@color/colorBackground</item>


### PR DESCRIPTION
Six texts on the setup and toolchain screens fall under the 4.5:1 WCAG AA asks
for their size.

Every ratio below was computed from the colours the widgets **actually resolve at
runtime**, not from the values sitting in `colors.xml`. Those are different
questions, and the difference is what makes the first item wrong only on a dark
device.

| What | Before | After | Fix |
|---|---|---|---|
| Continue button label | **2.92:1** | 4.51:1 | declare `colorOnPrimary` |
| Cancel on the download screen | 3.70:1 | 5.43:1 | lighter blue for text |
| Card action button | 3.40:1 | 4.99:1 | same |
| "Failed" on a download row | **3.28:1** | 6.79:1 | stop dimming a result |
| "Done" on a download row | 3.81:1 | 8.18:1 | same |
| Card size line | 3.47:1 | 5.44:1 | alpha 0.5 to 0.7 |
| Picker note | 3.62:1 | 5.78:1 | alpha 0.5 to 0.7 |

## The Continue button

`colorPrimary` was overridden without `colorOnPrimary`, so Material3 supplied its
own: a dark violet from the dark palette. On this app's blue that is 2.92:1,
which fails even the 3:1 floor for large text, and it is the label of the control
the whole picker exists to reach.

**The new margin is 0.01.** White on `#007ACC` is 4.51:1. The comment says so.
Moving the button ground to `colorPrimaryDark` would give 7.10:1, but that
changes how the button looks, which is a design decision rather than an
accessibility fix. It is raised here, not taken.

## The brand blue is fine as a ground and not as text

`#007ACC` measures 3.70:1 on the window and 3.40:1 on a card. It stays where it
works, as a button ground with white on it. Text buttons and links now use
`colorPrimaryText`, a lighter tone measuring 5.43:1 and 4.99:1 on those same two
grounds.

## The download result was dimmed on purpose and never undimmed

The worst item, and the most instructive. A download row's status text runs at
reduced opacity while it counts percentages, which is right for a number changing
every second and wrong for the one word the user has to read at the end. The code
set the result **colour** and left the dimming in place.

`showResult` now sets colour and opacity together. A helper rather than two lines
twice, because the pairing is the point: the next result added there cannot
reintroduce the defect by copying one half of it.

## Verification

Every ratio recomputed independently from the resolved colours, including the
replacements, before any value was changed. The full suite is 1285 tests, 0
failures, and lint holds at 52 warnings.

`assembleDebug` cannot run in this checkout: `checkPatchFingerprints` correctly
fails because the local asset tree predates patch 0014, which landed on main
after this tree was copied. That is the gate working, not a defect here, and CI
fetches the current tree.

## Not in this change

Four more findings in the same sweep are announcement rather than contrast: the
toolchain toolbar's back arrow has no label, picker selection is not announced
and has no checked state, and neither first-run progress nor the download queue
reaches a screen reader. They need a different kind of verification and land
separately.

One finding is deliberately not mine to take: the key row's buttons measure
39-41dp against a 48dp minimum, and fixing it changes the layout of five pages.
That is a design decision.
