### PR TITLE
fix(app): survive the one config change nobody triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The system dark theme flipping no longer moves you out of your workspace, or restarts first-run extraction if it lands while setup is running.
 - The menubar no longer closes itself when the on-screen keyboard drops. The resize that follows the tap shut the menu 40ms after it opened, leaving no route to the File or Terminal menus.
 - A screen reader now hears the Toolchains back arrow, which toolchain is selected in the picker, that setup failed, and that a download finished.
 - Six texts on the setup and toolchain screens were too faint to read, including the Continue button and the word that says a download failed.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -28,11 +28,39 @@
         tools:targetApi="34">
 
         <!-- Splash screen: shown during binary extraction and server startup -->
+        <!-- uiMode is in both lists below, and it is the only one of the eleven
+             undeclared qualifiers that fires with no user interaction at all: a
+             sunset-to-sunrise dark schedule and battery saver's forced dark both
+             flip it while the app is in use. Here the cost is the worst in the
+             app. runSetup() runs inside lifecycleScope, and
+             FirstRunSetup.markSetupComplete() is the last statement of the same
+             block, so a relaunch cancels it before setup is ever marked
+             complete, isFirstRun() stays true, and the whole extraction starts
+             over. In MainActivity the cost is smaller but unattended: the fresh
+             WebView holds only the data: placeholder, folderFromUrl refuses an
+             opaque URI, and loadVSCode falls through to the default projects
+             directory, so the user is silently moved out of their workspace.
+
+             This is safe to declare because neither activity has anything that
+             resolves differently by night: the module has no values-night
+             directory at all, and every layout these two inflate names its
+             colours as fixed @color resources rather than ?attr, picker card
+             included. That is the condition, not a coincidence. If anyone adds
+             a values-night qualifier, or switches one of these layouts to
+             ?attr/colorSurface, this declaration becomes a bug: the framework
+             stops relaunching and nothing re-resolves, leaving the screen in the
+             previous appearance. Handle onConfigurationChanged then, or take
+             uiMode back out.
+
+             The other ten stay undeclared deliberately. locale, layoutDirection,
+             fontScale, density, colorMode and fontWeightAdjustment all need the
+             user to leave the app and change a system setting, and a relaunch is
+             the correct answer to them. -->
         <activity
             android:name=".SplashActivity"
             android:exported="true"
             android:noHistory="true"
-            android:configChanges="orientation|screenSize|keyboard|keyboardHidden|screenLayout|smallestScreenSize"
+            android:configChanges="orientation|screenSize|keyboard|keyboardHidden|screenLayout|smallestScreenSize|uiMode"
             android:theme="@style/Theme.VSCodroid">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -45,7 +73,7 @@
             android:name=".MainActivity"
             android:exported="true"
             android:launchMode="singleTask"
-            android:configChanges="orientation|screenSize|keyboard|keyboardHidden|screenLayout|smallestScreenSize"
+            android:configChanges="orientation|screenSize|keyboard|keyboardHidden|screenLayout|smallestScreenSize|uiMode"
             android:windowSoftInputMode="adjustResize"
             android:theme="@style/Theme.VSCodroid">
 

--- a/android/app/src/test/kotlin/com/vscodroid/keyboard/HardwareKeyboardTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/keyboard/HardwareKeyboardTest.kt
@@ -155,7 +155,21 @@ class HardwareKeyboardTest {
         // attribute, it costs the same teardown, and a message that says to keep
         // the rest of the string while checking none of it is an invitation to
         // trim the attribute down to what this test reads.
-        val required = listOf("keyboard", "keyboardHidden", "orientation", "screenSize")
+        // uiMode joins them for the same reason and a worse consequence. It is the
+        // only qualifier outside this list that fires with nobody touching the
+        // device: a sunset-to-sunrise dark schedule, and battery saver's forced
+        // dark, both flip it mid-session. In MainActivity that silently moves the
+        // user out of their workspace, because the rebuilt WebView carries only
+        // the data: placeholder and loadVSCode falls through to the default
+        // projects directory. In SplashActivity it restarts the whole first-run
+        // extraction, because runSetup() lives in lifecycleScope and the relaunch
+        // cancels it before markSetupComplete() runs.
+        //
+        // Declaring it is only safe while neither activity has anything that
+        // resolves by night. The manifest comment states that condition; this
+        // list is what fails if the declaration is removed, not if the condition
+        // stops holding, and no test can see the second half.
+        val required = listOf("keyboard", "keyboardHidden", "orientation", "screenSize", "uiMode")
         val unguarded = guarded.filterNot { name ->
             declared[name].orEmpty().split("|").containsAll(required)
         }


### PR DESCRIPTION
Of the eleven configuration qualifiers `MainActivity` and `SplashActivity` do not declare, `uiMode` is the only one that fires with nobody touching the device. A sunset-to-sunrise dark schedule flips it once a day, and battery saver's forced dark flips it during exactly the long unplugged sessions this app exists for. The other ten all need the user to leave the app and change a system setting, and a relaunch is the right answer to those.

## Measured, before and after

On an API 33 emulator, with a folder and a file open, toggling the system theme:

| | Before (`configChanges=0xdb3`) | After (`0xfb3`) |
|---|---|---|
| Activity relaunch events | present | **0** |
| `Loading VS Code at ...` | present, naming the default folder | **0** |
| Folder after the flip | `projects` (default) | **`projects/uji-state01`** |
| Editor tabs after the flip | `[]` | unchanged |

The masks are read from the built APK with `aapt2 dump xmltree` and from the running system with `dumpsys activity activities`, not from the source, because the source is not what runs.

Reopening the folder did bring the tab set back even before this change, so nothing was ever destroyed. What the user lost was being moved out of their workspace without being told.

## Why it happens

`loadVSCode` resolves the folder as `folderPath ?: folderFromUrl(webView?.url) ?: ensureProjectsDir()`. Two of its three callers pass no folder; only `recreateWebView` carries one, read off the dying WebView. A rebuilt activity inflates a fresh WebView that still holds the `data:` placeholder from `setupWebView`, `folderFromUrl` refuses an opaque URI at its `isHierarchical` guard, and the third term wins.

`SplashActivity` is the worse half, and the reason this is not only about the editor. `runSetup()` runs inside `lifecycleScope` and `FirstRunSetup.markSetupComplete()` is the last statement of the same block, so a relaunch cancels it before setup is marked complete, `isFirstRun()` stays true, and the whole extraction runs again.

## Why declaring it is safe here

Neither activity has anything that resolves differently by night, and that is checked rather than assumed:

- the module has no `values-night` directory at all
- every layout these two inflate names its colours as fixed `@color` resources rather than `?attr`, the toolchain picker card included
- the positive control is `activity_toolchain.xml`, which does use `?attr` twice and belongs to a third activity this does not touch

The manifest comment states that condition and what to do if it stops holding, because no test can see that half: adding a `values-night` qualifier, or switching one of these layouts to `?attr/colorSurface`, turns this declaration into a bug where the framework stops relaunching and nothing re-resolves.

## Scope

Deliberately not included: restoring the workspace on a cold start or after a background process kill. Both land on the default folder today by design, and changing that is a product decision rather than a defect.

## Verification

`uiMode` joins the `required` list in `HardwareKeyboardTest`. Negative controls, each run from a settled `UP-TO-DATE` state on a committed tree: removing `uiMode` from `MainActivity` alone reddens the case, and removing it from `SplashActivity` alone reddens it too. Clean tree green. Suite: 1292 tests, 0 failures.
