### PR TITLE
test(a11y): stop the picker guards passing on commented-out code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Two accessibility guards stopped passing on code that is commented out, and one no longer loses its scope to a brace inside a comment.
 - The user guide no longer promises that certificate errors should not happen. It says which roots the bundle carries, that a private CA is not among them, and that npm does not use it.
 - The picker's checked state and the Toolchains back-arrow label are now pinned by tests. Both are invisible to a sighted reviewer, so either could be deleted without a symptom.
 - Editing a layout or a string no longer leaves the unit suite up to date. Two suites read those files, and both were skipped on exactly the edits they exist to catch.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -41,16 +41,29 @@
              opaque URI, and loadVSCode falls through to the default projects
              directory, so the user is silently moved out of their workspace.
 
-             This is safe to declare because neither activity has anything that
-             resolves differently by night: the module has no values-night
-             directory at all, and every layout these two inflate names its
-             colours as fixed @color resources rather than ?attr, picker card
-             included. That is the condition, not a coincidence. If anyone adds
-             a values-night qualifier, or switches one of these layouts to
-             ?attr/colorSurface, this declaration becomes a bug: the framework
-             stops relaunching and nothing re-resolves, leaving the screen in the
-             previous appearance. Handle onConfigurationChanged then, or take
-             uiMode back out.
+             Safe to declare because almost nothing on these two screens resolves
+             by night. The module has no values-night directory at all, and every
+             colour these layouts render is a fixed @color: backgroundTint,
+             textColor, progressTint, indeterminateTint, and the card's
+             cardBackgroundColor. The one thing not pinned, stated because an
+             earlier version of this comment claimed there was nothing: the two
+             ProgressBars carry style="?android:attr/progressBarStyleHorizontal",
+             whose TRACK colour comes from the theme. Their fill is pinned by
+             progressTint, so what can go stale after a night flip is the shade of
+             a progress track, against the alternative of restarting an 875 MB
+             extraction. Sweep for it with '?[a-zA-Z:]*attr/', not '?attr/': the
+             narrower pattern cannot see ?android:attr and is what missed these.
+
+             uiMode is also wider than night. CONFIG_UI_MODE covers the whole
+             uiMode field, so this suppresses relaunch for car, desk, television,
+             appliance and vr-headset modes too. There are no ui-mode-qualified
+             resources here either, so that costs nothing today.
+
+             If anyone adds a values-night or values-television qualifier, or
+             switches one of these layouts to ?attr/colorSurface, this declaration
+             becomes a bug: the framework stops relaunching and nothing
+             re-resolves, leaving the screen in the previous appearance. Handle
+             onConfigurationChanged then, or take uiMode back out.
 
              The other ten stay undeclared deliberately. locale, layoutDirection,
              fontScale, density, colorMode and fontWeightAdjustment all need the

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -1653,16 +1653,17 @@ class MainActivity : AppCompatActivity() {
      * mouse or a DeX-style desktop reports `fine` and correctly gets none of this.
      *
      * Height would have been the wrong axis for the same reason it looks tempting:
-     * `windowSoftInputMode="adjustResize"` (AndroidManifest.xml:49) shrinks the
+     * `windowSoftInputMode="adjustResize"` on MainActivity in the manifest shrinks the
      * window when the soft keyboard opens, and the WebView takes what is left
      * (`layout_weight="1"`), so a height threshold would switch the sizing on and off
      * while the user types.
      *
      * It has to be a media query rather than anything sampled in Kotlin: this runs
-     * once per page load, and MainActivity declares `configChanges` for `orientation`,
-     * `screenSize` and `screenLayout` (AndroidManifest.xml:48) with no
+     * once per page load, and MainActivity's `configChanges` in the manifest absorbs
+     * `orientation`, `screenSize` and `screenLayout` among others, with no
      * `onConfigurationChanged`, so nothing re-invokes the injection when the window
-     * changes. Letting the browser hold the condition costs nothing and never goes
+     * changes. Line numbers are left off deliberately: both citations here named
+     * the right attribute and the wrong line within a day of being written. Letting the browser hold the condition costs nothing and never goes
      * stale.
      */
     private fun injectTouchTargetCSS() {

--- a/android/app/src/test/kotlin/com/vscodroid/ExtensionCallbackTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/ExtensionCallbackTest.kt
@@ -1339,9 +1339,11 @@ class RestoreWatcherTest {
  *
  * [RestoreWatcherTest] pins which folder a failure leaves watched; this pins what
  * counts as a failure in the first place. The sync runs in `lifecycleScope`, so
- * destroying the Activity cancels it, a scheduled dark-mode switch, a font-size
- * or language change, or "Don't keep activities" while the user is in another
- * app, none of which the manifest's `configChanges` absorbs. Kotlin's
+ * destroying the Activity cancels it: a font-size or display-size change, a
+ * language change, the accessibility Bold Text switch, or "Don't keep
+ * activities" while the user is in another app, none of which the manifest's
+ * `configChanges` absorbs. A scheduled dark-mode switch used to belong on that
+ * list and no longer does, because `uiMode` is declared now. Kotlin's
  * `CancellationException` is a plain `Exception`, so the catch-all sees it and
  * every statement in that handler runs.
  *

--- a/android/app/src/test/kotlin/com/vscodroid/keyboard/HardwareKeyboardTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/keyboard/HardwareKeyboardTest.kt
@@ -165,10 +165,11 @@ class HardwareKeyboardTest {
         // extraction, because runSetup() lives in lifecycleScope and the relaunch
         // cancels it before markSetupComplete() runs.
         //
-        // Declaring it is only safe while neither activity has anything that
-        // resolves by night. The manifest comment states that condition; this
-        // list is what fails if the declaration is removed, not if the condition
-        // stops holding, and no test can see the second half.
+        // Declaring it is only safe while almost nothing on those two screens
+        // resolves by night, and the manifest comment states that condition
+        // precisely, including the one exception it originally missed. This list
+        // is what fails if the declaration is removed, not if the condition stops
+        // holding, and no test can see the second half.
         val required = listOf("keyboard", "keyboardHidden", "orientation", "screenSize", "uiMode")
         val unguarded = guarded.filterNot { name ->
             declared[name].orEmpty().split("|").containsAll(required)

--- a/android/app/src/test/kotlin/com/vscodroid/setup/PickerAccessibilityWiringTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/PickerAccessibilityWiringTest.kt
@@ -55,14 +55,51 @@ class PickerAccessibilityWiringTest {
         // sentence written for them below.
         assertTrue(i >= 0, "no body follows `$signature` in ${source.name}")
         val open = i
+        // Braces inside comments do not count. A single `{` in a comment anywhere
+        // in the function makes the depth never return to zero at the real closing
+        // brace, so the body runs on into whatever follows. Measured on this file:
+        // one `{` in a comment beside the checkable call widened the body from
+        // 1877 characters to 5295, swallowing the next function whole. Scoping to
+        // the owning function is the entire reason this helper exists rather than
+        // a file-wide search, so a comment that silently unscopes it defeats the
+        // guard exactly as a file-wide search would.
         while (i < text.length) {
-            when (text[i]) {
-                '{' -> depth++
-                '}' -> if (--depth == 0) return text.substring(open, i + 1)
+            when {
+                text.startsWith("//", i) -> while (i < text.length && text[i] != '\n') i++
+                text.startsWith("/*", i) -> {
+                    i += 2
+                    while (i < text.length && !text.startsWith("*/", i)) i++
+                    i += 2
+                }
+                text[i] == '{' -> { depth++; i++ }
+                text[i] == '}' -> {
+                    depth--
+                    if (depth == 0) return text.substring(open, i + 1)
+                    i++
+                }
+                else -> i++
             }
-            i++
         }
         error("unbalanced braces after `$signature` in ${source.name}")
+    }
+
+    /**
+     * The control for [bodyOf], because a body that quietly ran past its function
+     * would satisfy every assertion above by finding the token somewhere else.
+     *
+     * `bindManagerMode` is the declaration immediately after `bindPickerMode`, so
+     * its name appearing inside the extracted body is precisely the failure this
+     * guards, and its absence is what says the scope held.
+     */
+    @Test
+    fun `the extracted body stops at the function it names`() {
+        val body = bodyOf(adapter, "private fun bindPickerMode(")
+
+        assertTrue(
+            "bindManagerMode" !in body,
+            "bodyOf ran past bindPickerMode and swallowed the next declaration, so " +
+                "every assertion here is really a file-wide search: ${body.length} chars",
+        )
     }
 
     /**
@@ -75,13 +112,21 @@ class PickerAccessibilityWiringTest {
     fun `picker binding sets both halves of the checked state`() {
         val body = bodyOf(adapter, "private fun bindPickerMode(")
 
+        // Anchored to the start of a line, with only whitespace allowed in front.
+        // A substring search finds the call inside `// card.isCheckable = true`
+        // just as readily as the call itself, and commenting a line out is how a
+        // developer disables something while debugging. Measured: with all three
+        // of the calls below commented rather than deleted, every case here stayed
+        // green while the wiring was entirely dead. The anchor also drops the
+        // whitespace-exact literal this used to be, so `isCheckable=true` no
+        // longer reddens it for a reformat that changed nothing.
         assertTrue(
-            body.contains("isCheckable = true"),
+            Regex("""(?m)^\s*card\.isCheckable\s*=\s*true""").containsMatchIn(body),
             "bindPickerMode does not make the card checkable, so it reports " +
                 "checkable=false and a screen reader offers no state at all",
         )
         assertTrue(
-            Regex("""isChecked\s*=\s*isSelected""").containsMatchIn(body),
+            Regex("""(?m)^\s*card\.isChecked\s*=\s*isSelected""").containsMatchIn(body),
             "bindPickerMode does not tie isChecked to the selection, so the state " +
                 "it reports is fixed and the card sounds the same either way",
         )
@@ -96,7 +141,11 @@ class PickerAccessibilityWiringTest {
     @Test
     fun `the selection rebind carries a payload`() {
         val body = bodyOf(adapter, "private fun bindPickerMode(")
-        val calls = Regex("""notifyItemChanged\([^)]*\)""").findAll(body).map { it.value }.toList()
+        // Line-anchored for the same reason as the checked-state case above: a
+        // commented-out call is still a call to a substring search, and this one
+        // counts calls, so a commented one would also inflate the count.
+        val calls = Regex("""(?m)^\s*(notifyItemChanged\([^)]*\))""")
+            .findAll(body).map { it.groupValues[1] }.toList()
 
         assertEquals(
             1, calls.size,

--- a/docs/07-TESTING_STRATEGY.md
+++ b/docs/07-TESTING_STRATEGY.md
@@ -23,7 +23,7 @@ VSCodroid has unique testing challenges: it's a hybrid app (Kotlin + WebView + N
 ```mermaid
 flowchart TD
   E2E["Manual / E2E Tests<br/>Real devices, UX testing<br/>14 scenarios"] --> INT["Instrumented Tests<br/>WebView + Node.js + Kotlin<br/>26 tests, run by hand on a device"]
-  INT --> UNIT["Unit Tests<br/>1292 Kotlin tests in 203 classes (JVM)<br/>8 node:assert scripts for the bundled JavaScript"]
+  INT --> UNIT["Unit Tests<br/>1296 Kotlin tests in 203 classes (JVM)<br/>8 node:assert scripts for the bundled JavaScript"]
 ```
 
 ---
@@ -46,7 +46,7 @@ flowchart TD
 | SafSyncEngine | Mirror reconciliation, write-back filtering, rename pairing | `SafSyncEngineTest`, `SafWriteBackFilterTest`, `SafRenamePairingTest` |
 | VSCodroidWebViewClient | CDN interception, `vscode-remote` resource serving, downloads | `ResourceInterceptionWiringTest`, `WebviewResourceResolutionTest`, `DownloadCoordinatorTest` |
 
-The suite is **1292 tests in 203 classes**, and it is green. A test that needs a
+The suite is **1296 tests in 203 classes**, and it is green. A test that needs a
 filesystem builds its tree under a JUnit `@TempDir` rather than touching the
 checkout.
 

--- a/docs/DEVICE_TEST_CHECKLIST.md
+++ b/docs/DEVICE_TEST_CHECKLIST.md
@@ -75,7 +75,7 @@
 | ED-6 | Copy/Paste (system) | Copy from external app, paste in editor | Text pastes correctly | | |
 | ED-7 | Undo/Redo | Make edits, Ctrl+Z, Ctrl+Shift+Z | Undo and redo work correctly | | |
 | ED-8 | Format document | Open JS file, run Format Document (Prettier) | File formatted, no errors | | |
-| ED-9 | Application Menu with the keyboard up | Tap a text field so the keyboard rises, then tap the menubar button. Watch it for a few seconds rather than glancing: the failure this catches lasted about 40ms and left the button looking dead | The menu opens and stays open, listing File, Edit, Selection, View, Go and Run. Tapping outside and pressing Esc still close it, and tapping File still opens its submenu | | |
+| ED-9 | Application Menu with the keyboard up | Tap a text field so the keyboard rises, then tap the menubar button. Watch it for a few seconds rather than glancing: the failure this catches lasted about 40ms and left the button looking dead | The menu opens and stays open, listing File, Edit, Selection, View, Go and Run. Tapping outside still closes it, and tapping File still opens its submenu. Do not look for Esc here: the key row that carries it is hidden the moment the keyboard drops, which is the very event under test | | |
 | ED-10 | Application Menu across a rotation | Open the Application Menu, tap File so its submenu opens, then rotate the device | Both menus close. They must not stay open: the submenu would be anchored where it no longer fits and would be clipped off the edge | | |
 
 ## 6. Extensions


### PR DESCRIPTION
A self-review of the six commits landed earlier today. Everything here is a defect those commits introduced, found by attacking them rather than by re-reading them.

## The guards passed on commented-out code

`PickerAccessibilityWiringTest` asserts on the source of `bindPickerMode`, and a substring search finds a call inside `// card.isCheckable = true` exactly as readily as the call itself. Commenting a line out is how a developer disables something while debugging, so the shape the guards exist to catch was the one they could not see.

**Measured before:** with all three guarded calls commented rather than deleted, all four cases stayed green while the wiring was entirely dead.

The three call assertions are line-anchored now, with only whitespace allowed in front. That also removes a brittleness in the other direction: one compared against the whitespace-exact literal `isCheckable = true`, so a reformat to `isCheckable=true` would have reddened it for a change that altered nothing.

| Control | Before | After |
|---|---|---|
| all three calls commented out | green | **2 cases red** |
| reformat to `isCheckable=true` | would have reddened | **green** |

## bodyOf lost its scope to a brace in a comment

The same defect one level down. `bodyOf` exists to scope each assertion to the function that owns the call, because a file-wide search is satisfied by any copy of the token anywhere. A single `{` inside a comment made the depth never reach zero at the real closing brace.

**Measured:** one comment brace beside the checkable call widened the extracted body from 1877 characters to 5295, swallowing the next function whole. A guard that silently unscopes itself is a file-wide search wearing a scope.

`bodyOf` skips comments while matching braces now, and a fifth case pins the scope directly by asserting the extracted body does not contain the name of the declaration that follows it. Its control: with the comment-awareness disabled and a brace planted, that case and only that case reddens.

## Claims the commits made that were not true

- `AndroidManifest.xml`'s new comment and its sibling in `HardwareKeyboardTest` asserted that "every layout these two inflate names its colours as fixed `@color` resources rather than `?attr`". The sweep behind that used the pattern `?attr/`, which cannot see `?android:attr/`. Two layouts on SplashActivity's own path carry `style="?android:attr/progressBarStyleHorizontal"`. Both pin their fill with `progressTint`, so the claim's conclusion survives and its wording did not. The comment now says what is pinned, what is not, and which pattern to sweep with.
- The same comment treated `uiMode` as night mode. `CONFIG_UI_MODE` covers the whole `uiMode` field, so the declaration also suppresses relaunch for car, desk, television, appliance and vr-headset modes. There are no ui-mode-qualified resources here, so it costs nothing, but it is now stated rather than implied.
- `ExtensionCallbackTest`'s KDoc listed "a scheduled dark-mode switch" among the things "the manifest's `configChanges` [does not absorb]". Declaring `uiMode` made that false the same day.
- Two KDoc citations in `MainActivity` named `AndroidManifest.xml:48` and `:49`. The 28-line comment added above `SplashActivity` pushed both down, and they now pointed into the middle of that comment. They name the attribute instead of a line, and say why.
- `docs/07-TESTING_STRATEGY.md` was re-measured to 1292 in one commit and left stale by another three commits later, which added three cases. It is re-measured again rather than incremented: 1296.
- Checklist row ED-9 asked the tester to press Esc at the exact moment the key row that carries it is hidden. `ExtraKeyRow` sets `visibility = if (imeVisible) VISIBLE else GONE`, and the keyboard dropping is the event under test, so that instruction was unperformable on a touch-only device. The row now says so instead of asking for it.

## Checked and found sound

Three claims raised against the commits did not survive checking, recorded so nobody re-opens them:

- **mcc/mnc are not an unhandled trigger.** The measured mask is `0xfb3`, which carries both bits: Android adds them unless `recreateOnConfigChanges` names them, and from Android O the platform does not recreate for them at all. minSdk here is 33.
- **The progress bar is not day/night sensitive.** At API 33, `Widget.Material.Light.ProgressBar.Horizontal` is an empty alias of the same style the dark theme uses, and both give `@drawable/progress_horizontal_material`.
- **`ToolchainActivity` is untouched.** It declares no `configChanges` at all, so it still relaunches, and it is the only screen whose layout uses `?attr` for anything.

## Verification

Suite 1296 tests, 0 failures. Ten gates green: build steps, workflow pinning, bridge API spec, local network permission, lint baseline, bundled extensions, toolchain claims, checklist totals, patch fingerprints, docs site.
