### PR TITLE
fix(npm): stop discarding what npm config set wrote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - The system dark theme flipping no longer moves you out of your workspace, or restarts first-run extraction if it lands while setup is running.
+- Opening the app no longer discards what `npm config set` wrote. A private registry, its auth token, `cafile` and `strict-ssl` all survive a launch now.
 - The menubar no longer closes itself when the on-screen keyboard drops. The resize that follows the tap shut the menu 40ms after it opened, leaving no route to the File or Terminal menus.
 - A screen reader now hears the Toolchains back arrow, which toolchain is selected in the picker, that setup failed, and that a download finished.
 - Six texts on the setup and toolchain screens were too faint to read, including the Continue button and the word that says a download failed.

--- a/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
@@ -1070,7 +1070,35 @@ class FirstRunSetup(
         // npm's fallback is a POSIX shell and this app's scripts assume bash
         // os[]: install optional deps for both linux and android so tools like
         // @rollup/rollup-android-arm64 get installed alongside linux fallbacks
-        val expectedContent = "script-shell=$bashPath\nos[]=linux\nos[]=android\n"
+        //
+        // Reconciled rather than rewritten, and that is the whole point of the
+        // shape below. This used to build the three lines and write them over
+        // whatever was there, on every launch. `.npmrc` is also where npm itself
+        // writes: `npm config set registry`, an auth token for a private
+        // registry, `cafile`, `strict-ssl`. All of it worked until the app was
+        // next opened, and then it was gone, with nothing on screen and nothing
+        // in the log to say the app had done it. A user who lost a token twice
+        // would have no way to reach that conclusion.
+        //
+        // So only the two keys this app owns are replaced. `script-shell` is
+        // owned because it has to track nativeLibraryDir, which Android moves on
+        // every reinstall, and because npm's fallback is a POSIX shell while this
+        // app's scripts assume bash. `os[]=linux` and `os[]=android` are owned so
+        // optional dependencies resolve for both, which is what gets
+        // @rollup/rollup-android-arm64 installed beside the linux fallback. Every
+        // other line is carried through untouched, in the order it was written.
+        //
+        // The owned lines go first so the file still reads exactly as it did when
+        // nothing else is present, which keeps existing installs from seeing a
+        // rewrite on the launch after this ships.
+        val ownedLine = Regex("""^\s*(script-shell\s*=|os\[]\s*=\s*(linux|android)\s*$)""")
+        val carriedOver = (if (npmrc.exists()) npmrc.readText() else "")
+            .lines()
+            .filterNot { ownedLine.containsMatchIn(it) }
+            .dropLastWhile { it.isBlank() }
+        val expectedContent =
+            (listOf("script-shell=$bashPath", "os[]=linux", "os[]=android") + carriedOver)
+                .joinToString("\n", postfix = "\n")
         if (!npmrc.exists() || npmrc.readText() != expectedContent) {
             // Atomically, like every other setup file this class writes. This one
             // was the exception, and it is a bad one to be: `writeText` truncates

--- a/android/app/src/test/kotlin/com/vscodroid/setup/BashrcAtomicityTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/BashrcAtomicityTest.kt
@@ -324,6 +324,90 @@ class BashrcAtomicityTest {
         )
     }
 
+    /**
+     * `.npmrc` is npm's file too, and the app is a guest in it.
+     *
+     * `npm config set` writes here: the registry for a private mirror, the auth
+     * token that reaches it, `cafile`, `strict-ssl`. The launch-time update used
+     * to replace the whole file with the three lines this app owns, so every one
+     * of those was discarded the next time the app was opened, silently, with
+     * nothing in the log naming the app as the cause. A token lost twice gives a
+     * user no way to reach the right conclusion.
+     */
+    @Test
+    fun `the launch-time update keeps the keys npm itself wrote`() {
+        bundleNpm()
+        val npmrc = File(filesDir, "home/.npmrc").apply {
+            writeText(
+                "script-shell=/old/bash\n" +
+                    "registry=https://registry.internal.example/\n" +
+                    "//registry.internal.example/:_authToken=abc123\n" +
+                    "strict-ssl=false\n" +
+                    "os[]=linux\n",
+            )
+        }
+
+        FirstRunSetup(context).createNpmWrappers()
+
+        val after = npmrc.readText()
+        for (line in listOf(
+            "registry=https://registry.internal.example/",
+            "//registry.internal.example/:_authToken=abc123",
+            "strict-ssl=false",
+        )) {
+            assertTrue(line in after, "the launch-time update discarded `$line`:\n$after")
+        }
+    }
+
+    /**
+     * The other half, and it is not implied by the one above: carrying user lines
+     * through is worthless if the owned keys stop being maintained, because
+     * `script-shell` has to follow nativeLibraryDir across every reinstall.
+     */
+    @Test
+    fun `the owned keys are still corrected, exactly once each`() {
+        bundleNpm()
+        File(filesDir, "home/.npmrc").apply {
+            writeText("script-shell=/old/bash\nregistry=https://x.example/\nos[]=linux\n")
+        }
+
+        FirstRunSetup(context).createNpmWrappers()
+
+        val lines = File(filesDir, "home/.npmrc").readText().lines().filter { it.isNotBlank() }
+        assertEquals(
+            1, lines.count { it.startsWith("script-shell=") },
+            "script-shell is duplicated or missing: $lines",
+        )
+        assertTrue(
+            lines.none { it == "script-shell=/old/bash" },
+            "the stale script-shell survived, so npm would still reach a bash that moved: $lines",
+        )
+        assertEquals(
+            1, lines.count { it == "os[]=linux" }, "os[]=linux is duplicated or missing: $lines",
+        )
+        assertEquals(
+            1, lines.count { it == "os[]=android" }, "os[]=android is missing: $lines",
+        )
+    }
+
+    /**
+     * A file the app has never seen has to come out in the shape it always had.
+     * Anything else means every existing install takes one rewrite on the launch
+     * after this ships, for no reason a user could see.
+     */
+    @Test
+    fun `a fresh npmrc is byte for byte the shape it was before`() {
+        bundleNpm()
+
+        FirstRunSetup(context).createNpmWrappers()
+
+        val after = File(filesDir, "home/.npmrc").readText()
+        assertTrue(
+            Regex("""^script-shell=\S*libbash\.so\nos\[]=linux\nos\[]=android\n$""").matches(after),
+            "a fresh .npmrc is no longer the three owned lines and nothing else: $after",
+        )
+    }
+
     /** Blocks only `.npmrc`, so the `.bashrc` append ahead of it still succeeds. */
     private fun blockTheNpmrcWrite(): File =
         File(filesDir, "home/.npmrc.tmp~").also {


### PR DESCRIPTION
The launch-time `.npmrc` update built the three lines this app owns and wrote them over whatever was there. `.npmrc` is also npm's own file: the registry for a private mirror, the auth token that reaches it, `cafile`, `strict-ssl`. Every one of those worked until the app was next opened, and then it was gone, with nothing on screen and nothing in the log naming the app as the cause. A user who loses a token twice has no way to reach the right conclusion.

## What changed

`FirstRunSetup.createNpmWrappers` now reconciles only the two keys the app owns and carries every other line through in the order it was written.

- `script-shell` is owned because it has to track `nativeLibraryDir`, which Android moves on every reinstall, and because npm's fallback is a POSIX shell while this app's scripts assume bash.
- `os[]=linux` and `os[]=android` are owned so optional dependencies resolve for both, which is what puts `@rollup/rollup-android-arm64` beside the linux fallback.

The owned lines are written first, so a file with nothing else in it comes out byte for byte as it did before. That is deliberate rather than incidental: without it, every existing install would take one rewrite on the launch after this ships, for no reason a user could see.

## Verification

Three new cases, and the second is not implied by the first:

| Case | What it pins |
|---|---|
| the launch-time update keeps the keys npm itself wrote | a registry, an auth token and `strict-ssl` all survive |
| the owned keys are still corrected, exactly once each | a stale `script-shell` is replaced, not merely preserved, and nothing is duplicated |
| a fresh npmrc is byte for byte the shape it was before | existing installs see no rewrite |

Negative controls, each from a settled state on a committed tree:

- putting the wholesale rewrite back reddens **only** the first case, and leaves the shape case green, which is what says the fix does not change the file for anyone who never touched it
- dropping `script-shell` from the owned set reddens the second and third, and also the pre-existing `the npmrc write is what the failure case is withholding`

The atomicity this file already had is untouched: the write still goes through `writeAtomically`, and the two existing cases covering it still pass. Suite: 1295 tests, 0 failures.

## Scope

This is not certificate work and is not argued as any. `cafile` surviving is one consequence among several; the reason to fix it is that the app was silently discarding a file it does not own.
