### PR TITLE
fix(report): carry the server output in bug reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Bug reports now carry the server's own output. The report always had a section for it, and nothing ever wrote the file it reads, so it was always empty.
 - The gesture trackpad now offers four accessibility actions to move the cursor. A drag was the only way to send an arrow, and a screen reader cannot drag.
 - Long pressing a key through a screen reader now opens its alternate characters. The layer needed a finger held on the key, so `'` and `\` were unreachable.
 

--- a/android/app/src/main/kotlin/com/vscodroid/service/ProcessManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/service/ProcessManager.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import com.vscodroid.util.Environment
 import com.vscodroid.util.Logger
 import com.vscodroid.util.PortFinder
+import com.vscodroid.util.ServerLog
 import kotlinx.coroutines.delay
 import org.json.JSONObject
 import java.io.BufferedReader
@@ -31,6 +32,16 @@ import kotlin.concurrent.thread
 class ProcessManager(private val context: Context) {
 
     private val tag = "ProcessManager"
+
+    /**
+     * Where the server's own output is kept for a bug report to pick up.
+     *
+     * Fed directly from [startOutputReader] rather than through [onServerOutput].
+     * That seam is public and documented as one, so a consumer assigning it would
+     * silently replace this writer, and the symptom would be a report that is
+     * empty again with nothing to say why.
+     */
+    private val serverLog = ServerLog(File(Environment.getLogsDir(context), "server.log"))
 
     private var serverProcess: Process? = null
     private var watchdogThread: Thread? = null
@@ -389,10 +400,10 @@ class ProcessManager(private val context: Context) {
         // nothing and cannot see the one whose death would take the editor away.
         //
         // Worth knowing before designing the fix: the app already SEES this
-        // happen. `startOutputReader` receives that EADDRINUSE line, and
-        // [onServerOutput] is a seam it is forwarded to -- with no production
-        // consumer, so the line reaches `Logger.d` and stops, which in a release
-        // build is nowhere at all.
+        // happen. `startOutputReader` receives that EADDRINUSE line and now
+        // writes it to `server.log`, so a bug report carries it. The same line
+        // also goes to `Logger.d`, which in a release build is nowhere, and to
+        // [onServerOutput], which still has no production consumer.
         //
         // What the spawn below now does NOT do is last forever. A pair that
         // cannot bind stays alive indefinitely, the measurement above is the
@@ -1094,6 +1105,7 @@ class ProcessManager(private val context: Context) {
                 BufferedReader(InputStreamReader(process.inputStream)).use { reader ->
                     reader.lineSequence().forEach { line ->
                         Logger.d(tag, "[node] $line")
+                        serverLog.append(line)
                         onServerOutput?.invoke(line)
                     }
                 }

--- a/android/app/src/main/kotlin/com/vscodroid/util/CrashReporter.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/util/CrashReporter.kt
@@ -124,9 +124,10 @@ object CrashReporter {
         }
         sb.appendLine()
 
-        // Node.js server log (last 200 lines). Nothing in this repository writes
-        // that file, so the block never fires today; it is redacted with the
-        // rest so it is not the one raw path left if something starts to.
+        // Node.js server log (last 200 lines), written by [ServerLog] from the
+        // output reader in `ProcessManager`. Redacted here as well as on the way
+        // in: this reader is where the rule belongs, and keeping it means the
+        // report stays clean whatever else ever writes to that file.
         val serverLog = File(Environment.getLogsDir(context), "server.log")
         if (serverLog.exists()) {
             sb.appendLine("--- Server Log (last 200 lines) ---")

--- a/android/app/src/main/kotlin/com/vscodroid/util/ServerLog.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/util/ServerLog.kt
@@ -1,0 +1,77 @@
+package com.vscodroid.util
+
+import com.vscodroid.webview.redactToken
+import java.io.File
+import java.io.IOException
+
+/**
+ * Mirrors the Node server's output into `server.log` so a bug report carries it.
+ *
+ * [CrashReporter] has always appended the last 200 lines of that file to every
+ * report, and nothing ever wrote it, so every report shipped with no server
+ * output at all. Among the lines lost that way is the one that identifies a
+ * whole class of failure: a second server that loses the race for the port
+ * prints `EADDRINUSE` and keeps running, and the note above
+ * `ProcessManager.startServer` describes what that costs. Until now that line
+ * reached `Logger.d` and stopped there, which in a release build is nowhere.
+ *
+ * Written straight through rather than batched. A server about to die says why
+ * in its last few lines, so a buffer flushed on a cadence drops precisely the
+ * part anyone reads. The cost is one append per line, the same order as the
+ * `Logger.d` already on that path, over a stream that is startup chatter and
+ * occasional warnings rather than a hot loop.
+ *
+ * Redacted on the way in, not only on the way out. The connection token is a
+ * live credential and a report is something a user hands to a stranger, so it
+ * should not reach the file in the first place. [CrashReporter] still redacts
+ * what it reads and now finds nothing to replace; the overlap is deliberate,
+ * because it is what keeps that reader correct if anything else ever writes here.
+ */
+internal class ServerLog(private val file: File) {
+
+    /**
+     * Appends one line, rotating first if the file has outgrown [MAX_BYTES].
+     *
+     * Swallows I/O failure on purpose. This runs on the output reader thread,
+     * whose real job is to drain the process's stdout, and an exception escaping
+     * here ends that loop: the pipe buffer then fills and the server blocks on
+     * its next write. A report missing its server output is the state this class
+     * improves on, and it is not worth trading a running server for.
+     */
+    fun append(line: String) {
+        try {
+            // One stat answers both questions, because length() is 0 for a file
+            // that does not exist. The logs directory is created by the server
+            // rather than by anything on this side, so the first line can arrive
+            // before there is a directory to write it into.
+            val size = file.length()
+            if (size == 0L) file.parentFile?.mkdirs() else if (size > MAX_BYTES) rotate()
+            file.appendText(redactToken(line) + "\n")
+        } catch (_: IOException) {
+        }
+    }
+
+    /**
+     * Rewrites the file with its last [KEEP_LINES] lines.
+     *
+     * Truncating to empty would be shorter and wrong: a report taken shortly
+     * after a rotation would carry almost nothing, which is the failure this
+     * class exists to remove. Keeping more than the 200 lines the reader takes
+     * leaves a margin, so a rotation just before a report still fills it.
+     */
+    private fun rotate() {
+        val keep = file.readLines().takeLast(KEEP_LINES)
+        file.writeText(keep.joinToString("\n", postfix = "\n"))
+    }
+
+    private companion object {
+        /**
+         * The cap is on bytes rather than lines so that one pathological line
+         * cannot outgrow it, and it is generous enough that rotation is rare:
+         * [KEEP_LINES] typical lines are a small fraction of it, so the file
+         * spends most of its life holding far more than the reader will take.
+         */
+        const val MAX_BYTES = 256L * 1024
+        const val KEEP_LINES = 400
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/util/ServerLogTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/util/ServerLogTest.kt
@@ -1,0 +1,192 @@
+package com.vscodroid.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+/**
+ * [ServerLog] and the one line that connects it to the server's output.
+ *
+ * The connection matters as much as the class. A bug report that carries no
+ * server output looks exactly like one whose server had nothing to say, so if
+ * the call ever goes missing there is no symptom to notice and no other test
+ * that would redden.
+ */
+class ServerLogTest {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    private fun logFile() = File(tempDir, "logs/server.log")
+
+    @Test
+    fun `each line lands in the file as its own line`() {
+        val file = logFile()
+        val log = ServerLog(file)
+
+        log.append("listening on 41003")
+        log.append("Extension host started")
+
+        assertEquals(
+            listOf("listening on 41003", "Extension host started"),
+            file.readLines(),
+            "CrashReporter reads this file by lines and takes the last 200 of them",
+        )
+    }
+
+    /**
+     * The directory is created by the server, from its own `--logsPath` argument,
+     * so on a cold start the first line of output can be read before the server
+     * has got that far.
+     */
+    @Test
+    fun `the first line creates the directory it needs`() {
+        val file = File(tempDir, "a/b/c/server.log")
+        assertFalse(file.parentFile.exists(), "the directory must not exist yet")
+
+        ServerLog(file).append("first")
+
+        assertEquals(listOf("first"), file.readLines())
+    }
+
+    /**
+     * The token is a live credential and a bug report is something a user hands
+     * to a stranger. Redacting only in the reader would still leave it written
+     * down on the device, where nothing ever removes it.
+     */
+    @Test
+    fun `the connection token never reaches the file`() {
+        val file = logFile()
+
+        ServerLog(file).append("GET /?folder=/home&tkn=8f3c1d2e-secret HTTP/1.1")
+
+        val written = file.readText()
+        assertFalse(
+            "8f3c1d2e-secret" in written,
+            "the token was written to disk verbatim: $written",
+        )
+        assertTrue("tkn=<redacted>" in written, "expected the redacted form, got: $written")
+    }
+
+    /**
+     * This runs on the thread that drains the process's stdout. An exception
+     * escaping ends that loop, after which the pipe buffer fills and the server
+     * blocks on its next write, which is a far worse outcome than a thin report.
+     */
+    @Test
+    fun `an unwritable destination does not take the reader thread down`() {
+        // A regular file where the directory should be, so mkdirs cannot succeed
+        // and the append that follows has nowhere to go.
+        val blocked = File(tempDir, "blocked")
+        blocked.writeText("not a directory")
+        val file = File(blocked, "server.log")
+
+        ServerLog(file).append("this cannot be written")
+
+        assertFalse(file.exists(), "nothing should have been created under a regular file")
+    }
+
+    /**
+     * Rotation keeps the tail rather than truncating to empty, because a report
+     * taken shortly after a rotation would otherwise carry almost nothing, which
+     * is the failure the class exists to remove.
+     *
+     * 300 KB is written to exceed the class's own cap. If that cap is ever raised
+     * past this figure the case reddens by finding no rotation, which is the
+     * direction that says so out loud.
+     */
+    @Test
+    fun `rotation drops the oldest lines and keeps enough for a full report`() {
+        val file = logFile()
+        file.parentFile.mkdirs()
+        val filler = "x".repeat(600)
+        file.writeText((0 until 500).joinToString("\n", postfix = "\n") { "line-$it $filler" })
+        val sizeBefore = file.length()
+        assertTrue(sizeBefore > 256L * 1024, "the fixture must exceed the cap, was $sizeBefore")
+
+        ServerLog(file).append("after rotation")
+
+        val lines = file.readLines()
+        assertTrue(file.length() < sizeBefore, "the file did not shrink, so nothing rotated")
+        assertEquals("after rotation", lines.last(), "the appended line is missing")
+        assertFalse(
+            lines.any { it.startsWith("line-0 ") },
+            "the oldest line survived, so the tail is not what was kept",
+        )
+        assertTrue(
+            lines.last { it.startsWith("line-") }.startsWith("line-499 "),
+            "the newest line before the append was dropped, so the wrong end was kept",
+        )
+        assertTrue(
+            lines.size > 200,
+            "CrashReporter takes the last 200 lines and a rotation left only " +
+                "${lines.size}, so a report taken now would be short",
+        )
+    }
+
+    /**
+     * The wiring, read from the source because the only behavioural route to it
+     * needs a live server process.
+     *
+     * Deliberately not routed through `onServerOutput`. That seam is public and
+     * documented as one, so a consumer assigning it would replace this writer
+     * rather than join it, and the symptom would be an empty report again.
+     */
+    @Test
+    fun `the output reader writes every line it reads`() {
+        val body = outputReaderBody()
+
+        // Anchored to the start of a line so that a commented-out call, which is
+        // how a developer disables something while debugging, cannot satisfy it.
+        assertTrue(
+            Regex("""(?m)^\s*serverLog\.append\(line\)""").containsMatchIn(body),
+            "startOutputReader does not write to the server log, so every bug " +
+                "report carries no server output and looks like a quiet server",
+        )
+    }
+
+    /**
+     * The control for [outputReaderBody]. A body that ran past its own closing
+     * brace would satisfy the case above by finding the call somewhere else in
+     * the file, so its scope has to be asserted rather than assumed.
+     *
+     * `startAdoptionWatch` is the declaration after `startOutputReader`, which
+     * makes its name appearing inside the extracted body exactly the failure
+     * being guarded against.
+     */
+    @Test
+    fun `the extracted body stops at the end of its own function`() {
+        val body = outputReaderBody()
+
+        assertFalse(
+            "startAdoptionWatch" in body,
+            "the extraction ran past startOutputReader, so the case above is " +
+                "really a file-wide search: ${body.length} chars",
+        )
+    }
+
+    /**
+     * `startOutputReader` runs to the first line that is exactly a closing brace
+     * at member indentation. Every brace nested inside it is indented further, so
+     * this identifies the real end without counting braces, and the control above
+     * is what turns a formatting change that broke the assumption into a failure
+     * rather than a silent widening.
+     */
+    private fun outputReaderBody(): String {
+        val source = File("src/main/kotlin/com/vscodroid/service/ProcessManager.kt")
+        assertTrue(
+            source.isFile,
+            "${source.absolutePath} is missing; this test would otherwise pass by " +
+                "reading nothing",
+        )
+        val text = source.readText()
+        val start = text.indexOf("private fun startOutputReader()")
+        assertTrue(start >= 0, "ProcessManager has no startOutputReader")
+        val end = text.indexOf("\n    }\n", start)
+        assertTrue(end > start, "startOutputReader has no closing brace at member indentation")
+        return text.substring(start, end)
+    }
+}


### PR DESCRIPTION
`CrashReporter` has always appended the last 200 lines of `server.log` to every bug report. Nothing in the app has ever written that file, so the section has been empty in every report the app has produced, and an empty section is indistinguishable from a server that had nothing to say.

One of the lines lost that way identifies a whole class of failure on its own: a second server that loses the race for the port prints `EADDRINUSE` and keeps running. That line reached `Logger.d` and stopped, which in a release build is nowhere at all.

## What changed

- `ServerLog` mirrors the server's output into `server.log`, fed from the output reader in `ProcessManager`.
- Lines are written straight through rather than batched. A server about to die says why in its last few lines, so a buffer flushed on a cadence drops precisely the part anyone reads.
- The file rotates on a byte cap and keeps more lines than the reader takes, so a report made just after a rotation is still full rather than nearly empty.
- The connection token is redacted on the way in. It is a live credential and a report is something a user hands to a stranger, so it should not be written down in the first place. `CrashReporter` still redacts what it reads, which keeps that reader correct on its own terms.
- Two comments that described the old state, in `ProcessManager` and `CrashReporter`, now describe the current one.

The writer is called directly from the reader rather than through the existing `onServerOutput` seam. That seam is public and documented as one, so a consumer assigning it would replace this writer rather than join it, and the symptom would be an empty report again with nothing to explain it.

## Verification

`ServerLogTest` covers the line format the reader depends on, directory creation before the server has made one, token redaction, rotation keeping the newest lines and enough of them, and an unwritable destination not throwing on the thread that drains the process stdout.

Each case was checked against a deliberate break of the behaviour it claims: removing the call from the reader, disabling redaction, truncating on rotation instead of keeping the tail, keeping the oldest lines instead of the newest, dropping the directory creation, rethrowing from the catch, and widening the source extraction past its own function. Every one reddened the case it targets, and the tree returns to green when reverted.

Full unit suite 1303 tests, no failures. Lint clean.