### PR TITLE
docs: stop promising certificate errors cannot happen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The user guide no longer promises that certificate errors should not happen. It says which roots the bundle carries, that a private CA is not among them, and that npm does not use it.
 - The picker's checked state and the Toolchains back-arrow label are now pinned by tests. Both are invisible to a sighted reviewer, so either could be deleted without a symptom.
 - Editing a layout or a string no longer leaves the unit suite up to date. Two suites read those files, and both were skipped on exactly the edits they exist to catch.
 - A test no longer states that AGP builds no release unit test task. It does build one, and it has run; what is true is that no workflow invokes it.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -783,7 +783,7 @@ If `npm install` fails with errors:
 ### Git Push/Pull Fails
 
 - **Permission denied (publickey)** -- generate an SSH key with `ssh-keygen -t ed25519` in the terminal and add it to your GitHub/GitLab account.
-- **SSL certificate error** -- this should not occur with bundled certificates. If it does, check that you are using `git@` (SSH) URLs instead of `https://`.
+- **SSL certificate error** -- the CA bundle git uses is built from your device's own system roots, so a public certificate authority is already trusted and a private or corporate one is not. Installing that CA through Android Settings does not change it either: user-installed certificates live in a separate store this app does not read. The practical answer for an internal host is an SSH remote (`git@`) instead of `https://`. Note that npm does not use that bundle at all, so a private registry behind its own CA is a different wall rather than the same one.
 
 ### App Uses Too Much Storage
 


### PR DESCRIPTION
The troubleshooting entry read *"this should not occur with bundled certificates"*. It can occur, and the guide left anyone it happened to with nothing: a promise that their situation was impossible, and no map.

## What the bundle actually carries

`FirstRunSetup.setupGitCaBundle` concatenates `/apex/com.android.conscrypt/cacerts`, or `/system/etc/security/cacerts` where that is absent, into `filesDir/usr/etc/tls/cert.pem`. `Environment.buildProcessEnvironment` points `GIT_SSL_CAINFO` at that file, with `GIT_SSL_CAPATH` and `SSL_CERT_DIR` on the system directory.

So the device's system roots are trusted, a private or corporate CA is not, and installing that CA through Android Settings does not reach it either: user-installed certificates live in a store nothing here reads.

## What changed

One entry in `docs/USER_GUIDE.md`. It now says which roots are in the bundle and which are not, keeps the SSH advice it already gave (for an internal git host that is the right cheap answer rather than a deflection), and adds one sentence the entry did not have and a reader needs: **npm does not use that bundle at all.** `NODE_EXTRA_CA_CERTS` is unset and Node resolves against its own compiled-in list, so a private registry behind its own CA is a different wall. Without that, someone reading this entry after an `npm install` failure would spend the afternoon on git's trust store.

## Scope

Deliberately one entry, not a new section. The guide already owned this slot; a stores-and-levers section beside it would be a second owner with different advice, and the two would drift.

No trust store is changed, and none is proposed. This corrects what the document claims, nothing else.

## Checked across the tree

A false promise usually has neighbours, so the sweep was over every document rather than this file:

- after this change, `should not occur` appears in no document at all
- the only other certificate mentions are the environment table in `docs/04-TECHNICAL_SPEC.md` and the protocol table in `docs/06-SECURITY.md`, both accurate
- one lexical near miss, recorded so the next reader does not re-check it: `__tls_init_tp` in the technical specification is glibc thread-local storage, not transport security

Doc gates pass: `check-toolchain-claims`, `check-build-steps`, `check-checklist-totals`, `build-docs-site`.
