### PR TITLE
test(a11y): pin the wiring nobody can see, and let it run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The picker's checked state and the Toolchains back-arrow label are now pinned by tests. Both are invisible to a sighted reviewer, so either could be deleted without a symptom.
+- Editing a layout or a string no longer leaves the unit suite up to date. Two suites read those files, and both were skipped on exactly the edits they exist to catch.
 - The security document no longer calls the extension host a sandbox. It is a fault boundary, and an extension reaches app-private storage exactly as the app does.
 - The landing page quotes the storage figure the app computes and says extraction repeats after an update, which every other document already said.
 - The design documents now describe the build that ships: two on-demand toolchains, terminals that spawn bash on a real PTY, and how the server is actually patched and built.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -452,6 +452,38 @@ tasks.withType<Test> {
     )
         .withPropertyName("statedRequirements")
         .withPathSensitivity(PathSensitivity.RELATIVE)
+
+    // Resources, for the same reason and with one difference that makes them
+    // easier to miss than everything above: they DO have a tool standing behind
+    // them, and it is not enough. aapt turns res/ into R, so an edit that adds or
+    // removes a resource id recompiles and the tests re-run. An edit that changes
+    // only an attribute VALUE, or deletes an attribute, produces the same ids and
+    // the same R, so the compiled classpath this task depends on is byte for byte
+    // what it was and Gradle answers UP-TO-DATE. That is precisely the shape of
+    // edit these suites exist to catch.
+    //
+    // Measured on this module, both directions, with the task made UP-TO-DATE
+    // first: deleting `app:navigationContentDescription` from
+    // activity_toolchain.xml left `> Task :app:testDebugUnitTest UP-TO-DATE`,
+    // BUILD SUCCESSFUL in 1s, and the previous run's results XML served back
+    // green; flipping `android:enforceStatusBarContrast` to true in themes.xml
+    // did the same. With this declaration each re-runs the suite and turns its
+    // reader red. Renaming a resource is NOT a control for this: it changes the
+    // id, so `processDebugResources` fails first and never reaches the test.
+    //
+    //   res/layout    PickerAccessibilityWiringTest
+    //   res/values    PickerAccessibilityWiringTest, ThemeEdgeToEdgeTest
+    //
+    // layout/ and values/ only. Nothing reads drawable/, mipmap-*/ or xml/, and
+    // the mipmaps are images whose hashes would be paid for on every run and
+    // never asked about. Widen this the moment a suite reads one of them:
+    //   grep -rn 'File("src/main/res' android/app/src/test/kotlin
+    inputs.files(
+        fileTree("src/main/res/layout"),
+        fileTree("src/main/res/values"),
+    )
+        .withPropertyName("readableResources")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
 }
 
 // The server tree in assets/ has to carry this checkout's patches, and nothing

