### PR TITLE
feat(webview): say when a page is blocked by a certificate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,9 +55,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A file you edited on the device is no longer overwritten by the app's copy after a write-back that failed once and later succeeded.
 - Cancelling a toolchain download while it installs no longer deletes the files being copied out of it, which left a part-written toolchain behind.
 - A selected toolchain in the first-run picker no longer draws two check marks in the same corner.
+- A terminal opened on a folder now stays in it. The shell profile moved every new terminal to the last folder the app recorded, whatever was open.
+- The Java toolchain now ships OpenJDK's own licence and third-party notices. The download stripped them, so the JDK reached devices with none of its attribution.
 - Values the editor page hands the app no longer reach logcat in the clear: a download's name and failure detail, a folder URI, and a toolchain name.
 - A link that fails to open now says why. Every refusal blamed a missing app, including a stale session and a URL Android refused outright.
 - The connection token no longer reaches logcat when a link fails to open. The URL was logged whole, twice, on a line that ships in release builds.
+- A link that fails to open no longer repeats its address inside the exception message. The redaction covered the log line and not the throwable beside it.
+- A page in the editor loading an https address with a bad certificate now says which host was blocked and why. The load was refused in silence.
 - The system dark theme flipping no longer moves you out of your workspace, or restarts first-run extraction if it lands while setup is running.
 - Opening the app no longer discards what `npm config set` wrote. A private registry, its auth token, `cafile` and `strict-ssl` all survive a launch now.
 - The menubar no longer closes itself when the on-screen keyboard drops. The resize that follows the tap shut the menu 40ms after it opened, leaving no route to the File or Terminal menus.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -146,6 +146,8 @@ GMP is copyleft; its source offer is in `docs/LEGAL_NOTICES.md` beside the rest.
 | Ruby | BSD 2-Clause | https://www.ruby-lang.org |
 | OpenJDK | GPL v2 + Classpath | https://openjdk.org |
 
+OpenJDK's own licence and third-party notice files ship inside the Java pack at `usr/lib/jvm/java-17-openjdk/legal`; Ruby's per-gem licence files likewise ship inside the Ruby pack.
+
 ## Extension Marketplace
 
 | Service | License | URL |

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -55,6 +55,7 @@ import com.vscodroid.service.StartupNotice
 import com.vscodroid.setup.FirstRunSetup
 import com.vscodroid.storage.SafStorageManager
 import com.vscodroid.util.Logger
+import com.vscodroid.util.MainThreadWatch
 import com.vscodroid.util.Notices
 import com.vscodroid.webview.DownloadCoordinator
 import com.vscodroid.webview.DownloadHost
@@ -63,9 +64,12 @@ import com.vscodroid.webview.VSCodroidWebChromeClient
 import com.vscodroid.webview.VSCodroidWebView
 import com.vscodroid.webview.VSCodroidWebViewClient
 import com.vscodroid.webview.RETRY_URL
+import com.vscodroid.webview.TlsFailure
+import com.vscodroid.webview.TlsFailureReason
 import com.vscodroid.webview.publishedResourceRoots
 import com.vscodroid.webview.redactToken
 import com.vscodroid.webview.sensitiveLocations
+import com.vscodroid.webview.tlsFailureToAnnounce
 import org.json.JSONException
 import org.json.JSONObject
 import kotlinx.coroutines.CancellationException
