### PR TITLE
fix(bridge): report why a link could not be opened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A link that fails to open now says why. Every refusal blamed a missing app, including a stale session and a URL Android refused outright.
+- The connection token no longer reaches logcat when a link fails to open. The URL was logged whole, twice, on a line that ships in release builds.
 - The system dark theme flipping no longer moves you out of your workspace, or restarts first-run extraction if it lands while setup is running.
 - Opening the app no longer discards what `npm config set` wrote. A private registry, its auth token, `cafile` and `strict-ssl` all survive a launch now.
 - The menubar no longer closes itself when the on-screen keyboard drops. The resize that follows the tap shut the menu 40ms after it opened, leaving no route to the File or Terminal menus.

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -1714,8 +1714,8 @@ class MainActivity : AppCompatActivity() {
                     if (url && /^https?:/.test(url) && typeof AndroidBridge !== 'undefined') {
                         var t = (window.__vscodroid || {}).authToken;
                         // Only claim the click if the bridge actually opened it.
-                        // `openExternalUrl` answers false when the launch itself fails,
-                        // not when it disapproves of the destination: SecurityManager
+                        // `openExternalUrl` answers with a reason when the launch itself
+                        // fails, not when it disapproves of the destination: SecurityManager
                         // has no URL allow-list and says so at the point one used to
                         // stand. Reading this as a destination filter is the mistake to
                         // avoid, because it invites re-deriving the fall-through around

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -1720,10 +1720,17 @@ class MainActivity : AppCompatActivity() {
                         // stand. Reading this as a destination filter is the mistake to
                         // avoid, because it invites re-deriving the fall-through around
                         // a constraint that is gone.
-                        // Swallowing the false here meant the click did nothing and
+                        // Swallowing the refusal here meant the click did nothing and
                         // said nothing; falling through lets the WebView navigation
                         // path open it, which is where opening anything already lives.
-                        if (t && AndroidBridge.openExternalUrl(url, t)) { return null; }
+                        //
+                        // Compared against the empty string, never used as a bare
+                        // condition. The bridge answers with the reason it did not
+                        // open, so success is the falsy value and every failure is
+                        // truthy: a bare `if` reads backwards, claims every click it
+                        // failed to open, and lets the one it did open through to the
+                        // WebView as well.
+                        if (t && AndroidBridge.openExternalUrl(url, t) === '') { return null; }
                     }
                     return orig.apply(window, arguments);
                 };
@@ -1964,16 +1971,20 @@ class MainActivity : AppCompatActivity() {
                             // Posting ok:true for this one turned a blocked URL into a
                             // resolved promise, and the caller's error handler never ran.
                             //
-                            // Both conditions are named and neither is claimed as the
-                            // cause. With the URL allow-list gone there is only one
-                            // cause left worth naming: nothing on the device claimed the
-                            // link. Saying so points at the fix -- install an app that
-                            // handles the scheme -- instead of at a rule that no longer
-                            // exists.
+                            // The reason comes from the bridge, which is the only
+                            // side that knows it. This used to post one fixed sentence
+                            // for every refusal, blaming a missing app even when the
+                            // session token was stale or Android had refused the URL
+                            // outright, and a user following that advice installs
+                            // something that cannot help.
+                            //
+                            // Empty means opened. Anything else is the reason, so the
+                            // comparison is against the empty string rather than a
+                            // bare truthiness test, which would read backwards.
                             result = AndroidBridge.openExternalUrl(d.url, token);
-                            ch.postMessage(result
+                            ch.postMessage(result === ''
                                 ? {id: d.id, ok: true}
-                                : {id: d.id, ok: false, error: 'VSCodroid did not open it. No app on this device handles that link.'});
+                                : {id: d.id, ok: false, error: result});
                         }
                     } catch(err) {
                         ch.postMessage({id: d.id, ok: false, error: String(err)});

--- a/android/app/src/main/kotlin/com/vscodroid/bridge/AndroidBridge.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/bridge/AndroidBridge.kt
@@ -1,6 +1,7 @@
 package com.vscodroid.bridge
 
 import android.app.Activity
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.content.res.Configuration
@@ -151,6 +152,31 @@ internal fun authRequestIdsIn(url: String): List<String> =
  * reopens the window. No arithmetic happens here; the window is applied by
  * `authCallbackIsExpected`, which this object deliberately does not call.
  */
+/**
+ * Why [AndroidBridge.openExternalUrl] did not open anything.
+ *
+ * Named constants rather than literals at each exit so a test can pin which
+ * reason belongs to which failure without pinning the wording, which is not the
+ * contract. The wording is user facing: the extension's "Open in Browser" puts
+ * whichever of these comes back straight into a `showErrorMessage`.
+ */
+internal const val OPEN_URL_STALE_SESSION =
+    "VSCodroid did not accept the request. Reload the window and try again."
+
+/** The reason that is worth acting on, and the only one the relay used to give. */
+internal const val OPEN_URL_NO_HANDLER =
+    "VSCodroid did not open it. No app on this device handles that link."
+
+/**
+ * Everything else, with the exception's class name appended.
+ *
+ * The class name and not its message: `ActivityNotFoundException` quotes the
+ * whole Intent it could not match, and `FileUriExposedException` quotes the
+ * file, so a message here would hand the URL to the page that supplied it and,
+ * through the extension, to a notification a user may screenshot.
+ */
+internal const val OPEN_URL_FAILED_PREFIX = "VSCodroid could not open that link: "
+
 object AuthTabWindow {
 
     private val launches = object : LinkedHashMap<String, Long>() {
@@ -319,13 +345,17 @@ class AndroidBridge(
      * bundled extension's "Open in Browser" closed its input box with its own
      * error handler sitting unreachable behind a promise that always resolved.
      *
-     * @return true when the URL was handed to a browser, false when the token
-     *   was rejected or no activity took the intent -- which, with no filtering
-     *   left, is the only way a well-formed call fails.
+     * @return the empty string when the URL was handed to a browser, and
+     *   otherwise a sentence naming why it was not. Which sentence matters,
+     *   because the failures are not one failure: a stale session token and an
+     *   intent nothing claimed both came back as `false`, and the relay turned
+     *   every `false` into "no app handles that link". That is the right advice
+     *   for one of them and unfollowable for the rest, `file://` included, which
+     *   Android refuses outright rather than for want of an app.
      */
     @JavascriptInterface
-    fun openExternalUrl(url: String, authToken: String): Boolean {
-        if (!security.validateToken(authToken)) return false
+    fun openExternalUrl(url: String, authToken: String): String {
+        if (!security.validateToken(authToken)) return OPEN_URL_STALE_SESSION
         // Empty until the launch arms something, and then the ids to take back if
         // the launch that armed them throws. Arming has to precede the launch, so
         // without this a launch nothing accepted still left the callback relay
@@ -361,11 +391,24 @@ class AndroidBridge(
                 }
                 context.startActivity(intent)
             }
-            true
+            ""
         } catch (e: Exception) {
             AuthTabWindow.disarm(armed)
-            Logger.e(tag, "Failed to open URL: $url", e)
-            false
+            // The URL is page supplied and this line is not gated on a debuggable
+            // build, so it ships. That is the same reasoning [logToNative] gives,
+            // and it carries here for the same reason: the workbench holds the
+            // connection token and a URL it hands over can carry it.
+            //
+            // The throwable is deliberately not passed. It is printed with its
+            // message, and both exceptions this realistically catches put the
+            // whole URI there: ActivityNotFoundException names the Intent it
+            // could not match, FileUriExposedException names the file it refused.
+            // Redacting the interpolation while handing the same URL to logcat
+            // inside the trace would only look like redaction. The frames behind
+            // it are all framework, so the class name is what was being read for.
+            Logger.e(tag, "Failed to open URL: ${redactToken(url)} (${e.javaClass.simpleName})")
+            if (e is ActivityNotFoundException) OPEN_URL_NO_HANDLER
+            else OPEN_URL_FAILED_PREFIX + e.javaClass.simpleName
         }
     }
 

--- a/android/app/src/test/kotlin/com/vscodroid/bridge/OpenExternalUrlRefusalTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/bridge/OpenExternalUrlRefusalTest.kt
@@ -1,5 +1,6 @@
 package com.vscodroid.bridge
 
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -16,7 +17,9 @@ import io.mockk.mockkStatic
 import io.mockk.verify
 import io.mockk.verifyOrder
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -98,6 +101,16 @@ class OpenExternalUrlRefusalTest {
                 "http%3A%2F%2F127.0.0.1%3A13337%2Fcallback%3Fvscode-reqid%3D808"
 
         const val REMOTE_HTTP_REQUEST_ID = "808"
+
+        /** The secret half of [TOKEN_BEARING], kept apart so the check names it. */
+        const val TOKEN_SECRET = "3f9a1c77-not-a-real-token"
+
+        /**
+         * The editor's own address, which is what the workbench hands over when a
+         * user asks to open the current page in a browser, and which carries the
+         * connection token as a query parameter.
+         */
+        const val TOKEN_BEARING = "http://127.0.0.1:41003/?folder=/home&tkn=" + TOKEN_SECRET
     }
 
     /**
@@ -141,14 +154,15 @@ class OpenExternalUrlRefusalTest {
     @Test
     fun `a URL with a good token reaches the launch, rather than being turned away`() {
         // The counterpart to the token case at the bottom, and the reason that
-        // one means anything. Both return false -- no browser can be launched
-        // from a JVM test -- so the load-bearing assertion in each is the verify,
-        // not the assertFalse: reaching Uri.parse is what separates "tried and
-        // could not" from "turned away at the door".
-        assertFalse(
+        // one means anything. Both fail, because no browser can be launched from
+        // a JVM test, but they no longer fail identically. While both answered
+        // `false` the verify was the only thing separating "tried and could not"
+        // from "turned away at the door"; the reason now says which happened, so
+        // the two assertions corroborate each other instead of one carrying both.
+        assertNotEquals(
+            OPEN_URL_STALE_SESSION,
             bridge.openExternalUrl(LOCAL, security.getSessionToken()),
-            "no browser can be launched from a JVM test, so this is false for a reason " +
-                "the verify below distinguishes from a refusal",
+            "a valid token was treated as a stale one, so the call never reached the launch",
         )
         verify(exactly = 1) {
             Uri.parse(LOCAL)
@@ -179,10 +193,11 @@ class OpenExternalUrlRefusalTest {
         mockkConstructor(Intent::class)
         every { anyConstructed<Intent>().addFlags(any()) } returns mockk(relaxed = true)
 
-        assertTrue(
-            bridge.openExternalUrl(LOCAL, security.getSessionToken()),
-            "a URL that was handed to an activity must report true; the relay posts ok:false " +
-                "on anything else, so a false here puts an error in front of every successful open",
+        assertEquals(
+            "", bridge.openExternalUrl(LOCAL, security.getSessionToken()),
+            "a URL that was handed to an activity must come back with no reason; the relay " +
+                "posts ok:false on anything else, so a reason here puts an error in front of " +
+                "every successful open",
         )
         verify(exactly = 1) { context.startActivity(any()) }
     }
@@ -234,9 +249,9 @@ class OpenExternalUrlRefusalTest {
         // is needed and neither failure mode returns. Real behaviour still runs.
         mockkObject(AuthTabWindow)
 
-        assertFalse(
-            bridge.openExternalUrl(REMOTE, security.getSessionToken()),
-            "no Custom Tab can be launched from a JVM test, so this must report failure",
+        assertNotEquals(
+            "", bridge.openExternalUrl(REMOTE, security.getSessionToken()),
+            "no Custom Tab can be launched from a JVM test, so this must report a reason",
         )
 
         verifyOrder {
@@ -350,8 +365,8 @@ class OpenExternalUrlRefusalTest {
         mockkConstructor(Intent::class)
         every { anyConstructed<Intent>().addFlags(any()) } returns mockk(relaxed = true)
 
-        assertTrue(
-            bridge.openExternalUrl(REMOTE_HTTP, security.getSessionToken()),
+        assertEquals(
+            "", bridge.openExternalUrl(REMOTE_HTTP, security.getSessionToken()),
             "the system browser branch must report the launch it made"
         )
         verify(exactly = 1) { context.startActivity(any()) }
@@ -362,11 +377,104 @@ class OpenExternalUrlRefusalTest {
         )
     }
 
+    /**
+     * The URL here is supplied by the page, and `Logger.e` is not gated on a
+     * debuggable build, so this line ships. logcat is readable by anything holding
+     * `READ_LOGS`, and the workbench that supplies the URL is also what holds the
+     * connection token, so a URL it hands over can carry it. That is the same
+     * reasoning `logToNative` states for redacting there.
+     *
+     * The throwable is asserted absent for the same reason the redaction is
+     * present. `ActivityNotFoundException` quotes the whole Intent it could not
+     * match, so passing it to `Logger.e` would print the unredacted URL inside the
+     * trace right under a message that had just been redacted, and the redaction
+     * would only look like one.
+     */
+    @Test
+    fun `the failure log carries neither the token nor the throwable that repeats it`() {
+        val logged = mutableListOf<String>()
+        every { Logger.e(any(), capture(logged), any()) } just Runs
+
+        val uri = mockk<Uri>(relaxed = true)
+        every { uri.host } returns "127.0.0.1"
+        every { uri.scheme } returns "http"
+        every { Uri.parse(TOKEN_BEARING) } returns uri
+        mockkConstructor(Intent::class)
+        every { anyConstructed<Intent>().addFlags(any()) } returns mockk(relaxed = true)
+        every { context.startActivity(any()) } throws
+            ActivityNotFoundException("No Activity found to handle Intent { dat=" + TOKEN_BEARING + " }")
+
+        bridge.openExternalUrl(TOKEN_BEARING, security.getSessionToken())
+
+        assertTrue(logged.isNotEmpty(), "the failure was not logged at all, so nothing was checked")
+        val line = logged.last()
+        assertFalse(
+            line.contains(TOKEN_SECRET),
+            "the connection token was written to logcat verbatim: " + line,
+        )
+        assertTrue(
+            line.contains("tkn=<redacted>"),
+            "the URL is not in the line at all, so this case would pass on a line that " +
+                "dropped it rather than one that redacted it: " + line,
+        )
+        // Asserted at the argument rather than by capturing it, because a captured
+        // null and an argument that was never recorded look the same in a list.
+        verify(exactly = 1) { Logger.e(any(), any(), null) }
+    }
+
+    /**
+     * The distinction a boolean could not carry, and the whole point of answering
+     * with a reason.
+     *
+     * Both halves below fail at the same line. While the answer was `false` the
+     * relay reported both as "no app on this device handles that link", which is
+     * the right advice for the first and unfollowable for the second: Android
+     * refused that launch itself, and installing an app does not change its mind.
+     *
+     * `SecurityException` stands in for that family because it is easy to throw
+     * here. The case met on a device is `FileUriExposedException`, which Android
+     * raises for a `file://` URL handed to another app, and which the extension's
+     * "Open in Browser" box will produce for anyone who types a path.
+     */
+    @Test
+    fun `the reason separates a missing app from a launch Android refused`() {
+        val uri = mockk<Uri>(relaxed = true)
+        every { uri.host } returns "localhost"
+        every { uri.scheme } returns "http"
+        every { Uri.parse(LOCAL) } returns uri
+        mockkConstructor(Intent::class)
+        every { anyConstructed<Intent>().addFlags(any()) } returns mockk(relaxed = true)
+
+        every { context.startActivity(any()) } throws ActivityNotFoundException("nothing handles it")
+
+        assertEquals(
+            OPEN_URL_NO_HANDLER,
+            bridge.openExternalUrl(LOCAL, security.getSessionToken()),
+            "nothing claimed the intent, which is the one cause the user can act on",
+        )
+
+        every { context.startActivity(any()) } throws SecurityException("refused by policy")
+        val refused = bridge.openExternalUrl(LOCAL, security.getSessionToken())
+
+        assertNotEquals(
+            OPEN_URL_NO_HANDLER, refused,
+            "a launch Android refused on its own terms was reported as a missing app, which " +
+                "sends the user to install something that cannot help",
+        )
+        assertTrue(
+            refused.startsWith(OPEN_URL_FAILED_PREFIX) && refused.endsWith("SecurityException"),
+            "the reason has to name what actually failed, got: " + refused,
+        )
+    }
+
     @Test
     fun `a rejected token is refused before the URL is even looked at`() {
-        assertFalse(
+        assertEquals(
+            OPEN_URL_STALE_SESSION,
             bridge.openExternalUrl(LOCAL, "not the session token"),
-            "a URL that would otherwise open must still be refused with a bad token",
+            "a URL that would otherwise open must still be refused with a bad token, and " +
+                "the reason has to say so: blaming a missing app sends the user to install " +
+                "something that cannot help",
         )
         verify(exactly = 0) {
             Uri.parse(any())

--- a/docs/05-API_SPEC.md
+++ b/docs/05-API_SPEC.md
@@ -182,22 +182,28 @@ fun hasClipboardText(authToken: String): Boolean
 
 ```kotlin
 @JavascriptInterface
-fun openExternalUrl(url: String, authToken: String): Boolean  // note: token LAST
+fun openExternalUrl(url: String, authToken: String): String  // note: token LAST
 // Hands the URL to a browser: a Chrome Custom Tab for https, and a plain VIEW
 // intent for the rest, which is what the localhost dev-server preview needs.
 // Used by: VS Code "Open in Browser" actions.
 //
-// Returns whether it was opened. TWO things return false and the caller cannot
-// tell them apart: the token was rejected, or no installed app took the intent.
-// The URL itself is never judged -- there is no scheme or host filter on this
-// path, so a LAN address, a custom scheme and a typo are all simply handed to
-// Android. `false` means nothing on the device handles that link.
+// Returns the empty string when it opened, and otherwise the reason it did not,
+// which the relay forwards to the user unchanged. Three reasons exist: the
+// session token was stale, no installed app took the intent, or Android refused
+// the launch outright, which is what a `file://` URL gets. The URL itself is
+// never judged: there is no scheme or host filter on this path, so a LAN address,
+// a custom scheme and a typo are all simply handed to Android.
 //
-// It returned Unit until the fix that gave it this signature, so a refusal was
+// CALLERS MUST COMPARE AGAINST THE EMPTY STRING. Success is the falsy value, so
+// a truthiness test reads backwards and claims every click it failed to open.
+//
+// It returned Unit until the fix that first gave it an answer, so a refusal was
 // indistinguishable from a launch. The relay reported ok:true because there was
 // nothing else it could report, and "Open in Browser" closed its input box and
 // did nothing for every LAN address pasted into it, with the extension's own
-// error handler unreachable behind a promise that always resolved.
+// error handler unreachable behind a promise that always resolved. It then
+// returned a boolean, which said that something had failed without saying what,
+// and the relay filled the gap with one fixed sentence blaming a missing app.
 
 @JavascriptInterface
 fun onBackPressed(authToken: String): Boolean

--- a/scripts/test-bridge-relay.js
+++ b/scripts/test-bridge-relay.js
@@ -32,7 +32,30 @@ const ROOT = path.join(__dirname, '..');
 const MAIN_ACTIVITY = path.join(
     ROOT, 'android/app/src/main/kotlin/com/vscodroid/MainActivity.kt',
 );
+const ANDROID_BRIDGE = path.join(
+    ROOT, 'android/app/src/main/kotlin/com/vscodroid/bridge/AndroidBridge.kt',
+);
 const EXTENSIONS_DIR = path.join(ROOT, 'android/app/src/main/assets/extensions');
+
+/**
+ * One of the user-facing decline reasons, read from where it now lives.
+ *
+ * The relay used to hold this sentence as a literal and the checks below read it
+ * from there. It moved to the bridge, which is the only side that knows which
+ * failure happened, so the checks follow it rather than being dropped: the
+ * question they ask is about the words a user is shown, and those words are the
+ * same words wherever they are declared.
+ */
+function bridgeReason(name) {
+    const src = fs.readFileSync(ANDROID_BRIDGE, 'utf8');
+    const m = src.match(new RegExp('const val ' + name + '\\s*=\\s*"([^"]*)"'));
+    assert.ok(
+        m,
+        name + ' is gone from AndroidBridge.kt, so this check has nothing to read. If the ' +
+        'reasons moved, point this at their new home rather than deleting the check.',
+    );
+    return m[1];
+}
 
 /** How a literal dollar is written inside a Kotlin raw string. */
 const DOLLAR_ESCAPE = "${'$'}";
@@ -72,22 +95,31 @@ function bridgeExtension() {
 }
 
 /**
- * The body of the raw string in `injectBridgeRelay()`, with the indentation
- * `trimIndent()` removes taken off, which is the text the WebView is given.
+ * The body of the raw string in one of MainActivity's injectors, with the
+ * indentation `trimIndent()` removes taken off, which is the text the WebView is
+ * given.
+ *
+ * Takes the function name because there are two scripts worth running here, not
+ * one. `injectWindowOpenOverride` calls the same bridge method as the relay and
+ * reads its answer differently, so a change to that answer can be right in one
+ * and inverted in the other.
+ *
+ * @param mustMention a token the extracted text has to contain, so that pulling
+ *   the wrong block fails here instead of passing as a scan of something else.
  */
-function extractRelay() {
+function extractInjected(fnName, mustMention) {
     const lines = fs.readFileSync(MAIN_ACTIVITY, 'utf8').split('\n');
-    const fn = lines.findIndex((l) => l.includes('private fun injectBridgeRelay()'));
+    const fn = lines.findIndex((l) => l.includes('private fun ' + fnName + '()'));
     assert.notStrictEqual(
         fn, -1,
-        'injectBridgeRelay() is gone from MainActivity.kt, so this check has nothing to run. ' +
-        'If the relay moved, point this at its new home rather than deleting the check.',
+        fnName + '() is gone from MainActivity.kt, so this check has nothing to run. ' +
+        'If it moved, point this at its new home rather than deleting the check.',
     );
 
     const open = lines.findIndex((l, i) => i > fn && l.trim() === '"""');
     const close = lines.findIndex((l, i) => i > open && l.trim().startsWith('"""'));
     assert.ok(open !== -1 && close !== -1 && close > open + 1,
-        'could not find the raw string in injectBridgeRelay(); its shape changed');
+        'could not find the raw string in ' + fnName + '(); its shape changed');
 
     const body = lines.slice(open + 1, close);
     const indent = Math.min(
@@ -106,15 +138,17 @@ function extractRelay() {
         'the relay contains a bare $, which Kotlin interpolates into the raw string before the ' +
         'WebView sees it. Escape it, or the injected script is not what is written here.',
     );
-    assert.ok(js.includes('openExternalUrl'),
-        'the extracted text does not mention openExternalUrl, so the wrong block was extracted');
+    assert.ok(js.includes(mustMention),
+        'the extracted text does not mention ' + mustMention + ', so the wrong block was extracted');
 
     // Resolve the escapes the way Kotlin does, so what runs below is what runs there.
     return js.split(DOLLAR_ESCAPE).join('$');
 }
 
 // ---- the Android side, stubbed -------------------------------------------
-let bridgeAnswer = false;
+// The bridge answers with the reason it did not open, and the empty string when
+// it did. A boolean here would let a relay that inverted the test stay green.
+let bridgeAnswer = '';
 const bridgeCalls = [];
 const AndroidBridge = {
     openExternalUrl(url, token) {
@@ -229,7 +263,8 @@ function checkCommandCoverage(relay) {
 }
 
 async function main() {
-    const relay = extractRelay();
+    const relay = extractInjected('injectBridgeRelay', 'openExternalUrl');
+    const NO_HANDLER = bridgeReason('OPEN_URL_NO_HANDLER');
     const coverage = checkCommandCoverage(relay);
     vm.runInNewContext(relay, {
         AndroidBridge,
@@ -262,7 +297,7 @@ async function main() {
     // the relay used to post ok:true here, which resolved the extension's promise
     // and left its error handler unreachable.
     const LAN = 'http://192.168.1.5:3000';
-    const refused = await run(LAN, false);
+    const refused = await run(LAN, NO_HANDLER);
     assert.strictEqual(refused.calls.length, 1, 'the relay never reached the bridge');
 
     // What it passed, not just that it passed something. The relay calls
@@ -291,11 +326,21 @@ async function main() {
     // relay that answers nothing leaves the extension to reject on its own
     // five-second timeout, which is also exactly one message, and says the app
     // may not be running.
-    const declined = relay.match(/error: '([^']+)'/);
-    assert.ok(declined, 'no decline message found in the relay; its shape changed');
     assert.ok(
-        refused.error[0].includes(declined[1]),
-        'the message the user saw is not the one the relay sends. Saw: ' + refused.error[0],
+        refused.error[0].includes(NO_HANDLER),
+        'the message the user saw is not the reason the bridge gave. Saw: ' + refused.error[0],
+    );
+
+    // Forwarded, not re-stated. The relay posted one fixed sentence for every
+    // refusal and the check above would accept that again, since the sentence it
+    // posted is the one the bridge now returns for this case. A reason no source
+    // file contains can only arrive by being passed through.
+    const ONLY_HERE = 'a reason that exists only inside this check';
+    const passedThrough = await run('http://192.168.1.5:3000', ONLY_HERE);
+    assert.ok(
+        passedThrough.error.length === 1 && passedThrough.error[0].includes(ONLY_HERE),
+        'the relay did not forward the reason the bridge gave, so it is stating a cause it ' +
+        'cannot know. Saw: ' + JSON.stringify(passedThrough.error),
     );
 
     // The message must not describe a URL policy. This asked for the opposite
@@ -308,36 +353,34 @@ async function main() {
     // and the policy are in different files and only one of them fails a build.
     for (const stale of ['https, mailto', 'allow', 'localhost', 'scheme']) {
         assert.ok(
-            !declined[1].toLowerCase().includes(stale),
+            !NO_HANDLER.toLowerCase().includes(stale),
             `the decline message mentions "${stale}", which reads as a URL restriction. There ` +
             'is none: any URL is handed to the platform, and the only way to get here is that ' +
-            `no installed app took the intent. Message: ${declined[1]}`,
+            `no installed app took the intent. Message: ${NO_HANDLER}`,
         );
     }
     assert.ok(
-        /no app|handles that link/i.test(declined[1]),
+        /no app|handles that link/i.test(NO_HANDLER),
         'the decline message no longer names the one cause that can produce it -- that nothing ' +
-        'on the device handles the link: ' + declined[1],
+        'on the device handles the link: ' + NO_HANDLER,
     );
 
-    // An allowed scheme that still fails to open. NOT the ActivityNotFound case:
-    // the bridge is stubbed here and ignores the URL, so this run is identical to
-    // the one above and cannot fail independently of it. What it does pin is that
-    // the SAME message is surfaced for a scheme the message itself calls allowed,
-    // which is the wording property -- the cause it stands in for lives in Kotlin
-    // and is not reachable from this harness.
-    const allowedButUnopened = await run('mailto:someone@example.com', false);
+    // A different scheme, same handling. The bridge is stubbed here and ignores
+    // the URL, so this cannot fail independently of the run above; what it pins is
+    // that the relay does not branch on the scheme before deciding what to say.
+    // Which failure produced the reason is decided in Kotlin and is covered there.
+    const allowedButUnopened = await run('mailto:someone@example.com', NO_HANDLER);
     assert.strictEqual(allowedButUnopened.error.length, 1,
         'an allowed URL that failed to open must still reach the user');
     assert.ok(
-        allowedButUnopened.error[0].includes(declined[1]),
+        allowedButUnopened.error[0].includes(NO_HANDLER),
         'the mailto case surfaced a different message: ' + allowedButUnopened.error[0],
     );
 
     // The control. Without it, a relay that reported failure unconditionally
     // would satisfy the assertion above and put an error in front of every
     // successful open.
-    const opened = await run('http://localhost:3000', true);
+    const opened = await run('http://localhost:3000', '');
     assert.strictEqual(opened.calls.length, 1, 'the relay never reached the bridge');
     assert.strictEqual(
         opened.error.length, 0,
@@ -346,16 +389,58 @@ async function main() {
 
     // Cancelling the input box must not reach Android at all.
     for (const [label, value] of [['cancelled', undefined], ['whitespace', '   ']]) {
-        const inert = await run(value, false);
+        const inert = await run(value, '');
         assert.strictEqual(inert.calls.length, 0, `${label} input still called the bridge`);
         assert.strictEqual(inert.error.length, 0, `${label} input surfaced an error`);
     }
+
+    // The other reader of the same answer. `injectWindowOpenOverride` calls the
+    // same bridge method and decides from its answer whether the click was
+    // handled, it is injected JavaScript that nothing compiles, and it reads the
+    // answer the opposite way round from the relay: success is the empty string,
+    // so a bare truthiness test claims every click it FAILED to open and lets the
+    // one it did open fall through to the WebView as well. Both directions are
+    // asserted, because that inversion satisfies either one on its own.
+    const override = extractInjected('injectWindowOpenOverride', 'openExternalUrl');
+
+    function windowOpen(answer, url) {
+        const seen = { bridge: 0, orig: 0 };
+        const win = {
+            __vscodroid: { authToken: 'test-token' },
+            open() { seen.orig++; return 'fell through to the WebView'; },
+        };
+        vm.runInNewContext(override, {
+            window: win,
+            AndroidBridge: {
+                openExternalUrl() { seen.bridge++; return answer; },
+            },
+        });
+        return { ...seen, result: win.open(url), calls: seen };
+    }
+
+    const claimed = windowOpen('', 'https://example.com/docs');
+    assert.strictEqual(claimed.calls.bridge, 1, 'window.open never reached the bridge');
+    assert.strictEqual(
+        claimed.calls.orig, 0,
+        'the bridge opened the URL and window.open fell through as well, so the page opens ' +
+        'twice: once in a browser and once inside the WebView',
+    );
+    assert.strictEqual(claimed.result, null, 'a click that was handled must report that it was');
+
+    const fellThrough = windowOpen(NO_HANDLER, 'https://example.com/docs');
+    assert.strictEqual(fellThrough.calls.bridge, 1, 'window.open never reached the bridge');
+    assert.strictEqual(
+        fellThrough.calls.orig, 1,
+        'the bridge did not open the URL and window.open swallowed the click anyway, so it ' +
+        'did nothing and said nothing',
+    );
 
     const unused = coverage.unused.length
         ? `; ${coverage.unused.length} relay branches have no sender (${coverage.unused.join(', ')})`
         : '';
     say(
-        `ok -- a declined URL surfaces "${refused.error[0]}", an opened one stays silent; ` +
+        `ok -- a declined URL surfaces "${refused.error[0]}", an opened one stays silent, ` +
+        'and window.open claims only the clicks the bridge opened; ' +
         `all ${coverage.sent} commands sent by an extension have a relay branch${unused}\n`,
     );
 }


### PR DESCRIPTION
`AndroidBridge.openExternalUrl` answered with a boolean, so a rejected session token and an intent nothing claimed were the same event from the page's side. The relay turned every refusal into a single fixed sentence, `No app on this device handles that link`. That is the right advice for one of the causes and unfollowable for the rest: a `file://` URL, which the bundled extension's "Open in Browser" box produces for anyone who types a path, is refused by Android itself and no installation changes that.

The same method also logged the URL it failed to open, in the clear, on a line that is not gated on a debuggable build and therefore ships. The URL is supplied by the page, and the workbench that supplies it holds the connection token, so a URL it hands over can carry one. That is the reasoning `logToNative` already states one screen away in the same class.

## What changed

- `openExternalUrl` answers with the reason it did not open, and the empty string when it did.
- The relay forwards that reason instead of stating a cause it cannot know.
- The `window.open` override compares the answer against the empty string. With a reason as the failure value, a truthiness test reads backwards: it would claim every click it failed to open and let the one it did open through to the WebView as well.
- The failure log redacts the URL, and no longer passes the throwable. `ActivityNotFoundException` quotes the whole Intent in its message, so printing it repeated the URL the line had just redacted.
- The relay harness runs the `window.open` override as well as the relay, and reads the user-facing sentence from the bridge rather than from the relay literal that used to hold it.

## Risk

The two consumers of the return value are injected JavaScript that nothing compiles. Both are covered by `scripts/test-bridge-relay.js`, which runs them for real, and both directions are asserted because the inversion satisfies either one alone.

## Verification

Every assertion was checked against a deliberate break of what it claims: disabling the redaction, passing the throwable back, collapsing all reasons to one, answering an empty string for a rejected token, restoring the bare truthiness test in each of the two readers, re-hardcoding the sentence in the relay, and renaming the constant the harness reads. All eight reddened the check that targets them, and the tree returns to green when reverted.

Full unit suite 1298 tests, no failures. `node scripts/test-bridge-relay.js` passes. Lint clean.