### PR TITLE
test(toolchain): correct what this test says about its own variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The picker's checked state and the Toolchains back-arrow label are now pinned by tests. Both are invisible to a sighted reviewer, so either could be deleted without a symptom.
 - Editing a layout or a string no longer leaves the unit suite up to date. Two suites read those files, and both were skipped on exactly the edits they exist to catch.
+- A test no longer states that AGP builds no release unit test task. It does build one, and it has run; what is true is that no workflow invokes it.
 - The security document no longer calls the extension host a sandbox. It is a fault boundary, and an extension reaches app-private storage exactly as the app does.
 - The landing page quotes the storage figure the app computes and says extraction repeats after an update, which every other document already said.
 - The design documents now describe the build that ships: two on-demand toolchains, terminals that spawn bash on a real PTY, and how the server is actually patched and built.

--- a/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainDigestTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainDigestTest.kt
@@ -393,12 +393,24 @@ class LatestReleasePinningTest {
         // useless, since `removeSuffix` strips exactly that string, so the only
         // suffixes that survive to be asserted on are the ones it does not match.
         //
-        // The release variant has no unit test task to run this under: AGP builds
-        // test components for `testBuildType` only, which is debug. So this runs
-        // against the debug value, which is the release versionName plus "-debug",
-        // and the suffix stripping is the half it can prove. The release value
-        // differs from it only by that suffix. Not quoted here: the literal went
-        // stale at the first version bump, while the property it describes did not.
+        // What runs this is the debug variant, so the value read here is the
+        // release versionName plus "-debug" and suffix stripping is the half it
+        // proves. The un-suffixed form is proved beside it, by literal, in
+        // `an install reaches the release its own version names`.
+        //
+        // Not because a release unit test task does not exist. It does, and it
+        // runs: `testReleaseUnitTest` produced 192 result files, 1221 tests and
+        // zero failures on 2026-08-20. `testBuildType` selects the INSTRUMENTED
+        // component; unit test tasks are generated for every build type. What is
+        // true is narrower and is about CI rather than AGP: no workflow invokes
+        // it. Measured, and scoped away from this comment so it does not count
+        // itself: `git grep -c testReleaseUnitTest -- .github scripts '*.kts'`
+        // is 0, while the same search for the debug task is 5, of which two are
+        // the `./gradlew testDebugUnitTest` lines in build.yml and release.yml.
+        // So only a local run has ever exercised the release variant.
+        //
+        // Not quoted here: the literal went stale at the first version bump,
+        // while the property it describes did not.
         val tag = appReleaseTag(BuildConfig.VERSION_NAME)
 
         assertNotNull(


### PR DESCRIPTION
A comment in `ToolchainDigestTest` states that the release variant has no unit test task, because "AGP builds test components for `testBuildType` only, which is debug". That is not what `testBuildType` selects. It selects the instrumented component; unit test tasks are generated for every build type, and the release one has run: `testReleaseUnitTest` left 192 result files, 1221 tests and zero failures dated 2026-08-20.

The comment is load-bearing in the way stale comments usually are. It tells the next reader that a whole variant is untestable, which is the sort of thing nobody re-checks, and it was offered as the reason the un-suffixed `versionName` cannot be pinned.

## What changed

- The AGP claim is replaced by what is actually true, which is about CI rather than AGP: no workflow invokes the task. Measured and scoped so the comment cannot count itself, `git grep -c testReleaseUnitTest -- .github scripts '*.kts'` is 0, while the same search for the debug task is 5, two of them the `./gradlew testDebugUnitTest` lines in `build.yml` and `release.yml`.
- The implication that the un-suffixed `versionName` is unproven is removed. It is proved by literal one test above, in `an install reaches the release its own version names`, which asserts `appReleaseTag("1.0.0")` pins `v1.0.0`. The comment now points at it rather than leaving a reader to assume a gap and close it a second time.

## Scope

Comment only. No assertion changed, no production code touched. Suite is 1288 tests, 0 failures.

Adding `testReleaseUnitTest` to CI is deliberately **not** part of this. It is arguable on its own merits and it should not be argued as shrinker coverage, which it does not buy: unit tests are JVM tests and cannot load dex, and the class names in those release result files are unobfuscated.
