### PR TITLE
fix(bridge): keep page-supplied values out of logcat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Values the editor page hands the app no longer reach logcat in the clear: a download's name and failure detail, a folder URI, and a toolchain name.
 - A link that fails to open now says why. Every refusal blamed a missing app, including a stale session and a URL Android refused outright.
 - The connection token no longer reaches logcat when a link fails to open. The URL was logged whole, twice, on a line that ships in release builds.
 - The system dark theme flipping no longer moves you out of your workspace, or restarts first-run extraction if it lands while setup is running.

--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -360,10 +360,11 @@ M6 (Release)   → Play Store release
    - [x] `StorageManager.isStorageLow()` — low storage warning with Toast
    - [x] Exposed to JS via `AndroidBridge` (`getStorageInfo`, `clearCaches`, `getAvailableStorage`)
 
-6. **GitHub OAuth integration** (`AndroidBridge.kt`, `MainActivity.kt`)
-   - [x] `startGitHubAuth()` opens OAuth URL via Chrome Custom Tabs
-   - [x] Deep link callback: `vscodroid://oauth/github?code=XXX&state=YYY`
-   - [x] `handleOAuthCallback()` in `MainActivity` forwards to VS Code auth handler via JS
+6. **Browser sign-in callback relay** (`AndroidBridge.kt`, `MainActivity.kt`)
+   - [x] `openExternalUrl()` opens the authorisation URL, in a Chrome Custom Tab for https
+   - [x] Deep link callback: `vscodroid://callback?data=ENCODED_JSON`, generic rather than per provider
+   - [x] `MainActivity.onNewIntent` reads the id with `callbackRequestId()` and injects the payload into the page
+   - [x] `AuthTabWindow` arms the request ids a launch carries, so a callback nothing asked for is refused
    - [x] Push/pull to GitHub works from VS Code SCM panel after auth
 
 7. **External storage access (SAF)** (`SafStorageManager.kt`, `SafSyncEngine.kt`, `vscodroid-saf-bridge` extension)

--- a/android/app/src/androidTest/kotlin/com/vscodroid/util/ServerReadyHelper.kt
+++ b/android/app/src/androidTest/kotlin/com/vscodroid/util/ServerReadyHelper.kt
@@ -8,9 +8,10 @@ import java.net.URL
  * Shared helper for instrumented tests that need the VS Code server to be running.
  *
  * Provides:
- * - [waitForServerPort] — polls logcat for the server-ready message and returns the port.
- * - [markSetupComplete] — writes the setup_version pref so SplashActivity skips extraction.
- * - [healthCheck] — verifies the server responds to HTTP on the given port.
+ * - [markSetupComplete] writes the setup_version pref so SplashActivity skips extraction.
+ * - [clearSetupState] removes it again, plus the toolchain picker flag.
+ * - [healthCheck] asks the server for /version on a port and says whether it answered.
+ * - [waitForPort] polls that same check until the port answers or the timeout runs out.
  */
 object ServerReadyHelper {
 

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -342,7 +342,17 @@ class MainActivity : AppCompatActivity() {
         }
 
         override fun report(outcome: DownloadOutcome, fileName: String, detail: String?) {
-            if (detail != null) Logger.w(tag, "Download of $fileName: $detail")
+            // Both halves are page supplied and this line is not gated on a
+            // debuggable build, so it ships. `fileName` arrives through
+            // `DownloadCoordinator.onDownloadNamed`, where the page names the file
+            // itself, and `detail` reaches here from `onComplete(requestId, error)`,
+            // whose error string the page also writes. Neither is followed by a
+            // predicate that could catch this, because both are renamed on the way
+            // in, which is how this site was missed while its siblings in
+            // `AndroidBridge` were redacted.
+            if (detail != null) {
+                Logger.w(tag, "Download of ${redactToken(fileName)}: ${redactToken(detail)}")
+            }
             val message = when (outcome) {
                 DownloadOutcome.SAVED -> "Saved $fileName"
                 DownloadOutcome.CANCELLED -> "Download cancelled"

--- a/android/app/src/main/kotlin/com/vscodroid/bridge/AndroidBridge.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/bridge/AndroidBridge.kt
@@ -526,7 +526,7 @@ class AndroidBridge(
     fun openRecentFolder(authToken: String, uriString: String) {
         if (!security.validateToken(authToken)) return
         val uri = Uri.parse(uriString)
-        Logger.i(tag, "Opening recent SAF folder: $uri")
+        Logger.i(tag, "Opening recent SAF folder: ${redactToken(uri.toString())}")
         onOpenRecentFolder(uri)
     }
 
@@ -823,7 +823,7 @@ class AndroidBridge(
     @JavascriptInterface
     fun installToolchain(name: String, authToken: String) {
         if (!security.validateToken(authToken)) return
-        Logger.i(tag, "JS requested toolchain install: $name")
+        Logger.i(tag, "JS requested toolchain install: ${redactToken(name)}")
         toolchainManager.install(name)
     }
 
@@ -833,7 +833,7 @@ class AndroidBridge(
     @JavascriptInterface
     fun removeToolchain(name: String, authToken: String) {
         if (!security.validateToken(authToken)) return
-        Logger.i(tag, "JS requested toolchain removal: $name")
+        Logger.i(tag, "JS requested toolchain removal: ${redactToken(name)}")
         toolchainManager.uninstall(name)
     }
 

--- a/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
@@ -2484,15 +2484,16 @@ private const val BASH_ENV_HEADER = """# VSCodroid: sourced by NON-INTERACTIVE b
 # command's output instead of on a screen.
 """
 
-/**
- * The prompt block written into `.bashrc`, shared by the first-run write and by
- * [FirstRunSetup.ensurePromptFix], which replaces the legacy empty-PS1 prompt.
- */
+/** Bumped whenever [PROMPT_BLOCK] changes, so an older block is recognised and replaced. */
 private const val PROMPT_VERSION = "v2"
 private const val PROMPT_BEGIN = "# >>> vscodroid prompt"
 private const val PROMPT_END = "# <<< vscodroid prompt"
 private const val PROMPT_MARKER_CURRENT = "$PROMPT_BEGIN $PROMPT_VERSION >>>"
 
+/**
+ * The prompt block written into `.bashrc`, shared by the first-run write and by
+ * [FirstRunSetup.ensurePromptFix], which replaces the legacy empty-PS1 prompt.
+ */
 private val PROMPT_BLOCK = """
     $PROMPT_MARKER_CURRENT
     # PROMPT_COMMAND computes the directory, PS1 renders it. The \[ \] markers tell

--- a/android/app/src/test/kotlin/com/vscodroid/bridge/OpenExternalUrlRefusalTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/bridge/OpenExternalUrlRefusalTest.kt
@@ -310,7 +310,7 @@ class OpenExternalUrlRefusalTest {
      * silently gives up is the reason the ordering exists -- `launchUrl` hands
      * off to another process, and a browser that answers instantly can return
      * before the window it needs is open, refusing a sign-in that really did
-     * happen. It also strands the rollback: `armedFrom` would stay null and the
+     * happen. It also strands the rollback: `armed` would stay empty and the
      * `disarm` call become dead code.
      *
      * The property is about ordering against another process, so there is

--- a/android/app/src/test/kotlin/com/vscodroid/bridge/PageSuppliedLoggingTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/bridge/PageSuppliedLoggingTest.kt
@@ -1,0 +1,144 @@
+package com.vscodroid.bridge
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * That nothing a page hands the bridge reaches logcat in the clear.
+ *
+ * `Logger.i`, `Logger.w` and `Logger.e` are not gated on a debuggable build, so
+ * they ship, and logcat is readable by anything holding `READ_LOGS`. The page on
+ * the other side of these methods is the workbench, which holds the connection
+ * token, so a string it passes can carry one. `logToNative` states that reasoning
+ * and redacts; this makes it true of every method rather than of the one whose
+ * author thought of it.
+ *
+ * Written as a predicate over the parameters, not as a list of known sites. Four
+ * sites were already redacted by hand and three more were not, and the three were
+ * missed because a reader sweeping for `url` and `uri` does not match `name` or
+ * `uriString`. A list would have been written from the same sweep and inherited
+ * the same blind spot.
+ */
+class PageSuppliedLoggingTest {
+
+    private val bridge = File("src/main/kotlin/com/vscodroid/bridge/AndroidBridge.kt")
+
+    /**
+     * One chunk per `@JavascriptInterface`, from the annotation to the next one.
+     *
+     * A superset of the method body rather than the body exactly: a private helper
+     * declared between two bridge methods falls into the earlier chunk. That is the
+     * safe direction. Such a helper is reached from the bridge and holds the same
+     * values, so examining it too is not a false alarm, while missing it would be a
+     * real one.
+     */
+    private fun bridgeMethods(): List<String> {
+        assertTrue(
+            bridge.isFile,
+            "${bridge.absolutePath} is missing; this test would otherwise pass by reading nothing",
+        )
+        return bridge.readText().split("@JavascriptInterface").drop(1)
+    }
+
+    @Test
+    fun `every page supplied value reaching a log call is redacted`() {
+        val methods = bridgeMethods()
+        // The control for the split above. check-bridge-api-spec.py counts 31 bridge
+        // methods, so a split that returns a handful means the annotation moved or
+        // the file did, and every assertion below would then pass by examining almost
+        // nothing.
+        assertTrue(
+            methods.size >= 25,
+            "only ${methods.size} @JavascriptInterface methods were found; the scan is " +
+                "looking at the wrong thing, and passing here would mean nothing",
+        )
+
+        val offenders = mutableListOf<String>()
+        var examined = 0
+        for (chunk in methods) {
+            val signature = Regex("""fun\s+(\w+)\s*\(([^)]*)\)""").find(chunk) ?: continue
+            val name = signature.groupValues[1]
+            // authToken is the session token the page already holds, and it is never
+            // logged; it is excluded so its absence cannot be mistaken for coverage.
+            val params = signature.groupValues[2]
+                .split(",")
+                .mapNotNull { it.substringBefore(":").trim().ifEmpty { null } }
+                .filter { it != "authToken" && it.matches(Regex("""\w+""")) }
+            if (params.isEmpty()) continue
+
+            // A parameter renamed on the way to the log line is the case that made
+            // this necessary: `openRecentFolder` logged `uri`, a local built by
+            // `Uri.parse(uriString)`, so a search for the parameter name found
+            // nothing. Locals assigned from a parameter carry its taint.
+            val tainted = params.toMutableSet()
+            for (m in Regex("""val\s+(\w+)\s*=\s*([^\n]+)""").findAll(chunk)) {
+                if (tainted.any { Regex("""\b$it\b""").containsMatchIn(m.groupValues[2]) }) {
+                    tainted += m.groupValues[1]
+                }
+            }
+
+            for (call in Regex("""Logger\.[diwe]\(([^\n]*)""").findAll(chunk)) {
+                val text = call.groupValues[1]
+                examined++
+                for (value in tainted) {
+                    val interpolated = Regex("""\$\{?$value\b""").containsMatchIn(text)
+                    val redacted = Regex("""redactToken\(\s*$value\b""").containsMatchIn(text)
+                    if (interpolated && !redacted) {
+                        offenders += "$name logs $value unredacted: ${text.trim()}"
+                    }
+                }
+            }
+        }
+
+        // The second control. If no bridge method logs any of its own values, the
+        // loop above proves nothing, and a refactor that moved every log line out
+        // would leave this test green while removing everything it watches.
+        assertTrue(
+            examined > 0,
+            "no log call inside any bridge method was examined, so this test is vacuous",
+        )
+        assertTrue(
+            offenders.isEmpty(),
+            "a value the page supplied reaches a shipping log line in the clear:\n" +
+                offenders.joinToString("\n") { "  $it" },
+        )
+    }
+
+    /**
+     * The one site a predicate over `AndroidBridge` cannot reach.
+     *
+     * `DownloadCoordinator` takes the file name from `onDownloadNamed`, which the
+     * page calls, and the failure detail from `onComplete(requestId, error)`, whose
+     * error string the page also writes. Both are renamed twice on the way to
+     * `MainActivity`'s `DownloadHost.report`, so no scan anchored on a bridge
+     * parameter name can follow them, which is exactly why this line stayed in the
+     * clear while its siblings were fixed.
+     */
+    @Test
+    fun `the download report redacts both values it prints`() {
+        val activity = File("src/main/kotlin/com/vscodroid/MainActivity.kt")
+        assertTrue(
+            activity.isFile,
+            "${activity.absolutePath} is missing; this test would otherwise pass by reading nothing",
+        )
+        val report = activity.readText()
+            .substringAfter("override fun report(outcome: DownloadOutcome", "")
+        assertTrue(
+            report.isNotEmpty(),
+            "DownloadHost.report is gone from MainActivity; if it moved, point this at its " +
+                "new home rather than deleting the check",
+        )
+        val line = Regex("""(?m)^\s*Logger\.w\(tag, "Download of.*""").find(report)
+        assertTrue(line != null, "the download failure is no longer logged at all")
+        val text = line!!.value
+        assertTrue(
+            Regex("""redactToken\(\s*fileName\b""").containsMatchIn(text),
+            "the page-supplied file name reaches logcat in the clear: ${text.trim()}",
+        )
+        assertTrue(
+            Regex("""redactToken\(\s*detail\b""").containsMatchIn(text),
+            "the page-supplied failure detail reaches logcat in the clear: ${text.trim()}",
+        )
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/service/NodeServiceTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/service/NodeServiceTest.kt
@@ -308,7 +308,7 @@ class EndsUnreportedTest {
 /**
  * That the two start failures actually go through the recoverable stop.
  *
- * [SpawnedNothingTest] pins the decision; this pins that it is consulted
+ * [EndsUnreportedTest] pins the decision; this pins that it is consulted
  * and acted on. Neither subsumes the other: the predicate can be perfect and
  * called from nowhere, which is the exact shape of the defect being closed —
  * `enterTerminalState` did the right thing and the two start failures simply did

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafMirrorReclamationTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafMirrorReclamationTest.kt
@@ -78,7 +78,6 @@ class SafMirrorReclamationTest {
         every { uri } returns granted
     }
 
-    /** Builds the mirror directory and the sync record the engine keeps beside it. */
     /**
      * The journal is keyed on the mirror's real path, and the pass renames the
      * mirror before deleting it.
@@ -161,6 +160,9 @@ class SafMirrorReclamationTest {
     }
 
     /**
+     * Builds the mirror directory and the sync record the engine keeps beside it,
+     * which is what the pair it returns holds.
+     *
      * A mirror the reclaim pass is entitled to delete: every file in it is one the
      * record vouches for, in the format [SafSyncEngine.recordIdentity] writes.
      *

--- a/scripts/test-process-monitor-extension.js
+++ b/scripts/test-process-monitor-extension.js
@@ -49,15 +49,15 @@ Module._resolveFilename = function (request, ...rest) {
 };
 require.cache.vscode = { id: 'vscode', filename: 'vscode', loaded: true, exports: vscodeStub };
 
+// Captured before the first call overwrites TMPDIR, which os.tmpdir() reads.
+const BASE_TMP = os.tmpdir();
+
 /**
  * Activates a FRESH copy of the extension against one snapshot and returns the
  * notification it raised. Fresh because warningShownAtThreshold is module
  * state: a second activation of the same instance is latched and stays silent,
  * which would make the comparison below pass by saying nothing twice.
  */
-// Captured before the first call overwrites TMPDIR, which os.tmpdir() reads.
-const BASE_TMP = os.tmpdir();
-
 function notificationFor(snapshot) {
     const tmp = fs.mkdtempSync(path.join(BASE_TMP, 'vscodroid-ext-'));
     process.env.TMPDIR = tmp;


### PR DESCRIPTION
`Logger.i`, `Logger.w` and `Logger.e` are not gated on a debuggable build, so they ship, and logcat is readable by anything holding `READ_LOGS`. Seven values the editor page hands the app were printed raw: the recent-folder URI in `openRecentFolder`, the toolchain names in `installToolchain` and `removeToolchain`, and the file name and failure detail in the download report. The page on the other side of those methods is the workbench, which holds the connection token. That is the reasoning `logToNative` already states one screen away in the same class.

Three of the seven were missed by an earlier sweep because they are not named `url` or `uri`. Two more were missed because they are renamed twice on the way from the bridge to the log line: the download's file name arrives through `onDownloadNamed`, and the detail through `onComplete(requestId, error)`, whose error string the page writes.

## What changed

- The five remaining sites redact through `redactToken`.
- `PageSuppliedLoggingTest` expresses the rule as a predicate over the parameters of every `@JavascriptInterface` method, and follows a parameter into locals assigned from it, which is what the renamed cases needed. A list of known sites would have been written from the same sweep that missed them.
- Documentation that named things which do not exist is corrected: a helper `ServerReadyHelper` advertises and never had, a sibling test class, a local variable, and a milestone section describing a GitHub-specific OAuth entry point where the shipped mechanism is a generic callback relay. Three further doc blocks sat on the declaration next to the one they describe.

## Verification

Each redaction was checked against its removal: reverting any one of the five reddens the case that covers it, and the tree returns to green. The predicate carries two controls of its own, one asserting the scan finds at least 25 bridge methods and one asserting it examined a log call at all, so a split that stopped matching cannot pass by looking at nothing.

Full unit suite, the bridge API spec gate, and `scripts/test-bridge-relay.js` all pass.