### PR TITLE
fix(keyboard): give a key the whole width it is allotted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A link that no installed app can open now says so. The tap did nothing and said nothing, which reads as a broken link rather than a missing app.
 - Activating a key on the extra key row through a screen reader now types it. Every key offered activation and none of them did anything.
 - A latched Ctrl, Alt or Shift now says so to a screen reader. The latch was carried by colour alone, so it could be switched but not observed.
+- Keys on the extra key row are wider to touch. The 2dp gap between them was taken off each key, which left them under Android's minimum target size.
 - Dragging a finger inside an application menu now scrolls it instead of closing the submenu. A menu that cannot scroll still reported scrolling, and the submenu closed on it.
 - Tapping the editor now raises the keyboard, and what it types now arrives. The app never took Android input focus for its view, so keyboard input was silently discarded.
 - Brackets, quotes and other symbols on the extra key row now type into the editor. On recent WebViews they inserted nothing at all.

--- a/android/app/src/androidTest/kotlin/com/vscodroid/keyboard/KeyRowAccessibilityInstrumentedTest.kt
+++ b/android/app/src/androidTest/kotlin/com/vscodroid/keyboard/KeyRowAccessibilityInstrumentedTest.kt
@@ -260,6 +260,93 @@ class KeyRowAccessibilityInstrumentedTest {
         }
     }
 
+    /**
+     * Lays out one page at a given row width and returns each child's width in dp.
+     *
+     * Built from [keyLayoutParams] and [padLayoutParams] rather than from params
+     * written here, so the numbers below come from the same call the adapter
+     * makes. A page is a plain horizontal `LinearLayout` (KeyPageAdapter's
+     * `PageViewHolder`), and the row width is fixed with an EXACTLY spec because
+     * that is what ViewPager2 hands it, and it is the reason `minWidth` on a key
+     * is inert.
+     */
+    private fun keyWidthsDp(rowWidthDp: Int, keys: Int, withPad: Boolean): List<Float> {
+        val density = context.resources.displayMetrics.density
+        val widths = mutableListOf<Float>()
+        onMain {
+            val row = android.widget.LinearLayout(context).apply {
+                orientation = android.widget.LinearLayout.HORIZONTAL
+            }
+            repeat(keys) { row.addView(ExtraKeyButton(context), keyLayoutParams()) }
+            if (withPad) row.addView(GestureTrackpad(context), padLayoutParams())
+
+            val widthPx = (rowWidthDp * density).toInt()
+            row.measure(
+                android.view.View.MeasureSpec.makeMeasureSpec(widthPx, android.view.View.MeasureSpec.EXACTLY),
+                android.view.View.MeasureSpec.makeMeasureSpec((56 * density).toInt(), android.view.View.MeasureSpec.EXACTLY),
+            )
+            row.layout(0, 0, widthPx, (56 * density).toInt())
+            for (i in 0 until row.childCount) {
+                if (row.getChildAt(i) is ExtraKeyButton) widths.add(row.getChildAt(i).width / density)
+            }
+        }
+        return widths
+    }
+
+    @Test
+    fun aKeyGetsTheWholeShareOfTheRow() {
+        // The property the fix guarantees, and the only one that holds at every
+        // screen width: nothing is subtracted from a key before the finger gets
+        // it. A margin would show up here as a shortfall on every key.
+        val density = context.resources.displayMetrics.density
+        for (rowDp in listOf(320, 360, 411, 448, 800)) {
+            val widths = keyWidthsDp(rowDp, keys = 8, withPad = false)
+            assertEquals("expected eight keys at ${rowDp}dp", 8, widths.size)
+            val total = widths.sum()
+            assertTrue(
+                "keys at ${rowDp}dp add up to ${total}dp, so ${rowDp - total}dp of the row " +
+                    "is not on any key. A gap has moved back onto the layout params, and " +
+                    "every dp of it comes off a touch target",
+                kotlin.math.abs(total - rowDp) <= 8f / density,
+            )
+        }
+    }
+
+    @Test
+    fun keysClearFortyEightDpOnAMainstreamPhone() {
+        // 411dp is this emulator and the common Pixel width. Narrower phones do
+        // not clear the guideline on width even with the whole row shared out,
+        // and that needs a different decision: fewer keys per page, which means
+        // more pages. This case pins what the fix does reach, so a regression
+        // that puts the gap back is caught by a number rather than by a shape.
+        val page1 = keyWidthsDp(411, keys = 7, withPad = true)
+        val others = keyWidthsDp(411, keys = 8, withPad = false)
+
+        assertTrue(
+            "page 1 keys are ${page1.min()}dp beside the trackpad, under the 48dp target",
+            page1.min() >= 48f,
+        )
+        assertTrue(
+            "pages 2 to 5 keys are ${others.min()}dp, under the 48dp target",
+            others.min() >= 48f,
+        )
+    }
+
+    @Test
+    fun theGapBetweenKeysIsStillDrawn() {
+        // The gap did not disappear, it moved. If the inset goes too, the keys
+        // butt together and the row reads as one slab.
+        lateinit var bg: android.graphics.drawable.Drawable
+        onMain {
+            bg = ExtraKeyButton(context).background
+        }
+        assertTrue(
+            "the key background is no longer inset, so the 2dp gap is gone from the " +
+                "drawing as well as from the layout: it is ${bg.javaClass.simpleName}",
+            bg is android.graphics.drawable.InsetDrawable,
+        )
+    }
+
     @Test
     fun theTrackpadOffersOneActionPerArrow() {
         inWindow({ ctx -> GestureTrackpad(ctx) }) { _, node ->
@@ -305,4 +392,5 @@ class KeyRowAccessibilityInstrumentedTest {
             )
         }
     }