@@ -83,6 +87,18 @@ class MainActivity : AppCompatActivity() {
     private var serverPort = 0
     private var backgroundedAt = 0L
     private var bridgeInitialized = false
+
+    /**
+     * The TLS refusals already put on screen, so a page failing many requests to
+     * one host is one message rather than a minute of them. See
+     * [tlsFailureToAnnounce], which owns the rule and is tested without an
+     * Activity.
+     *
+     * Held here rather than in the client because that class has no mutable state
+     * and is worth keeping that way, and because the presenter is what knows when
+     * a message was actually shown.
+     */
+    private val announcedTlsFailures = mutableSetOf<TlsFailure>()
 
     /**
      * Whether a workbench page is loaded and able to receive an auth callback.
@@ -122,8 +138,9 @@ class MainActivity : AppCompatActivity() {
      * The directories this app publishes into the WebView, resolved once.
      *
      * Resolved on the main thread, deliberately. [publishedResourceRoots] stats
-     * external storage and canonicalises four paths, so it is disk I/O and a
-     * debug build with StrictMode on will say so. It is also the allowlist that
+     * external storage and canonicalises four paths, so it is disk I/O, and
+     * [MainThreadWatch] makes a debug build say so: it is the first violation
+     * logged on every launch, and it is expected. It is also the allowlist that
      * `shouldInterceptRequest` compares every resource request against, and
      * [initBridge] installs the client immediately before [navigateToFolder]
      * starts the page loading — so resolved on another thread, the first requests
@@ -444,6 +461,13 @@ class MainActivity : AppCompatActivity() {
         // survive the app being killed while the browser had the screen. See
         // receiveCallbackIntent.
         receiveCallbackIntent(intent)
+
+        // Last, and the position is the whole of it. Everything above runs once
+        // per launch and touches the filesystem on purpose; what comes after is
+        // the editor session, which is where an unexpected main-thread read is
+        // worth knowing about. Debug builds only, log only. See MainThreadWatch,
+        // which lists what is expected to fire.
+        MainThreadWatch.install()
     }
 
     override fun onNewIntent(intent: Intent) {
@@ -734,8 +758,12 @@ class MainActivity : AppCompatActivity() {
                 safManager.startFileWatcher(mirrorDir, uri)
                 watchedSafFolder = mirrorDir to uri
 
-                // Write active folder so new terminals cd to the right place
-                writeActiveFolder(mirrorDir.absolutePath)
+                // Write active folder so new terminals cd to the right place.
+                // Off the main thread: lifecycleScope dispatches on
+                // Main.immediate, so this was a file write on the UI thread
+                // inside a modal dialog. withContext suspends until it returns,
+                // so the ordering the rest of this block depends on is unchanged.
+                withContext(Dispatchers.IO) { writeActiveFolder(mirrorDir.absolutePath) }
 
                 dialog.dismiss()
 
@@ -1216,8 +1244,9 @@ class MainActivity : AppCompatActivity() {
         // which is true from the moment the process is spawned and stays true for
         // the seconds the editor server takes to bind its port, and for the whole
         // of a restart after a crash. Navigating on it points the WebView at a
-        // port with nothing listening, and onReceivedError only logs, so what the
-        // user gets is a connection-refused page that nothing clears.
+        // port with nothing listening, and onReceivedError only logs a refused
+        // connection, so what the user gets is a connection-refused page that
+        // nothing clears.
         //
         // The real probe is HTTP and cannot run here — NetworkOnMainThreadException
         // — which is what made the wrong question attractive. isServerReady()
@@ -1467,6 +1496,17 @@ class MainActivity : AppCompatActivity() {
                     Toast.makeText(this@MainActivity, message, Toast.LENGTH_LONG).show()
                 }
             },
+            // A certificate the device does not trust used to produce an empty
+            // frame and nothing else: the platform default cancels the request
+            // and tells nobody, and no load error reaches a page-level state
+            // here. The record of what has been said is consulted inside
+            // runOnUiThread, so the set has one owner thread whatever the
+            // platform guarantees about which thread the callback arrives on.
+            onTlsFailure = { failure ->
+                runOnUiThread {
+                    tlsFailureToAnnounce(failure, announcedTlsFailures)?.let { reportTlsFailure(it) }
+                }
+            },
             onPageLoaded = { url ->
                 folderFromUrl(url)?.let {
                     openWorkspaceFolder = it
@@ -1504,6 +1544,31 @@ class MainActivity : AppCompatActivity() {
 
         val keyInjector = KeyInjector(wv)
         extraKeyRow?.keyInjector = keyInjector
+    }
+
+    /**
+     * Puts one TLS refusal on screen.
+     *
+     * A notice and not a prompt. It offers no way to continue and there is no path
+     * from here to `SslErrorHandler.proceed`, which is what the WebView javadoc
+     * asks for and what Google Play's insecure-SSL-error-handler policy requires.
+     * The wording differs per
+     * reason because the four causes need four different next steps from the
+     * reader, and a single "certificate problem" would leave a developer with an
+     * expired certificate reading about trust.
+     *
+     * The host is named and the address never is; see [TlsFailure].
+     */
+    private fun reportTlsFailure(failure: TlsFailure) {
+        val host = failure.host ?: getString(R.string.tls_unknown_host)
+        val message = when (failure.reason) {
+            TlsFailureReason.UNTRUSTED -> getString(R.string.tls_blocked_untrusted, host)
+            TlsFailureReason.HOSTNAME -> getString(R.string.tls_blocked_hostname, host)
+            TlsFailureReason.DATE -> getString(R.string.tls_blocked_date, host)
+            TlsFailureReason.INVALID -> getString(R.string.tls_blocked_invalid, host)
+            TlsFailureReason.HANDSHAKE -> getString(R.string.tls_blocked_handshake, host)
+        }
+        Toast.makeText(this, message, Toast.LENGTH_LONG).show()
     }
 
     /**
@@ -2286,8 +2351,8 @@ class MainActivity : AppCompatActivity() {
      * OS does not, and emulators or custom ROMs carrying an older WebView than
      * their API level implies. On those the workbench loads against something it
      * was never tested on, and the failure is missing CSS or a blank editor
-     * rather than a clean refusal. `onReceivedError` only logs, so nothing else
-     * would reach the user.
+     * rather than a clean refusal. `onReceivedError` announces a TLS handshake
+     * failure and otherwise only logs, so nothing else would reach the user.
      *
      * It warns and continues rather than refusing to start. The floor is a
      * tested one, not a hard incompatibility, and an editor that degrades is
@@ -2555,8 +2620,8 @@ internal fun isWorkbenchUrl(url: String?, port: Int): Boolean {
  * [ready] is the health probe's own finding, never process liveness. A process is
  * alive from the instant it is spawned and stays alive through the seconds before
  * its port is bound and through a whole post-crash restart; navigating on that
- * points the WebView at nothing, and `onReceivedError` only logs, so the
- * connection-refused page it produces is never cleared.
+ * points the WebView at nothing, and `onReceivedError` only logs a refused
+ * connection, so the connection-refused page it produces is never cleared.
  */
 internal fun bindDecision(notice: StartupNotice?, port: Int, ready: Boolean): BindDecision = when {
     notice != null && notice.terminal -> BindDecision.ShowGaveUp(notice.message)

--- a/android/app/src/main/kotlin/com/vscodroid/SplashActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/SplashActivity.kt
@@ -92,6 +92,7 @@ class SplashActivity : AppCompatActivity() {
         repair("the npm wrappers") { setup.createNpmWrappers() }
         repair("the toolchain env sourcing") { setup.ensureToolchainEnvSourcing() }
         repair("the prompt block") { setup.ensurePromptFix() }
+        repair("the startup directory guard") { setup.ensureStartupDirGuard() }
         // The same commands for shells that never read .bashrc. Outside the
         // three above rather than inside them: it writes its own file whole, so
         // it neither needs a .bashrc to exist nor leaves anything behind in one.

--- a/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
@@ -1250,8 +1250,9 @@ class FirstRunSetup(
      * `. "$HOME/.bashrc"`. Measured: `bash -lc` runs both, `bash -c` runs only
      * this one. So under `-lc` the wrappers are defined twice,
      * `toolchain-env.sh` is sourced twice and every installed toolchain lands on
-     * PATH twice, and `.bashrc`'s closing `cd` moves the shell out of the
-     * directory it was started in. Redefining a function and re-prepending a PATH
+     * PATH twice. The closing `cd` in `.bashrc` runs twice as well, and no longer
+     * moves a shell out of the directory it was started in: it fires only when
+     * `PWD` is `HOME`. Redefining a function and re-prepending a PATH
      * entry are both harmless, which is why the overlap is left alone rather than
      * guarded. Anything added to this file that is NOT safe to run twice has to
      * bring its own guard.
@@ -1387,6 +1388,52 @@ class FirstRunSetup(
             return
         }
         Logger.i(tag, "Rewrote the .bashrc prompt block ($PROMPT_VERSION)")
+    }
+
+    /**
+     * Guards the closing `cd` in `.bashrc` so it fires only for a shell that was
+     * given no directory of its own, rewriting the unguarded shape every earlier
+     * release wrote.
+     *
+     * [createBashrc] writes the guarded block now, but its own guard is whether
+     * the file exists, and `isFirstRun` gates on the version rather than on the
+     * contents, so an install that already has a `.bashrc` would keep the
+     * unguarded `cd` for ever. This is the half that reaches those devices, and
+     * it is why it runs at every launch rather than at setup.
+     *
+     * Safe to call every launch: it returns as soon as the current marker is
+     * there, and a block the user edited matches [LEGACY_STARTUP_DIR_BLOCK]
+     * nowhere, so it is left exactly as they wrote it.
+     *
+     * Latin-1 and atomic for the two reasons [ensurePromptFix] documents at
+     * length: the mapping is lossless for any byte the user's file holds and
+     * makes the offsets below byte offsets, so the halves either side of the
+     * block go out as the bytes they came in as; and the marker is the first
+     * thing in the block, so a rewrite cut short would otherwise leave a file
+     * that certifies itself and is never repaired again.
+     */
+    fun ensureStartupDirGuard() {
+        val bashrc = File(context.filesDir, "home/.bashrc")
+        if (!bashrc.exists()) return
+
+        val bytes = bashrc.readBytes()
+        val content = String(bytes, Charsets.ISO_8859_1)
+        if (content.contains(STARTUP_DIR_MARKER_CURRENT)) return
+
+        val start = content.indexOf(LEGACY_STARTUP_DIR_BLOCK)
+        if (start < 0) return
+        val end = start + LEGACY_STARTUP_DIR_BLOCK.length
+
+        val written = writeAtomically(bashrc) {
+            it.write(bytes, 0, start)
+            it.write(STARTUP_DIR_BLOCK.toByteArray())
+            it.write(bytes, end, bytes.size - end)
+        }
+        if (!written) {
+            Logger.w(tag, "Could not guard the startup cd in .bashrc; it keeps the shape it had")
+            return
+        }
+        Logger.i(tag, "Guarded the startup cd in .bashrc ($STARTUP_DIR_VERSION)")
     }
 
     private fun npmBashFunctions(): String = """
@@ -1563,16 +1610,7 @@ claude() {
 
                 # On-demand toolchain env vars (Go, Ruby, Java, etc.)
                 [ -f "${'$'}HOME/.vscodroid/toolchain-env.sh" ] && . "${'$'}HOME/.vscodroid/toolchain-env.sh"
-
-                # Start in the active folder (SAF or default projects dir)
-                if [ -f "${'$'}HOME/.vscodroid_folder" ]; then
-                    __folder="${'$'}(cat "${'$'}HOME/.vscodroid_folder" 2>/dev/null)"
-                    [ -d "${'$'}__folder" ] && cd "${'$'}__folder" 2>/dev/null || cd "${'$'}PROJECTS_DIR" 2>/dev/null || true
-                    unset __folder
-                else
-                    cd "${'$'}PROJECTS_DIR" 2>/dev/null || true
-                fi
-            """.trimIndent() + "\n"
+            """.trimIndent() + "\n\n" + STARTUP_DIR_BLOCK + "\n"
             // Thrown, not logged. This runs only from runSetupLocked, whose
             // markSetupComplete() is the last statement of the same try block --
             // so swallowing the failure certifies an install that has no
@@ -2485,6 +2523,74 @@ private const val BASH_ENV_HEADER = """# VSCodroid: sourced by NON-INTERACTIVE b
 """
 
 /** Bumped whenever [PROMPT_BLOCK] changes, so an older block is recognised and replaced. */
+/**
+ * Where an interactive shell starts when, and only when, nobody chose for it.
+ *
+ * bash runs `.bashrc` for every interactive shell, including the ones VS Code
+ * started in a directory it picked. The server's `getCwd` takes the launch
+ * config's `cwd` first, which is the folder right-clicked in the explorer or the
+ * one an extension passed to `createTerminal`, then `terminal.integrated.cwd`,
+ * and only then the active workspace folder. An unconditional `cd` here overrode
+ * all three, so a terminal opened on a folder was moved somewhere else before
+ * the user ever saw a prompt.
+ *
+ * `HOME` is the one directory the server never picks on purpose: it is the last
+ * fallback in `getCwd`, reached only when no workspace folder is open. Landing
+ * there is therefore the signal that nobody chose, and that this block still has
+ * a job to do.
+ *
+ * `-ef` rather than `=`, because it compares device and inode instead of text.
+ * `${'$'}PWD` comes from `getcwd()` in the child while `${'$'}HOME` is the string this app
+ * exported, and the guard must not turn on whether the two spell one directory
+ * the same way. It is a bash builtin, so it costs no process, and `.bashrc` is
+ * already bash-only.
+ *
+ * Concatenated after `trimIndent()` rather than written inside the raw string
+ * above, so its indentation is fixed here and cannot be re-flowed by a later
+ * edit to the lines around it. [ensureStartupDirGuard] matches this text byte
+ * for byte on devices that already have a `.bashrc`.
+ */
+private const val STARTUP_DIR_VERSION = "v1"
+private const val STARTUP_DIR_BEGIN = "# >>> vscodroid startup dir"
+private const val STARTUP_DIR_END = "# <<< vscodroid startup dir"
+private const val STARTUP_DIR_MARKER_CURRENT = "$STARTUP_DIR_BEGIN $STARTUP_DIR_VERSION >>>"
+
+private val STARTUP_DIR_BLOCK = """
+    $STARTUP_DIR_MARKER_CURRENT
+    # Start in the active folder ONLY when this shell was given no directory of
+    # its own. See FirstRunSetup.ensureStartupDirGuard for why the test is -ef.
+    if [ "${'$'}PWD" -ef "${'$'}HOME" ]; then
+        if [ -f "${'$'}HOME/.vscodroid_folder" ]; then
+            __folder="${'$'}(cat "${'$'}HOME/.vscodroid_folder" 2>/dev/null)"
+            [ -d "${'$'}__folder" ] && cd "${'$'}__folder" 2>/dev/null || cd "${'$'}PROJECTS_DIR" 2>/dev/null || true
+            unset __folder
+        else
+            cd "${'$'}PROJECTS_DIR" 2>/dev/null || true
+        fi
+    fi
+    $STARTUP_DIR_END $STARTUP_DIR_VERSION <<<
+""".trimIndent()
+
+/**
+ * The block as every release before this one wrote it, byte for byte.
+ *
+ * Frozen, and never to be regenerated from [STARTUP_DIR_BLOCK]. It is what sits
+ * on every device that already has the app, and matching it exactly is what
+ * makes the migration safe: a `.bashrc` whose block the user edited matches this
+ * nowhere and is left exactly as they wrote it. Deriving it from the new block
+ * would disarm that on the first edit to the new one.
+ */
+private val LEGACY_STARTUP_DIR_BLOCK = """
+    # Start in the active folder (SAF or default projects dir)
+    if [ -f "${'$'}HOME/.vscodroid_folder" ]; then
+        __folder="${'$'}(cat "${'$'}HOME/.vscodroid_folder" 2>/dev/null)"
+        [ -d "${'$'}__folder" ] && cd "${'$'}__folder" 2>/dev/null || cd "${'$'}PROJECTS_DIR" 2>/dev/null || true
+        unset __folder
+    else
+        cd "${'$'}PROJECTS_DIR" 2>/dev/null || true
+    fi
+""".trimIndent()
+
 private const val PROMPT_VERSION = "v2"
 private const val PROMPT_BEGIN = "# >>> vscodroid prompt"
 private const val PROMPT_END = "# <<< vscodroid prompt"

--- a/android/app/src/main/kotlin/com/vscodroid/util/MainThreadWatch.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/util/MainThreadWatch.kt
@@ -1,0 +1,99 @@
+package com.vscodroid.util
+
+import android.os.StrictMode
+import com.vscodroid.BuildConfig
+
+/**
+ * Makes main-thread disk I/O visible in a debug build, and only after launch.
+ *
+ * Installed from the tail of `MainActivity.onCreate`, deliberately not from
+ * `VSCodroidApp.onCreate`. Everything before that point touches the filesystem on
+ * the main thread on purpose and says so in place: the block of launch repairs in
+ * `SplashActivity.onCreate` carries the comment "These touch the filesystem on the
+ * main thread at launch", and it runs before the first frame. The volume is not a
+ * handful either. `setupGitCore` alone does an lstat and usually a readlink per
+ * entry over `assets/usr/lib/git-core/gitcore-symlinks`, which holds 146 lines
+ * today, and it is one repair among more than a dozen. A policy installed at
+ * process start therefore logs violations by the hundred on every single launch,
+ * against code that already documents why each one is there, and a diagnostic that
+ * noisy is one that gets deleted rather than read. Installed here it covers the
+ * editor session instead, where the expected list below is short enough to act on.
+ *
+ * Network is not detected here, because the platform already detects it and kills
+ * for it. `StrictMode.initThreadDefaults` calls `detectNetwork()` and
+ * `penaltyDeathOnNetwork()` for any app whose targetSdk is Honeycomb or later,
+ * and this app relies on that: the NetworkOnMainThreadException note in
+ * `MainActivity.setupServiceCallbacks` is written around the readiness probe being
+ * unable to run on this thread.
+ *
+ * That is exactly why the builder below is seeded from the policy already in force
+ * rather than from a bare `Builder()`, and this is the one line here that is not
+ * cosmetic. `Builder()` starts at mask 0 and `setThreadPolicy` assigns the mask
+ * wholesale, so installing a freshly built disk-only policy would DELETE the
+ * platform's network detection and its death penalty for the rest of the editor
+ * session. Main-thread HTTP would then quietly succeed in a debug build and still
+ * die in release, which is the worst arrangement available and the opposite of
+ * what a diagnostic is for. `Builder(ThreadPolicy)` copies the existing mask and
+ * every `detect`/`penalty` call is an OR onto it, so what is added below is added
+ * and nothing is taken away.
+ *
+ * penaltyLog and nothing else. penaltyDeath fires from inside an arbitrary
+ * framework call, and the first violation on every launch is
+ * `publishedResourceRoots`, which is deliberate and documented, so death would
+ * make the debug build unusable over a design decision. It would also fire for the
+ * emoji font load that androidx.startup schedules through the InitializationProvider
+ * in the merged manifest, which is not this repository's to fix. penaltyDialog
+ * would put a dialog over the workbench during the very interaction being
+ * investigated.
+ *
+ * What is expected to fire, so that a new line stands out against it:
+ *  - `publishedResourceRoots` and `sensitiveLocations`, from the `resourceRoots`
+ *    lazy in `initBridge`: six canonicalPath calls plus getExternalFilesDir. First
+ *    and unavoidable, since the allowlist has to exist before the page starts
+ *    loading or every extension resource 404s without a sound.
+ *  - `ensureProjectsDir` from `loadVSCode`: getExternalFilesDir plus mkdirs.
+ *  - `ProcessManager.readTokenFile` from `navigateToFolder`: once per process, and
+ *    then cached.
+ *  - `folderFromUrl` and `SafStorageManager.getPersistedFolders` from
+ *    `onPageFinished`: twice per folder switch, because the server redirects.
+ *  - `writeMemoryPressure` from either `onTrimMemory`: a short write that has to
+ *    stay synchronous, because onTrimMemory can be the last code that runs before
+ *    the process is killed and a write handed to an executor may never land. It
+ *    cannot be wrapped in StrictMode.allowThreadDiskWrites either: `MemoryPressureTest`
+ *    calls it on the JVM and `app/build.gradle.kts` sets no `isReturnDefaultValues`,
+ *    so the android.jar stub would throw and redden that suite.
+ *  - a WebView construction after `recreateWebView`, and the emoji font load.
+ *
+ * Anything not on that list is worth reading. What this cannot see is stated
+ * rather than left to be discovered: a ThreadPolicy is per-thread, so nothing
+ * arriving on the WebView's JavaBridge thread, on Dispatchers.IO, on the
+ * `saf-writeback` thread or on the resource interceptor's thread is covered, and
+ * neither is anything that runs before this call. For a launch-time inventory,
+ * move the [install] call to `VSCodroidApp.onCreate` for one run and put it back.
+ */
+object MainThreadWatch {
+
+    /**
+     * Whether this build watches.
+     *
+     * `BuildConfig.DEBUG` and not `Logger`'s debuggable check, and the difference
+     * is what keeps this out of release rather than merely quiet there. The
+     * debuggable flag is read from ApplicationInfo at runtime, which R8 cannot
+     * fold, so the StrictMode call would survive into the release DEX and a
+     * re-signed debuggable release would install a policy in production. This
+     * constant is `false` in release and the branch is gone with it.
+     */
+    internal fun shouldWatch(): Boolean = BuildConfig.DEBUG
+
+    fun install() {
+        if (!shouldWatch()) return
+        StrictMode.setThreadPolicy(
+            StrictMode.ThreadPolicy.Builder(StrictMode.getThreadPolicy())
+                .detectDiskReads()
+                .detectDiskWrites()
+                .penaltyLog()
+                .build()
+        )
+        Logger.i("MainThreadWatch", "Main-thread disk policy installed (log only)")
+    }
+}

--- a/android/app/src/main/kotlin/com/vscodroid/webview/VSCodroidWebViewClient.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/webview/VSCodroidWebViewClient.kt
@@ -4,10 +4,12 @@ import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
 import android.net.Uri
+import android.net.http.SslError
 import android.os.SystemClock
 import android.webkit.RenderProcessGoneDetail
 import android.webkit.ServiceWorkerClient
 import android.webkit.ServiceWorkerController
+import android.webkit.SslErrorHandler
 import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
@@ -23,6 +25,8 @@ import java.io.File
 import java.io.FileInputStream
 import java.io.IOException
 import java.net.HttpURLConnection
+import java.net.URI
+import java.net.URISyntaxException
 import java.net.URL
 
 /**
@@ -250,6 +254,138 @@ internal fun redactToken(text: String?): String =
  */
 internal const val RETRY_URL = "vscodroid://retry-server"
 
+/**
+ * Why the WebView refused a certificate, in the shape a sentence can be built from.
+ *
+ * [HANDSHAKE] is not one of `SslError`'s codes and never arrives as one. It
+ * stands for the other half of TLS failure: the javadoc on
+ * `WebViewClient.onReceivedSslError` says that callback is reached only for
+ * recoverable certificate errors, and that a non-recoverable one is delivered to
+ * `onReceivedError` with `ERROR_FAILED_SSL_HANDSHAKE` instead. Both halves are
+ * reported as this one type so that the presenter has one thing to branch on
+ * rather than two channels that can drift apart.
+ */
+enum class TlsFailureReason { UNTRUSTED, HOSTNAME, DATE, INVALID, HANDSHAKE }
+
+/**
+ * One refusal, carrying as much of it as is safe to repeat back to the user.
+ *
+ * The host, and never the address. The failing URL here is whatever the open page
+ * asked for, and a dev server's address can carry an OAuth code or an API key in
+ * its query, so quoting it would put a credential into a toast and into logcat.
+ * `url_handoff_no_app` names a scheme rather than a whole address for the same
+ * reason, and keeping to the host is also why [redactToken] needs no widening for
+ * this path.
+ *
+ * The host is null when [tlsHostLabel] could not read one. The presenter has a
+ * phrase for that case; interpolating an empty string would leave a sentence with
+ * a hole in it.
+ *
+ * Public, unlike the helpers around it, and not by preference: it is the type the
+ * public constructor's `onTlsFailure` parameter carries, and Kotlin refuses an
+ * internal type in a public signature.
+ */
+data class TlsFailure(val host: String?, val reason: TlsFailureReason)
+
+/**
+ * The reason behind an `SslError`'s primary code.
+ *
+ * Only four of the six codes can reach this from a WebView.
+ * `SslError.SslErrorFromChromiumErrorCode` builds every error the platform
+ * produces here with `SSL_IDMISMATCH`, `SSL_DATE_INVALID`, `SSL_UNTRUSTED` or
+ * `SSL_INVALID`, so `SSL_EXPIRED` and `SSL_NOTYETVALID` are legacy values on this
+ * path. They are still listed, because they mean exactly what the DATE branch
+ * says and letting them fall to the `else` would tell a user with an expired
+ * certificate that it could not be validated, which sends them looking at the
+ * wrong thing.
+ *
+ * An unrecognised code becomes INVALID rather than throwing. This runs inside a
+ * callback whose contract is that the request gets an answer, and a slightly
+ * vague word in a message costs far less than a load that never resolves.
+ */
+internal fun tlsReasonOf(primaryError: Int): TlsFailureReason = when (primaryError) {
+    SslError.SSL_UNTRUSTED -> TlsFailureReason.UNTRUSTED
+    SslError.SSL_IDMISMATCH -> TlsFailureReason.HOSTNAME
+    SslError.SSL_DATE_INVALID, SslError.SSL_EXPIRED, SslError.SSL_NOTYETVALID ->
+        TlsFailureReason.DATE
+    else -> TlsFailureReason.INVALID
+}
+
+/**
+ * The `host:port` a failing URL names, or null when it does not yield one.
+ *
+ * Parsed with `java.net.URI` and deliberately not `android.net.Uri`: the second is
+ * a stub in the unit-test `android.jar`, so a case written against it would
+ * measure the mock rather than the parse. `UrlAllowlistWiringTest` already
+ * records that trade in the same words.
+ *
+ * The price of that choice, accepted rather than overlooked: `java.net.URI`
+ * answers a null host for a name containing an underscore, where `android.net.Uri`
+ * would answer one. It degrades to the presenter's generic phrase and decides
+ * nothing, because this label is only ever printed and never compared.
+ *
+ * Everything unreadable has to reach null rather than an empty label, and it gets
+ * there by two routes rather than three. `URI("nonsense")` returns a null host
+ * without throwing, while `URI("not a url")` throws on the space, so the null host
+ * and the exception both have to answer null. The empty string that two of
+ * `SslError`'s four constructors set the url to is deliberately NOT a third route:
+ * it parses to a null host like any other address with nothing in it, and a guard
+ * in front of it would be a line no test could ever redden. The null check that
+ * remains is not optional, because `URI` has no constructor taking null.
+ *
+ * The port is left off when there is none, because `URI.getPort()` answers -1 and
+ * a message reading `host:-1` looks like a bug in the app rather than a fact about
+ * the server.
+ */
+internal fun tlsHostLabel(url: String?): String? {
+    if (url == null) return null
+    return try {
+        val parsed = URI(url)
+        val host = parsed.host ?: return null
+        if (parsed.port > 0) "$host:${parsed.port}" else host
+    } catch (e: URISyntaxException) {
+        null
+    }
+}
+
+/**
+ * How many distinct refusals are remembered before the record starts over.
+ *
+ * The hosts that end up in it are chosen by whatever page is open, and one of
+ * those pages is the bundled simple browser holding an arbitrary remote site. So
+ * an unbounded record is an allocation a remote page controls. Clearing at the cap
+ * trades a message that may repeat once past eight distinct failures for a set
+ * that cannot grow.
+ */
+internal const val MAX_TLS_FAILURES_ANNOUNCED = 8
+
+/**
+ * The refusal worth putting on screen, or null when it has been said already.
+ *
+ * The same rule `reasonToAnnounce` applies to a failed toolchain download, for the
+ * same reason: toasts stack rather than replace, each one holds the screen for
+ * about three and a half seconds, and one page can fail many requests to one host
+ * with nothing in between. A markdown preview pulling a dozen images from a host
+ * with a self-signed certificate would otherwise hold the bottom of the editor for
+ * the better part of a minute, over an editor the user has gone back to working in.
+ *
+ * Keyed on the host and the reason together. A second image from the same host is
+ * the same fact and adds nothing to act on; a second host, or the same host
+ * failing a different way, is a new fact and still gets through.
+ *
+ * [alreadySaid] belongs to the presenter, which keeps this class free of mutable
+ * state, and its lifetime falls out of that: it survives a renderer crash, because
+ * the certificate has not changed, and it dies with the Activity, so a fresh
+ * launch says everything again.
+ */
+internal fun tlsFailureToAnnounce(
+    failure: TlsFailure,
+    alreadySaid: MutableSet<TlsFailure>,
+): TlsFailure? {
+    if (alreadySaid.size >= MAX_TLS_FAILURES_ANNOUNCED) alreadySaid.clear()
+    return if (alreadySaid.add(failure)) failure else null
+}
+
 class VSCodroidWebViewClient(
     private val allowedPort: Int,
     private val resourceRoots: List<String>,
@@ -277,6 +413,19 @@ class VSCodroidWebViewClient(
      * destination allowlist under another name. The exception is the signal.
      */
     private val onHandoffFailed: (Uri, Throwable) -> Unit = { _, _ -> },
+    /**
+     * Told when the WebView refused a certificate, or could not negotiate TLS at all.
+     *
+     * A constructor parameter for the reason [onHandoffFailed] is one: this class
+     * has no screen and no context of its own beyond the one the request carries,
+     * so the caller decides how a refusal is said.
+     *
+     * Nothing was told before this existed. The platform default for
+     * `onReceivedSslError` cancels the request and reports to no channel at all,
+     * and the handshake half of the same failure was dropped by the main-frame
+     * gate in [onReceivedError]. What the user saw was an empty tab.
+     */
+    private val onTlsFailure: (TlsFailure) -> Unit = { },
 ) : WebViewClient() {
 
     private val tag = "WebViewClient"
@@ -346,7 +495,23 @@ class VSCodroidWebViewClient(
             Logger.i(tag, "Opened external URL: ${redactToken(url.toString())}")
         } catch (e: Exception) {
             AuthTabWindow.disarm(armed)
-            Logger.e(tag, "Failed to open external URL: ${redactToken(url.toString())}", e)
+            // The throwable is deliberately not passed, and leaving it in was a
+            // redaction that only looked like one. `Log.e(tag, msg, tr)` prints
+            // the throwable with its message, and both exceptions this
+            // realistically catches put the whole address there:
+            // ActivityNotFoundException quotes the Intent it could not match,
+            // `dat=` and all, and FileUriExposedException names the file it
+            // refused. So the URL [redactToken] had just taken out of the message
+            // arrived in logcat two lines below it, on a statement that is not
+            // gated on a debuggable build and therefore ships. The frames behind
+            // it are all framework, so the class name is what the trace was being
+            // read for anyway. Same shape and same reasoning as
+            // `AndroidBridge.openExternalUrl`.
+            Logger.e(
+                tag,
+                "Failed to open external URL: ${redactToken(url.toString())} " +
+                    "(${e.javaClass.simpleName})"
+            )
             onHandoffFailed(url, e)
         }
         return true  // Don't navigate WebView to external URL
@@ -402,11 +567,80 @@ class VSCodroidWebViewClient(
         onPageLoaded(url)
     }
 
+    /**
+     * Refuses the certificate, and says so.
+     *
+     * Without this override the platform default runs, and its entire behaviour
+     * is to cancel: the javadoc on `WebViewClient.onReceivedSslError` states that
+     * in those words. So the request was already being refused before this
+     * existed. What is added here is that the refusal is now audible, and that
+     * matters because nothing downstream turns a failed load into anything on
+     * screen: `MainActivity.showServerGaveUp` is driven by the server's startup
+     * state and never by a load error, so what the user got was an empty simple
+     * browser tab or an empty preview pane and no way to tell why.
+     *
+     * It reports and never proceeds. `proceed()` would trust a certificate that
+     * nothing validated; the same javadoc says to always cancel and never proceed
+     * past errors, and Google Play's insecure-SSL-error-handler policy refuses
+     * applications that do. Cancelling and
+     * reporting is not that decision and does not approach it.
+     *
+     * It is a notice and not a prompt, which is the platform's other instruction
+     * in the same block: do not prompt the user about SSL errors, because they
+     * cannot make an informed decision and the WebView shows no certificate
+     * detail to base one on. There is no control here that could continue, and
+     * adding one is the change this comment exists to refuse.
+     *
+     * The callback carries no `WebResourceRequest` and no `isForMainFrame`, so it
+     * answers for the main frame, subframes and subresources alike. The first of
+     * those cannot arise in this app: the workbench is loaded over plain http on
+     * loopback. What is left is the realistic case, a page the user pointed the
+     * editor at.
+     *
+     * It does not make a private CA work, and the message must not suggest it
+     * might. This app trusts the Android system store only, because
+     * `network_security_config.xml` declares no trust anchors and `targetSdk` is
+     * 36, for which the platform default is system roots. A CA installed through
+     * Android Settings is therefore not read. Changing that means declaring a user
+     * certificate source, which widens every https connection the app makes and is
+     * a separate decision from this one.
+     */
+    override fun onReceivedSslError(view: WebView, handler: SslErrorHandler, error: SslError) {
+        // First, and on every path through this method, with nothing above it
+        // that can throw. The contract is that exactly one of cancel() and
+        // proceed() is called, so an override that returns having called neither
+        // leaves that request's certificate decision outstanding for ever, which
+        // is a worse silence than the one being closed here.
+        handler.cancel()
+        val failure = TlsFailure(tlsHostLabel(error.url), tlsReasonOf(error.primaryError))
+        Logger.w(
+            tag, "TLS refused for ${failure.host ?: "an unreadable address"}: ${failure.reason}"
+        )
+        onTlsFailure(failure)
+    }
+
     override fun onReceivedError(
         view: WebView,
         request: WebResourceRequest,
         error: WebResourceError
     ) {
+        // The other half of TLS failure, and the half that reached no channel at
+        // all. onReceivedSslError is called only for recoverable certificate
+        // errors; its javadoc says a non-recoverable one, such as the server
+        // rejecting the client, arrives here with ERROR_FAILED_SSL_HANDSHAKE
+        // instead. The main-frame gate below then swallowed it outright for a
+        // subframe or a subresource, which is where every https load in this app
+        // happens: the workbench itself is plain http on loopback.
+        //
+        // The int comparison comes first so an ordinary load error costs one
+        // comparison, as this callback's javadoc asks. There is deliberately no
+        // early return, so a handshake failure in the main frame still reaches
+        // the line below; two log lines for that one case is the cheaper trade.
+        if (error.errorCode == WebViewClient.ERROR_FAILED_SSL_HANDSHAKE) {
+            onTlsFailure(
+                TlsFailure(tlsHostLabel(request.url.toString()), TlsFailureReason.HANDSHAKE)
+            )
+        }
         if (request.isForMainFrame) {
             Logger.e(tag, "Page load error: ${error.errorCode} - ${error.description}")
         }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -61,6 +61,31 @@
          worth putting in a bug report. -->
     <string name="url_handoff_failed">Could not open that %1$s link (%2$s).</string>
 
+    <!-- A page inside the editor asked for an https address the WebView would not
+         load: a dev server previewed in the Simple Browser, an image in a preview,
+         a fetch from an extension's webview. The request was already refused
+         before these strings existed; what was missing was any word about it, so
+         the frame simply came up empty.
+
+         Each cause gets its own wording because each needs a different next step
+         from the reader, and a single "certificate problem" would send a developer
+         with an expired certificate looking at trust settings.
+
+         The host and never the address: a dev server URL can carry an OAuth code
+         or an API key in its query. `tls_unknown_host` stands in when the address
+         yields no host at all, so the sentence still reads as one.
+
+         None of these offers to continue, and none should be given a button that
+         does. The WebView documentation asks that SSL errors are not put to the
+         user as a choice, and Google Play's insecure-SSL-error-handler policy
+         refuses an app whose override proceeds past them. -->
+    <string name="tls_blocked_untrusted">Blocked %1$s: its certificate is not trusted by this device. Use http, or a certificate from a system-trusted CA.</string>
+    <string name="tls_blocked_hostname">Blocked %1$s: its certificate is issued for a different host name.</string>
+    <string name="tls_blocked_date">Blocked %1$s: its certificate is expired or not yet valid.</string>
+    <string name="tls_blocked_invalid">Blocked %1$s: its certificate could not be validated.</string>
+    <string name="tls_blocked_handshake">Blocked %1$s: the secure connection could not be negotiated.</string>
+    <string name="tls_unknown_host">that address</string>
+
     <!-- Shown on the page itself, not in a toast, when the restart budget is
          spent. The screen behind it read "Starting server..." and went on
          reading that for ever, so the only thing it said was the only thing

--- a/android/app/src/test/kotlin/com/vscodroid/setup/LaunchRepairWiringTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/LaunchRepairWiringTest.kt
@@ -78,6 +78,7 @@ class LaunchRepairWiringTest {
         "createNpmWrappers",
         "ensureToolchainEnvSourcing",
         "ensurePromptFix",
+        "ensureStartupDirGuard",
         "createBashEnvFile",
         "updateSettingsNativeLibPaths",
         "ensureProjectsDir",

--- a/android/app/src/test/kotlin/com/vscodroid/setup/StartupDirGuardTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/StartupDirGuardTest.kt
@@ -1,0 +1,301 @@
+package com.vscodroid.setup
+
+import android.content.Context
+import com.vscodroid.util.Environment
+import com.vscodroid.util.Logger
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+/**
+ * That `.bashrc` moves a shell only when nobody chose where it should start.
+ *
+ * bash runs `.bashrc` for every interactive shell, including the ones VS Code
+ * started in a directory it picked, so the unguarded `cd` that used to end the
+ * file overrode the folder right-clicked in the explorer, an extension's
+ * `createTerminal({cwd})`, the `terminal.integrated.cwd` setting, and the
+ * directory a revived terminal was restored to.
+ *
+ * The first four cases run real bash against the real generated file, because a
+ * text assertion cannot tell a guard that works from one that never fires. What
+ * they do is what `shellIntegration-bash.sh` does on the device: source
+ * `.bashrc` from a shell started in a given directory, then ask where it ended
+ * up.
+ */
+class StartupDirGuardTest {
+
+    @TempDir
+    lateinit var filesDir: File
+
+    @TempDir
+    lateinit var externalDir: File
+
+    private lateinit var context: Context
+    private val home: File get() = File(filesDir, "home")
+    private val bashrc: File get() = File(home, ".bashrc")
+    private val projects: File get() = File(externalDir, "projects")
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(Logger)
+        every { Logger.d(any(), any()) } just Runs
+        every { Logger.i(any(), any()) } just Runs
+        every { Logger.w(any(), any()) } just Runs
+        every { Logger.w(any(), any(), any()) } just Runs
+        every { Logger.e(any(), any(), any()) } just Runs
+
+        context = mockk(relaxed = true)
+        every { context.filesDir } returns filesDir
+        // Named rather than relaxed, because PROJECTS_DIR is what three of the
+        // cases below assert on: a relaxed mock answers with a File whose path is
+        // empty, the export becomes PROJECTS_DIR='/projects', and every cd fails
+        // for a reason that has nothing to do with the guard.
+        every { context.getExternalFilesDir(null) } returns externalDir
+
+        home.mkdirs()
+        projects.mkdirs()
+    }
+
+    @AfterEach
+    fun tearDown() = unmockkObject(Logger)
+
+    private fun createBashrc() {
+        FirstRunSetup::class.java
+            .getDeclaredMethod("createBashrc")
+            .apply { isAccessible = true }
+            .invoke(FirstRunSetup(context))
+    }
+
+    /**
+     * Where a shell started in [from] ends up after sourcing the generated file.
+     *
+     * `bash -c` sourcing `.bashrc` is the honest reproduction rather than a
+     * shortcut: it is literally what the shell integration script the ptyHost
+     * injects does. `BASH_ENV`, `SSH_CLIENT` and `SSH2_CLIENT` are removed for
+     * the reason `NonInteractiveShellEnvTest` documents: either SSH variable
+     * makes bash source `~/.bashrc` in place of `$BASH_ENV`, which would make the
+     * result depend on the host that ran the suite.
+     */
+    private fun endsUpIn(from: File): String {
+        assumeTrue(File("/bin/bash").canExecute(), "no /bin/bash on this host")
+        val builder = ProcessBuilder("/bin/bash", "-c", ". \"\$HOME/.bashrc\"; pwd")
+            .directory(from)
+            .redirectErrorStream(true)
+        builder.environment().apply {
+            remove("BASH_ENV")
+            remove("SSH_CLIENT")
+            remove("SSH2_CLIENT")
+            put("HOME", home.path)
+        }
+        val process = builder.start()
+        val out = process.inputStream.bufferedReader().readText()
+        assertTrue(process.waitFor(30, TimeUnit.SECONDS), "bash did not finish")
+        val lines = out.lines().map { it.trim() }.filter { it.isNotEmpty() }
+        assertEquals(
+            1, lines.size,
+            "sourcing .bashrc printed something other than the one path: $lines",
+        )
+        return File(lines.single()).canonicalPath
+    }
+
+    @Test
+    fun `a shell started in a folder stays in it`() {
+        val workspace = File(filesDir, "workspace").apply { mkdirs() }
+        val recorded = File(filesDir, "recorded").apply { mkdirs() }
+        createBashrc()
+        File(home, ".vscodroid_folder").writeText(recorded.path)
+
+        assertEquals(
+            workspace.canonicalPath, endsUpIn(workspace),
+            "the shell was moved out of the directory VS Code started it in, which " +
+                "is what the explorer's Open in Integrated Terminal relies on",
+        )
+    }
+
+    /**
+     * The control for the case above. Without it a guard that is simply always
+     * false satisfies the first case while removing the behaviour entirely.
+     */
+    @Test
+    fun `a shell started in HOME still goes to the projects directory`() {
+        createBashrc()
+
+        assertEquals(
+            projects.canonicalPath, endsUpIn(home),
+            "nobody chose a directory for this shell, so the block still has a job " +
+                "to do and did not do it",
+        )
+    }
+
+    @Test
+    fun `a shell started in HOME prefers the recorded folder`() {
+        val recorded = File(filesDir, "recorded").apply { mkdirs() }
+        createBashrc()
+        File(home, ".vscodroid_folder").writeText(recorded.path)
+
+        assertEquals(recorded.canonicalPath, endsUpIn(home), "the recorded folder was ignored")
+    }
+
+    @Test
+    fun `a recorded folder that no longer exists falls back to the projects directory`() {
+        createBashrc()
+        File(home, ".vscodroid_folder").writeText(File(filesDir, "deleted").path)
+
+        // endsUpIn asserts the output is exactly one line, which is the second half
+        // of this case: a failed cd that printed a diagnostic would corrupt the
+        // terminal's first prompt as surely as landing in the wrong place.
+        assertEquals(
+            projects.canonicalPath, endsUpIn(home),
+            "a stale recorded folder left the shell in HOME instead of falling back",
+        )
+    }
+
+    /**
+     * The case the `[ -d ]` test is actually for.
+     *
+     * Measured while checking that each clause earns its place: with the recorded
+     * folder merely deleted, dropping `[ -d ]` changes nothing, because `cd` to a
+     * missing path fails and the `||` already falls through to the projects
+     * directory. An EMPTY recorded file is different. `__folder` is then the empty
+     * string, `cd ""` succeeds in bash and moves nowhere, so without the test the
+     * shell simply stays in HOME and the fallback never runs.
+     */
+    @Test
+    fun `an empty recorded folder falls back rather than staying put`() {
+        createBashrc()
+        File(home, ".vscodroid_folder").writeText("")
+
+        assertEquals(
+            projects.canonicalPath, endsUpIn(home),
+            "an empty recorded folder left the shell in HOME: cd to the empty string " +
+                "succeeds, so only the -d test can send it to the fallback",
+        )
+    }
+
+    // -- The migration, for devices that already have a .bashrc --
+
+    /**
+     * The historical file, with the unguarded block exactly as every release
+     * before this one wrote it, and with content on both sides of it so that a
+     * rewrite which loses one half is visible.
+     */
+    private fun writeLegacyBashrc(): ByteArray {
+        val text = """
+            # VSCodroid bash configuration
+
+            export PROJECTS_DIR='${projects.path}'
+            alias ll='ls -la'
+
+            # Start in the active folder (SAF or default projects dir)
+            if [ -f "${'$'}HOME/.vscodroid_folder" ]; then
+                __folder="${'$'}(cat "${'$'}HOME/.vscodroid_folder" 2>/dev/null)"
+                [ -d "${'$'}__folder" ] && cd "${'$'}__folder" 2>/dev/null || cd "${'$'}PROJECTS_DIR" 2>/dev/null || true
+                unset __folder
+            else
+                cd "${'$'}PROJECTS_DIR" 2>/dev/null || true
+            fi
+
+            npm() { :; }
+            # the user's own alias
+        """.trimIndent() + "\n"
+        bashrc.writeText(text)
+        return text.toByteArray()
+    }
+
+    @Test
+    fun `the unguarded block is rewritten and everything around it survives`() {
+        val before = writeLegacyBashrc()
+
+        FirstRunSetup(context).ensureStartupDirGuard()
+
+        val after = bashrc.readText()
+        assertTrue(after.contains("vscodroid startup dir"), "the block was not replaced")
+        assertFalse(
+            after.contains("# Start in the active folder (SAF or default projects dir)"),
+            "the unguarded block is still there as well",
+        )
+        for (kept in listOf("export PROJECTS_DIR", "alias ll=", "npm() { :; }", "# the user's own alias")) {
+            assertTrue(after.contains(kept), "the rewrite lost $kept")
+        }
+        val prefix = String(before).substringBefore("# Start in the active folder")
+        assertTrue(after.startsWith(prefix), "the bytes before the block did not survive unchanged")
+    }
+
+    @Test
+    fun `guarding is idempotent`() {
+        writeLegacyBashrc()
+        val setup = FirstRunSetup(context)
+
+        setup.ensureStartupDirGuard()
+        val once = bashrc.readBytes()
+        setup.ensureStartupDirGuard()
+
+        assertArrayEquals(once, bashrc.readBytes(), "a second launch rewrote a file that was already guarded")
+    }
+
+    /**
+     * A file whose block the user edited matches the frozen legacy text nowhere,
+     * so it is left exactly as written. That is the whole reason the legacy text
+     * is frozen rather than regenerated from the current block.
+     */
+    @Test
+    fun `a block the user edited is left alone`() {
+        writeLegacyBashrc()
+        val edited = bashrc.readText().replace(
+            """cd "${'$'}PROJECTS_DIR" 2>/dev/null || true""",
+            """cd "${'$'}HOME/somewhere-else" 2>/dev/null || true""",
+        )
+        bashrc.writeText(edited)
+
+        FirstRunSetup(context).ensureStartupDirGuard()
+
+        assertEquals(edited, bashrc.readText(), "an edited block was rewritten")
+        assertFalse(bashrc.readText().contains("vscodroid startup dir"), "a marker was added anyway")
+    }
+
+    @Test
+    fun `a file with no bashrc at all is left absent`() {
+        bashrc.delete()
+
+        FirstRunSetup(context).ensureStartupDirGuard()
+
+        assertFalse(bashrc.exists(), "the guard created a .bashrc where setup had written none")
+    }
+
+    /**
+     * The generated file and the migrated one have to agree, or a device that
+     * upgrades ends up with different shell behaviour from one that installs
+     * fresh. Compared as text rather than asserted twice, so the two cannot
+     * drift apart without this failing.
+     */
+    @Test
+    fun `a fresh install and a migrated one write the same block`() {
+        createBashrc()
+        val fresh = bashrc.readText().substringAfter("# >>> vscodroid startup dir")
+
+        bashrc.delete()
+        writeLegacyBashrc()
+        FirstRunSetup(context).ensureStartupDirGuard()
+        val migrated = bashrc.readText().substringAfter("# >>> vscodroid startup dir")
+
+        assertEquals(
+            fresh.substringBefore("# <<< vscodroid startup dir"),
+            migrated.substringBefore("# <<< vscodroid startup dir"),
+            "the block written on a fresh install differs from the one the migration writes",
+        )
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/util/MainThreadWatchTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/util/MainThreadWatchTest.kt
@@ -1,0 +1,181 @@
+package com.vscodroid.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * That the main-thread disk diagnostic is debug-only, log-only, and installed
+ * where the design says.
+ *
+ * The ceiling first, because a guard whose limits are not written down gets
+ * trusted past them. `StrictMode.setThreadPolicy` is an `android.jar` stub and
+ * `app/build.gradle.kts` declares no `testOptions { unitTests { isReturnDefaultValues } }`,
+ * so calling [MainThreadWatch.install] here throws "not mocked". Only the guard in
+ * front of it is executable. Everything else below reads source text, which sees a
+ * token and not a behaviour.
+ *
+ * So these cases cannot show that the policy fires on anything, that `install()`
+ * still has a body, or that the call sits at the END of `onCreate` rather than the
+ * start. That last one is the whole design: the launch path before it touches the
+ * filesystem on the main thread on purpose and says so in a comment, and one of
+ * its repairs alone walks a 146-line manifest doing an lstat per entry, so a
+ * policy that covered it would bury every finding worth reading. Only a device run
+ * answers those, and `androidTest/README.md` records why CI cannot do it here.
+ *
+ * What they do cover is the four ways this rots into something worse than nothing:
+ * a guard inverted so release installs the policy, a penalty upgraded to one that
+ * kills a debug build over a documented violation, a builder that replaces the
+ * platform's own policy instead of adding to it, and the call drifting up into the
+ * launch path where it floods.
+ */
+class MainThreadWatchTest {
+
+    private val watch = File("src/main/kotlin/com/vscodroid/util/MainThreadWatch.kt")
+    private val mainActivity = File("src/main/kotlin/com/vscodroid/MainActivity.kt")
+    private val app = File("src/main/kotlin/com/vscodroid/VSCodroidApp.kt")
+    private val splash = File("src/main/kotlin/com/vscodroid/SplashActivity.kt")
+
+    /**
+     * A file's source with comment lines dropped.
+     *
+     * Not decoration here. [MainThreadWatch]'s own KDoc names `penaltyDeath`,
+     * `penaltyDialog`, `detectNetwork` and `detectAll` in prose, arguing against
+     * each, so a guard reading the raw text would fail on the untouched file.
+     * Anchored on `trimStart()` the way `ServerReadinessCallSiteTest.codeLines()`
+     * is.
+     */
+    private fun code(file: File): String {
+        check(file.isFile) {
+            "${file.name} not found at ${file.absolutePath}, so this test would otherwise " +
+                "pass by looking at nothing"
+        }
+        return file.readLines().filterNot { line ->
+            val t = line.trimStart()
+            t.startsWith("//") || t.startsWith("*") || t.startsWith("/*")
+        }.joinToString("\n")
+    }
+
+    /**
+     * The only case here that is not a source read.
+     *
+     * `BuildConfig.DEBUG` rather than `Logger`'s debuggable check, and the
+     * difference is what keeps the policy out of release rather than merely quiet
+     * there: the debuggable flag is read from ApplicationInfo at runtime, which R8
+     * cannot fold, so the StrictMode call would survive into the release DEX and a
+     * re-signed debuggable release would install a policy in production.
+     */
+    @Test
+    fun `the debug build is the one that watches`() {
+        assertTrue(
+            MainThreadWatch.shouldWatch(),
+            "the unit suite runs the debug variant, so this must be true here. False means the " +
+                "guard is inverted and the policy is installed in release instead of in debug",
+        )
+    }
+
+    /**
+     * Log only, and only the two disk detectors.
+     *
+     * `penaltyDeath` would kill the debug build within seconds of the editor
+     * loading: the first violation on every launch is `publishedResourceRoots`,
+     * which is deliberate and documented, and the emoji font load androidx.startup
+     * schedules would trip it for a reason this repository cannot fix.
+     * `penaltyDialog` would put a dialog over the workbench during the interaction
+     * being investigated.
+     *
+     * `detectAll` would drag in `detectUnbufferedIo`, `detectResourceMismatches`
+     * and `detectCustomSlowCalls` over code that has not been read for any of them.
+     * `detectNetwork` would add nothing here: the platform already detects it and
+     * installs `penaltyDeathOnNetwork` at this targetSdk, and the comment in
+     * `MainActivity.setupServiceCallbacks` naming NetworkOnMainThreadException is
+     * written around that. What keeps it in force once this runs is the seeding
+     * case below, not a call here.
+     */
+    @Test
+    fun `the policy logs and never kills, and detects only disk`() {
+        val source = code(watch)
+
+        assertTrue(
+            source.contains("penaltyLog()"),
+            "the policy has to report somewhere; found no penaltyLog() in ${watch.name}",
+        )
+        assertTrue(
+            source.contains("detectDiskReads()") && source.contains("detectDiskWrites()"),
+            "both disk detectors are the subject of this diagnostic",
+        )
+        // `penaltyDeath()` and not `penaltyDeath`, so that an explicit
+        // `penaltyDeathOnNetwork()` is not refused under a message about killing
+        // the debug build. That call would be a harmless restatement of what the
+        // platform already installed, and the seeding case above is what keeps it
+        // in force whether or not anyone writes it.
+        for (forbidden in listOf(
+            "penaltyDeath()", "penaltyDropBox", "penaltyDialog", "detectAll(", "detectNetwork("
+        )) {
+            assertTrue(
+                !source.contains(forbidden),
+                "$forbidden must not be in ${watch.name}. Each is argued against in its KDoc; " +
+                    "reaching for one means reopening that argument rather than editing past it",
+            )
+        }
+    }
+
+    /**
+     * The policy is added to the one already in force, never substituted for it.
+     *
+     * `StrictMode.setThreadPolicy` assigns the whole mask, and `ThreadPolicy.Builder()`
+     * starts at mask 0. So building disk detection from a bare builder and installing
+     * it deletes what the platform put there at process start: `initThreadDefaults`
+     * calls `detectNetwork()` and `penaltyDeathOnNetwork()` for every app targeting
+     * Honeycomb or later, and this app relies on main-thread network being fatal in
+     * writing. Losing it would let main-thread HTTP succeed in a debug build and die
+     * in release, which is worse than having no diagnostic at all.
+     *
+     * `Builder(ThreadPolicy)` copies the existing mask and every detect and penalty
+     * call ORs onto it, so seeding is the whole of the fix. Asserted on the source
+     * because `getThreadPolicy` is an android.jar stub that throws here.
+     */
+    @Test
+    fun `the builder is seeded from the policy already in force`() {
+        val source = code(watch)
+
+        assertTrue(
+            source.contains("StrictMode.ThreadPolicy.Builder(StrictMode.getThreadPolicy())"),
+            "the builder must start from the live policy; a bare Builder() silently drops the " +
+                "platform's detectNetwork and penaltyDeathOnNetwork for the whole session",
+        )
+        assertTrue(
+            !source.contains("ThreadPolicy.Builder()"),
+            "an empty ThreadPolicy.Builder() in ${watch.name} means the installed mask replaces " +
+                "the platform's rather than adding to it",
+        )
+    }
+
+    /**
+     * One call, and it is in the Activity.
+     *
+     * Moving it to `VSCodroidApp.onCreate` or `SplashActivity.onCreate` to "cover
+     * more" is the change that ends this diagnostic: everything on that path does
+     * main-thread disk deliberately, so the log fills with violations against code
+     * that already explains itself, and what gets deleted is the policy rather than
+     * the noise.
+     */
+    @Test
+    fun `the policy is installed from the activity and nowhere else`() {
+        val calls = code(mainActivity).lines().count { it.contains("MainThreadWatch.install()") }
+        assertEquals(
+            1, calls,
+            "MainActivity must install the policy exactly once; found $calls call site(s)",
+        )
+
+        for (file in listOf(app, splash)) {
+            assertTrue(
+                !code(file).contains("MainThreadWatch"),
+                "${file.name} runs before the editor session and touches the filesystem on the " +
+                    "main thread on purpose at dozens of call sites. Installing the policy there " +
+                    "buries every finding worth reading",
+            )
+        }
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/webview/ConnectionTokenLoggingTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/ConnectionTokenLoggingTest.kt
@@ -1,6 +1,10 @@
 package com.vscodroid.webview
 
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
 import android.net.Uri
+import android.os.SystemClock
 import android.webkit.ConsoleMessage
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
@@ -12,6 +16,7 @@ import io.mockk.mockkConstructor
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
+import io.mockk.verify
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -265,6 +270,78 @@ class ConnectionTokenLoggingTest {
         client.onPageFinished(view, url)
 
         assertNothingLeaked()
+    }
+
+    /**
+     * A hand-off that no app took, which is the one line here that redacted its
+     * message and then handed the same address to logcat anyway.
+     *
+     * `Log.e(tag, msg, tr)` prints the throwable with its message, and the two
+     * exceptions this catch realistically sees both quote the address:
+     * `ActivityNotFoundException` names the Intent it could not match, `dat=` and
+     * all, and `FileUriExposedException` names the file it refused. So the URL that
+     * [redactToken] had just taken out of the message arrived two lines below it,
+     * on a statement at `Logger.e`, which is not gated on a debuggable build and
+     * therefore ships.
+     *
+     * The absence of the throwable is asserted at the argument rather than by
+     * capturing it, because a captured null and an argument that was never recorded
+     * look identical in a list. The message assertions above it are what make that
+     * verify a measurement: without them a call that logged nothing useful would
+     * satisfy it.
+     */
+    @Test
+    fun `a failed hand-off logs neither the token nor the throwable that repeats it`() {
+        mockkConstructor(Intent::class)
+        every { anyConstructed<Intent>().addFlags(any()) } returns mockk(relaxed = true)
+        // The hand-off reads the clock to record the sign-in it carries. The stub
+        // android.jar throws for it, and that throw would land in the very catch
+        // under test, so the line would be reached by the wrong route.
+        mockkStatic(SystemClock::class)
+        every { SystemClock.elapsedRealtime() } returns 1_700_111L
+
+        val address = "https://dev.example.com/preview?tkn=$token"
+        val context = mockk<Context>(relaxed = true)
+        every { context.startActivity(any()) } throws ActivityNotFoundException(
+            "No Activity found to handle Intent { act=android.intent.action.VIEW dat=$address }"
+        )
+        val view = mockk<WebView>(relaxed = true)
+        every { view.context } returns context
+
+        val uri = mockk<Uri>(relaxed = true)
+        every { uri.scheme } returns "https"
+        every { uri.host } returns "dev.example.com"
+        every { uri.port } returns -1
+        every { uri.toString() } returns address
+        val request = mockk<WebResourceRequest>(relaxed = true)
+        every { request.url } returns uri
+        every { request.isForMainFrame } returns true
+
+        val client = VSCodroidWebViewClient(
+            allowedPort = 41234,
+            resourceRoots = emptyList(),
+            sensitiveLocations = emptyList(),
+            openFolder = { null },
+            connectionToken = { token },
+            onCrash = {},
+            onPageLoaded = {},
+            onRetryServer = {},
+        )
+
+        client.shouldOverrideUrlLoading(view, request)
+
+        assertNothingLeaked()
+        assertTrue(
+            logged.last().contains("tkn=<redacted>"),
+            "the URL is not in the line at all, so this case would pass on a statement that " +
+                "dropped it rather than one that redacted it: " + logged.last(),
+        )
+        assertTrue(
+            logged.last().contains("ActivityNotFoundException"),
+            "the exception type is the part of the trace worth having, and dropping the " +
+                "throwable has to keep it: " + logged.last(),
+        )
+        verify(exactly = 1) { Logger.e(any(), any(), null) }
     }
 
     /**

--- a/android/app/src/test/kotlin/com/vscodroid/webview/ExternalUrlHandoffTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/ExternalUrlHandoffTest.kt
@@ -427,10 +427,12 @@ class ExternalUrlHandoffTest {
     }
 
     /**
-     * The three exception types the audit named land in one catch, and the user
-     * cannot tell them apart from the outside. Each still has to produce a
-     * notice, because a channel that only covers the easy one leaves the same
-     * silence for the other two.
+     * Three different exceptions land in one catch, and from outside the app they
+     * are indistinguishable: `ActivityNotFoundException` for a scheme nothing
+     * claims, `FileUriExposedException` for a `file://` URI, and
+     * `SecurityException` for a `content://` URI with no grant. Each still has to
+     * produce a notice, because a channel that covers only the easy one leaves
+     * the same silence behind for the other two.
      */
     @Test
     fun `a file URI Android refuses to expose is announced`() {

--- a/android/app/src/test/kotlin/com/vscodroid/webview/TlsFailureNoticeTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/TlsFailureNoticeTest.kt
@@ -1,0 +1,344 @@
+package com.vscodroid.webview
+
+import android.net.http.SslError
+import android.webkit.SslErrorHandler
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import android.net.Uri
+import com.vscodroid.util.Logger
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+
+/**
+ * What the WebView says when it refuses a certificate.
+ *
+ * It said nothing at all. `onReceivedSslError` had no override, so the platform
+ * default ran, and the javadoc describes that default in one line: cancel the
+ * resource load. Nothing else in the app turns a failed load into anything a user
+ * can see, because the only page-level failure state is driven by the server's
+ * startup and not by a load error. So a dev server previewed in the Simple Browser
+ * over https with a self-signed certificate came up as an empty tab, and the
+ * developer had nothing to distinguish that from a dev server that was not running.
+ *
+ * The other half was worse: `onReceivedSslError` is reached only for RECOVERABLE
+ * certificate errors, and the javadoc says a non-recoverable one is delivered to
+ * `onReceivedError` with `ERROR_FAILED_SSL_HANDSHAKE`. That callback gated its one
+ * log line on `isForMainFrame`, and every https load in this app is a subframe or
+ * a subresource, since the workbench itself is plain http on loopback. That half
+ * reached no channel at all, not even logcat.
+ *
+ * The rule these cases pin is report, never proceed. Two of them exist to keep it
+ * that way rather than to describe it: nothing may call `proceed()`, and an
+ * ordinary load error must stay silent, which is what keeps the notice from
+ * becoming a toast on every offline fetch and every connection-refused page.
+ *
+ * `SslError` and `SslErrorHandler` are mocked because the stub `android.jar`
+ * answers neither. What is NOT mocked is every decision under test: the real
+ * `tlsHostLabel` parses, the real `tlsReasonOf` maps and the real
+ * `tlsFailureToAnnounce` deduplicates.
+ */
+class TlsFailureNoticeTest {
+
+    private lateinit var view: WebView
+    private lateinit var client: VSCodroidWebViewClient
+
+    /** Every refusal the client announced, in order. */
+    private val announced = mutableListOf<TlsFailure>()
+
+    @BeforeEach
+    fun setUp() {
+        announced.clear()
+        mockkObject(Logger)
+        every { Logger.w(any(), any(), any()) } just Runs
+        every { Logger.e(any(), any(), any()) } just Runs
+
+        view = mockk(relaxed = true)
+
+        client = VSCodroidWebViewClient(
+            allowedPort = 13337,
+            resourceRoots = emptyList(),
+            sensitiveLocations = emptyList(),
+            openFolder = { null },
+            connectionToken = { null },
+            onCrash = {},
+            onPageLoaded = {},
+            onRetryServer = {},
+            onTlsFailure = { announced += it },
+        )
+    }
+
+    private fun sslError(url: String, primary: Int): SslError {
+        val error = mockk<SslError>(relaxed = true)
+        every { error.url } returns url
+        every { error.primaryError } returns primary
+        return error
+    }
+
+    private fun loadError(errorCode: Int, url: String, fromMainFrame: Boolean): Pair<WebResourceRequest, WebResourceError> {
+        val uri = mockk<Uri>(relaxed = true)
+        every { uri.toString() } returns url
+        val request = mockk<WebResourceRequest>(relaxed = true)
+        every { request.url } returns uri
+        // Stated rather than left to the relaxed mock, which answers false and
+        // would quietly make every case here a subframe case.
+        every { request.isForMainFrame } returns fromMainFrame
+        val error = mockk<WebResourceError>(relaxed = true)
+        every { error.errorCode } returns errorCode
+        every { error.description } returns "load failed"
+        return request to error
+    }
+
+    /**
+     * The contract this override newly depends on: exactly one of `cancel()` and
+     * `proceed()` per handler.
+     *
+     * An override that returns having called neither leaves that request's
+     * certificate decision outstanding for ever, which is a worse silence than the
+     * one being closed. `cancel()` is therefore the first statement, with nothing
+     * above it that can throw.
+     *
+     * The `proceed()` half is a durable guard rather than a note in a review.
+     * Proceeding would trust a certificate nothing validated, which is what the
+     * WebView javadoc tells applications never to do and what Google Play's policy
+     * refuses outright.
+     *
+     * The announcement assertion is the sentinel. Without it a fixture that never
+     * entered the method at all would satisfy `exactly = 0`.
+     */
+    @Test
+    fun `the handler is cancelled and never proceeded`() {
+        val handler = mockk<SslErrorHandler>(relaxed = true)
+
+        client.onReceivedSslError(view, handler, sslError("https://192.168.1.50:5173/", SslError.SSL_UNTRUSTED))
+
+        verify(exactly = 1) { handler.cancel() }
+        verify(exactly = 0) { handler.proceed() }
+        assertEquals(
+            1, announced.size,
+            "the method has to have run at all for the proceed() assertion above to mean anything",
+        )
+    }
+
+    /**
+     * The whole path, once: the address the WebView refused becomes a host and a
+     * reason, and nothing more of it survives.
+     *
+     * The address is deliberately absent from what is reported. A dev server URL
+     * can carry an OAuth code or an API key in its query, and this value reaches
+     * both a toast and logcat.
+     */
+    @Test
+    fun `the reported failure names the host and the reason`() {
+        client.onReceivedSslError(
+            view,
+            mockk<SslErrorHandler>(relaxed = true),
+            sslError("https://192.168.1.50:5173/preview?token=s3cret", SslError.SSL_UNTRUSTED),
+        )
+
+        assertEquals(
+            listOf(TlsFailure("192.168.1.50:5173", TlsFailureReason.UNTRUSTED)),
+            announced,
+        )
+    }
+
+    /**
+     * Every code the WebView can actually produce reaches a distinct reason.
+     *
+     * `SslError.SslErrorFromChromiumErrorCode` builds errors with only four of the
+     * six codes, so those four are what has to be right. Collapsing them to one
+     * reason would tell a developer with an expired certificate that it is
+     * untrusted, and send them to install a CA that would not have helped.
+     */
+    @ParameterizedTest(name = "{0} is {1}")
+    @CsvSource(
+        "3, UNTRUSTED",   // SSL_UNTRUSTED
+        "2, HOSTNAME",    // SSL_IDMISMATCH
+        "4, DATE",        // SSL_DATE_INVALID
+        "5, INVALID",     // SSL_INVALID
+        "1, DATE",        // SSL_EXPIRED, legacy on this path
+        "0, DATE",        // SSL_NOTYETVALID, legacy on this path
+        "-1, INVALID",    // nothing the platform defines
+    )
+    fun `every SslError code the WebView produces maps to a reason`(code: Int, expected: TlsFailureReason) {
+        assertEquals(expected, tlsReasonOf(code))
+    }
+
+    /**
+     * The host label, over the real parse and with no mocks at all.
+     *
+     * This is the only new parsing in the change and it runs on input a remote page
+     * chooses, so its failure modes are worth stating one at a time. The default
+     * port has to disappear rather than print as -1, and the two shapes of
+     * unreadable address arrive by different routes: one returns a null host, the
+     * other throws.
+     */
+    @Test
+    fun `the host label carries a non-default port and nothing else`() {
+        assertEquals("192.168.1.50:5173", tlsHostLabel("https://192.168.1.50:5173/x"))
+        assertEquals(
+            "dev.example.com", tlsHostLabel("https://dev.example.com/x"),
+            "a default port must not be printed; URI.getPort() answers -1 for it",
+        )
+        assertNull(tlsHostLabel(""), "two of SslError's constructors set the url to an empty string")
+        assertNull(tlsHostLabel("nonsense"), "a bare word parses without throwing and has no host")
+        assertNull(tlsHostLabel("not a url"), "a space makes URI throw rather than answer null")
+        assertNull(tlsHostLabel(null))
+    }
+
+    /**
+     * One page failing many requests to one host is one message.
+     *
+     * Toasts stack rather than replace, so a markdown preview pulling a dozen
+     * images from a host with a self-signed certificate would hold the bottom of
+     * the editor for the better part of a minute.
+     */
+    @Test
+    fun `the same failure twice is announced once`() {
+        val said = mutableSetOf<TlsFailure>()
+        val failure = TlsFailure("dev.example.com", TlsFailureReason.UNTRUSTED)
+
+        assertEquals(failure, tlsFailureToAnnounce(failure, said))
+        assertNull(
+            tlsFailureToAnnounce(failure, said),
+            "a second image from the same host adds nothing the user can act on",
+        )
+    }
+
+    /**
+     * The half that makes the rule above a filter rather than a mute.
+     *
+     * Keyed on host and reason together: a second host is a second fact, and so is
+     * the same host failing a different way, since the two need different answers.
+     */
+    @Test
+    fun `a different host or a different reason is still announced`() {
+        val said = mutableSetOf<TlsFailure>()
+        tlsFailureToAnnounce(TlsFailure("dev.example.com", TlsFailureReason.UNTRUSTED), said)
+
+        assertEquals(
+            TlsFailure("other.example.com", TlsFailureReason.UNTRUSTED),
+            tlsFailureToAnnounce(TlsFailure("other.example.com", TlsFailureReason.UNTRUSTED), said),
+            "a different host is a fact the user has not been told",
+        )
+        assertEquals(
+            TlsFailure("dev.example.com", TlsFailureReason.DATE),
+            tlsFailureToAnnounce(TlsFailure("dev.example.com", TlsFailureReason.DATE), said),
+            "the same host failing a different way needs a different answer from the reader",
+        )
+    }
+
+    /**
+     * The record cannot grow without bound.
+     *
+     * The hosts in it are chosen by whatever page is open, including a remote site
+     * in the bundled simple browser, so an unbounded set is an allocation a remote
+     * page controls. What this case also documents is the residual: past the cap a
+     * message may be said a second time, and that is the intended trade rather than
+     * a defect.
+     */
+    @Test
+    fun `the record is bounded and starts over at the cap`() {
+        val said = mutableSetOf<TlsFailure>()
+        val first = TlsFailure("host0.example.com", TlsFailureReason.UNTRUSTED)
+
+        // One short of the cap, so the record is still whole.
+        for (i in 0 until MAX_TLS_FAILURES_ANNOUNCED - 1) {
+            val failure = TlsFailure("host$i.example.com", TlsFailureReason.UNTRUSTED)
+            assertEquals(failure, tlsFailureToAnnounce(failure, said), "distinct failure $i")
+        }
+        assertNull(
+            tlsFailureToAnnounce(first, said),
+            "below the cap nothing is forgotten, which is what makes the assertion below a reset " +
+                "rather than a set that never remembered anything",
+        )
+
+        val atCap = TlsFailure("atcap.example.com", TlsFailureReason.UNTRUSTED)
+        assertEquals(atCap, tlsFailureToAnnounce(atCap, said))
+
+        assertEquals(
+            first, tlsFailureToAnnounce(first, said),
+            "the record clears once it holds the cap, so an old failure is said a second time " +
+                "rather than the set growing on hosts a remote page chooses",
+        )
+    }
+
+    /**
+     * The non-recoverable half of TLS failure, which reached nothing at all.
+     *
+     * `onReceivedSslError` is never called for it. It arrives here instead, and the
+     * `isForMainFrame` gate below it dropped it: the workbench is plain http on
+     * loopback, so every https load in this app is a subframe or a subresource.
+     *
+     * The subframe is what the case drives, deliberately. Gating the new branch on
+     * `isForMainFrame` would restore the whole defect while a main-frame case
+     * stayed green.
+     */
+    @Test
+    fun `a TLS handshake failure in a subframe is reported`() {
+        val (request, error) = loadError(
+            WebViewClient.ERROR_FAILED_SSL_HANDSHAKE, "https://dev.example.com:8443/", fromMainFrame = false
+        )
+
+        client.onReceivedError(view, request, error)
+
+        assertEquals(
+            listOf(TlsFailure("dev.example.com:8443", TlsFailureReason.HANDSHAKE)),
+            announced,
+        )
+    }
+
+    /**
+     * The control, and the one that keeps this from fighting the server-gave-up
+     * page.
+     *
+     * A connection refused on loopback is what the gave-up page owns, and it is
+     * `ERROR_CONNECT`, not a handshake failure. Widening the branch to all error
+     * codes would turn every offline fetch and every connection-refused page into a
+     * toast, and without this case nothing else in the suite would object.
+     */
+    @Test
+    fun `an ordinary load error is not announced`() {
+        val (request, error) = loadError(
+            WebViewClient.ERROR_CONNECT, "http://127.0.0.1:13337/", fromMainFrame = true
+        )
+
+        client.onReceivedError(view, request, error)
+
+        assertTrue(announced.isEmpty(), "announced $announced for a plain connection failure")
+    }
+
+    /**
+     * The existing main-frame log line survives a handshake failure.
+     *
+     * The new branch has no early return for exactly this reason: the branch sits
+     * above the gate, so a main-frame handshake failure produces both. An early
+     * return would delete the one record the page-load path has always had.
+     */
+    @Test
+    fun `a main-frame handshake failure is both announced and logged`() {
+        val (request, error) = loadError(
+            WebViewClient.ERROR_FAILED_SSL_HANDSHAKE, "https://dev.example.com/", fromMainFrame = true
+        )
+
+        client.onReceivedError(view, request, error)
+
+        assertEquals(
+            listOf(TlsFailure("dev.example.com", TlsFailureReason.HANDSHAKE)),
+            announced,
+        )
+        verify { Logger.e("WebViewClient", match { it.startsWith("Page load error:") }, null) }
+    }
+}

--- a/docs/DEVICE_TEST_CHECKLIST.md
+++ b/docs/DEVICE_TEST_CHECKLIST.md
@@ -77,6 +77,7 @@
 | ED-8 | Format document | Open JS file, run Format Document (Prettier) | File formatted, no errors | | |
 | ED-9 | Application Menu with the keyboard up | Tap a text field so the keyboard rises, then tap the menubar button. Watch it for a few seconds rather than glancing: the failure this catches lasted about 40ms and left the button looking dead | The menu opens and stays open, listing File, Edit, Selection, View, Go and Run. Tapping outside still closes it, and tapping File still opens its submenu. Do not look for Esc here: the key row that carries it is hidden the moment the keyboard drops, which is the very event under test | | |
 | ED-10 | Application Menu across a rotation | Open the Application Menu, tap File so its submenu opens, then rotate the device | Both menus close. They must not stay open: the submenu would be anchored where it no longer fits and would be clipped off the edge | | |
+| ED-11 | An https preview with a bad certificate | Run `Simple Browser: Show` and enter `https://self-signed.badssl.com/`, then `https://expired.badssl.com/`, then the first one again. Offline variant: a local https server with a self-signed certificate, reached at `https://127.0.0.1:8443` | Each of the first two shows an empty tab plus a toast naming the host, the first saying the certificate is not trusted and the second that it is expired or not yet valid. The third shows no second toast: a repeat of a fact already said is suppressed. No dialog and no way to continue appears at any point | | |
 
 ## 6. Extensions
 
@@ -214,7 +215,7 @@ first launch of a build that has this line, so the row to run instead is TC-8.
 | Android Versions | 4 | | | |
 | Keyboard Input | 13 | | | |
 | Screen & Orientation | 6 | | | |
-| Editor Operations | 10 | | | |
+| Editor Operations | 11 | | | |
 | Extensions | 6 | | | |
 | Background/Foreground | 8 | | | |
 | Low Memory & Stress | 4 | | | |
@@ -222,7 +223,7 @@ first launch of a build that has this line, so the row to run instead is TC-8.
 | Toolchains | 6 | | | |
 | Terminal & Tools | 11 | | | |
 | SAF & Files | 8 | | | |
-| **Total** | **90** | | | |
+| **Total** | **91** | | | |
 
 **Overall Result**: [ ] PASS / [ ] FAIL
 

--- a/docs/LEGAL_NOTICES.md
+++ b/docs/LEGAL_NOTICES.md
@@ -527,6 +527,7 @@ VSCodroid bundles binaries licensed under the GNU General Public License (GPL). 
 - **xz / liblzma** (LGPL-2.1 / GPL-2.0 / GPL-3.0): Source available at https://github.com/termux/termux-packages (package: `liblzma`) — linked by Python's `lzma` module
 - **Zstandard** (GPL-2.0 as packaged by Termux; dual-licensed BSD-3-Clause upstream): Source available at https://github.com/termux/termux-packages (package: `zstd`) — linked by Python's `zstd` module
 - **GMP** (LGPL-3.0): Source available at https://github.com/termux/termux-packages (package: `libgmp`) — shipped inside the Ruby toolchain pack, not the base app, so it reaches only devices where Ruby was installed
+- **OpenJDK 17** (GPL-2.0 with the Classpath Exception): Source available at https://github.com/termux/termux-packages (package: `openjdk-17`), built from https://github.com/openjdk/jdk17u. Shipped inside the Java toolchain pack, not the base app, so it reaches only devices where Java was installed. The Classpath Exception grants an additional permission and removes none of the obligations above.
 
 Every entry after readline reaches the app as a dependency of something else
 rather than as a tool of its own, and each is dynamically linked and shipped as
@@ -552,6 +553,8 @@ These are the Free Software Foundation's texts as shipped in Termux's `liblzma` 
 They reach the device through the same `bundleNotices` task as this document, and are read straight out of the APK at **About > Licenses > License Texts**. They sit behind that chooser rather than inside the notices body because 78 KB of licence in front of the attribution and the source offer would bury the part a reader opened that screen for.
 
 Java is the one component above that arrives in an on-demand pack rather than in the base app, and the text covering it ships in the base app, which every device installing that pack already holds. Its licence is GPL-2.0 with the Classpath Exception, an additional permission that grants rights rather than requiring a copy of anything to travel; the exception is stated at https://openjdk.org/legal/gplv2+ce.html.
+
+OpenJDK's own notice set travels inside the Java pack, at `usr/lib/jvm/java-17-openjdk/legal`, beside the binaries it describes: the GPLv2 text it ships, the Assembly Exception, the Classpath Exception statement, and the third-party notices for the Apache, MPL, W3C, Unicode, ICU, BSD and MIT components inside it. Those components are not listed individually here, for the same reason the toolchain trees are not: the notices upstream wrote are what discharge their terms, and they ship. `scripts/download-java.sh` refuses to build the pack without them, and refuses one in which they arrived as symbolic links, because neither an asset pack nor the release ZIP can carry a link.
 
 GMP, in the Ruby toolchain pack, is LGPL-3.0 and is the one copyleft component with no text here; its licence is named and its source offered above.
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -408,6 +408,18 @@ save, tap reload — without leaving the app.
 
 Any loopback port works, whatever port your dev server picked.
 
+#### If your dev server is on https
+
+A preview served over https with a self-signed or private certificate is refused, and
+the editor now names the host it blocked and says why. Before, the tab simply came up
+empty and there was nothing to tell that apart from a server that was not running.
+
+Plain `http://` is the answer for a local preview: cleartext is permitted here precisely
+because that is what dev servers speak. Installing your own CA through Android Settings
+does not help either. The app trusts the device's system roots only, which is the same
+wall described for git above, so a certificate you issued yourself is not trusted no
+matter where you install it.
+
 #### Opening in the device's browser instead
 
 If you would rather use the device browser, the terminal route still works:

--- a/scripts/check-library-attribution.py
+++ b/scripts/check-library-attribution.py
@@ -419,6 +419,53 @@ def unlisted_toolchain_libs():
     return out
 
 
+def toolchain_notices():
+    """Packs on disk whose tree carries no upstream notice file at all.
+
+    A backstop, and deliberately a coarse one. The per-file question this module
+    asks of the base tree cannot be asked of a toolchain: `unlisted_toolchain_libs`
+    explains why, and widening either check to reach inside a JDK would demand a
+    row per object. What can be asked instead is whether the notices upstream
+    shipped are still in the pack, because a download script that strips them
+    redistributes the binaries with none of their attribution and nothing else
+    here would notice.
+
+    That is not hypothetical. `download-java.sh` deleted the JDK's `legal/`
+    directory, filed with `demo/` and `man/` under one comment about stripping
+    documentation, and `legal/` is not documentation: it is the notice set for the
+    seventy modules the pack still ships.
+
+    Coarse in both directions, stated so nobody reads more into a pass than is
+    there. It cannot tell a complete notice set from a partial one, and it cannot
+    see a pack that was never downloaded, since there is no tree to read.
+
+    Where it actually fires, measured rather than assumed: `build.yml` never runs
+    a toolchain download, so the pull-request run has no pack to read and this
+    passes over nothing. `release.yml` runs `download-java.sh` before its second
+    call to this script, so that is the run that answers. A developer who has
+    built a pack locally gets the answer too, and a pack built before the download
+    script stopped stripping notices reddens until it is rebuilt, which is correct
+    rather than a false alarm: that tree really would ship without attribution.
+    """
+    out = []
+    for module in sorted(TOOLCHAINS.glob("toolchain_*")):
+        usr = module / "src/main/assets/usr"
+        if not usr.is_dir():
+            continue
+        found = False
+        for path in usr.rglob("*"):
+            if path.is_symlink() or not path.is_file():
+                continue
+            name = path.name.lower()
+            if name.startswith(("license", "licence", "copying", "notice")) or \
+                    name.endswith((".md", ".txt")) and "licen" in name:
+                found = True
+                break
+        if not found:
+            out.append(module.name)
+    return out
+
+
 def shipped():
     """The redistributed binaries at the top level of the two flat directories,
     by file name.
@@ -706,6 +753,23 @@ def main():
               " attributing it. Add it to the `libs` array the download script"
               " writes, and give it a row in TOOLCHAIN_LIBRARIES and in both"
               " attribution documents", file=sys.stderr)
+        return 1
+
+    # After the two above, and for the same reason they are ordered: a pack with
+    # no manifest is already reported, and a pack whose payload was never
+    # downloaded has no tree for either check to read.
+    stripped = toolchain_notices()
+    if stripped:
+        print(f"FAIL {len(stripped)} toolchain pack(s) carry no upstream notice file:",
+              file=sys.stderr)
+        for module in stripped:
+            print(f"  {module}", file=sys.stderr)
+        print("  -> the pack redistributes upstream binaries with none of their"
+              " attribution. The notices ship inside the tree, beside what they"
+              " describe; check that the download script is not stripping them,"
+              " and that it copies with -L so none of them arrives as a symlink,"
+              " which neither an asset pack nor a release ZIP can carry",
+              file=sys.stderr)
         return 1
 
     for name, entry in for_check:

--- a/scripts/download-java.sh
+++ b/scripts/download-java.sh
@@ -68,7 +68,22 @@ if [ ! -d "$JDK_SRC" ]; then
 fi
 
 mkdir -p "$PACK_ASSETS/usr/lib/jvm"
-cp -r "$JDK_SRC" "$PACK_ASSETS/usr/lib/jvm/java-17-openjdk"
+# -RL, not a bare -r. legal/ is the only subtree of this JDK carrying symbolic
+# links: measured on openjdk-17, bin, conf, lib, man, jmods and include carry
+# none between them while legal carries 208, and every one of those points at
+# another module's copy of the same notice.
+#
+# Neither delivery path can carry a link. An Android asset pack cannot hold one,
+# which is why this pack's sonames are created at install time from the
+# manifest, and ToolchainManager.extractZip writes every non-directory entry
+# with a FileOutputStream, so a link entry in the ZIP would arrive on a device
+# as a text file whose contents are "../java.base/LICENSE". Dereferencing here
+# is what keeps the tree in the AAB and the tree in the release ZIP the same
+# tree.
+#
+# A dangling link upstream makes this fail rather than pass silently, which is
+# the right direction and not a reason to go back to -r.
+cp -RL "$JDK_SRC" "$PACK_ASSETS/usr/lib/jvm/java-17-openjdk"
 
 # Copy shared library dependencies
 echo ""
@@ -178,10 +193,13 @@ echo "Stripping unnecessary files..."
 JDK_DIR="$PACK_ASSETS/usr/lib/jvm/java-17-openjdk"
 BEFORE_SIZE=$(du -sk "$PACK_ASSETS/usr" | cut -f1)
 
-# Strip demo, man, legal docs (keep src.zip for IDE source navigation)
+# Strip the sample programs and the man pages. NOT legal/, which was filed here
+# with two directories whose removal takes their subject matter away with them.
+# Removing legal/ takes only the notices for everything that stays: lib/modules
+# still carries all 70 modules, and legal/ is their attribution. Step 5b below
+# refuses to build a pack without it.
 rm -rf "$JDK_DIR/demo" 2>/dev/null || true
 rm -rf "$JDK_DIR/man" 2>/dev/null || true
-rm -rf "$JDK_DIR/legal" 2>/dev/null || true
 # Strip jmods (module files, large, not needed at runtime)
 rm -rf "$JDK_DIR/jmods" 2>/dev/null || true
 # Strip header files (not needed without JNI compilation)
@@ -203,6 +221,55 @@ rm -f "$JDK_DIR/lib/libjavajpeg.so" "$JDK_DIR/lib/libjsound.so" "$JDK_DIR/lib/li
 
 AFTER_SIZE=$(du -sk "$PACK_ASSETS/usr" | cut -f1)
 echo "  Java: ${BEFORE_SIZE}K -> ${AFTER_SIZE}K (saved $((BEFORE_SIZE - AFTER_SIZE))K)"
+
+# --- Step 5b: the notices have to have survived, as real files ---
+#
+# Two separate failures, and the second is the one a present-file check misses.
+# `[ -f ]` follows a link, so a tree copied without -L passes a check for
+# presence while every notice on the device is a one-line text file naming a
+# path that is not there. The counts are printed either way so that a run which
+# examined nothing cannot read as a clean one.
+echo ""
+echo "Checking the OpenJDK notices..."
+NOTICES_MISSING=0
+NOTICES_LINKED=0
+NOTICES_PRESENT=0
+if [ ! -d "$JDK_DIR/legal" ]; then
+    echo "ERROR: $JDK_DIR/legal is absent. It is the only copy of OpenJDK's"
+    echo "       third-party notices that reaches a device, and the pack must not"
+    echo "       ship without it."
+    exit 1
+fi
+while IFS= read -r entry; do
+    # An empty legal/ makes find print nothing, and a heredoc holding nothing
+    # still feeds read one empty line, which would be counted as a missing
+    # notice and report the wrong cause. Skipping it is what lets the
+    # examined-nothing check below be reached at all.
+    [ -n "$entry" ] || continue
+    if [ -L "$entry" ]; then
+        echo "  SYMLINK ${entry#"$JDK_DIR/"}"
+        NOTICES_LINKED=$((NOTICES_LINKED + 1))
+    elif [ -f "$entry" ]; then
+        NOTICES_PRESENT=$((NOTICES_PRESENT + 1))
+    else
+        echo "  MISSING ${entry#"$JDK_DIR/"}"
+        NOTICES_MISSING=$((NOTICES_MISSING + 1))
+    fi
+done <<EOF
+$(find "$JDK_DIR/legal" \( -type f -o -type l \))
+EOF
+if [ "$NOTICES_MISSING" -ne 0 ] || [ "$NOTICES_LINKED" -ne 0 ]; then
+    echo "ERROR: $NOTICES_MISSING notice(s) absent, $NOTICES_LINKED left as symlinks."
+    echo "       Neither an asset pack nor the release ZIP can carry a symbolic"
+    echo "       link, so a link here becomes a text file naming a missing path."
+    echo "       Copy the JDK with 'cp -RL' and do not delete legal/."
+    exit 1
+fi
+if [ "$NOTICES_PRESENT" -eq 0 ]; then
+    echo "ERROR: legal/ holds no files at all, so this check examined nothing."
+    exit 1
+fi
+echo "  $NOTICES_PRESENT notice files present, none a symlink"
 
 # --- Step 6: Write manifest.json ---
 echo ""


### PR DESCRIPTION
Four silences, each of which left a developer with a symptom and no cause.

## A TLS failure inside the WebView said nothing at all

`VSCodroidWebViewClient` never overrode `onReceivedSslError`, and the platform default's entire behaviour is to cancel the load. A dev server on https with a self-signed certificate, or a host behind a private CA, rendered a blank frame with no explanation. The other half of the same silence is `onReceivedError`, which was gated to the main frame, so a non-recoverable handshake failure in a subframe reached no channel whatever. The realistic cases are exactly the ones it could not see: the main frame here is loopback http, so what fails is a Simple Browser iframe, a preview subresource, or a fetch from an extension webview.

Both now report the host and the reason through the notice channel the URL hand-off already uses, deduplicated per host and reason and capped, on the same rule the splash screen uses for the same reason.

**Nothing proceeds.** `handler.cancel()` is the first statement on every path, and the app still trusts the Android system store only. Reporting a refusal is not trusting a certificate, and this does not make a private CA work: `network_security_config.xml` sets no `<trust-anchors>`, so a CA installed through Android Settings is not read. Changing that is a separate product decision affecting every https connection the app makes, and the new message says which of the two the user is looking at.

## Main-thread disk I/O was invisible

`MainThreadWatch` installs a log-only StrictMode policy in debug builds, from the tail of `MainActivity.onCreate` rather than from the application, because everything before that point does main-thread disk deliberately and documents why in place. A policy installed at process start would log sixty to eighty violations per launch against code that already explains itself, which is a diagnostic nobody keeps.

One line there is not cosmetic: the builder is seeded from `StrictMode.getThreadPolicy()`. A bare `Builder()` starts at mask zero and `setThreadPolicy` assigns the mask wholesale, so a fresh disk-only policy would discard the `detectNetwork()` and `penaltyDeathOnNetwork()` the platform installs for this targetSdk, and main-thread HTTP would then succeed in debug and die in release. Network is not added, because the platform already detects it and kills for it, and this codebase depends on that in writing.

The first violation it surfaced is fixed here: `writeActiveFolder` now runs on `Dispatchers.IO`.

## Every interactive terminal left the directory VS Code gave it

bash runs `.bashrc` for every interactive shell, including the ones the server started in a directory it picked. The server's `getCwd` takes the launch config's `cwd` first, then `terminal.integrated.cwd`, then the active workspace folder; the unconditional `cd` at the end of `.bashrc` overrode all three. Affected: the explorer's Open in Integrated Terminal, an extension's `createTerminal({cwd})`, the setting, and the directory a revived persistent terminal was restored to. Tasks are **not** affected and never were: they run `bash -c`, which is non-interactive and reads `BASH_ENV`, where there is no `cd`.

The `cd` is guarded on `[ "$PWD" -ef "$HOME" ]`, which is the one directory the server never picks on purpose, being the last fallback in `getCwd` and reached only when no workspace folder is open. `-ef` compares device and inode rather than text, because `$PWD` comes from `getcwd()` in the child while `$HOME` is a string this app exported.

`createBashrc` only writes when the file is absent, so a source change alone would never reach an installed device. `ensureStartupDirGuard` runs at every launch and rewrites the unguarded block, matching the historical text byte for byte so that a block the user edited matches nothing and is left as they wrote it.

## The Java toolchain shipped with none of OpenJDK's notices

`download-java.sh` deleted `legal/`, filed with `demo/` and `man/` under one comment about stripping documentation. Removing those two takes their subject matter away with them; removing `legal/` takes only the attribution for everything that stays, and `lib/modules` still carries all seventy modules. Measured on this machine: the built Java pack has zero notice files anywhere in its tree, while the Ruby pack has per-gem licence files.

It is kept now and copied with `cp -RL`, because 208 of its 239 entries are symlinks and neither an asset pack nor the release ZIP can carry one: `ToolchainManager.extractZip` writes every non-directory entry with a `FileOutputStream`, so a link would arrive on a device as a text file naming a path that is not there. A new step refuses to build a pack whose notices are absent, or present only as links, and `check-library-attribution.py` gains a coarse backstop for the same question. `docs/LEGAL_NOTICES.md` and `NOTICE.md` record where the notices travel and close the missing source offer for OpenJDK.

## Also

The external-URL failure log no longer passes the throwable. `Log.e` prints it with its message, and `ActivityNotFoundException` quotes the whole Intent including the URL, so that line redacted its interpolation and then handed the same URL to logcat inside the trace. The sibling site in `AndroidBridge` was fixed for this reason already; this is the one the predicate guarding it could not reach, because it inspects the message argument only.

## Verification

Thirty-one negative controls across the two Kotlin changes. Thirty reddened the case they target on the first attempt. One stayed green and the cause was a decorative clause in `tlsHostLabel`, which was deleted rather than papered over: an empty URL reaches the same null through `URI("").host`.

Ten more for the shell change, including four that run real bash against the generated file and one that measures what `[ -d ]` is actually for: with the recorded folder merely deleted the `||` already handles it, so the clause only shows up when the recorded file is empty, where `cd ""` succeeds and moves nowhere.

The notices gate was driven through four states, each with its own message: a correct tree, a deleted `legal/`, a tree copied without `-L`, and an empty `legal/`. The last of those found a defect in the gate itself, since an empty heredoc still feeds `read` one blank line.

Full unit suite 1342 tests, no failures. Lint unchanged at 53 warnings. The bridge API spec gate, the relay harness and the process-monitor harness all pass.

Two things are not verifiable off-device and are written up rather than claimed: that Android invokes `onReceivedSslError` for a Simple Browser iframe, which `docs/DEVICE_TEST_CHECKLIST.md` now covers, and which line the StrictMode policy reports first.