### PR TITLE
docs: put each KDoc block back on the symbol it describes

### DIFF
--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -627,12 +627,6 @@ class MainActivity : AppCompatActivity() {
     }
 
     /**
-     * Handles a SAF folder selection result:
-     * 1. Persists the URI permission
-     * 2. Syncs folder contents to a local mirror (with progress dialog)
-     * 3. Reloads VS Code with the mirror path
-     */
-    /**
      * Starts watching a mirror the workbench opened without going through Kotlin.
      *
      * VS Code switches folders by navigating its own WebView: Open Recent, the
@@ -661,6 +655,12 @@ class MainActivity : AppCompatActivity() {
         openSafFolder(folder.uri, navigate = false)
     }
 
+    /**
+     * Handles a SAF folder selection result:
+     * 1. Persists the URI permission
+     * 2. Syncs folder contents to a local mirror (with progress dialog)
+     * 3. Reloads VS Code with the mirror path
+     */
     private fun handleSafFolderSelected(uri: Uri) = openSafFolder(uri, navigate = true)
 
     /**
@@ -2497,17 +2497,6 @@ internal sealed interface BindDecision {
 }
 
 /**
- * The notice is read first, and that ordering is load-bearing: it may be terminal
- * or it may be a slow start still coming up, and in both cases the server is not
- * serving, so it must not be shadowed by a port that happens to look plausible.
- *
- * [ready] is the health probe's own finding, never process liveness. A process is
- * alive from the instant it is spawned and stays alive through the seconds before
- * its port is bound and through a whole post-crash restart; navigating on that
- * points the WebView at nothing, and `onReceivedError` only logs, so the
- * connection-refused page it produces is never cleared.
- */
-/**
  * Whether [url] is a page the local server served, as opposed to one this app
  * drew itself.
  *
@@ -2543,6 +2532,22 @@ internal fun isWorkbenchUrl(url: String?, port: Int): Boolean {
     return (hostName == "127.0.0.1" || hostName == "localhost") && parsed.port == port
 }
 
+/**
+ * The notice is read first, and that ordering is load-bearing: it may be terminal
+ * or it may be a slow start still coming up, and in both cases the server is not
+ * serving, so it must not be shadowed by a port that happens to look plausible.
+ *
+ * Which of the two it is then decides the answer: a terminal notice gives
+ * [BindDecision.ShowGaveUp] and any other gives [BindDecision.ShowNotice],
+ * because a server that has stopped trying needs the loading page replaced,
+ * while a slow start may still come up under a toast.
+ *
+ * [ready] is the health probe's own finding, never process liveness. A process is
+ * alive from the instant it is spawned and stays alive through the seconds before
+ * its port is bound and through a whole post-crash restart; navigating on that
+ * points the WebView at nothing, and `onReceivedError` only logs, so the
+ * connection-refused page it produces is never cleared.
+ */
 internal fun bindDecision(notice: StartupNotice?, port: Int, ready: Boolean): BindDecision = when {
     notice != null && notice.terminal -> BindDecision.ShowGaveUp(notice.message)
     notice != null -> BindDecision.ShowNotice(notice.message)

--- a/android/app/src/main/kotlin/com/vscodroid/bridge/AndroidBridge.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/bridge/AndroidBridge.kt
@@ -113,6 +113,31 @@ internal fun authRequestIdsIn(url: String): List<String> =
     AUTH_REQUEST_ID.findAll(url).map { it.groupValues[1] }.distinct().toList()
 
 /**
+ * Why [AndroidBridge.openExternalUrl] did not open anything.
+ *
+ * Named constants rather than literals at each exit so a test can pin which
+ * reason belongs to which failure without pinning the wording, which is not the
+ * contract. The wording is user facing: the extension's "Open in Browser" puts
+ * whichever of these comes back straight into a `showErrorMessage`.
+ */
+internal const val OPEN_URL_STALE_SESSION =
+    "VSCodroid did not accept the request. Reload the window and try again."
+
+/** The reason that is worth acting on, and the only one the relay used to give. */
+internal const val OPEN_URL_NO_HANDLER =
+    "VSCodroid did not open it. No app on this device handles that link."
+
+/**
+ * Everything else, with the exception's class name appended.
+ *
+ * The class name and not its message: `ActivityNotFoundException` quotes the
+ * whole Intent it could not match, and `FileUriExposedException` quotes the
+ * file, so a message here would hand the URL to the page that supplied it and,
+ * through the extension, to a notification a user may screenshot.
+ */
+internal const val OPEN_URL_FAILED_PREFIX = "VSCodroid could not open that link: "
+
+/**
  * The sign-in requests this app launched a browser for, and when.
  *
  * Keyed by request id rather than being a single reading, and that is the whole
@@ -152,31 +177,6 @@ internal fun authRequestIdsIn(url: String): List<String> =
  * reopens the window. No arithmetic happens here; the window is applied by
  * `authCallbackIsExpected`, which this object deliberately does not call.
  */
-/**
- * Why [AndroidBridge.openExternalUrl] did not open anything.
- *
- * Named constants rather than literals at each exit so a test can pin which
- * reason belongs to which failure without pinning the wording, which is not the
- * contract. The wording is user facing: the extension's "Open in Browser" puts
- * whichever of these comes back straight into a `showErrorMessage`.
- */
-internal const val OPEN_URL_STALE_SESSION =
-    "VSCodroid did not accept the request. Reload the window and try again."
-
-/** The reason that is worth acting on, and the only one the relay used to give. */
-internal const val OPEN_URL_NO_HANDLER =
-    "VSCodroid did not open it. No app on this device handles that link."
-
-/**
- * Everything else, with the exception's class name appended.
- *
- * The class name and not its message: `ActivityNotFoundException` quotes the
- * whole Intent it could not match, and `FileUriExposedException` quotes the
- * file, so a message here would hand the URL to the page that supplied it and,
- * through the extension, to a notification a user may screenshot.
- */
-internal const val OPEN_URL_FAILED_PREFIX = "VSCodroid could not open that link: "
-
 object AuthTabWindow {
 
     private val launches = object : LinkedHashMap<String, Long>() {

--- a/android/app/src/main/kotlin/com/vscodroid/keyboard/ExtraKeyButton.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/keyboard/ExtraKeyButton.kt
@@ -120,6 +120,26 @@ class ExtraKeyButton @JvmOverloads constructor(
     }
 
     /**
+     * Opens the alternates layer when a service long presses this key.
+     *
+     * The same gap as [performClick], one gesture over: the popup's only entry
+     * was [GestureDetector]'s `onLongPress`, which needs a finger held on the
+     * view, and touch exploration never delivers one. Five of the eight
+     * alternates are top-level keys on other pages and one is Shift plus
+     * backtick, but `'` and `\` are on no page at all, so without this they
+     * exist on the row for sighted users only.
+     *
+     * A key with no alternates falls through to `super`, which is what keeps
+     * the row honest: those keys advertise no long click, so nothing offers an
+     * action that would open an empty popup.
+     */
+    override fun performLongClick(): Boolean {
+        if (alternates.isEmpty()) return super.performLongClick()
+        onLongPressAction?.invoke(this, alternates)
+        return true
+    }
+
+    /**
      * Delivers one press when an accessibility service activates this key.
      *
      * `isClickable` has been true on these buttons all along, so a screen
@@ -141,26 +161,6 @@ class ExtraKeyButton @JvmOverloads constructor(
      * service listens for; the return is `true` because this handled the click
      * regardless of what `super` reports with no listener attached.
      */
-    /**
-     * Opens the alternates layer when a service long presses this key.
-     *
-     * The same gap as [performClick], one gesture over: the popup's only entry
-     * was [GestureDetector]'s `onLongPress`, which needs a finger held on the
-     * view, and touch exploration never delivers one. Five of the eight
-     * alternates are top-level keys on other pages and one is Shift plus
-     * backtick, but `'` and `\` are on no page at all, so without this they
-     * exist on the row for sighted users only.
-     *
-     * A key with no alternates falls through to `super`, which is what keeps
-     * the row honest: those keys advertise no long click, so nothing offers an
-     * action that would open an empty popup.
-     */
-    override fun performLongClick(): Boolean {
-        if (alternates.isEmpty()) return super.performLongClick()
-        onLongPressAction?.invoke(this, alternates)
-        return true
-    }
-
     override fun performClick(): Boolean {
         emitPress()
         super.performClick()

--- a/android/app/src/main/kotlin/com/vscodroid/service/NodeService.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/service/NodeService.kt
@@ -25,26 +25,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 /**
- * Foreground Service that owns the Node.js server process.
- *
- * Responsibilities:
- * - Promoting itself to a foreground service with a persistent notification
- *   (specialUse FGS type for local dev server)
- * - Delegating process lifecycle to [ProcessManager]
- * - Automatically restarting the server on unexpected crashes (up to [MAX_RESTARTS])
- * - Exposing server state to bound clients (typically [MainActivity])
- *
- * Binding pattern: Activities bind to this service to receive the port number
- * and server readiness callbacks. The service remains alive independently of
- * any bound clients because it is started as a foreground service.
- *
- * Threading: [restartCount], [isServiceRunning] and [launchJob] are touched only
- * from [serviceScope]'s dispatcher, which is the main thread. Service lifecycle
- * callbacks already arrive there; the one caller that does not is the watchdog,
- * and [setupProcessCallbacks] hands its report to the scope rather than acting on
- * the watchdog thread.
- */
-/**
  * What a client that binds after a start attempt has to be told, and whether
  * that attempt was the last one.
  *
@@ -58,6 +38,27 @@ import kotlinx.coroutines.withContext
  */
 data class StartupNotice(val message: String, val terminal: Boolean)
 
+/**
+ * Foreground Service that owns the Node.js server process.
+ *
+ * Responsibilities:
+ * - Promoting itself to a foreground service with a persistent notification
+ *   (specialUse FGS type for local dev server)
+ * - Delegating process lifecycle to [ProcessManager]
+ * - Automatically restarting the server on unexpected crashes (up to [MAX_RESTARTS])
+ * - Exposing server state to bound clients (typically [MainActivity])
+ *
+ * Binding pattern: Activities bind to this service to receive the port number
+ * and server readiness callbacks. The service remains alive independently of
+ * any bound clients because it is started as a foreground service.
+ *
+ * Threading: the state this service keeps for itself, namely [restartCount],
+ * [isServiceRunning], [launchJob], [runId], [failureRaised] and
+ * [startupNotice], is touched only from [serviceScope]'s dispatcher, which is
+ * the main thread. Service lifecycle callbacks already arrive there; the one
+ * caller that does not is the watchdog, and [setupProcessCallbacks] hands its
+ * report to the scope rather than acting on the watchdog thread.
+ */
 class NodeService : Service() {
 
     private val tag = "NodeService"

--- a/android/app/src/main/kotlin/com/vscodroid/service/ProcessManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/service/ProcessManager.kt
@@ -894,14 +894,12 @@ class ProcessManager(private val context: Context) {
     }
 
     /**
-     * Stops the server process.
-     *
-     * Attempts a graceful shutdown via [Process.destroy]. If the process does not
-     * exit, falls back to [Process.destroyForcibly]. Sets [isShuttingDown] to
-     * suppress watchdog crash callbacks.
-     */
-    /**
      * Stops the server, waiting briefly for it to go before killing it.
+     *
+     * [isShuttingDown] is set first, and that is what keeps [startWatchdog]
+     * quiet: the exit that follows is expected, so no crash callback fires and
+     * nothing restarts the server behind this call. It was the one thing a
+     * second, older copy of this documentation said that this one did not.
      *
      * The wait is short because it is paid on whichever thread calls this, and
      * the Stop action on the notification calls it from Service.onDestroy --
@@ -1118,17 +1116,6 @@ class ProcessManager(private val context: Context) {
     }
 
     /**
-     * Starts a daemon thread that waits for the server process to exit.
-     *
-     * If [isShuttingDown] is `true`, the exit is expected and no callback fires.
-     * Otherwise, [onServerCrashed] is invoked with the exit code.
-     *
-     * Exit code interpretation:
-     * - 0: clean exit
-     * - 137 (SIGKILL): typically OOM killer or phantom process limit
-     * - other: unexpected crash
-     */
-    /**
      * Watches a server nobody here spawned.
      *
      * This is the whole answer to the objection that kept adoption out of the
@@ -1178,6 +1165,23 @@ class ProcessManager(private val context: Context) {
         }
     }
 
+    /**
+     * Starts a daemon thread that waits for the server process to exit.
+     *
+     * Readiness is cleared whatever the reason and before the shutdown branch,
+     * because a process that has exited is not serving.
+     *
+     * If [isShuttingDown] is `true`, the exit is expected and no callback fires.
+     * Otherwise, [onServerCrashed] is invoked with the exit code.
+     *
+     * Exit code interpretation:
+     * - 0: clean exit
+     * - 137: SIGKILL, typically the OOM killer or the phantom process limit
+     * - 129 to 192: killed by some other signal, named through [signalName].
+     *   This said "unexpected crash" while the bootstrap collapsed every signal
+     *   to a clean zero, which made even the 137 above unreachable
+     * - anything else: unexpected crash
+     */
     private fun startWatchdog() {
         watchdogThread = thread(name = "node-watchdog", isDaemon = true) {
             try {

--- a/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
@@ -404,6 +404,10 @@ class FirstRunSetup(
     }
 
     /**
+     * @param onBytes told how many bytes each extracted file wrote, so a caller can
+     *   report progress across a step that would otherwise show none. Null for the
+     *   short steps, where the cost of reporting outweighs what it shows.
+     *
      * @return false if any file under [assetPath] was present in the APK and
      *   could not be written. An asset that is simply absent is not a failure --
      *   several are, in builds that skip a download script -- so it answers
@@ -428,11 +432,6 @@ class FirstRunSetup(
      *
      * Nothing on device verifies those trees are complete;
      * `verify-server-tree.py` checks the build, not the install.
-     */
-    /**
-     * @param onBytes told how many bytes each extracted file wrote, so a caller can
-     *   report progress across a step that would otherwise show none. Null for the
-     *   short steps, where the cost of reporting outweighs what it shows.
      */
     private fun extractAssetDir(
         assetPath: String,
@@ -2669,47 +2668,6 @@ private class SettingPin(val key: String, valuePattern: String, val value: Strin
 private val FIRST_PROPERTY = Regex("""(?<=\{)\s*\n([ \t]*)(?=")""")
 
 /**
- * Reconciles the settings.json values this app manages, returning the updated
- * document or `null` when nothing needed changing.
- *
- * Two jobs. `git.path` still embeds `nativeLibraryDir`, which a reinstall moves,
- * so it is re-pointed whenever it has gone stale. The terminal profile is instead
- * migrated *off* `nativeLibraryDir` and onto the `usr/bin/bash` symlink, which
- * `setupToolSymlinks()` already repairs on every launch — after that move the
- * pattern no longer matches and the profile never goes stale again.
- *
- * The move carries the other two halves of the shell-integration fix with it,
- * because all three were written by the same release. Bundling them keeps the
- * migration one-shot: once the path is off `/data/app/`, nothing here fires
- * again, so a user who later turns shell integration back off keeps it off.
- *
- * Substitutes values in place and leaves every other byte untouched.
- * settings.json is JSONC: comments and trailing commas are legal there, so
- * parsing the document to re-serialise it would strip the user's comments,
- * escape every slash, and turn `["-i",]` into `["-i", null]`.
- *
- * A pattern that does not match changes nothing, so a file the user has
- * restructured is left as they wrote it rather than mangled.
- */
-/**
- * Names the extension directories left behind by an earlier bundled version.
- *
- * Bundled extensions are extracted to `publisher.name-version` directories, so
- * bumping a version extracts a new directory beside the old one. The scanner
- * shows only what `extensions.json` — the default profile's manifest — lists,
- * not what sits on disk, so the deletion here is half of the swap: it is what
- * lets reconcileExtensionsManifest drop the old entry and list the new version
- * in its place. The other stake is disk, which never comes back on its own:
- * the Python extension alone is 29 MB, kept for as long as the app is
- * installed. (An earlier version of this comment claimed the scanner discovers
- * extensions by listing directories; the manifest is what it reads.)
- *
- * Only strictly older copies are named. A user who installed a newer build of the
- * same extension from the marketplace keeps it — that is their copy, and the
- * scanner already prefers it. A version that is not purely numeric is left alone
- * rather than guessed at.
- */
-/**
  * Directories under our own publisher that this build no longer bundles.
  *
  * `vscodroid.*` never appears on the marketplace, so such a directory can only
@@ -2848,33 +2806,6 @@ internal fun bundledDirsToExtract(present: List<String>, bundled: List<String>):
     bundled.filter { it.startsWith(OWN_EXTENSION_PREFIX) || it !in present }
 
 /**
- * Whether the setup recorded on this device belongs to a build other than the
- * one now running, and therefore has to be redone.
- *
- * Both halves of the identity are compared, and the versionCode is the half
- * that carries the guarantee. A versionName is a label a build declares about
- * itself and nothing stops two builds declaring the same one: 1.1.0 was
- * published under versionCode 11 and then again under 12. Comparing the label
- * alone, which is what this did, answers "same build" for those two -- so a
- * device holding the first takes the second, skips setup entirely, and keeps
- * running the older server tree under the newer app. Nothing reports it,
- * because from the app's side setup completed; it completed for a different
- * build.
- *
- * Play refuses an upload whose versionCode is not greater than the last, so the
- * code cannot repeat where the name can. Comparing both means the name stays
- * free to be whatever a release wants to call itself.
- *
- * A stored code of 0 is the value getInt returns when the
- * key was never written, which is any install predating the code being
- * recorded. Those are treated as stale, which redoes an extraction that is
- * idempotent, rather than trusting a record that was never made.
- *
- * Pure, and takes the four values rather than a Context, so the decision can be
- * pinned by a unit test; the reads themselves are one call each and have no
- * branch to get wrong.
- */
-/**
  * How much of `filesDir` the toolchains named in `toolchains.json` occupy.
  *
  * A withdrawn toolchain is still counted. `ToolchainRegistry.find` answers null
@@ -2902,6 +2833,33 @@ internal fun toolchainBytesFor(names: List<String>): Long = names.sumOf { name -
         ?: 0L
 }
 
+/**
+ * Whether the setup recorded on this device belongs to a build other than the
+ * one now running, and therefore has to be redone.
+ *
+ * Both halves of the identity are compared, and the versionCode is the half
+ * that carries the guarantee. A versionName is a label a build declares about
+ * itself and nothing stops two builds declaring the same one: 1.1.0 was
+ * published under versionCode 11 and then again under 12. Comparing the label
+ * alone, which is what this did, answers "same build" for those two -- so a
+ * device holding the first takes the second, skips setup entirely, and keeps
+ * running the older server tree under the newer app. Nothing reports it,
+ * because from the app's side setup completed; it completed for a different
+ * build.
+ *
+ * Play refuses an upload whose versionCode is not greater than the last, so the
+ * code cannot repeat where the name can. Comparing both means the name stays
+ * free to be whatever a release wants to call itself.
+ *
+ * A stored code of 0 is the value getInt returns when the
+ * key was never written, which is any install predating the code being
+ * recorded. Those are treated as stale, which redoes an extraction that is
+ * idempotent, rather than trusting a record that was never made.
+ *
+ * Pure, and takes the four values rather than a Context, so the decision can be
+ * pinned by a unit test; the reads themselves are one call each and have no
+ * branch to get wrong.
+ */
 internal fun setupIsStale(
     storedName: String?,
     storedCode: Int,
@@ -3150,6 +3108,24 @@ internal fun bundledIdsToRelist(
     }
 }
 
+/**
+ * Names the extension directories left behind by an earlier bundled version.
+ *
+ * Bundled extensions are extracted to `publisher.name-version` directories, so
+ * bumping a version extracts a new directory beside the old one. The scanner
+ * shows only what `extensions.json` — the default profile's manifest — lists,
+ * not what sits on disk, so the deletion here is half of the swap: it is what
+ * lets reconcileExtensionsManifest drop the old entry and list the new version
+ * in its place. The other stake is disk, which never comes back on its own:
+ * the Python extension alone is 29 MB, kept for as long as the app is
+ * installed. (An earlier version of this comment claimed the scanner discovers
+ * extensions by listing directories; the manifest is what it reads.)
+ *
+ * Only strictly older copies are named. A user who installed a newer build of the
+ * same extension from the marketplace keeps it — that is their copy, and the
+ * scanner already prefers it. A version that is not purely numeric is left alone
+ * rather than guessed at.
+ */
 internal fun supersededExtensionDirs(present: List<String>, bundled: List<String>): List<String> {
     fun split(dir: String): Pair<String, String>? {
         val cut = dir.lastIndexOf('-')
@@ -3180,6 +3156,36 @@ internal fun supersededExtensionDirs(present: List<String>, bundled: List<String
     }
 }
 
+/**
+ * Reconciles the settings.json values this app manages, returning the updated
+ * document or `null` when nothing needed changing.
+ *
+ * Two of the jobs are about paths. `git.path` still embeds `nativeLibraryDir`,
+ * which a reinstall moves, so it is re-pointed whenever it has gone stale. The
+ * terminal profile is instead migrated *off* it and onto `usr/bin/bash`, which
+ * `setupToolSymlinks()` already repairs on every launch — after that move the
+ * pattern no longer matches and the profile never goes stale again.
+ *
+ * The move carries the other two halves of the shell-integration fix with it,
+ * because all three were written by the same release. Bundling them keeps the
+ * migration one-shot: once the path is off `/data/app/`, nothing here fires
+ * again, so a user who later turns shell integration back off keeps it off.
+ *
+ * The remaining values are not migrations. They are inserted when absent rather
+ * than only refreshed, so they reach installs made before the setting existed:
+ * `claudeCode.claudeProcessWrapper`, itself a `nativeLibraryDir` path and so
+ * refreshed too, but left alone when it points somewhere the user chose;
+ * `extensions.verifySignature`; and the two Python pins [PYTHON_LOCATOR] and
+ * [PYTHON_ENV_EXTENSION].
+ *
+ * Substitutes values in place and leaves every other byte untouched.
+ * settings.json is JSONC: comments and trailing commas are legal there, so
+ * parsing the document to re-serialise it would strip the user's comments,
+ * escape every slash, and turn `["-i",]` into `["-i", null]`.
+ *
+ * A pattern that does not match changes nothing, so a file the user has
+ * restructured is left as they wrote it rather than mangled.
+ */
 internal fun refreshManagedPaths(
     content: String,
     shellPath: String,

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
@@ -55,10 +55,11 @@ class ToolchainManager(private val context: Context) {
         Thread(r, "toolchain-io").apply { isDaemon = true }
     }
 
-    /** Callback for progress/state updates: (packName, status, percentDone) */
     /**
      * Progress and outcome for one pack.
      *
+     * The first three arguments are the pack name, an `AssetPackStatus` value,
+     * and how far along it is as a percentage.
      * The fourth argument is why it failed, and it is null for every status that
      * is not a failure. It exists because "Failed" on its own is the same word
      * for a full disk, a dropped connection and a release that never published
@@ -1832,32 +1833,6 @@ class ToolchainManager(private val context: Context) {
 }
 
 /**
- * Whether these opening bytes are an ELF object's.
- *
- * The same four bytes the packaging gates read. Separated so the repair pass can
- * be checked against real files rather than a mock that would only agree with
- * the implementation it was written from.
- */
-/**
- * Gives the execute bit to every ELF object under [root], returning how many
- * needed it.
- *
- * At file scope and taking its symlink predicate as a parameter so a test can
- * reach it. [isSymlink] uses `Os.lstat`, which cannot run in a JVM unit test --
- * it throws, the catch turns that into "not a link", and every entry then looks
- * like a regular file. Injecting the predicate is what lets the skip-links
- * behaviour be asserted rather than assumed; production still passes
- * [isSymlink].
- *
- * Links are stepped over rather than followed: a toolchain's `usr/lib` is shared
- * with the base install, so a link there can point at a file this pass has no
- * business changing the permissions of.
- *
- * Only ELF objects. Scripts are deliberately excluded -- they are wrapped in
- * shell functions that route them through their interpreter, because nothing
- * under `filesDir` can be executed directly whatever its mode.
- */
-/**
  * A staging directory belonging to one download rather than to the class.
  *
  * The path used to be a constant, and the `finally` that cleans up deletes the
@@ -1981,6 +1956,25 @@ internal fun copyDirectoryTree(
     }
 }
 
+/**
+ * Gives the execute bit to every ELF object under [root], returning how many
+ * needed it.
+ *
+ * At file scope and taking its symlink predicate as a parameter so a test can
+ * reach it. [isSymlink] uses `Os.lstat`, which cannot run in a JVM unit test --
+ * it throws, the catch turns that into "not a link", and every entry then looks
+ * like a regular file. Injecting the predicate is what lets the skip-links
+ * behaviour be asserted rather than assumed; production still passes
+ * [isSymlink].
+ *
+ * Links are stepped over rather than followed: a toolchain's `usr/lib` is shared
+ * with the base install, so a link there can point at a file this pass has no
+ * business changing the permissions of.
+ *
+ * Only ELF objects. Scripts are deliberately excluded -- they are wrapped in
+ * shell functions that route them through their interpreter, because nothing
+ * under `filesDir` can be executed directly whatever its mode.
+ */
 internal fun markExecutablesIn(root: File, isLink: (File) -> Boolean = ::isSymlink): Int {
     var fixed = 0
     root.walkTopDown()
@@ -2159,22 +2153,6 @@ internal fun toolchainFailureFor(errorCode: Int): ToolchainFailure = when (error
     else -> ToolchainFailure.INTERNAL
 }
 
-/** The digest manifest's filename, as `release.yml` writes it beside the ZIPs. */
-/**
- * Toolchains this build removes from any install that still has one.
- *
- * Short names, the form `toolchains.json` records. An entry belongs here when it
- * has left [ToolchainRegistry.available]: see [ToolchainManager.removeRetiredToolchainsSync]
- * for why leaving it alone is the one option that helps nobody.
- *
- * `go` is here because it could not compile. Android refuses to execute a file
- * under the app's data directory, and `go build` and `go run` fork the compiler,
- * assembler and linker themselves, so those forks are refused however the `go`
- * command itself is reached. Measured in the app's own SELinux domain, with a
- * control: a plain shell script placed there and marked executable is refused
- * too. It ran, it printed a version, and it could not build a program, for
- * 179 MB.
- */
 /**
  * Toolchains no longer offered, against the space each still occupies on a
  * device that installed one before it was withdrawn.
@@ -2188,9 +2166,22 @@ internal fun toolchainFailureFor(errorCode: Int): ToolchainFailure = when (error
  *
  * Keyed by short name, the form [toolchainShortName] produces, so a record
  * written as either `go` or `toolchain_go` resolves.
+ *
+ * An entry belongs here when it has left [ToolchainRegistry.available]: see
+ * [ToolchainManager.removeRetiredToolchainsSync] for why leaving it alone is the
+ * one option that helps nobody.
+ *
+ * `go` is here because it could not compile. Android refuses to execute a file
+ * under the app's data directory, and `go build` and `go run` fork the compiler,
+ * assembler and linker themselves, so those forks are refused however the `go`
+ * command itself is reached. Measured in the app's own SELinux domain, with a
+ * control: a plain shell script placed there and marked executable is refused
+ * too. It ran, it printed a version, and it could not build a program, for
+ * 179 MB.
  */
 internal val RETIRED_TOOLCHAINS = mapOf("go" to 179_000_000L)
 
+/** The digest manifest's filename, as `release.yml` writes it beside the ZIPs. */
 private const val MANIFEST_NAME = "toolchains.sha256"
 
 /**

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafStorageManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafStorageManager.kt
@@ -119,17 +119,6 @@ class SafStorageManager(private val context: Context) {
     // -- Recent Folders --
 
     /**
-     * Returns the list of recently opened SAF folders with persisted permissions.
-     * Folders whose permissions have been externally revoked are pruned from the list.
-     *
-     * Pruning the list is all this does. Deleting the mirror of a pruned folder used to
-     * happen here too, which put a recursive delete of the user's files inside a method
-     * the workbench calls whenever it wants the recent list — and made a permission that
-     * read as absent for a moment enough to take the mirror of the folder currently open
-     * in the editor out from under it. That reclamation lives in [reclaimRevokedMirrors]
-     * alone now.
-     */
-    /**
      * The device folder whose mirror the workbench has opened, if it opened one.
      *
      * VS Code switches folders by navigating its own WebView, so a folder reached
@@ -141,6 +130,17 @@ class SafStorageManager(private val context: Context) {
     fun folderForOpenedPath(opened: String): SafFolderInfo? =
         folderForOpenedPath(getPersistedFolders(), opened)
 
+    /**
+     * Returns the list of recently opened SAF folders with persisted permissions.
+     * Folders whose permissions have been externally revoked are pruned from the list.
+     *
+     * Pruning the list is all this does. Deleting the mirror of a pruned folder used to
+     * happen here too, which put a recursive delete of the user's files inside a method
+     * the workbench calls whenever it wants the recent list — and made a permission that
+     * read as absent for a moment enough to take the mirror of the folder currently open
+     * in the editor out from under it. That reclamation lives in [reclaimRevokedMirrors]
+     * alone now.
+     */
     fun getPersistedFolders(): List<SafFolderInfo> {
         val json = prefs.getString(KEY_RECENT_FOLDERS, "[]") ?: "[]"
         val array = JSONArray(json)
@@ -529,16 +529,6 @@ class SafStorageManager(private val context: Context) {
         private const val MAX_RECENT = 10
 
         /**
-         * An entry in `saf-mirrors` that this app created: a mirror directory, or the
-         * sync record beside it.
-         *
-         * [com.vscodroid.util.Environment.getSafMirrorDir] names a mirror after the first
-         * six bytes of a digest, so twelve hex characters. Pinned by
-         * `SafMirrorReclamationTest`, because the length lives there and the consequence
-         * of the two drifting apart is a reclamation pass that stops recognising its own
-         * mirrors — or starts recognising files it did not write.
-         */
-        /**
          * Whether a mirror with no live permission may be deleted, given the writes
          * this app records as never having reached the device.
          *
@@ -561,18 +551,6 @@ class SafStorageManager(private val context: Context) {
         }
 
         /**
-         * The persisted folder whose mirror contains [opened], if any.
-         *
-         * The subdirectory case is not a nicety. Open Folder can point at a
-         * directory *inside* a mirror, and the watcher's root has to be the
-         * mirror root or every relative path the sync computes is resolved
-         * against the wrong base.
-         *
-         * The separator matters for the same reason it does in the reclaim gate:
-         * mirror names are a hash prefix, so one being a prefix of another is
-         * ordinary, and a bare `startsWith` would match the wrong folder.
-         */
-        /**
          * Splits the recent list into what is kept and what falls off the end.
          *
          * Returned as a pair rather than trimmed in place because the tail is not
@@ -587,6 +565,19 @@ class SafStorageManager(private val context: Context) {
         ): Pair<List<SafFolderInfo>, List<SafFolderInfo>> =
             folders.take(max) to folders.drop(max)
 
+        /**
+         * The folder in [folders] whose mirror contains [opened], if any. The one
+         * production caller passes the persisted list.
+         *
+         * The subdirectory case is not a nicety. Open Folder can point at a
+         * directory *inside* a mirror, and the watcher's root has to be the
+         * mirror root or every relative path the sync computes is resolved
+         * against the wrong base.
+         *
+         * The separator matters for the same reason it does in the reclaim gate:
+         * mirror names are a hash prefix, so one being a prefix of another is
+         * ordinary, and a bare `startsWith` would match the wrong folder.
+         */
         internal fun folderForOpenedPath(
             folders: List<SafFolderInfo>,
             opened: String,
@@ -594,6 +585,16 @@ class SafStorageManager(private val context: Context) {
             opened == it.mirrorPath || opened.startsWith(it.mirrorPath + File.separator)
         }
 
+        /**
+         * An entry in `saf-mirrors` that this app created: a mirror directory, or the
+         * sync record beside it.
+         *
+         * [com.vscodroid.util.Environment.getSafMirrorDir] names a mirror after the first
+         * six bytes of a digest, so twelve hex characters. Pinned by
+         * `SafMirrorReclamationTest`, because the length lives there and the consequence
+         * of the two drifting apart is a reclamation pass that stops recognising its own
+         * mirrors — or starts recognising files it did not write.
+         */
         internal val MIRROR_ENTRY =
             Regex("^[0-9a-f]{12}(${Regex.escape(SafSyncEngine.SYNCED_RECORD_SUFFIX)})?$")
 

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
@@ -601,12 +601,6 @@ class SafSyncEngine(private val context: Context) {
         "$path\t${file.lastModified()}\t${file.length()}"
 
     /**
-     * The lines of the last complete sync's record, or none when there is no usable one.
-     *
-     * Each is `path`, `modification time` and `length` separated by tabs. Parsing is the
-     * caller's, because a line it cannot read has to be dropped rather than repaired.
-     */
-    /**
      * Whether every file under [mirrorDir] is one this app can prove it copied from the
      * device folder, unchanged since.
      *
@@ -663,6 +657,15 @@ class SafSyncEngine(private val context: Context) {
         }
     }
 
+    /**
+     * The lines of the last complete sync's record, or none when there is no file to
+     * read or the read failed.
+     *
+     * The first line is [RECORD_HEADER]; every line after it is `path`, `modification
+     * time` and `length` separated by tabs. The header check and the parsing are both
+     * the caller's, because a record in a format this build does not know has to be
+     * discarded whole and a line it cannot read has to be dropped rather than repaired.
+     */
     private fun readSyncedRecord(record: File): List<String> =
         if (!record.isFile) {
             emptyList()
@@ -982,25 +985,6 @@ class SafSyncEngine(private val context: Context) {
     }
 
     /**
-     * Writes a local file's contents back to its corresponding SAF document.
-     *
-     * The copy is bracketed by the in-flight journal, and the bracket is the whole
-     * point of this method's shape: `"wt"` truncates the document at open, and the
-     * provider stamps a fresh modification time on the shorter bytes, so a copy
-     * that dies partway leaves the device holding a *newer* copy of a file whose
-     * only complete version is the mirror's. That is indistinguishable, at the
-     * next sync, from an edit made on the device, and the sync would copy the
-     * truncation over the edit. The journal line is written before the stream
-     * opens and removed only by a copy that ran to its end, so the next sync can
-     * tell the two apart by the one fact it can know: whether this app was
-     * mid-upload when the copy stopped.
-     *
-     * One retry, because a first attempt that fails has already paid the
-     * truncation, and a second full write is cheaper than a session of a stale
-     * device copy. Permission loss is not retried: nothing about a revoked grant
-     * gets better within a second.
-     */
-    /**
      * Whether the device document and the mirror hold the same bytes.
      *
      * The one question that can be answered without a clock, and the only one this
@@ -1079,6 +1063,29 @@ class SafSyncEngine(private val context: Context) {
      */
     private val documentWritesInFlight = ConcurrentHashMap.newKeySet<String>()
 
+    /**
+     * Writes a local file's contents back to its corresponding SAF document.
+     *
+     * Declines outright when another write already holds the document, so two streams
+     * never interleave into one file: see [documentWritesInFlight].
+     *
+     * The copy itself runs in [writeLocalToSafHoldingDocument], bracketed by the
+     * in-flight journal, and the bracket is the whole point of that method's shape:
+     * `"wt"` truncates the document at open, and the provider stamps a fresh
+     * modification time on the shorter bytes, so a copy
+     * that dies partway leaves the device holding a *newer* copy of a file whose
+     * only complete version is the mirror's. That is indistinguishable, at the
+     * next sync, from an edit made on the device, and the sync would copy the
+     * truncation over the edit. The journal line is written before the stream
+     * opens and removed only by a copy that ran to its end, so the next sync can
+     * tell the two apart by the one fact it can know: whether this app was
+     * mid-upload when the copy stopped.
+     *
+     * One retry, because a first attempt that fails has already paid the
+     * truncation, and a second full write is cheaper than a session of a stale
+     * device copy. Permission loss is not retried: nothing about a revoked grant
+     * gets better within a second.
+     */
     private fun writeLocalToSaf(localFile: File, safDocUri: Uri) {
         val document = safDocUri.toString()
         if (!documentWritesInFlight.add(document)) {
@@ -2158,51 +2165,6 @@ class SafSyncEngine(private val context: Context) {
         internal const val MAX_UPLOAD_ENTRIES = 2000
 
         /**
-         * Whether the mirror copy may be replaced with the one from the device folder.
-         *
-         * Opening a folder re-runs the whole copy, so this is what stands between a
-         * reopen and the loss of edits not yet written back.
-         *
-         * Timestamps alone are not enough to decide this, for two reasons found the
-         * hard way:
-         *
-         * - A size mismatch beats any timestamp. A copy that fails part-way leaves a
-         *   short file carrying a *fresh* mtime, which timestamps alone would read as
-         *   "newer, keep it" — freezing the truncation in place forever and letting
-         *   the write-back push it onto the device. Different sizes mean the mirror is
-         *   not a copy of the source, whatever the clocks say.
-         * - An unknown source timestamp (0) is decided by [mirrorIsOurCopy], not by the
-         *   clock, because there is no clock to ask. COLUMN_LAST_MODIFIED is optional and
-         *   arrives as 0 from MTP, some USB-OTG and some network providers.
-         *
-         *   Both obvious answers are wrong. "Always copy" freezes nothing but replaces a
-         *   local edit on every reopen, which is what this used to do. "Always keep"
-         *   protects the edit and freezes the folder for ever, since nothing in the app
-         *   can clear a mirror. The record settles it without guessing: if the mirror is
-         *   still exactly what the last sync wrote there, it is this app's own copy and
-         *   the device is entitled to replace it, so the folder still heals. If it is
-         *   not, it holds something written since, and that is the only copy.
-         *
-         * The comparison is only sound because [copyDocumentToLocal] stamps the mirror
-         * with the source's own timestamp, so both sides come from the same clock.
-         */
-        /**
-         * Whether writing [localPath] back would replace a device document this sync
-         * never read.
-         *
-         * Extracted because two paths ask it and only one of them can be reached from a
-         * JVM test. [handleMirrorEvent] asks before queueing a job; [createOneInSaf] asks
-         * again while walking into a directory, which no event-driven test can drive here
-         * at all, since delivering a directory event constructs a `FileObserver` and that
-         * runs a static initializer reaching native code (see [SafWatchCoverageTest]).
-         * Naming the rule once is what lets it be asserted at all, and what stops the two
-         * call sites drifting apart, which is how the second one came to be missing it.
-         *
-         * [deviceHoldsDocument] is the provider's answer, not a guess: the set alone is a
-         * memory of what this sync could not read, and the document may have been deleted
-         * on the device since, in which case the local file is an ordinary new file.
-         */
-        /**
          * How many bytes phase 2 would have to fetch for [documents] into [mirrorDir].
          *
          * Counts only what a copy would actually spend: a directory costs nothing, a
@@ -2228,12 +2190,62 @@ class SafSyncEngine(private val context: Context) {
                 }
                 .sumOf { it.size }
 
+        /**
+         * Whether writing [localPath] back would replace a device document this sync
+         * never read.
+         *
+         * Extracted because two paths ask it and only one of them can be reached from a
+         * JVM test. [handleMirrorEvent] asks before queueing a job; [createOneInSaf] asks
+         * again while walking into a directory, which no event-driven test can drive here
+         * at all, since delivering a directory event constructs a `FileObserver` and that
+         * runs a static initializer reaching native code (see [SafWatchCoverageTest]).
+         * Naming the rule once is what lets it be asserted at all, and what stops the two
+         * call sites drifting apart, which is how the second one came to be missing it.
+         *
+         * [deviceHoldsDocument] is the provider's answer, not a guess: the set alone is a
+         * memory of what this sync could not read, and the document may have been deleted
+         * on the device since, in which case the local file is an ordinary new file.
+         */
         internal fun writeWouldReplaceUnreadDocument(
             localPath: String,
             deviceHoldsDocument: Boolean,
             unfetched: Set<String>,
         ): Boolean = deviceHoldsDocument && localPath in unfetched
 
+        /**
+         * Whether the mirror copy may be replaced with the one from the device folder.
+         *
+         * Opening a folder re-runs the whole copy, so this is what stands between a
+         * reopen and the loss of edits not yet written back.
+         *
+         * Timestamps alone are not enough to decide this, for two reasons found the
+         * hard way:
+         *
+         * - A size mismatch decides the tie, and only when the two timestamps agree.
+         *   Writers that preserve mtime (unzip, cp -p, rsync -t, git checkout) land
+         *   there with different lengths and still have to copy. Size came first once,
+         *   against a copy cut short leaving a short file with a *fresh* mtime, and it
+         *   cost far more than it saved: almost every edit changes a file's length, so
+         *   almost every unsaved edit read as "not a copy of the source" and was
+         *   overwritten by the older device copy. That truncation case is closed
+         *   elsewhere now, by [copyDocumentToLocal] writing beside the destination and
+         *   renaming only once the stream finished, so an interrupted copy leaves no
+         *   file at the destination at all.
+         * - An unknown source timestamp (0) is decided by [mirrorIsOurCopy], not by the
+         *   clock, because there is no clock to ask. COLUMN_LAST_MODIFIED is optional and
+         *   arrives as 0 from MTP, some USB-OTG and some network providers.
+         *
+         *   Both obvious answers are wrong. "Always copy" freezes nothing but replaces a
+         *   local edit on every reopen, which is what this used to do. "Always keep"
+         *   protects the edit and freezes the folder for ever, since nothing in the app
+         *   can clear a mirror. The record settles it without guessing: if the mirror is
+         *   still exactly what the last sync wrote there, it is this app's own copy and
+         *   the device is entitled to replace it, so the folder still heals. If it is
+         *   not, it holds something written since, and that is the only copy.
+         *
+         * The comparison is only sound because [copyDocumentToLocal] stamps the mirror
+         * with the source's own timestamp, so both sides come from the same clock.
+         */
         internal fun shouldOverwriteMirror(
             mirrorExists: Boolean,
             mirrorModified: Long,
@@ -2348,20 +2360,6 @@ class SafSyncEngine(private val context: Context) {
         }
 
         /**
-         * The directories a watch has to cover for [root]: [root] itself and everything
-         * below it that the walk would have mirrored.
-         *
-         * The exclusions are [SKIP_DIRECTORIES], the set [walkTree] already obeys —
-         * nothing inside them is mirrored in, so a watch there would spend a kernel
-         * descriptor on changes with nowhere to go. That is also what keeps the count
-         * survivable: one `node_modules` runs to thousands of directories on its own.
-         *
-         * Breadth-first, and capped at [limit]. The order matters only once the cap
-         * bites, and then it decides which directories go unwatched: breadth-first
-         * spends the budget on the shallow ones, which is where a person edits, rather
-         * than on wherever a depth-first descent happened to reach first.
-         */
-        /**
          * Everything under [root] that has to be created on the device when [root]
          * itself is created, parents before children.
          *
@@ -2442,6 +2440,18 @@ class SafSyncEngine(private val context: Context) {
         /**
          * The directories a watch has to cover for [root], one per directory, capped
          * at [limit] and spent breadth-first.
+         *
+         * [root] itself is included, and below it everything the walk would have
+         * mirrored: the exclusions are [SKIP_DIRECTORIES], the set [walkTree] already
+         * obeys, so nothing inside them is mirrored in and a watch there would spend a
+         * kernel descriptor on changes with nowhere to go. That is also what keeps the
+         * count survivable: one `node_modules` runs to thousands of directories on its
+         * own.
+         *
+         * The order matters only once the cap bites, and then it decides which
+         * directories go unwatched: breadth-first spends the budget on the shallow
+         * ones, which is where a person edits, rather than on wherever a depth-first
+         * descent happened to reach first.
          *
          * Symbolic links are not followed, for the same reason [uploadableEntries]
          * refuses them and with the same words: a mirror is routinely a checked-out

--- a/android/app/src/main/kotlin/com/vscodroid/util/PortFinder.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/util/PortFinder.kt
@@ -129,8 +129,7 @@ object PortFinder {
      * what this rests on, and deliberately so — nobody has measured it on
      * Android, and a check that happens to agree with the server on one platform
      * is a check that disagrees with it on another.
-     */
-    /**
+     *
      * Binds the way the server that will use the port binds: with `SO_REUSEADDR`
      * set before the bind.
      *

--- a/android/app/src/main/kotlin/com/vscodroid/util/StorageManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/util/StorageManager.kt
@@ -49,10 +49,6 @@ object StorageManager {
     }
 
     /**
-     * Clears caches: npm-cache, tmp dir, crash logs, VS Code logs.
-     * Returns the number of bytes freed.
-     */
-    /**
      * The breakdown keys [clearCaches] can actually free.
      *
      * Declared here because this is the only place that knows. The storage
@@ -64,6 +60,10 @@ object StorageManager {
      */
     internal val CLEARABLE_KEYS = setOf("logs", "cache")
 
+    /**
+     * Clears caches: npm-cache, tmp dir, crash logs, VS Code logs.
+     * Returns the number of bytes freed.
+     */
     fun clearCaches(context: Context): Long {
         var freed = 0L
 

--- a/android/app/src/main/kotlin/com/vscodroid/webview/VSCodroidWebViewClient.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/webview/VSCodroidWebViewClient.kt
@@ -62,23 +62,6 @@ internal fun publishedResourceRoots(context: Context): List<String> = listOf(
 ).mapNotNull(::canonicalOrNull)
 
 /**
- * The file a resource request names, or null if it is not a published resource.
- *
- * The published roots are named individually rather than described by a prefix
- * because everything this app owns -- the SSH private key written without a
- * passphrase, the server's connection token -- shares a prefix with everything
- * it serves. A prefix test over app-private storage admits all of it, so it can
- * only ever stop a traversal out of the sandbox, never a read within it.
- *
- * Symbolic links are resolved rather than normalised away lexically. A
- * workspace is a published root and a workspace is routinely a checked-out
- * repository, so a link inside one is attacker-supplied in the ordinary case;
- * `..` handling alone would follow it out.
- *
- * The canonical path is what comes back, not the path as asked for, so that the
- * file opened is the file that was checked.
- */
-/**
  * What the interceptor decided about one webview resource request.
  *
  * Separated from building the response because a `WebResourceResponse` cannot be
@@ -115,6 +98,12 @@ internal fun resourceOutcome(path: String, resourceRoots: List<String>): Resourc
 /**
  * The file a webview resource request names, if it resolves inside a published
  * root, and null otherwise.
+ *
+ * The published roots are named individually rather than described by a prefix
+ * because everything this app owns -- the SSH private key written without a
+ * passphrase, the server's connection token -- shares a prefix with everything
+ * it serves. A prefix test over app-private storage admits all of it, so it can
+ * only ever stop a traversal out of the sandbox, never a read within it.
  *
  * Symbolic links are resolved rather than normalised away lexically. A workspace
  * is a published root and a workspace is routinely a checked-out repository, so a

--- a/android/app/src/test/kotlin/com/vscodroid/storage/InitialSyncWiringTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/InitialSyncWiringTest.kt
@@ -43,8 +43,7 @@ class InitialSyncWiringTest {
      * it — so it lands outside the directory `@TempDir` cleans up, and each test method
      * gets a fresh directory and therefore a fresh name. Removed here so the runs do not
      * accumulate one small file apiece in the system temp root.
-     */
-    /**
+     *
      * One method rather than two: JUnit 5 orders same-class lifecycle methods
      * deterministically but not by declaration, so a second @AfterEach would leave the
      * order between them written nowhere. Nothing here depends on it today -- the

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafDirectoryRenameTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafDirectoryRenameTest.kt
@@ -219,12 +219,6 @@ class SafDirectoryRenameTest {
     }
 
     /**
-     * `moveDocument` sits behind `FLAG_SUPPORTS_MOVE`, which a provider may withhold while
-     * still offering rename. The fallback has to be what the code did before there was a
-     * move at all: build the new name from the mirror and leave the old copy alone, rather
-     * than deleting a subtree the mirror cannot fully replace.
-     */
-    /**
      * `mkdir lib && mv util lib/` in one write-back tick. At event time the
      * destination folder's document does not exist yet, its own create job is
      * still ahead of this one in the queue, so the parent URI the move needs
@@ -384,6 +378,12 @@ class SafDirectoryRenameTest {
         verify(exactly = 0) { DocumentsContract.moveDocument(any(), any(), any(), any()) }
     }
 
+    /**
+     * `moveDocument` sits behind `FLAG_SUPPORTS_MOVE`, which a provider may withhold while
+     * still offering rename. The fallback has to be what the code did before there was a
+     * move at all: build the new name from the mirror and leave the old copy alone, rather
+     * than deleting a subtree the mirror cannot fully replace.
+     */
     @Test
     fun `a provider that will not move still gets the new name`() {
         deviceTree(mapOf("root" to listOf("util", "lib"), "doc:lib" to emptyList()))


### PR DESCRIPTION
Kotlin attaches a documentation block to the declaration that immediately follows it. In 26 places across the app two or three blocks sat stacked with nothing between them, so only the last one was attached and every block above it was orphaned. Each of those left two symbols wrong at once: the attached declaration was described by text about something else, and the symbol the text actually belongs to carried no documentation at all.

Among the symbols that had none as a result: `startWatchdog`, `clearCaches`, `performClick`, `handleSafFolderSelected`, `bindDecision`, `getPersistedFolders`, `setupIsStale`, `isElfFile`, `markExecutablesIn`.

## What changed

Each block was traced to its owner by reading the body it describes, not by proximity, and checked against that body before being moved. Several had drifted out of date while detached, and are corrected here rather than relocated unchanged:

- `startWatchdog` listed three exit-code branches. The code has four since it gained signal naming, and the fourth was still described as an unexpected crash.
- `bindDecision` was documented for a three-branch `when` over a `String` notice. It now takes `StartupNotice` and separates terminal from non-terminal ahead of the port check.
- `NodeService` named three main-thread-confined fields; there are six.

Where both blocks documented the same declaration, the facts were merged rather than one discarded. `stopServer`'s older copy was the only record that `isShuttingDown` is what keeps the watchdog quiet, and `isPortAvailable`'s two blocks separately explained the loopback bind and `SO_REUSEADDR`.

## Risk

None to behaviour. Every declaration in the diff appears on both sides of it, relocated relative to the block that moved past it; a mechanical comparison of added against removed lines finds zero non-comment lines that are not present on both sides.

## Verification

Full unit suite 1305 tests, no failures. A tree-wide scan for a doc block whose closing brace is immediately followed by another opening one now returns zero, against 26 before.