+
 }

--- a/android/app/src/main/kotlin/com/vscodroid/keyboard/ExtraKeyButton.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/keyboard/ExtraKeyButton.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Typeface
 import android.graphics.drawable.GradientDrawable
+import android.graphics.drawable.InsetDrawable
 import android.util.AttributeSet
 import android.util.TypedValue
 import android.view.GestureDetector
@@ -173,7 +174,10 @@ class ExtraKeyButton @JvmOverloads constructor(
         maxLines = 1
         minWidth = dpToPx(48)
         minimumHeight = dpToPx(56)
-        setPadding(dpToPx(4), dpToPx(6), dpToPx(4), dpToPx(6))
+        // Horizontal padding carries the inset as well as the old padding, so
+        // the distance from the text to the edge of the drawn key is what it
+        // was before the gap moved off the layout params.
+        setPadding(dpToPx(4 + KEY_GAP_DP), dpToPx(6), dpToPx(4 + KEY_GAP_DP), dpToPx(6))
         isClickable = true
         isFocusable = false
 
@@ -226,10 +230,24 @@ class ExtraKeyButton @JvmOverloads constructor(
     }
 
     fun applyRoundedBackground(color: Int) {
-        background = GradientDrawable().apply {
-            setColor(color)
-            cornerRadius = dpToPx(6).toFloat()
-        }
+        // Inset rather than a margin, and the difference is the whole point of
+        // this drawable being built here. A 2dp gap between keys used to come
+        // from marginStart/marginEnd on the layout params, which takes the dp
+        // away from the view itself and therefore from what a finger can hit.
+        // As an inset it is taken from the drawing of the background instead:
+        // the gap between keys is the same 4dp and the touch target is 4dp
+        // wider. Measured on a 411dp screen, one visible change comes with it:
+        // the trackpad grows by about 5dp, because it never carried a margin
+        // and so now takes its weighted share of the dp the margins used to
+        // consume. A wider drag area is the right direction for the one
+        // control on the row that wants area, so it stays.
+        background = InsetDrawable(
+            GradientDrawable().apply {
+                setColor(color)
+                cornerRadius = dpToPx(KEY_GAP_DP * 3).toFloat()
+            },
+            dpToPx(KEY_GAP_DP), 0, dpToPx(KEY_GAP_DP), 0,
+        )
     }
 
     private fun dpToPx(dp: Int): Int =
@@ -274,3 +292,13 @@ internal fun toggleStateDescription(isToggle: Boolean, isActive: Boolean): CharS
         isActive -> "on"
         else -> "off"
     }
+
+/**
+ * The gap drawn on each side of a key, in dp.
+ *
+ * It is a drawing inset, not a layout margin. A margin subtracts from the
+ * view, so on a row that divides the width by weight it subtracts from the
+ * touch target of every key; an inset subtracts only from the background,
+ * leaving the view, and the finger's target, the full share of the row.
+ */
+internal const val KEY_GAP_DP = 2

--- a/android/app/src/main/kotlin/com/vscodroid/keyboard/KeyPageAdapter.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/keyboard/KeyPageAdapter.kt
@@ -87,11 +87,13 @@ class KeyPageAdapter(
                         toggleButtons[item.value] = button
                     }
 
