### PR TITLE
fix(a11y): say out loud what the screens only showed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A screen reader now hears the Toolchains back arrow, which toolchain is selected in the picker, that setup failed, and that a download finished.
 - Six texts on the setup and toolchain screens were too faint to read, including the Continue button and the word that says a download failed.
 - Two write-backs of one device file can no longer interleave. Each opened the document with truncation, so the copy on the device could end up neither version.
 - A file the device folder refuses to create now says so. It stayed inside the app looking synced, and the difference only showed after an uninstall.

--- a/android/app/src/main/kotlin/com/vscodroid/SplashActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/SplashActivity.kt
@@ -230,6 +230,17 @@ class SplashActivity : AppCompatActivity() {
         runOnUiThread {
             statusText.text = message
             progressBar.visibility = View.GONE
+            // Spoken, because the screen alone cannot say it. Setup writes into one
+            // label for minutes; a user not touching the screen hears nothing between
+            // the window opening and MainActivity arriving, so "still extracting" and
+            // "gave up" sound identical and they wait on a screen that is finished.
+            //
+            // announceForAccessibility rather than a live region on the label: a live
+            // region would speak every progress update too, and a percentage read
+            // aloud every few hundred milliseconds is a way of saying nothing while
+            // making noise. What has to be spoken is the transition, and this is the
+            // only place a failure passes through.
+            statusText.announceForAccessibility(message)
             // Show retry button dynamically
             val parent = statusText.parent as? android.view.ViewGroup ?: return@runOnUiThread
             val retryButton = Button(this).apply {
@@ -261,6 +272,14 @@ class SplashActivity : AppCompatActivity() {
             } else {
                 parent.addView(retryButton)
             }
+            // Deliberately NOT moving accessibility focus to the Retry button, and
+            // that is a reversal: the first attempt did, and lint's AccessibilityFocus
+            // check refused it. It is right. Stealing focus contradicts what a screen
+            // reader user expects of every other app, and it drops them somewhere they
+            // did not navigate to. What they need instead is to know the screen has
+            // changed and what to do about it, and both failure strings already end in
+            // "Tap Retry", so the announcement above carries the instruction and
+            // ordinary swiping reaches the control.
         }
     }
 
@@ -441,9 +460,22 @@ class SplashActivity : AppCompatActivity() {
      * result colour without the opacity is the defect, and the next result added
      * here should not be able to reintroduce it by copying one half.
      */
-    private fun showResult(view: android.widget.TextView, colorRes: Int) {
+    private fun showResult(view: android.widget.TextView, colorRes: Int, packLabel: String) {
         view.setTextColor(getColor(colorRes))
         view.alpha = 1f
+        // And spoken. The queue holds the user until every pack finishes, and rows
+        // moved Waiting -> percent -> Done or Failed with nothing said, so a stalled
+        // download and a progressing one sounded the same and there was no way to
+        // tell whether to wait or press Cancel.
+        //
+        // Terminal states only, deliberately. A live region on this label would
+        // announce every percentage tick, which is noise rather than information;
+        // the framework already emits a progress event for the bar beside it, and a
+        // user can swipe to a row and hear the current value on demand. What could
+        // not be reached at all was the end of the story.
+        // Named, because a queue speaks several of these and "Done" on its own says
+        // which of them only to someone watching the rows move.
+        view.announceForAccessibility("$packLabel: ${view.text}")
     }
 
     private fun handleDownloadState(packName: String, status: Int, percent: Int) {
@@ -477,7 +509,7 @@ class SplashActivity : AppCompatActivity() {
             AssetPackStatus.COMPLETED -> {
                 row.progressBar.progress = 100
                 row.statusText.text = getString(R.string.progress_done)
-                showResult(row.statusText, R.color.colorSuccess)
+                showResult(row.statusText, R.color.colorSuccess, row.nameText.text.toString())
             }
             AssetPackStatus.PENDING, AssetPackStatus.WAITING_FOR_WIFI -> {
                 row.statusText.text = getString(R.string.progress_waiting)
@@ -498,7 +530,7 @@ class SplashActivity : AppCompatActivity() {
                     Logger.w(tag, "Pack $packName ended at status $status")
                 }
                 row.statusText.text = getString(R.string.progress_failed)
-                showResult(row.statusText, R.color.colorError)
+                showResult(row.statusText, R.color.colorError, row.nameText.text.toString())
             }
         }
 

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainPickerAdapter.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainPickerAdapter.kt
@@ -90,6 +90,15 @@ class ToolchainPickerAdapter(
         )
         holder.checkmark.visibility = if (isSelected) View.VISIBLE else View.GONE
 
+        // The state a screen reader can read. MaterialCardView implements Checkable
+        // and already forwards these into the node and into the change event, but
+        // nothing ever turned it on, so every card reported checkable=false and
+        // checked=false in both states. Selection existed only as a stroke, a
+        // background colour and a checkmark that vanishes when deselected, which is
+        // to say only in the visual channel.
+        card.isCheckable = true
+        card.isChecked = isSelected
+
         // Hide MANAGER-only views
         holder.statusBadge.visibility = View.GONE
         holder.actionButton.visibility = View.GONE
@@ -97,7 +106,12 @@ class ToolchainPickerAdapter(
 
         card.setOnClickListener {
             cards.toggleSelection(info.packName)
-            notifyItemChanged(holder.bindingAdapterPosition)
+            // With a payload rather than without: a plain notifyItemChanged runs the
+            // default change animation, which swaps the item view and takes
+            // accessibility focus with it, so the user who just double-tapped a card
+            // is returned to the top of the list. RecyclerView skips that animation
+            // when a payload is supplied, and the rebind below is the same work.
+            notifyItemChanged(holder.bindingAdapterPosition, PAYLOAD_SELECTION)
             onSelectionChanged?.invoke(cards.selectedPackNames())
         }
     }
@@ -163,6 +177,14 @@ class ToolchainPickerAdapter(
     }
 
     companion object {
+        /**
+         * Marks a rebind that only changes selection.
+         *
+         * Its value is never read; supplying any payload is what makes RecyclerView
+         * skip the change animation, and skipping it is what keeps accessibility
+         * focus on the card the user just tapped.
+         */
+        private const val PAYLOAD_SELECTION = "selection"
         private fun labelFor(action: ToolchainAction): Int = when (action) {
             ToolchainAction.INSTALL -> R.string.toolchain_install
             ToolchainAction.REMOVE -> R.string.toolchain_remove

--- a/android/app/src/main/res/layout/activity_toolchain.xml
+++ b/android/app/src/main/res/layout/activity_toolchain.xml
@@ -14,6 +14,7 @@
         android:layout_height="?attr/actionBarSize"
         android:background="@color/colorSurface"
         app:navigationIcon="?attr/homeAsUpIndicator"
+        app:navigationContentDescription="@string/toolchain_navigate_up"
         app:navigationIconTint="@color/colorOnSurface"
         app:title="@string/toolchain_settings_title"
         app:titleTextColor="@color/colorOnSurface" />

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -162,4 +162,10 @@
          separately because the cause is a limit this app chose, not the device saying
          no, and the user's next move is to copy the rest out by hand. -->
     <string name="saf_upload_capped">%1$s is too large to copy out whole. The rest of it stayed inside VSCodroid.</string>
+
+    <!-- The Toolchains toolbar's only icon-only control, and the app's only visible
+         way back out of that screen. Without it a screen reader announces an
+         unlabelled button: setSupportActionBar is never called, so the framework's
+         own "Navigate up" default never applies. -->
+    <string name="toolchain_navigate_up">Back to the editor</string>
 </resources>


### PR DESCRIPTION
Four states existed only in the visual channel. Each is a different shape of the
same defect, and one of them is a screen's only way out.

## The Toolchains back arrow had no label

`setSupportActionBar` is never called anywhere in the app, so the framework's own
"Navigate up" default never applies, and no toolbar style supplies one. It is the
only icon-only control on that screen and the only visible way off it. System
back still works, so this degraded rather than trapped.

## Picker cards had no checked state

Selection was a stroke, a background colour, and a checkmark that disappears when
deselected. `MaterialCardView` already implements `Checkable` and forwards it into
the node and the change event, but nothing ever turned it on, so every card
reported `checkable=false, checked=false` in both states.

`notifyItemChanged` also ran the default change animation, which swaps the item
view and takes accessibility focus with it. A user who double-tapped a card was
returned to the top of the list. A payload skips that animation and does the same
rebind.

## Two transitions were silent

Setup writes into one label for minutes, so "still extracting" and "gave up"
sounded identical to a user not touching the screen. Download rows moved to Done
or Failed with nothing said, so a stalled download and a progressing one were
indistinguishable and there was no way to know whether to wait or cancel.

**`announceForAccessibility` rather than a live region, deliberately.** A live
region on either label would speak every progress tick as well, and a percentage
read aloud every few hundred milliseconds is a way of making noise while saying
nothing. What has to be spoken is the transition. The download announcement names
its pack, because a queue speaks several of these and "Done" alone identifies
which one only to someone watching the rows.

## One reversal, found by lint

The first attempt moved accessibility focus to the Retry button when it appears.
Lint's `AccessibilityFocus` check refuses that, and **it is right**: stealing
focus contradicts what a screen reader user expects of every other app, and drops
them somewhere they did not navigate to.

It is removed, and the comment says why rather than leaving the next person to
rediscover it. Both failure strings already end in "Tap Retry", so the
announcement carries the instruction and ordinary swiping reaches the control.

Lint is back to 52 warnings, the same as before this branch. That number is the
check: had the focus call been suppressed rather than removed, it would read 52
too.

## Verification

Full suite 1288 tests, 0 failures. All 11 gates pass.

The behaviour these fix is a screen-reader property, and no runner family GitHub
offers can execute the instrumented suite, so what CI proves here is that the
code compiles and nothing else regressed. The device evidence for the same class
of change is in the checklist rows added alongside the key row work.

`assembleDebug` cannot run in this checkout: `checkPatchFingerprints` correctly
fails because the local asset tree predates patch 0014. That is the gate working,
and CI fetches the current tree.

## Scope

Six contrast findings from the same sweep landed separately. One finding is not
mine: the key row's touch targets, which is being handled by whoever holds
`keyboard/`.
