### PR TITLE
build(gate): notice when the packaging checks come unattached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- A build that packages the app now fails loudly if the checks guarding its bundled tree have come unattached, instead of going quiet and shipping an unchecked tree.
 - Two accessibility guards stopped passing on code that is commented out, and one no longer loses its scope to a brace inside a comment.
 - The user guide no longer promises that certificate errors should not happen. It says which roots the bundle carries, that a private CA is not among them, and that npm does not use it.
 - The picker's checked state and the Toolchains back-arrow label are now pinned by tests. Both are invisible to a sighted reviewer, so either could be deleted without a symptom.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1045,11 +1045,20 @@ tasks.matching { it.name.contains("Lint") || it.name.contains("lint") }
 // A dependency of the merge, not of the package or the assemble: the point is
 // to stop the wrong tree getting into an APK rather than to describe one that
 // already did.
+// The eight, once. They were written twice before, here as task providers and
+// again below as a list of strings for the graph check, with nothing keeping the
+// two in step. The dangerous drift is one-directional and quiet: add a ninth gate
+// here and forget the other list, and the new gate is wired but never verified,
+// which is the state the check exists to make impossible.
+val packagingGates = listOf(
+    checkPatchFingerprints, verifyServerTree, verifyBundledBinaries,
+    verifyBundledShellPaths, verifyRubyPackShellPaths, verifyNativeAddons,
+    checkPackOverlap, verifyPythonPlatform,
+)
+
 tasks.matching { it.name.startsWith("merge") && it.name.endsWith("Assets") }
     .configureEach {
-        dependsOn(checkPatchFingerprints, verifyServerTree, verifyBundledBinaries,
-            verifyBundledShellPaths, verifyRubyPackShellPaths, verifyNativeAddons,
-            checkPackOverlap, verifyPythonPlatform)
+        dependsOn(packagingGates)
         dependsOn(bundleNotices)
     }
 
@@ -1079,11 +1088,16 @@ tasks.matching { it.name.startsWith("merge") && it.name.endsWith("Assets") }
 // hint. Whoever turns it on has to move this to a build service or flow action.
 // The question being asked is about the graph, so leaving that unexplained is
 // the failure mode, not the assertion itself.