-                    val lp = LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 1f).apply {
-                        marginStart = dpToPx(holder.container.context, 2)
-                        marginEnd = dpToPx(holder.container.context, 2)
-                    }
-                    holder.container.addView(button, lp)
+                    // No margins. The row divides its width by weight, so every
+                    // dp given to a margin is a dp taken off the touch target of
+                    // the key beside it, and these keys are already under the
+                    // 48dp guideline on a narrow phone. The 2dp gap now comes
+                    // from an inset inside the key's own background, which looks
+                    // the same and leaves the target whole.
+                    holder.container.addView(button, keyLayoutParams())
                 }
 
                 is KeyItem.GesturePad -> {
@@ -103,8 +105,7 @@ class KeyPageAdapter(
                             this@KeyPageAdapter.onDragEnd()
                         }
                     }
-                    val lp = LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 1.5f)
-                    holder.container.addView(trackpad, lp)
+                    holder.container.addView(trackpad, padLayoutParams())
                 }
             }
         }
@@ -124,8 +125,23 @@ class KeyPageAdapter(
         toggleButtons[keyValue]?.isToggleActive = active
     }
 
-    private fun dpToPx(context: android.content.Context, dp: Int): Int =
-        android.util.TypedValue.applyDimension(
-            android.util.TypedValue.COMPLEX_UNIT_DIP, dp.toFloat(), context.resources.displayMetrics
-        ).toInt()
 }
+
+/**
+ * How one key claims its share of the row.
+ *
+ * Weight with a zero width, so the row is divided rather than measured: the
+ * page container is measured EXACTLY, which means `LinearLayout` remeasures
+ * each of these children with an EXACTLY spec of its own and `TextView`'s
+ * minWidth clamp never runs. That is why [ExtraKeyButton]'s `minWidth` cannot
+ * hold a key at 48dp, and why nothing here may hand width back through a
+ * margin.
+ *
+ * Named rather than inline so a test can measure the real thing.
+ */
+internal fun keyLayoutParams(): LinearLayout.LayoutParams =
+    LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 1f)
+
+/** The trackpad's share, one and a half keys wide, for the same reason. */
+internal fun padLayoutParams(): LinearLayout.LayoutParams =
+    LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 1.5f)


### PR DESCRIPTION
Each key on the extra key row carried a 2dp margin on each side. The row divides its width by weight, so those 4dp came off the key itself rather than out of spare space, and `ExtraKeyButton`'s own `minWidth = 48dp` could not stop it: the page container is measured EXACTLY, so `LinearLayout` remeasures every weighted child with an EXACTLY spec of its own and `TextView`'s clamp never runs.

Measured on a 411dp screen: **44.3dp** a key on page 1, against Android's 48dp minimum touch target. A mis-tap here is not a no-op. It types a wrong character into a file, or fires a wrong editor chord.

## What changed

The gap moves into the key's own background as a drawing inset. The view, and so the finger's target, now spans its full share of the row, while the gap between keys stays the same 4dp. Layout params come from named functions (`keyLayoutParams`, `padLayoutParams`) so a test can build a page from the same call the adapter makes.

Measured after the change, at 411dp: **48.3dp** on page 1, **51.3dp** on pages 2 to 5.

One visible change comes with it: the trackpad grows by about 5dp, because it never carried a margin and now takes its weighted share of the dp the margins used to consume. More area is the right direction for the one control on the row that wants area.

## What this does not do

It does not reach 48dp on every screen. Measured across widths:

| row width | page 1 | pages 2-5 |
|---|---|---|
| 320dp | 37.3 | 40.0 |
| 360dp | 42.3 | 45.0 |
| 384dp | 45.0 | **48.0** |
| 411dp | **48.3** | **51.3** |
| 448dp | **52.7** | **56.0** |

Pages 2 to 5 clear the guideline from 384dp up, page 1 from about 409dp. A 360dp phone still sits short. Closing that needs fewer keys per page and therefore more pages, which is a product decision, not a defect fix, so it is not in here.

## Verification

Three instrumented cases, run on API 33 and API 37:

- every key takes its full share of the row, at five widths from 320dp to 800dp
- keys clear 48dp at 411dp, on page 1 and on the other pages
- the gap is still drawn, so it moved rather than vanished

Restoring the margins reddens the first two on both devices, with the shortfall in the failure message. Removing the inset reddens the third. The row was also driven by hand on a device: a key still types exactly one character, and the row is pixel-compared before and after, which is how the trackpad's 5dp came to light.
