### PR TITLE
fix(menus): keep the menubar open when the keyboard drops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The menubar no longer closes itself when the on-screen keyboard drops. The resize that follows the tap shut the menu 40ms after it opened, leaving no route to the File or Terminal menus.
 - A screen reader now hears the Toolchains back arrow, which toolchain is selected in the picker, that setup failed, and that a download finished.
 - Six texts on the setup and toolchain screens were too faint to read, including the Continue button and the word that says a download failed.
 - Two write-backs of one device file can no longer interleave. Each opened the document with truncation, so the copy on the device could end up neither version.

--- a/docs/04-TECHNICAL_SPEC.md
+++ b/docs/04-TECHNICAL_SPEC.md
@@ -531,6 +531,8 @@ flowchart TD
   P --> P11["0011 brand the web walkthrough"]
   P --> P12["0012 serve /callback before the connection-token check"]
   P --> P13["0013 shorten the reconnection grace when a client is connected"]
+  P --> P14["0014 menus: dismiss a submenu only on a real scroll"]
+  P --> P15["0015 menubar: stay open when only the keyboard resized"]
 ```
 
 Five of these are load-bearing in ways their titles understate:

--- a/docs/DEVICE_TEST_CHECKLIST.md
+++ b/docs/DEVICE_TEST_CHECKLIST.md
@@ -75,6 +75,8 @@
 | ED-6 | Copy/Paste (system) | Copy from external app, paste in editor | Text pastes correctly | | |
 | ED-7 | Undo/Redo | Make edits, Ctrl+Z, Ctrl+Shift+Z | Undo and redo work correctly | | |
 | ED-8 | Format document | Open JS file, run Format Document (Prettier) | File formatted, no errors | | |
+| ED-9 | Application Menu with the keyboard up | Tap a text field so the keyboard rises, then tap the menubar button. Watch it for a few seconds rather than glancing: the failure this catches lasted about 40ms and left the button looking dead | The menu opens and stays open, listing File, Edit, Selection, View, Go and Run. Tapping outside and pressing Esc still close it, and tapping File still opens its submenu | | |
+| ED-10 | Application Menu across a rotation | Open the Application Menu, tap File so its submenu opens, then rotate the device | Both menus close. They must not stay open: the submenu would be anchored where it no longer fits and would be clipped off the edge | | |
 
 ## 6. Extensions
 
@@ -212,7 +214,7 @@ first launch of a build that has this line, so the row to run instead is TC-8.
 | Android Versions | 4 | | | |
 | Keyboard Input | 13 | | | |
 | Screen & Orientation | 6 | | | |
-| Editor Operations | 8 | | | |
+| Editor Operations | 10 | | | |
 | Extensions | 6 | | | |
 | Background/Foreground | 8 | | | |
 | Low Memory & Stress | 4 | | | |
@@ -220,7 +222,7 @@ first launch of a build that has this line, so the row to run instead is TC-8.
 | Toolchains | 6 | | | |
 | Terminal & Tools | 11 | | | |
 | SAF & Files | 8 | | | |
-| **Total** | **88** | | | |
+| **Total** | **90** | | | |
 
 **Overall Result**: [ ] PASS / [ ] FAIL
 

--- a/patches/0015-menubar-keep-open-on-keyboard-resize.patch
+++ b/patches/0015-menubar-keep-open-on-keyboard-resize.patch
@@ -1,0 +1,105 @@
+Keep the menubar open when only the keyboard resized the window.
+
+Tapping the menubar on a phone opened the menu and closed it again about 40ms
+later, so the button read as completely dead. Measured on an API 33 emulator
+with the menu container watched by a MutationObserver: added at t+8.7ms,
+removed at t+55.5ms, four times in a row. On a compact menubar that button is
+the only route to the File, Edit, Selection, View, Go, Run and Terminal menus,
+and the state it fails in is the state a phone is usually in.
+
+The chain is short. Focus normally sits in a text field, so the on-screen
+keyboard is up. Tapping the menubar moves focus to the menu, the field blurs,
+the keyboard comes down, and the viewport grows back. That fires a window
+resize, and this listener answers every resize by blurring the menubar, which
+returns focus to whatever held it before and disposes the open menu.
+
+Measured both directions before changing anything, with input dispatched two
+ways so the host's touch handling could be ruled in or out:
+
+  keyboard down, focus not in a text field  no resize, menu stays open
+  keyboard up, then tap the menubar         innerHeight 266 to 360, menu gone
+
+Dispatching the same tap inside the page rather than through the touchscreen
+reproduced it identically, so nothing outside the page is involved.
+
+iOS is already excused from this listener outright, for the same underlying
+reason. Excusing Android the same way also works, and was measured working,
+but it costs something: a rotation with a submenu open then leaves that
+submenu anchored where it no longer fits, clipped off the edge of a viewport
+that is now narrower than the submenu is wide (measured: submenu right edge at
+607px in a 412px viewport). So Android is excused only for the keyboard's
+signature, a resize that leaves the width alone. A rotation changes both
+dimensions and still blurs, exactly as before.
+
+Verified against the built bundle, all three cases: the keyboard resize no
+longer closes the menu, a rotation still closes it, and a rotation with a
+submenu open closes both rather than clipping. Tapping outside, Escape, and
+opening a submenu all still behave as they did.
+
+One note for whoever simplifies this later. The comparison is written as
+`mainWindow.innerWidth === lastWidth` and the assignment reads the property a
+second time, which looks like something to hoist into a local. Hoisting it
+removes the token `innerWidth===` from the built bundle, and that token is
+what patches/fingerprints.txt uses to prove this patch reached the package. If
+you hoist it, move that row to something the new shape introduces, and check
+the replacement occurs zero times in an unpatched bundle first.
+
+diff --git a/src/vs/workbench/browser/parts/titlebar/menubarControl.ts b/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
+index 9d3f6af..4192504 100644
+--- a/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
++++ b/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
+@@ -11,7 +11,7 @@ import { IContextKeyService } from '../../../../platform/contextkey/common/conte
+ import { IAction, Action, SubmenuAction, Separator, IActionRunner, ActionRunner, WorkbenchActionExecutedEvent, WorkbenchActionExecutedClassification, toAction } from '../../../../base/common/actions.js';
+ import { addDisposableListener, Dimension, EventType } from '../../../../base/browser/dom.js';
+ import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
+-import { isMacintosh, isWeb, isIOS, isNative } from '../../../../base/common/platform.js';
++import { isMacintosh, isWeb, isIOS, isAndroid, isNative } from '../../../../base/common/platform.js';
+ import { IConfigurationService, IConfigurationChangeEvent } from '../../../../platform/configuration/common/configuration.js';
+ import { Event, Emitter } from '../../../../base/common/event.js';
+ import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
+@@ -735,10 +735,43 @@ export class CustomMenubarControl extends MenubarControl {
+ 	protected override registerListeners(): void {
+ 		super.registerListeners();
+ 
++		// A resize that leaves the width alone is the on-screen keyboard arriving
++		// or leaving, not a window anyone resized. On Android that is what tapping
++		// the menubar itself produces: the tap moves focus off whatever text field
++		// held it, the keyboard comes down, the viewport grows, and this listener
++		// closed the menu roughly 40ms after it opened. From the outside the button
++		// reads as dead, and on a phone the compact menubar is the only route to the
++		// File, Edit, View and Terminal menus.
++		//
++		// iOS is already excused from this listener outright for the same underlying
++		// reason. Android is excused only for the keyboard's signature, a
++		// height-only change, so a real resize still blurs: rotating with a menu open
++		// closes it rather than leaving a submenu anchored off the edge of a viewport
++		// that is now narrower than the submenu is wide.
++		//
++		// Testing the width alone is direction-blind, and that is deliberate rather
++		// than overlooked. It also covers the keyboard coming back while a menu is
++		// open, where the viewport shrinks instead of growing. That is the same class
++		// of event, and it is barely reachable anyway: with a menu open, focus is in
++		// the menu rather than in a text field, so nothing asks for the keyboard.
++		let lastWidth = mainWindow.innerWidth;
+ 		this._register(addDisposableListener(mainWindow, EventType.RESIZE, () => {
+-			if (this.menubar && !(isIOS && BrowserFeatures.pointerEvents)) {
+-				this.menubar.blur();
++			const widthUnchanged = mainWindow.innerWidth === lastWidth;
++			lastWidth = mainWindow.innerWidth;
++
++			if (!this.menubar) {
++				return;
++			}
++
++			if (isIOS && BrowserFeatures.pointerEvents) {
++				return;
+ 			}
++
++			if (isAndroid && BrowserFeatures.pointerEvents && widthUnchanged) {
++				return;
++			}
++
++			this.menubar.blur();
+ 		}));
+ 
+ 		// Mnemonics require fullscreen in web

--- a/patches/fingerprints.txt
+++ b/patches/fingerprints.txt
@@ -91,3 +91,15 @@
 # minify of the new handler emits `!n.scrollTopChanged&&!n.scrollLeftChanged`,
 # so the token survives and only this patch introduces it.
 0014 menu submenu scroll dismiss|out/vs/workbench/workbench.web.main.internal.js|scrollTopChanged&&!
+# 0015 gates on the width comparison the guard needs. Measured in the packaged
+# pre-patch bundles, `innerWidth===` occurs zero times in both workbench.js and
+# workbench.web.main.internal.js, while the positive control `innerWidth` occurs
+# 16 times in each, so the operator is what makes it unique and the row cannot
+# pass on surrounding code. A minifier mangles `lastWidth` but not the property
+# read or the operator, so the token survives.
+#
+# This row therefore constrains the patch's shape, which is not obvious from
+# either file alone: hoisting `mainWindow.innerWidth` into a local, the tidier
+# way to write that handler, deletes the token and the row starts failing on a
+# tree that is correct. The patch header says so at the call site too.
+0015 menubar keyboard resize|out/vs/code/browser/workbench/workbench.js|innerWidth===


### PR DESCRIPTION
Tapping the menubar on a phone opens the menu and closes it again about 40ms later, so the button reads as completely dead. On a compact menubar that button is the only route to the File, Edit, Selection, View, Go, Run and Terminal menus, and the state it fails in is the state a phone is usually in.

Focus normally sits in a text field, so the keyboard is up. Tapping the menubar moves focus to the menu, the field blurs, the keyboard comes down and the viewport grows back. That fires a window resize, and `CustomMenubarControl` answers every resize by blurring the menubar, which disposes the open menu and hands focus back to the field it came from. iOS is excused from that listener; Android is not.

The resize is ours, and it cannot be taken away. The activity draws behind the system bars, so the IME arrives as an inset rather than a window resize, and `ExtraKeyRow`'s insets listener is what turns it into one: the container's bottom padding tracks `max(navBar, ime)` and the key row flips between VISIBLE and GONE, above a WebView laid out at height `0dp` weight `1`. Both of those are correct and have to stay, so the fix belongs on the other side.

## What changed

- `patches/0015-menubar-keep-open-on-keyboard-resize.patch` excuses Android from the resize blur only when the width is unchanged, which is the keyboard's signature. A rotation changes both dimensions and still blurs.
- `patches/fingerprints.txt` gains a row keyed on `innerWidth===`, measured at zero occurrences in both packaged bundles before the patch, against 16 for the bare property name.
- `docs/04-TECHNICAL_SPEC.md` lists 0014 and 0015 in the patch set, which stopped at 0013.
- `docs/DEVICE_TEST_CHECKLIST.md` gains ED-9 and ED-10. ED-9 opens the menu with the keyboard up and asks the reader to watch rather than glance, because the failure lasted 40ms. ED-10 pins the boundary the width gate keeps: rotate with a submenu open, both must close.

## Risk

Excusing Android outright, the way iOS is, was also measured working for the keyboard case, but it costs a rotation: with a submenu open, rotating leaves that submenu anchored where it no longer fits, right edge at 607px in a 412px viewport. Gating on the width avoids that and leaves rotation behaving exactly as it does today.

This patch changes the Code - OSS build input, so the `server-1.133.0` tarball is rebuilt from this branch before merge. The fingerprint gate in `scripts/fetch-vscode-oss.sh` is what makes an app build refuse a server tree that predates the patch rather than shipping it, so the ordering is enforced rather than remembered.

## Verification

Measured on an API 33 emulator, with the menu container watched by a MutationObserver over the live page:

| Case | Result |
|---|---|
| keyboard down, focus outside a text field | no resize fires, menu stays open indefinitely |
| keyboard up, then tap the menubar | `innerHeight` 266 to 360, menu added at t+8.7ms, removed at t+55.5ms |
| the same tap dispatched inside the page, not through the touchscreen | reproduces identically, so nothing outside the page is involved |

Against the built bundle with the patch applied, on the device:

- the keyboard resize no longer closes the menu, and the menu lists File, Edit, Selection, View, Go and Run
- a rotation still closes it
- a rotation with a submenu open closes both rather than clipping
- tapping outside, Escape, and opening the File submenu behave as they did

`git apply --check` against a pristine copy of `menubarControl.ts` at the pinned commit passes, `registerListeners()` is called exactly once from the constructor so the captured width cannot fork, and the unit suite is 1288 tests with 0 failures.