-val packagingGateNames = listOf(
-    "checkPatchFingerprints", "verifyServerTree", "verifyBundledBinaries",
-    "verifyBundledShellPaths", "verifyRubyPackShellPaths", "verifyNativeAddons",
-    "checkPackOverlap", "verifyPythonPlatform",
-)
+// Derived, not restated. What that changes, said plainly because it cuts both
+// ways: the two lists can no longer disagree, so "wired but not verified" and
+// "verified but not wired" both stop being possible states rather than becoming
+// detectable ones. What the check below can still see is a gate that is wired and
+// absent from the graph anyway, which is not hypothetical: `-x checkPatchFingerprints`
+// on an assembleDebug does exactly that, and was measured failing with that gate
+// named. What it can no longer see is a gate deleted from `packagingGates`
+// outright, because that deletes it from both sides at once. The alarm above is
+// what covers the detachment case that used to be argued for the second list.
+val packagingGateNames = packagingGates.map { it.name }
 
 gradle.taskGraph.whenReady {
     // This project's tasks only. The gates named below are this project's, so a
@@ -1097,6 +1111,34 @@ gradle.taskGraph.whenReady {
     val here = allTasks.filter { it.path.startsWith(prefix) }
     val packaging = here.map { it.name }
         .filter { it.startsWith("merge") && it.endsWith("Assets") }
+
+    // The second question, and the reason it is not the first one again. Asking
+    // "does this build package assets" with the SAME predicate the wiring uses
+    // cannot notice the wiring detaching: rename the family upstream and this
+    // list empties, the early return below fires, and the build goes quiet at
+    // exactly the moment an unchecked tree could ship. So the graph is asked a
+    // question the name shape does not answer.
+    //
+    // AGP builds the asset merge from MergeSourceSetFolders. Measured on this
+    // project, AGP 9.3.1: mergeDebugAssets is
+    // com.android.build.gradle.tasks.MergeSourceSetFolders_Decorated, and the only
+    // other task of that type in the graph is mergeDebugJniLibFolders. The two
+    // always travel together, also measured, across four graphs by --dry-run:
+    // assembleDebug 1 and 1, bundleRelease 1 and 1, testDebugUnitTest 0 and 0,
+    // and `optimizeReleaseResources lintVitalRelease` 0 and 0. So the type answers
+    // the same question as the name on every graph this project runs, while
+    // surviving the rename that the name cannot.
+    val merging = here.filter { it.javaClass.name.contains("MergeSourceSetFolders") }
+    if (packaging.isEmpty() && merging.isNotEmpty()) {
+        throw GradleException(
+            "This build merges source-set folders (${merging.joinToString(", ") { it.name }}) " +
+                "but no task in it is called merge*Assets, which is the name shape the " +
+                "packaging checks are attached by.\n\nThat attachment is therefore reaching " +
+                "nothing, and every check that decides whether the bundled tree may ship is " +
+                "silently absent from this build. Re-point the tasks.matching predicate near " +
+                "`packagingGates` at whatever the merge is called now."
+        )
+    }
     if (packaging.isEmpty()) return@whenReady
 
     val present = here.map { it.name }.toSet()


### PR DESCRIPTION
Eight checks decide whether the bundled tree may ship, and they are attached to AGP's asset merge by the shape of its name, `merge*Assets`. Matching a shape rather than two literal names is right: AGP has moved this family between versions, and naming them would fail the build the first time a third appeared. What the shape cannot do is notice when it stops matching.

## The check could not see the failure it was written for

It listed the graph's `merge*Assets` tasks and returned early when there were none. A rename upstream empties that list, the early return fires, and the build goes silent at exactly the moment an unchecked tree could ship. The question it asked the graph was the same question the wiring asks, so it could never disagree with the wiring.

It now asks a question the name shape does not answer: a graph that merges source-set folders while nothing in it answers to `merge*Assets` is a detached wiring, and that fails loudly.

**Measured on AGP 9.3.1**, because the type is only useful if it really is the asset merge:

| Task | Type |
|---|---|
| `mergeDebugAssets` | `com.android.build.gradle.tasks.MergeSourceSetFolders_Decorated` |
| `mergeDebugJniLibFolders` | same |
| `mergeDebugResources`, `mergeDebugJavaResource`, `mergeDebugNativeLibs`, the three dex merges | all different |

Two tasks share that type, so the next question is whether they can appear apart. Measured by `--dry-run` across four graphs:

| Graph | `merge*Assets` | `merge*JniLib*` |
|---|---|---|
| `assembleDebug` | 1 | 1 |
| `bundleRelease` | 1 | 1 |
| `testDebugUnitTest` | 0 | 0 |
| `optimizeReleaseResources lintVitalRelease` | 0 | 0 |

They always travel together, so the type answers the same question as the name on every graph this project runs, while surviving the rename the name cannot.

## The eight are written once now

They were written twice, as task providers for the wiring and again as strings for the graph check, with nothing keeping the two in step. The quiet drift was one-directional: add a ninth gate to the wiring, forget the other list, and the new gate ships wired but never verified.

That trade is stated in the file rather than assumed, because it cuts both ways. The two lists can no longer disagree, so the disagreement stops being a detectable state instead of becoming one. What the presence check can still see is a gate that is wired and absent from the graph anyway, and that is not hypothetical.

## Controls

| Control | Result |
|---|---|
| rename the shape the wiring matches | `assembleDebug` fails, message names `mergeDebugAssets, mergeDebugJniLibFolders` |
| `-x checkPatchFingerprints` | `assembleDebug` fails, message names that gate, "1 of the 8" |
| clean tree, `assembleDebug` and `bundleRelease` | pass, 3 gates observed in each graph |
| clean tree, the two graphs that package nothing | silent and green, two runs each |

Suite 1296 tests, 0 failures. `build.gradle.kts` is a declared input to the test task, so the suite really re-ran over this change rather than reporting UP-TO-DATE.

## Note for whoever enables the configuration cache

`gradle.taskGraph.whenReady` is not supported with it. That was already true of this block and is unchanged here; the file says so at the call site.
