### PR TITLE
fix(storage): release an upload claim when the write-back fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A file you edited on the device is no longer overwritten by the app's copy after a write-back that failed once and later succeeded.
+- Cancelling a toolchain download while it installs no longer deletes the files being copied out of it, which left a part-written toolchain behind.
+- A selected toolchain in the first-run picker no longer draws two check marks in the same corner.
 - Values the editor page hands the app no longer reach logcat in the clear: a download's name and failure detail, a folder URI, and a toolchain name.
 - A link that fails to open now says why. Every refusal blamed a missing app, including a stale session and a URL Android refused outright.
 - The connection token no longer reaches logcat when a link fails to open. The URL was logged whole, twice, on a line that ships in release builds.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -787,9 +787,11 @@ val verifyBundledBinaries = tasks.register<Exec>("verifyBundledBinaries") {
                     "fetch-vscode-oss.sh for libripgrep.so -- and let it fail there,\n" +
                     "where the message says which upstream package it came from.\n" +
                     "\n" +
-                    "In CI this most likely means a cached jniLibs restored a binary\n" +
-                    "that predates a change to scripts/verify-android-elf.py, which is\n" +
-                    "in neither cache key: bust the assets cache rather than refetching."
+                    "In CI a cached jniLibs is restored whole with every download step\n" +
+                    "skipped, so a binary here can be older than the tree. It cannot be\n" +
+                    "older than this checker: scripts/verify-android-elf.py is hashed\n" +
+                    "into all three cache keys, so tightening it misses the cache and\n" +
+                    "refetches. Re-run the owning script above; do not bust a cache."
             )
         }
     }

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
@@ -308,7 +308,24 @@ class ToolchainManager(private val context: Context) {
         // what the user just asked for. Releasing it here is what makes "cancelled"
         // and "not delivered" the same state, which is the only reading of Play's
         // records that reconcile can make.
-        releasePack(info.packName)
+        //
+        // Queued on [ioExecutor] rather than run here, because Play's removePack is
+        // a real recursive delete of the delivered directory, and the COMPLETED
+        // branch copies out of that same directory on this executor. The card goes
+        // on offering CANCEL throughout that copy, since handleStateUpdate does not
+        // report COMPLETED and the last status the UI holds is TRANSFERRING, so a
+        // tap in those seconds deleted the source under the reader and left a part
+        // written `usr/` tree behind. A single-thread executor puts the removal
+        // behind the copy instead.
+        //
+        // Bounded to this instance, and that is the whole of it: `ioExecutor` is an
+        // instance field, and every construction site makes its own manager. The two
+        // callers that can reach a live download, ToolchainActivity and the first-run
+        // queue in SplashActivity, each hold one manager for the download and the
+        // cancel alike, so both are covered. `AndroidBridge.cancelToolchainInstall`
+        // builds a fresh manager per call and would not be, but nothing in this tree
+        // sends that command.
+        ioExecutor.execute { releasePack(info.packName) }
         Logger.i(tag, "Cancelled download of ${info.packName}")
     }
 

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainPickerAdapter.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainPickerAdapter.kt
@@ -98,6 +98,12 @@ class ToolchainPickerAdapter(
         // to say only in the visual channel.
         card.isCheckable = true
         card.isChecked = isSelected
+        // Checkable is wanted for what it tells a screen reader, and not for what it
+        // draws. MaterialCardView answers isCheckable by switching on its own checked
+        // icon, in the top right, which is where this layout already constrains
+        // R.id.checkmark, so turning the state on put a second tick on top of the
+        // first one. Null removes the drawable without touching the state.
+        card.checkedIcon = null
 
         // Hide MANAGER-only views
         holder.statusBadge.visibility = View.GONE

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
@@ -1105,37 +1105,57 @@ class SafSyncEngine(private val context: Context) {
     /** The copy itself, with the document already claimed by the caller. */
     private fun writeLocalToSafHoldingDocument(localFile: File, safDocUri: Uri) {
         markUploadInFlight(localFile.absolutePath)
-        var attempts = 0
-        while (true) {
-            try {
-                val copied = context.contentResolver.openOutputStream(safDocUri, "wt")
-                    ?.use { output ->
-                        localFile.inputStream().use { input ->
-                            input.copyTo(output, COPY_BUFFER_SIZE)
-                        }
-                        true
-                    } ?: false
-                if (copied) {
-                    clearUploadInFlight(localFile.absolutePath)
+        // Released in a finally rather than at each exit, and this is not style.
+        // The claim taken above was originally dropped at the one exit its author
+        // had in mind, and the failure exits added later each returned without it,
+        // so the count never came back to zero for the life of the process. From
+        // then on [clearUploadInFlight] saw a writer that no longer existed and
+        // kept the journal line after a write-back that had landed, and
+        // [consumeStaleUploadRecord] refused to consume it, so every later
+        // initialSync force-pushed the mirror over whatever the device held. A
+        // device edit made in between was destroyed, silently, on every reopen.
+        //
+        // The distinction the two paths draw is what the journal means, and it is
+        // the reason there are two calls rather than one. The line records an edit
+        // that has not reached the device, so a landed write retires it and a
+        // failed one must leave it standing for the next sync to retry.
+        var landed = false
+        try {
+            var attempts = 0
+            while (true) {
+                try {
+                    val copied = context.contentResolver.openOutputStream(safDocUri, "wt")
+                        ?.use { output ->
+                            localFile.inputStream().use { input ->
+                                input.copyTo(output, COPY_BUFFER_SIZE)
+                            }
+                            true
+                        } ?: false
+                    if (copied) {
+                        landed = true
+                        return
+                    }
+                    attempts++
+                } catch (e: SecurityException) {
+                    Logger.e(tag, "Permission revoked while writing back: ${localFile.name}")
+                    onWriteBackFailed(localFile)
+                    return
+                } catch (e: Exception) {
+                    attempts++
+                }
+                if (attempts >= 2) {
+                    Logger.e(
+                        tag,
+                        "Write-back of ${localFile.name} did not finish; its device copy " +
+                            "is recorded as not to be trusted"
+                    )
+                    onWriteBackFailed(localFile)
                     return
                 }
-                attempts++
-            } catch (e: SecurityException) {
-                Logger.e(tag, "Permission revoked while writing back: ${localFile.name}")
-                onWriteBackFailed(localFile)
-                return
-            } catch (e: Exception) {
-                attempts++
             }
-            if (attempts >= 2) {
-                Logger.e(
-                    tag,
-                    "Write-back of ${localFile.name} did not finish; its device copy " +
-                        "is recorded as not to be trusted"
-                )
-                onWriteBackFailed(localFile)
-                return
-            }
+        } finally {
+            if (landed) clearUploadInFlight(localFile.absolutePath)
+            else releaseUploadClaim(localFile.absolutePath)
         }
     }
 
@@ -1269,6 +1289,21 @@ class SafSyncEngine(private val context: Context) {
      * so both writers address one file, and before the count the first to finish removed
      * the line the other was still inside.
      */
+    /**
+     * Drops this writer's claim while leaving standing whatever its failure recorded.
+     *
+     * The counterpart to [clearUploadInFlight], and deliberately not the same
+     * function. Both say "this writer is finished"; only one of them says "and the
+     * device copy is current now". A failed write-back has to say the first without
+     * the second, or the mirror edit it could not deliver is forgotten and the next
+     * sync has no reason to retry it.
+     */
+    private fun releaseUploadClaim(absolutePath: String) = synchronized(uploadJournalLock) {
+        val stillWriting = (uploadWriters[absolutePath] ?: 0) - 1
+        if (stillWriting > 0) uploadWriters[absolutePath] = stillWriting
+        else uploadWriters.remove(absolutePath)
+    }
+
     private fun clearUploadInFlight(absolutePath: String) = synchronized(uploadJournalLock) {
         val stillWriting = (uploadWriters[absolutePath] ?: 0) - 1
         if (stillWriting > 0) {

--- a/android/app/src/test/kotlin/com/vscodroid/setup/CancelReleaseOrderingTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/CancelReleaseOrderingTest.kt
@@ -1,0 +1,89 @@
+package com.vscodroid.setup
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * That cancelling a download does not delete the directory a copy is reading.
+ *
+ * Play's `removePack` is a recursive delete of the delivered pack directory, and
+ * the COMPLETED branch copies out of that same directory on `ioExecutor`. The
+ * card keeps offering CANCEL for the whole of that copy, because
+ * `handleStateUpdate` does not report COMPLETED and the last status the UI holds
+ * is TRANSFERRING. A tap in those seconds took the source away from the reader.
+ *
+ * Read from the source, which is the weaker layer and the only one available.
+ * The race needs a real Play delivery, a real multi-second copy and a tap landing
+ * inside it; a JVM test can build none of the three, and a mocked `removePack`
+ * that returns instantly cannot show an ordering that only matters when it does
+ * not. What can be pinned is that the release is handed to the executor the copy
+ * runs on rather than performed on the caller's thread, which is the whole of the
+ * fix.
+ */
+class CancelReleaseOrderingTest {
+
+    private val manager = File("src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt")
+
+    /**
+     * `cancel` runs to the first line that is a closing brace at member indentation.
+     * Every brace nested inside it is indented further, and the control below is
+     * what turns a formatting change that broke that assumption into a failure
+     * rather than a silent widening.
+     */
+    private fun cancelBody(): String {
+        assertTrue(
+            manager.isFile,
+            "${manager.absolutePath} is missing; this test would otherwise pass by reading nothing",
+        )
+        val text = manager.readText()
+        val start = text.indexOf("fun cancel(packName: String)")
+        assertTrue(start >= 0, "ToolchainManager has no cancel(packName)")
+        val end = text.indexOf("\n    }\n", start)
+        assertTrue(end > start, "cancel has no closing brace at member indentation")
+        return text.substring(start, end)
+    }
+
+    @Test
+    fun `the pack release is queued behind whatever the io executor is running`() {
+        val body = cancelBody()
+
+        // Anchored to the start of a line so a commented-out call cannot satisfy it,
+        // and matching the execute wrapper rather than the bare call, because the
+        // bare call is present in both the correct and the broken form.
+        assertTrue(
+            Regex("""(?m)^\s*ioExecutor\.execute\s*\{\s*releasePack\(""").containsMatchIn(body),
+            "cancel releases the pack on the caller's thread, so a tap during the " +
+                "copy deletes the directory the copy is reading and leaves a part " +
+                "written toolchain tree behind",
+        )
+        assertFalse(
+            Regex("""(?m)^\s*releasePack\(""").containsMatchIn(body),
+            "cancel still calls releasePack directly as well, so the race it was " +
+                "queued to avoid is back on the caller's thread",
+        )
+    }
+
+    /**
+     * The control for [cancelBody], and it names the declaration that actually
+     * follows `cancel` rather than the one whose body holds the tempting token.
+     *
+     * `installDeliveredPack` was the obvious sentinel and a useless one: it sits
+     * two hundred lines further down, so an extraction that ran past `cancel` by
+     * any realistic amount still stopped short of it and the control passed while
+     * the body was wrong. Measured: widening the search by 900 characters left this
+     * green. `showConfirmationDialog` is the next declaration, which is what an
+     * over-running body swallows first.
+     */
+    @Test
+    fun `the extracted body stops at the end of cancel`() {
+        val body = cancelBody()
+
+        assertFalse(
+            "showConfirmationDialog" in body,
+            "the extraction ran past cancel and swallowed the next declaration, so " +
+                "the case above is really a file-wide search: ${body.length} chars",
+        )
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/setup/PickerAccessibilityWiringTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/PickerAccessibilityWiringTest.kt
@@ -130,6 +130,17 @@ class PickerAccessibilityWiringTest {
             "bindPickerMode does not tie isChecked to the selection, so the state " +
                 "it reports is fixed and the card sounds the same either way",
         )
+
+        // The state is wanted for what it says, not for what it draws.
+        // MaterialCardView answers isCheckable by switching on a checked icon in the
+        // top right, and this layout already constrains R.id.checkmark to that exact
+        // corner, so the two assertions above put a second tick on top of the first
+        // one until this line removed the drawable.
+        assertTrue(
+            Regex("""(?m)^\s*card\.checkedIcon\s*=\s*null""").containsMatchIn(body),
+            "bindPickerMode leaves MaterialCardView's own checked icon on, so a " +
+                "selected card draws two check marks in the same corner",
+        )
     }
 
     /**

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafUploadInterruptionTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafUploadInterruptionTest.kt
@@ -153,6 +153,92 @@ class SafUploadInterruptionTest {
         assertFalse(journal.isFile, "a finished upload must not distrust its own document")
     }
 
+    /**
+     * The claim a failed write-back takes has to be given back, or the journal line
+     * outlives the failure that wrote it.
+     *
+     * The count is per path and process-wide, and the failure exits used to return
+     * without releasing it. From then on a landed write-back saw a writer that no
+     * longer existed and kept the line, and the case below shows what that costs.
+     * Neither existing case reaches it: each drives one outcome on a fresh path,
+     * and the defect needs both outcomes on the same one.
+     */
+    @Test
+    fun `a write-back that fails and then lands stops distrusting the document`() {
+        deviceHolding("notes.txt")
+        val local = File(mirror, "notes.txt").apply { writeText("the whole edit") }
+        every { resolver.openOutputStream(any(), any()) } throws java.io.IOException("cut short")
+
+        deliver(android.os.FileObserver.MODIFY, "notes.txt")
+        assertEquals(
+            listOf(local.absolutePath), journal.readLines(),
+            "the failed write-back must record the edit that never reached the device",
+        )
+
+        every { resolver.openOutputStream(any(), any()) } returns java.io.ByteArrayOutputStream()
+        deliver(android.os.FileObserver.MODIFY, "notes.txt")
+
+        val listed = if (journal.isFile) journal.readLines() else emptyList()
+        assertFalse(
+            listed.contains(local.absolutePath),
+            "the document is current now and the journal still distrusts it, so every " +
+                "later sync will force the mirror over whatever the device holds",
+        )
+    }
+
+    /**
+     * What the leak above costs, driven all the way to the file.
+     *
+     * With the claim stranded, the sync takes the branch that exists to rescue a
+     * truncated upload and applies it to a document that was edited on the device
+     * after the upload had already landed. The device's edit is overwritten with
+     * the mirror, silently, and it happens again on every reopen because the line
+     * that triggers it can no longer be consumed.
+     */
+    @Test
+    fun `a device edit survives a write-back that failed once and then landed`() {
+        deviceHolding("notes.txt")
+        val local = File(mirror, "notes.txt").apply { writeText("the whole edit") }
+        local.setLastModified(1_000_000_000_000L)
+        every { resolver.openOutputStream(any(), any()) } throws java.io.IOException("cut short")
+        deliver(android.os.FileObserver.MODIFY, "notes.txt")
+        every { resolver.openOutputStream(any(), any()) } returns java.io.ByteArrayOutputStream()
+        deliver(android.os.FileObserver.MODIFY, "notes.txt")
+
+        // Now the device copy moves ahead: newer, and holding text the mirror does
+        // not. Nothing about it is a truncation, and nothing should overwrite it.
+        val cursor = mockk<Cursor>(relaxed = true)
+        var row = -1
+        every { cursor.moveToNext() } answers { ++row == 0 }
+        every { cursor.getColumnIndexOrThrow(any()) } answers {
+            when (firstArg<String>()) {
+                DocumentsContract.Document.COLUMN_DOCUMENT_ID -> 0
+                DocumentsContract.Document.COLUMN_DISPLAY_NAME -> 1
+                DocumentsContract.Document.COLUMN_MIME_TYPE -> 2
+                else -> 3
+            }
+        }
+        every { cursor.getColumnIndex(DocumentsContract.Document.COLUMN_LAST_MODIFIED) } returns 4
+        every { cursor.isNull(any()) } returns false
+        every { cursor.getString(0) } returns "doc:notes.txt"
+        every { cursor.getString(1) } returns "notes.txt"
+        every { cursor.getString(2) } returns "text/plain"
+        every { cursor.getLong(3) } returns 11L
+        every { cursor.getLong(4) } returns 2_000_000_000_000L
+        every { resolver.query(any(), any(), any(), any(), any()) } returns cursor
+        every { resolver.openInputStream(any()) } answers {
+            ByteArrayInputStream("DEVICE EDIT".toByteArray())
+        }
+
+        runBlocking { engine.initialSync(treeUri, mirror) { _, _ -> } }
+
+        assertEquals(
+            "DEVICE EDIT", local.readText(),
+            "the sync treated a landed upload as an unfinished one and forced the " +
+                "mirror over an edit made on the device, which existed only there",
+        )
+    }
+
     @Test
     fun `a sync prefers the mirror of a file whose upload was cut short`() {
         // The device's copy is newer and shorter: exactly what a truncation looks


### PR DESCRIPTION
A write-back takes a per-path claim in `markUploadInFlight` before it starts, and dropped it only on the exit that succeeds. Both failure exits of `writeLocalToSafHoldingDocument` return without it, so the count never comes back to zero for the life of the process. `uploadWriters` lives on the companion object, so the leak outlives the engine instance.

From then on the two readers of that count are both wrong:

- `clearUploadInFlight` sees a writer that no longer exists, so it keeps the journal line after a write-back that has landed.
- `consumeStaleUploadRecord` returns early on the leaked key, so the line can never be consumed.

The journal line is what `initialSync` reads to decide that a mirror holds an edit the device never received. With the line stuck, every later sync takes that branch and forces the mirror over the device document. **An edit made on the device in between is destroyed, with nothing said, and again on every reopen.**

## What changed

- The claim is released in a `finally`, so an exit added later cannot leak it the way these two did. That is the shape of the original defect: the release sat at the one exit its author had in mind.
- `releaseUploadClaim` drops the claim without touching the journal, and `clearUploadInFlight` keeps doing both. The distinction is what the line means: a landed write retires it, a failed one must leave it standing for the next sync to retry.

Two further defects from the same range:

- `ToolchainManager.cancel` released the Play pack on the caller's thread while the delivered directory was still being copied out of on `ioExecutor`. `handleStateUpdate` never reports COMPLETED, so the card holds TRANSFERRING and offers CANCEL for the whole copy; a tap in those seconds deleted the source under the reader. The release is queued on the same single-thread executor. The bound is stated in the code: `ioExecutor` is an instance field, and the two callers that can reach a live download each hold one manager for the download and the cancel alike.
- Making the picker card checkable for a screen reader also switched on `MaterialCardView`'s own checked icon, in the same top-right corner the layout constrains `R.id.checkmark` to, so a selected card drew two check marks.
- The bundled-ELF gate's failure message still said `verify-android-elf.py` is "in neither cache key", 70 lines after the same file's comment was corrected to say it is hashed into three of them.

## Verification

Two new cases in `SafUploadInterruptionTest`: one that a path stops being distrusted after a write-back that failed and then landed, and one that drives the consequence to the file, asserting a device edit survives. Neither existing case reaches this, because each drives one outcome on a fresh path and the defect needs both on the same one. Removing the release reddens both.

Each new guard was checked against its own removal, and the scope control on the cancel guard was itself checked: its first sentinel sat two hundred lines past the function and stayed green under a widened extraction, so it names the next declaration instead, with the offset measured rather than guessed.

Full unit suite 1309 tests, no failures. Lint unchanged at 53 warnings.