--- a/android/app/src/test/kotlin/com/vscodroid/setup/PickerAccessibilityWiringTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/PickerAccessibilityWiringTest.kt
@@ -1,0 +1,168 @@
+package com.vscodroid.setup
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * The accessibility wiring on the first-run picker, and the one on the Toolchains
+ * toolbar, kept from being deleted by someone who cannot see what it does.
+ *
+ * Both are invisible to a sighted reviewer and to every other test here. Selection
+ * on a picker card was drawn as a stroke, a background colour and a checkmark, and
+ * reported `checkable=false, checked=false` to a screen reader in both states; the
+ * toolbar's back arrow, the only visible way off the Toolchains screen, announced
+ * as an unlabelled button. Neither had a symptom anyone would notice while looking
+ * at the screen, which is why neither was noticed.
+ *
+ * ⚠️ What this cannot see, stated because the alternative is a reader trusting it
+ * for more than it proves. These read source and XML, so they prove the calls are
+ * written, not that a screen reader speaks anything. The behaviour lives in
+ * `announceForAccessibility` and in the framework's node building, and no runner
+ * family GitHub offers can execute the instrumented suite that would reach it.
+ * `docs/DEVICE_TEST_CHECKLIST.md` is the instrument for that half.
+ *
+ * Scoped to the function that owns each call rather than to the file. A search over
+ * a whole file is satisfied by any copy of the token anywhere in it, which is how a
+ * guard of this shape passes while the thing it guards is gone.
+ */
+class PickerAccessibilityWiringTest {
+
+    private val adapter = File("src/main/kotlin/com/vscodroid/setup/ToolchainPickerAdapter.kt")
+    private val toolbarLayout = File("src/main/res/layout/activity_toolchain.xml")
+
+    /**
+     * The body of one function, brace-matched from its signature.
+     *
+     * Brace counting rather than a line range: a range drifts the moment anything
+     * above it grows, and a guard anchored to a line number stops guarding the
+     * function it was written for without saying so.
+     */
+    private fun bodyOf(source: File, signature: String): String {
+        assertTrue(
+            source.isFile,
+            "${source.path} is not at ${source.absolutePath}; this test would " +
+                "otherwise pass by reading nothing",
+        )
+        val text = source.readText()
+        val start = text.indexOf(signature)
+        assertTrue(start >= 0, "no function matching `$signature` in ${source.name}")
+        var depth = 0
+        var i = text.indexOf('{', start)
+        // Before the loop, not after it: at -1 the loop's first statement reads
+        // text[-1] and the reader gets an index-out-of-bounds instead of the
+        // sentence written for them below.
+        assertTrue(i >= 0, "no body follows `$signature` in ${source.name}")
+        val open = i
+        while (i < text.length) {
+            when (text[i]) {
+                '{' -> depth++
+                '}' -> if (--depth == 0) return text.substring(open, i + 1)
+            }
+            i++
+        }
+        error("unbalanced braces after `$signature` in ${source.name}")
+    }
+
+    /**
+     * `MaterialCardView` implements `Checkable` and already forwards these into the
+     * node and the change event. Nothing called them, so the only accessible trace
+     * of selection was a checkmark whose label vanishes when deselected, and a
+     * deselected card said nothing distinguishing at all.
+     */
+    @Test
+    fun `picker binding sets both halves of the checked state`() {
+        val body = bodyOf(adapter, "private fun bindPickerMode(")
+
+        assertTrue(
+            body.contains("isCheckable = true"),
+            "bindPickerMode does not make the card checkable, so it reports " +
+                "checkable=false and a screen reader offers no state at all",
+        )
+        assertTrue(
+            Regex("""isChecked\s*=\s*isSelected""").containsMatchIn(body),
+            "bindPickerMode does not tie isChecked to the selection, so the state " +
+                "it reports is fixed and the card sounds the same either way",
+        )
+    }
+
+    /**
+     * The rebind has to carry a payload. Without one RecyclerView runs the default
+     * change animation, which swaps the item view and takes accessibility focus
+     * with it, so a user who just double-tapped a card is returned to the top of
+     * the list and has to find their way back to hear what they changed.
+     */
+    @Test
+    fun `the selection rebind carries a payload`() {
+        val body = bodyOf(adapter, "private fun bindPickerMode(")
+        val calls = Regex("""notifyItemChanged\([^)]*\)""").findAll(body).map { it.value }.toList()
+
+        assertEquals(
+            1, calls.size,
+            "expected exactly one notifyItemChanged in bindPickerMode, found $calls",
+        )
+        assertTrue(
+            calls[0].contains(","),
+            "${calls[0]} passes no payload, so the default change animation runs and " +
+                "drops accessibility focus off the card that was just tapped",
+        )
+    }
+
+    /**
+     * `setSupportActionBar` is never called anywhere in this app, so the framework's
+     * own "Navigate up" default never applies and no toolbar style supplies one.
+     * The attribute in the layout is the only thing standing between a screen reader
+     * user and an unlabelled button where the only visible exit is.
+     */
+    @Test
+    fun `the toolchains toolbar names its navigation icon`() {
+        assertTrue(
+            toolbarLayout.isFile,
+            "${toolbarLayout.path} is missing; this test would otherwise pass by " +
+                "reading nothing",
+        )
+        val xml = toolbarLayout.readText()
+
+        // Anchored on the `=` rather than written as a substring. `app:navigationIcon`
+        // is a prefix of `app:navigationIconTint`, which this toolbar also sets, so a
+        // contains() check stays satisfied by the tint after the icon itself is gone.
+        // Measured: deleting only `app:navigationIcon` left all four cases green while
+        // the screen lost its one visible way out, and the label below went on
+        // describing an icon that no longer existed.
+        assertTrue(
+            Regex("""app:navigationIcon\s*=""").containsMatchIn(xml),
+            "the toolbar has no navigation icon at all, which makes the assertion " +
+                "below vacuous rather than satisfied",
+        )
+        assertTrue(
+            Regex("""app:navigationContentDescription="@string/\w+"""").containsMatchIn(xml),
+            "the toolbar's navigation icon has no label, and nothing else supplies " +
+                "one: setSupportActionBar is never called in this app",
+        )
+    }
+
+    /**
+     * The control for the assertion above, and the reason it names a resource rather
+     * than accepting any value: a literal would satisfy the pattern while being
+     * untranslatable, which is the shape lint's HardcodedText exists to refuse.
+     */
+    @Test
+    fun `the navigation label is a resource, and that resource exists`() {
+        val strings = File("src/main/res/values/strings.xml")
+        assertTrue(
+            toolbarLayout.isFile && strings.isFile,
+            "${toolbarLayout.path} or ${strings.path} is missing; without this the " +
+                "reader gets a FileNotFoundException instead of the sentence above",
+        )
+        val xml = toolbarLayout.readText()
+        val name = Regex("""app:navigationContentDescription="@string/(\w+)"""")
+            .find(xml)?.groupValues?.get(1)
+
+        assertTrue(name != null, "the navigation label is not a string resource")
+        assertTrue(
+            strings.readText().contains("""name="$name""""),
+            "activity_toolchain.xml names @string/$name, which strings.xml does not declare",
+        )
+    }
+}

--- a/docs/07-TESTING_STRATEGY.md
+++ b/docs/07-TESTING_STRATEGY.md
@@ -23,7 +23,7 @@ VSCodroid has unique testing challenges: it's a hybrid app (Kotlin + WebView + N
 ```mermaid
 flowchart TD
   E2E["Manual / E2E Tests<br/>Real devices, UX testing<br/>14 scenarios"] --> INT["Instrumented Tests<br/>WebView + Node.js + Kotlin<br/>26 tests, run by hand on a device"]
-  INT --> UNIT["Unit Tests<br/>1221 Kotlin tests in 192 classes (JVM)<br/>8 node:assert scripts for the bundled JavaScript"]
+  INT --> UNIT["Unit Tests<br/>1292 Kotlin tests in 203 classes (JVM)<br/>8 node:assert scripts for the bundled JavaScript"]
 ```
 
 ---
@@ -46,7 +46,7 @@ flowchart TD
 | SafSyncEngine | Mirror reconciliation, write-back filtering, rename pairing | `SafSyncEngineTest`, `SafWriteBackFilterTest`, `SafRenamePairingTest` |
 | VSCodroidWebViewClient | CDN interception, `vscode-remote` resource serving, downloads | `ResourceInterceptionWiringTest`, `WebviewResourceResolutionTest`, `DownloadCoordinatorTest` |
 
-The suite is **1221 tests in 192 classes**, and it is green. A test that needs a
+The suite is **1292 tests in 203 classes**, and it is green. A test that needs a
 filesystem builds its tree under a JUnit `@TempDir` rather than touching the
 checkout.
 


### PR DESCRIPTION
Two accessibility fixes shipped without a test. Both are invisible to a sighted reviewer and to every other test here, so either could be deleted and nothing would go red: a picker card reported `checkable=false, checked=false` to a screen reader in both states while drawing selection as a stroke and a checkmark, and the Toolchains toolbar's back arrow, the only visible way off that screen, announced as an unlabelled button.

The larger half of this change is that the guards can now run at all.

## Resources were not declared as test inputs

Gradle knew nothing about `res/`, so `:app:testDebugUnitTest` answered UP-TO-DATE for exactly the edits these cases exist to catch, and served the previous run's results back green.

aapt is not enough to cover it. Adding or removing a resource changes an id, which recompiles and re-runs the tests. Changing an attribute value, or deleting an attribute, produces the same ids and the same `R`, so the compiled classpath is byte for byte what it was.

Measured with the task settled UP-TO-DATE first:

| Edit | Before | After |
|---|---|---|
| delete `app:navigationContentDescription` from `activity_toolchain.xml` | `UP-TO-DATE`, BUILD SUCCESSFUL in 1s, four green results from the previous run | suite re-runs, two cases red |
| flip `android:enforceStatusBarContrast` to `true` in `themes.xml` | `UP-TO-DATE`, green | suite re-runs, `ThemeEdgeToEdgeTest` red |

The second row is not new to this branch. `ThemeEdgeToEdgeTest` already read `themes.xml` the same way and already had the gap; both readers are covered now. Renaming a resource is not a control for this, because it fails `processDebugResources` before the test is reached.

## One case matched a substring

`app:navigationIcon` is a prefix of `app:navigationIconTint`, which this toolbar also sets, so `contains("app:navigationIcon")` stayed satisfied after the icon itself was deleted. Measured: all four cases green while the screen lost its one visible way out, and the label went on describing an icon that no longer existed. The assertion is anchored on the `=` now.

## What changed

- `PickerAccessibilityWiringTest`, four cases, each scoped to the function that owns the call by brace-matching from its signature rather than by line range, so the guard follows the function instead of drifting off it.
- `android/app/build.gradle.kts` declares `res/layout` and `res/values` as inputs to the test task, with `drawable/`, `mipmap-*/` and `xml/` deliberately left out because no suite reads them.
- `docs/07-TESTING_STRATEGY.md` re-measured: it read 1221 tests in 192 classes, written before eight other test files landed. The runner reports 1292 in 203 on this branch.

## Verification

Seven negative controls, each run from a genuinely settled UP-TO-DATE state rather than from whatever the previous mutation left behind, which is the difference between a control and a coincidence:

| Mutation | Case that reddens |
|---|---|
| remove `isCheckable` | picker binding sets both halves of the checked state |
| untie `isChecked` from the selection | picker binding sets both halves of the checked state |
| drop the payload from `notifyItemChanged` | the selection rebind carries a payload |
| delete the navigation label | names its navigation icon, label is a resource |
| replace the label with a literal | names its navigation icon, label is a resource |
| delete `app:navigationIcon` | names its navigation icon |
| flip `android:enforceStatusBarContrast` | `ThemeEdgeToEdgeTest` |

The clean tree stays green: 1292 tests, 0 failures, 0 errors, 0 skipped.

## What these cannot see

They read source and XML, so they prove the calls are written, not that a screen reader speaks anything. No runner family GitHub offers can execute the instrumented suite that would reach it. `docs/DEVICE_TEST_CHECKLIST.md` remains the instrument for that half, and the file says so.
