### PR TITLE
docs: correct claims the code has since outgrown

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -231,7 +231,7 @@ VSCodroid/
 | `keyboard/ExtraKeyRow.kt` | Multi-page key bar with ViewPager2 and dot indicators |
 | `keyboard/GestureTrackpad.kt` | 3-speed drag-to-cursor-navigate widget: touch plumbing and drawing |
 | `keyboard/TrackpadGesture.kt` | The gears and the arrows a drag earns, with no Android types, so it can be tested on the JVM |
-| `keyboard/KeyInjector.kt` | Injects KeyboardEvent into WebView via JS |
+| `keyboard/KeyInjector.kt` | Types characters as real key presses; sends non-text keys and chords as KeyboardEvents via JS |
 | `service/NodeService.kt` | Foreground Service (specialUse) to keep Node.js alive |
 | `service/ProcessManager.kt` | Node.js process lifecycle, health check, auto-restart |
 | `setup/FirstRunSetup.kt` | Asset extraction, symlink creation, settings, .bashrc |
@@ -631,12 +631,14 @@ adb shell dumpsys meminfo com.vscodroid.debug
 adb shell ps -A | grep libnode
 ```
 
-There is no `server.log`; nothing here writes one. The Node process's stdout and stderr are
-merged and forwarded line by line to logcat by `ProcessManager`, under
-`VSCodroid.ProcessManager` with a `[node]` prefix. That goes through `Logger.d`, which emits
-only when the package is debuggable, so the lines are in a debug build and not in a release
-one. The editor server keeps its own logs on device, in the directory `ProcessManager` hands
-it as `--logsPath` (`Environment.getLogsDir`):
+The Node process's stdout and stderr are merged and forwarded line by line to logcat by
+`ProcessManager`, under `VSCodroid.ProcessManager` with a `[node]` prefix. That goes through
+`Logger.d`, which emits only when the package is debuggable, so the lines are in a debug
+build and not in a release one. The same reader also appends every line to `server.log`
+through `ServerLog`, in every build, which is what `CrashReporter.generateBugReport` reads
+its last 200 lines from. That file sits beside `remoteagent.log`, which the editor server
+writes itself, in the directory `ProcessManager` hands it as `--logsPath`
+(`Environment.getLogsDir`):
 
 ```bash
 adb shell run-as com.vscodroid.debug ls files/home/.vscodroid/data/logs

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1151,10 +1151,26 @@ gradle.taskGraph.whenReady {
                 "without ${missing.size} of the ${packagingGateNames.size} checks " +
                 "that decide whether the tree may ship:\n" +
                 missing.joinToString("\n") { "  $it" } +
-                "\n\nThe checks are attached by name shape to tasks called " +
-                "merge*Assets. A task above matched that shape and carries none of " +
-                "them, so the attachment is no longer reaching this variant. Fix " +
-                "the tasks.matching predicate that wires them, not this message."
+                "\n\nThe checks are attached by name shape to tasks called merge*Assets. " +
+                // Which advice is right depends on how many are missing, and saying
+                // the wrong one costs an afternoon in the common case. All of them
+                // absent means the attachment stopped reaching this variant. Some of
+                // them absent means it is reaching it, since the rest arrived, so the
+                // predicate is not the suspect: `-x checkPatchFingerprints` on an
+                // assembleDebug produces exactly this, measured, and sending that
+                // reader to rewrite a working predicate is misdirection. The total
+                // case is also nearly unproducible, because a genuine rename is
+                // caught by the MergeSourceSetFolders branch above before it ever
+                // reaches here.
+                if (missing.size == packagingGateNames.size) {
+                    "A task above matched that shape and carries none of them, so the " +
+                        "attachment is no longer reaching this variant. Fix the " +
+                        "tasks.matching predicate that wires them, not this message."
+                } else {
+                    "The rest of them are attached and present, so the wiring is intact. " +
+                        "A gate excluded with -x is the usual cause; re-run without the " +
+                        "exclusion, or restore the gate if it was deleted."
+                }
         )
     }
 }

--- a/android/app/src/androidTest/README.md
+++ b/android/app/src/androidTest/README.md
@@ -107,8 +107,10 @@ That accounted for 21 tests and roughly 52 s of test time. This paragraph claime
 three minutes for a long time; the recorded run says otherwise, which is what
 reading the XML is for.
 
-**At HEAD there are 26 tests across seven classes**, counted from the sources rather
-than from any run: `SafWatchWiringTest` arrived with the per-directory watch work
+**At HEAD there are 37 tests across eight classes**, counted from the sources rather
+than from any run, with `grep -cE '^\s*@Test'` over this directory:
+`KeyRowAccessibilityInstrumentedTest` arrived with the extra key row's accessibility
+work and adds eleven, `SafWatchWiringTest` arrived with the per-directory watch work
 and adds five, `ExtractionOnDeviceTest` arrived with the first-run setup work and
 adds four, and the classes have moved since besides. No recorded run covers
 this set, so there is no honest wall-clock figure to quote for it — the 52 s above
@@ -126,6 +128,7 @@ minutes". Read the times out of your own run's XML.
 | `SafWatchWiringTest` | That those semantics are wired up: a save two directories down and a `.vscode/` settings file are both queued for write-back, a scratch file beside an ordinary one is not, deleting a watched directory releases its watch, and a skipped directory is never watched at all. The layer above `FileObserverTreeSemanticsTest` — that one proves the platform behaves as assumed, this one proves the assumption was used. |
 | `ToolchainInsetsTest` | With edge-to-edge enforced, the Toolchains screen stays out of both system bars: toolbar below the status bar, grid above the navigation bar. The screen shipped drawing its title under the clock, so this is the regression the padding exists to prevent. |
 | `ExtractionOnDeviceTest` | The parts of bundled-extension extraction a JVM cannot answer: that `AssetManager.list()` returns an empty array for a leaf, which is the basis on which `extractAssetDir` decides file-or-directory and which every unit test stubs; that `deleteRecursively()` succeeds on app-private storage, which the retry after a failed unpack depends on; and the abort-and-retry itself, driven by a real out-of-space condition. Redirects `getFilesDir()` through a `ContextWrapper` so the real AssetManager stays in play, so it needs no server tree and no first-run setup. |
+| `KeyRowAccessibilityInstrumentedTest` | The extra key row and the trackpad as an accessibility service would find them: every key carries a content description, a latched modifier and the open alternates layer say so in their node state, a key with no alternates advertises no long click, each key clears 48dp on a mainstream phone, and the trackpad offers one action per arrow. It reads the `AccessibilityNodeInfo` and performs the actions it advertises by id rather than tapping. A `View` initialiser touches resources on its first line, so none of this is reachable from the JVM suite; the unit tests next door assert the wiring by reading the source instead. The view has to be inside a real window, because a detached one reports almost nothing. |
 
 ## A green run is not necessarily a run
 

--- a/android/app/src/androidTest/kotlin/com/vscodroid/storage/SafWatchWiringTest.kt
+++ b/android/app/src/androidTest/kotlin/com/vscodroid/storage/SafWatchWiringTest.kt
@@ -76,18 +76,18 @@ class SafWatchWiringTest {
     }
 
     /**
-     * The queued jobs, read as an untyped collection.
+     * The queued jobs, as the strings a `SyncJob` prints.
      *
-     * `SyncJob` is `internal`, and whether that reaches an instrumented source set is a
-     * question this file does not need to answer: a data class prints its fields, and the
-     * local path is one of them.
+     * Asked of the session rather than of the engine. The queue used to be a field on
+     * `SafSyncEngine` and was read here by reflection; it moved onto [WatchSession], and
+     * a name that no longer exists fails at `getDeclaredField` rather than at an
+     * assertion, so three of these five tests could only throw. Nothing catches that
+     * outside a device run, and nothing runs these on one automatically.
+     *
+     * `SyncJob` is `internal` and is deliberately not named in this signature: a data
+     * class prints its fields, and the local path is one of them.
      */
-    private fun queued(): List<String> {
-        val queue = SafSyncEngine::class.java.getDeclaredField("writeBackQueue")
-            .apply { isAccessible = true }
-            .get(engine) as Collection<*>
-        return queue.map { it.toString() }
-    }
+    private fun queued(): List<String> = engine.session.queue.map { it.toString() }
 
     /**
      * Read under the engine's own monitor, not the map's. The observer thread mutates

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -50,7 +50,7 @@
              ProgressBars carry style="?android:attr/progressBarStyleHorizontal",
              whose TRACK colour comes from the theme. Their fill is pinned by
              progressTint, so what can go stale after a night flip is the shade of
-             a progress track, against the alternative of restarting an 875 MB
+             a progress track, against the alternative of restarting an 810 MB
              extraction. Sweep for it with '?[a-zA-Z:]*attr/', not '?attr/': the
              narrower pattern cannot see ?android:attr and is what missed these.
 

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -399,10 +399,7 @@ class MainActivity : AppCompatActivity() {
             }
         }
 
-        // The other direction: documents the device holds that did not reach the editor.
-        // Its own wording, because "the only copy is inside VSCodroid" is the opposite of
-        // true for these, and would send the user looking for a file that is safe.
-        // The outbound direction of the same silence: a folder created in the editor
+        // The same silence, a whole folder at a time: a folder created in the editor
         // that did not arrive whole on the device. One notice per folder, and the cap
         // gets its own wording because it is a limit this app chose rather than the
         // device refusing.
@@ -417,6 +414,9 @@ class MainActivity : AppCompatActivity() {
             }
         }
 
+        // The other direction: documents the device holds that did not reach the editor.
+        // Its own wording, because "the only copy is inside VSCodroid" is the opposite of
+        // true for these, and would send the user looking for a file that is safe.
         safManager.onDocumentsNotCopied { count, outOfRoom ->
             runOnUiThread {
                 Toast.makeText(

--- a/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
@@ -2390,8 +2390,11 @@ claude() {
         /**
          * What the pre-flight requires, in whole MB, for messages shown to the
          * user. Asking [FirstRunSetup] rather than repeating a literal in the UI:
-         * a screen telling someone to free 500 MB when 875 is needed sends them
-         * to clear space, come back, and fail again in the same place.
+         * a screen telling someone to free 500 MB when 873 is needed sends them
+         * to clear space, come back, and fail again in the same place. (873 is
+         * the gate on a fresh install today: 809.5 MiB of assets plus the 64 MiB
+         * of [EXTRACTION_SLACK_BYTES]. It moves with the asset tree, which is
+         * the reason this function exists rather than a literal in the UI.)
          *
          * The refusal that has just happened is the honest answer, and the
          * whole-tree figure is the fallback for a caller asking before any

--- a/android/app/src/main/kotlin/com/vscodroid/util/CrashReporter.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/util/CrashReporter.kt
@@ -69,10 +69,13 @@ object CrashReporter {
      * - Device info (model, Android version, app version)
      * - Memory usage
      * - How many crash logs exist, plus the text of the three most recent
+     * - The last 200 lines of the Node server's output, from the `server.log`
+     *   that [ServerLog] writes off `ProcessManager.startOutputReader`
      *
-     * Not the server's output: the block below reads a `server.log` that
-     * nothing writes, so that section never appears. `docs/05-API_SPEC.md`
-     * and the logging table in `docs/03-ARCHITECTURE.md` say the same.
+     * That last section used to be dead: nothing wrote the file, so the block
+     * below found nothing and every report shipped without a line of server
+     * output. It is written now, in every build, which is the only reason the
+     * block is worth keeping.
      *
      * The report is copied to the clipboard and handed back across the JS
      * bridge, so everything read off disk goes through [redactToken] first: the

--- a/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainInstallSpaceTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainInstallSpaceTest.kt
@@ -37,12 +37,22 @@ class ToolchainInstallSpaceTest {
     }
 
     /**
-     * The Play path holds one copy, not two, and the difference is where the first sits.
+     * The Play path is charged for one copy, not two, and the difference is when the
+     * first one is written rather than where.
      *
-     * Play writes the pack outside `filesDir` before this app hears about it, so the
-     * only allocation the install makes is the copy into `usr/`, and `removePack` frees
-     * Play's copy afterwards. Charging for both would refuse devices for room they never
-     * need at once, which is the mirror of the mistake the HTTP figure was corrected for.
+     * Play delivers into `filesDir/assetpacks`, so by the time this figure is asked for,
+     * the delivered tree is already sitting on the filesystem `StatFs(filesDir)` measures
+     * and is already counted against it. The only NEW allocation the install makes is the
+     * copy into `usr/`, which is what this charges for; `removePack` frees Play's copy
+     * afterwards. Charging for both would double-count a tree already on disk.
+     *
+     * Peak usage is still two trees, which is why the reason matters more than the
+     * figure: it decides what to do when an install is refused for space. See
+     * `packInstallBytes`' KDoc for the bytecode this was verified from, and for the
+     * consequence, which is that deleting Play's copy on a refusal buys the retry
+     * nothing. The reason recorded here used to be that Play writes the pack outside
+     * `filesDir`, which is not what it does; the assertions below are the same either
+     * way, so nothing failed when that was disproved.
      */
     @Test
     fun `the Play reservation charges for the copy it makes and not for Play's own`() {

--- a/docs/03-ARCHITECTURE.md
+++ b/docs/03-ARCHITECTURE.md
@@ -319,7 +319,7 @@ flowchart TD
 - Additional languages can be added later by long-pressing the launcher icon and choosing **Manage
   toolchains**. There is no Settings entry: `ToolchainActivity` is not exported and the launcher
   shortcut `SplashActivity.publishToolchainShortcut()` pushes is the only route to it
-- Sideloads are served by the same registry rather than by the APK: `ToolchainManager.shouldUseHttpFallback()` reads `getInstallSourceInfo().installingPackageName`, and anything other than `com.android.vending` sends `install()` into `downloadViaHttp()`, which fetches the `releases/latest` ZIP that `ToolchainRegistry` records as each entry's `downloadUrl`
+- Sideloads are served by the same registry rather than by the APK: `ToolchainManager.shouldUseHttpFallback()` reads `getInstallSourceInfo().installingPackageName`, and anything other than `com.android.vending` sends `install()` into `downloadViaHttp()`, which fetches the `releases/latest` ZIP that `ToolchainRegistry` records as each entry's `downloadUrl`. `ToolchainManager.pinLatest` resolves that URL before the transfer: this build's own `releases/download/v<versionName>/` asset when the release publishes it, otherwise the tag `releases/latest` currently redirects to, and the unpinned `latest` URL if neither can be resolved. Pinning is what keeps a ZIP and the `toolchains.sha256` it is checked against from coming out of two different releases
 
 **Trade-off**: Requires internet for toolchain download after initial install. Core functionality (Node.js, Python, Git) works fully offline.
 
@@ -460,7 +460,7 @@ flowchart TD
   B1 --> B1a[".vscodroid/ (VS Code data folder)"]
   B1a --> B1a1["extensions/ (installed extensions)"]
   B1a --> B1a2["data/Machine/settings.json (default settings the server reads)"]
-  B1a --> B1a3["data/logs/remoteagent.log (server log)"]
+  B1a --> B1a3["data/logs/ (remoteagent.log, written by the server;<br/>server.log, the process output mirrored by ServerLog)"]
   B1a --> B1a4["data/token (connection token, mode 0600)"]
   B1 --> B1b[".gitconfig"]
   B1 --> B1c[".ssh/ (SSH keys)"]
@@ -508,15 +508,21 @@ under the bare `VSCodroid`. Filter on a full tag, for example
 | Component | Log Destination | Level |
 |-----------|----------------|-------|
 | Kotlin | Logcat, tag `VSCodroid.<class>` (`VSCodroid.MainActivity`, `VSCodroid.ProcessManager`, and so on) | INFO (release), DEBUG (debug) |
-| Node.js server | stdout with stderr merged into it, read by `ProcessManager.startOutputReader` and re-logged line by line as `[node] ...` under `VSCodroid.ProcessManager` | DEBUG, so debug builds only |
+| Node.js server | stdout with stderr merged into it, read by `ProcessManager.startOutputReader`, which both re-logs each line as `[node] ...` under `VSCodroid.ProcessManager` and appends it to `server.log` through `ServerLog` | the Logcat copy is DEBUG, so debug builds only; the `server.log` copy is written in every build |
 | Extension Host | worker_thread inside the server process (patch `0004`); `ExtensionHostConnection` pipes the worker's stdout and stderr into the server's log service, which writes them to `remoteagent.log` and prints them on the server console, from where the row above carries them into Logcat | INFO into `remoteagent.log` in every build; the Logcat copy is DEBUG, arriving as `[node]` lines |
 | WebView | `VSCodroidWebChromeClient.onConsoleMessage` mirrors every console message into Logcat under `VSCodroid.WebChromeClient`; Chrome DevTools additionally attaches on debug builds | ERROR and WARNING in every build, everything else DEBUG |
 
-Nothing writes `server.log` or `exthost.log`. `CrashReporter.generateBugReport` looks for
-the first under `Environment.getLogsDir` (`filesDir/home/.vscodroid/data/logs`) and never
-finds it, so a bug report carries no server-log section. That directory is not empty,
-though: `ProcessManager.startServer` points the server's `--logsPath` at it, and the
-server's own log service writes `remoteagent.log` there, Extension Host output included.
+`server.log` is written, `exthost.log` is not. `ProcessManager` holds a `ServerLog` over
+`Environment.getLogsDir` (`filesDir/home/.vscodroid/data/logs`) and appends every line
+`startOutputReader` receives to it, in every build rather than only in a debug one: the
+Logcat copy above is `Logger.d` and therefore nowhere in a release build, which is why the
+same line is also kept on disk. The token is replaced on the way in, and the file is
+rotated to its last lines once it outgrows a byte cap, so it cannot grow without bound.
+`CrashReporter.generateBugReport` appends the last 200 lines of it to every report.
+
+That directory holds more than this app writes: `ProcessManager.startServer` points the
+server's `--logsPath` at it, and the server's own log service writes `remoteagent.log`
+there, Extension Host output included. Nothing writes `exthost.log` under any name.
 
 ### 8.3 Configuration
 

--- a/docs/04-TECHNICAL_SPEC.md
+++ b/docs/04-TECHNICAL_SPEC.md
@@ -253,7 +253,8 @@ flowchart TD
   APP --> KEY["keyboard/"]
   KEY --> KEY1["ExtraKeyRow.kt (Custom View for extra keys)"]
   KEY --> KEY2["ExtraKeyButton.kt (Individual key button)"]
-  KEY --> KEY3["KeyInjector.kt (evaluateJavascript key injection)"]
+  KEY --> KEY3["KeyInjector.kt (real key presses for characters, JS KeyboardEvents for chords)"]
+  KEY --> KEY4["TextEntry.kt (isTextEntry: which of the two routes a press takes)"]
   APP --> SETUP["setup/"]
   SETUP --> SET1["FirstRunSetup.kt (Binary extraction, initialization)"]
   SETUP --> SET2["ToolchainManager.kt (On-demand toolchain install)"]
@@ -473,28 +474,30 @@ modifier clears exactly as it does on an ordinary key.
 
 ### 5.2 Key Injection
 
-Keys are injected into the WebView via JavaScript evaluation:
+`KeyInjector.injectKey` has two routes, and `isTextEntry` (`TextEntry.kt`) chooses
+between them. No snippet is reproduced here: this section carried one for a long time,
+it drifted from the signature, the event pair and the quoting all at once, and a stale
+copy of the code is worse than a pointer to it. `KeyInjector.kt` is the source of truth.
 
-```kotlin
-fun injectKey(key: String, ctrl: Boolean, alt: Boolean, shift: Boolean) {
-    val js = """
-        (function() {
-            var event = new KeyboardEvent('keydown', {
-                key: '$key',
-                code: '${keyToCode(key)}',
-                keyCode: ${keyToKeyCode(key)},
-                ctrlKey: $ctrl,
-                altKey: $alt,
-                shiftKey: $shift,
-                bubbles: true,
-                cancelable: true
-            });
-            document.activeElement.dispatchEvent(event);
-        })();
-    """.trimIndent()
-    webView.evaluateJavascript(js, null)
-}
-```
+**Characters are typed.** A single ASCII character in `0x20..0x7E` pressed with no Ctrl,
+Alt or Meta goes through `typeCharacter`, which asks `KeyCharacterMap.VIRTUAL_KEYBOARD`
+for the presses that produce it and dispatches them at the WebView as real Android
+`KeyEvent`s. The map supplies Shift itself where the character needs it, so no table of
+shifted forms is written by hand. This route exists because a `KeyboardEvent` constructed
+in the page is untrusted: listeners run, no default action is performed, and the
+character is never inserted. That is what made `{`, `;` and `"` do nothing at all.
+
+**Everything else is announced.** A key that names a command rather than a character
+(`Tab`, `Escape`, `F7`, `PageDown`), and any key held with Ctrl, Alt or Meta, is sent as
+a `keydown`/`keyup` pair built by `evaluateJavascript` at `document.activeElement`, since
+that is what the workbench resolves its key bindings from. Values going into that script
+are escaped by `KeyMapping.jsQuote`.
+
+A latched Shift is resolved before the split, by `KeyMapping.shiftedForm`, because it
+changes which character is typed rather than whether it is typed. If `typeCharacter`
+cannot produce a press on the layout in force it returns false and the announce route
+runs instead; that preserves the keystroke but still inserts nothing, and it logs a
+warning rather than a debug line so the case is visible in a release build.
 
 ### 5.3 Visibility Control
 
@@ -648,7 +651,7 @@ is absent.
 flowchart TD
   A["1. User selects a toolchain<br/>(first-run picker, or the launcher icon's Manage toolchains shortcut)"] --> B{"2. Install source is com.android.vending?"}
   B -- "Yes" --> C["3a. assetPackManager.fetch(packName)"]
-  B -- "No" --> D["3b. downloadViaHttp(): toolchain_<name>.zip from releases/latest, sha256 checked"]
+  B -- "No" --> D["3b. downloadViaHttp(): toolchain_<name>.zip, sha256 checked<br/>pinLatest resolves the URL first: this version's own release if it<br/>publishes the asset, else the tag releases/latest points at, else releases/latest"]
   C --> E["4. installFromDirectory(): copy into filesDir/usr"]
   D --> E
   E --> F["5. chmod +x binaries, create symlinks in usr/bin/"]

--- a/docs/05-API_SPEC.md
+++ b/docs/05-API_SPEC.md
@@ -98,13 +98,28 @@ These methods are called from Kotlin via `evaluateJavascript()`:
 
 There is no `window.__vscodroid.injectKey`, and this block described one until it
 was checked. The page is not asked to inject anything: `KeyInjector.injectKey` is
-Kotlin, and it evaluates a script that builds a `KeyboardEvent` and dispatches it
-straight at the focused element. Nothing needs to be defined on the page for that
-to work, and defining a hook by that name — which is what following the old text
-led to — leaves a function nothing ever calls.
+Kotlin, and it delivers the press itself, by one of two routes.
+
+A printable ASCII character pressed with no Ctrl, Alt or Meta is **typed**, as
+real Android `KeyEvent`s dispatched through `webView.dispatchKeyEvent`. A
+`KeyboardEvent` built in the page is untrusted, so the browser runs the listeners
+and performs no default action: that is why `{` announced as a DOM event inserted
+nothing at all. Text has to enter through the browser's own input path, and a real
+key press is the only way into it from Kotlin.
+
+Everything else is **announced**: a key spelled out rather than typed (`Tab`,
+`Escape`, `PageDown`), and any key held with Ctrl, Alt or Meta, becomes the
+`KeyboardEvent` below, because that is what the workbench resolves its bindings
+from. `isTextEntry` decides which route a press takes and `typeCharacter` is the
+first of them; both live in the `keyboard` package beside `KeyInjector`.
+
+Nothing needs to be defined on the page for either route to work, and defining a
+hook by that name — which is what following the old text led to — leaves a function
+nothing ever calls.
 
 ```javascript
-// What Kotlin evaluates, in outline. KeyInjector.kt is the source of truth.
+// What Kotlin evaluates on the announce route, in outline. A typed character
+// never reaches this. KeyInjector.kt is the source of truth.
 var target = document.activeElement || document.body;
 target.dispatchEvent(new KeyboardEvent('keydown', eventInit));
 target.dispatchEvent(new KeyboardEvent('keyup', eventInit));
@@ -459,11 +474,13 @@ fun generateBugReport(authToken: String): String
 // - Device info (model, Android version, app version)
 // - Memory usage
 // - How many crash logs exist, plus the text of the three most recent
-// Node.js server output is not in it, despite the section the code still
-// builds for it: ProcessManager reads the server's stdout and logs it in
-// debug builds, and no file is written for this to read.
+// - The last 200 lines of the Node server's output, read from `server.log`
+//   under Environment.getLogsDir. ProcessManager.startOutputReader mirrors
+//   every line the server prints into that file through ServerLog, in every
+//   build, so the section is present rather than silently empty.
 // Everything read off disk has the connection token replaced wherever it
-// appears as a `tkn=` parameter.
+// appears as a `tkn=` parameter, and the server log is redacted a second
+// time on the way in so the token never lands in the file at all.
 
 @JavascriptInterface
 fun clearCrashLogs(authToken: String)

--- a/docs/07-TESTING_STRATEGY.md
+++ b/docs/07-TESTING_STRATEGY.md
@@ -22,8 +22,8 @@ VSCodroid has unique testing challenges: it's a hybrid app (Kotlin + WebView + N
 
 ```mermaid
 flowchart TD
-  E2E["Manual / E2E Tests<br/>Real devices, UX testing<br/>14 scenarios"] --> INT["Instrumented Tests<br/>WebView + Node.js + Kotlin<br/>26 tests, run by hand on a device"]
-  INT --> UNIT["Unit Tests<br/>1296 Kotlin tests in 203 classes (JVM)<br/>8 node:assert scripts for the bundled JavaScript"]
+  E2E["Manual / E2E Tests<br/>Real devices, UX testing<br/>14 scenarios"] --> INT["Instrumented Tests<br/>WebView + Node.js + Kotlin<br/>37 tests, run by hand on a device"]
+  INT --> UNIT["Unit Tests<br/>1307 Kotlin tests in 205 classes (JVM)<br/>8 node:assert scripts for the bundled JavaScript"]
 ```
 
 ---
@@ -46,7 +46,9 @@ flowchart TD
 | SafSyncEngine | Mirror reconciliation, write-back filtering, rename pairing | `SafSyncEngineTest`, `SafWriteBackFilterTest`, `SafRenamePairingTest` |
 | VSCodroidWebViewClient | CDN interception, `vscode-remote` resource serving, downloads | `ResourceInterceptionWiringTest`, `WebviewResourceResolutionTest`, `DownloadCoordinatorTest` |
 
-The suite is **1296 tests in 203 classes**, and it is green. A test that needs a
+The suite is **1307 tests in 205 classes**, and it is green. Both figures come from
+the XML a run writes under `app/build/test-results/testDebugUnitTest/`, one file per
+class, rather than from a figure carried forward. A test that needs a
 filesystem builds its tree under a JUnit `@TempDir` rather than touching the
 checkout.
 
@@ -79,8 +81,10 @@ coverage task, no threshold, and nothing in any workflow that reads one.
 
 ### 3.2 Instrumented Tests
 
-Twenty-six tests across seven classes, in `android/app/src/androidTest/`. They
+Thirty-seven tests across eight classes, in `android/app/src/androidTest/`. They
 need an `arm64-v8a` device or emulator, because the app ships that ABI alone.
+Counted from the sources (`grep -cE '^\s*@Test'` over the directory), because no
+run covers the whole set and none of it is scheduled.
 
 | Test | Description | Setup |
 |------|-------------|-------|
@@ -91,6 +95,7 @@ need an `arm64-v8a` device or emulator, because the app ships that ABI alone.
 | **ToolchainInsetsTest** | With edge-to-edge enforced, the Toolchains screen stays clear of the status and navigation bars | arm64 device |
 | **FileObserverTreeSemanticsTest** | The platform behaviour SAF write-back rests on: a watch covers a directory and not a tree, and an event reports the bare entry name | arm64 device |
 | **SafWatchWiringTest** | That those semantics are wired up: a save two directories down is queued for write-back, a scratch file beside it is not, and a skipped directory is never watched | arm64 device |
+| **KeyRowAccessibilityInstrumentedTest** | The extra key row's screen-reader surface: content descriptions, the state a latched modifier and the alternates layer announce, per-key touch targets, and the trackpad's one action per arrow | arm64 device |
 
 **Framework**: AndroidJUnit4 + Espresso + UI Automator (JUnit 4, on device)
 
@@ -179,6 +184,14 @@ Manual test scenarios that verify the full user experience:
 | Color contrast | Native UI elements meet WCAG AA contrast ratio (4.5:1) | Accessibility Scanner app |
 
 > **Note**: WebView accessibility (VS Code UI) is managed by VS Code itself and the Chromium WebView engine. Native accessibility testing focuses on the Android shell: Extra Key Row, splash screen, dialogs, notifications, and Toolchain Manager UI.
+
+**Manual is not the same as unguarded** for the extra key row. The rows above are the
+whole-app sweep; `KeyRowAccessibilityInstrumentedTest` (§3.2) already pins that one
+surface, including the content descriptions, what a latched modifier and the alternates
+layer announce, and the 48dp touch targets. It takes the route a screen reader takes,
+reading the `AccessibilityNodeInfo` off a view held in a real window and performing the
+actions it advertises by id, rather than tapping coordinates: an injected tap arrives
+below the layer being tested, so its silence would prove nothing.
 
 **Run**: Before each major release, on reference device with TalkBack
 

--- a/docs/10-RELEASE_PLAN.md
+++ b/docs/10-RELEASE_PLAN.md
@@ -100,7 +100,7 @@ jobs:
 
 | Workflow | Schedule | Purpose | Failure Action |
 |----------|----------|---------|----------------|
-| `patch-drift.yml` | Monday 04:00 UTC, or dispatched with a tag | Applies `patches/` against an upstream VS Code tag with `git apply --check` | Rebase the patch set before the next version bump |
+| `patch-drift.yml` | Monday 04:00 UTC, or dispatched with a tag | Applies every patch in `patches/` to an upstream VS Code tag, cumulatively and in glob order, the way the build does. Not `git apply --check`: two patches touch the same server source, so checking them independently would judge the second against a tree the first was supposed to have changed | Rebase the patch set before the next version bump |
 | `r8.yml` | Monday 03:00 UTC, pushes to main, pull requests, or dispatched. The three event triggers are filtered to the files that configure the shrinkers, so a change to Kotlin alone still waits for the cron | Runs R8, the resource shrinker and `lintVitalRelease`, so a dependency that arrives without its consumer rules is caught before a tag | Fix the keep rules, or the shrinker configuration, before tagging |
 
 ### 2.3 Caching Strategy
@@ -456,11 +456,15 @@ holds whatever was compiled last.
 - Each GitHub Release includes: APK, AAB, the toolchain ZIPs, `toolchains.sha256`,
   `checksums.sha256`, a build manifest, and generated release notes (`release.yml`)
 - **The toolchain ZIPs are a delivery channel, not a convenience artifact.**
-  `ToolchainRegistry` points every non-Play install at `releases/latest/download/`, so a release
-  that omits them, or that publishes them without the matching `toolchains.sha256`, breaks
-  toolchain installation for those users, including ones who already have the app. The packs in
-  the AAB and the ZIPs on the release are built from the same download in the same job, so the
-  two channels cannot ship different toolchain versions for one app version.
+  `ToolchainRegistry` points every non-Play install at `releases/latest/download/`, and
+  `ToolchainManager.pinLatest` then prefers `releases/download/v<versionName>/` when that
+  release publishes the asset, falling back to `latest` when it does not. A release that omits
+  the ZIPs, or that publishes them without the matching `toolchains.sha256`, therefore breaks
+  toolchain installation for every install that resolves through it. Both halves have to hold:
+  an app version's own release is asked first, and `latest` still has to carry the ZIPs for
+  every install that falls back to it. The packs in the AAB and the ZIPs on the release are
+  built from the same download in the same job, so the two channels cannot ship different
+  toolchain versions for one app version.
 
 ### 8.3 Future: F-Droid
 


### PR DESCRIPTION
Every document here describes intent at the moment it was written, and several stopped matching the code. Each item below was checked against the code before the text was changed, and three of the corrections are to claims that turned out to be right, so the documents were left alone and the reasons are recorded here instead.

## A test that could only throw, and stayed green everywhere

`SafWatchWiringTest.queued` reads the write-back queue by reflection as `SafSyncEngine::class.java.getDeclaredField("writeBackQueue")`. That field moved onto `WatchSession`, so the call could only throw and the three cases that use it could only fail. It now reads `engine.session.queue`.

Nothing automated would have caught it: no workflow runs `connectedAndroidTest`, and `build.yml` only compiles the instrumented sources. The only invocations are `scripts/device-test.sh` and the command in `androidTest/README.md`.

## Documents that described a mechanism the code no longer has

- **`server.log` is written now.** `ProcessManager.startOutputReader` mirrors every server line into it and `CrashReporter` reads it. Six places still said the file exists but nothing writes it, including `CrashReporter`'s own KDoc, which carried two contradicting blocks with the stale one first.
- **Key injection takes two routes.** A printable character is typed with real `KeyEvent`s through `webView.dispatchKeyEvent`; only non-text keys and chords go through the injected script. Three documents described only the second.
- **HTTP toolchain installs try the release matching the app first.** Three documents described `releases/latest` as the only path.
- **`patch-drift` does not use `git apply --check`.** `scripts/check-patches-apply.sh` applies cumulatively, and its only mention of `--check` is a comment explaining why the flag must not be used.

## Counts, measured rather than estimated

The instrumented figure said twenty-six tests across seven classes. Counted with `grep -rcE '^[[:space:]]*@Test'`: **37 across 8**, with no `@Ignore` anywhere. The same file's JVM figure of 1296 tests in 203 classes was also stale; the run produces 205 result files and 1307 tests.

## Where the claims were checked and rejected

- The release-plan section's stated consequence is **not** backwards. `ToolchainRegistry` really does record `releases/latest/download/...` as each `downloadUrl`, and the pinned path falls back to it in several cases, so `latest` is still live. Only the undocumented pin needed adding.
- The comment moved in `MainActivity` was genuinely attached to the wrong handler, but the claimed way an editor would be misled does not exist: both lambdas name their string resources inline and take differently named parameters. Moving it also stranded a neighbouring sentence that was contrasting with it, so that clause is reworded too.
- Two of the three parts of the packaging-gate message claim were wrong. The count and the names lead the message, so nobody is misled about scope. What was true is that the closing advice only holds when all eight gates are absent, so the message now names the likelier cause first, and both branches were exercised on a dry run.
- The storage figures were not reintroduced into a swept population, and the user-facing string is filled from `requiredStorageMb()` rather than hardcoded. The two comments still disagreed with the measured tree, so both were corrected with the arithmetic recorded: 810 MB extracted, 873 MB demanded by the gate with its slack.

## Also

`ToolchainInstallSpaceTest`'s stated reason for its own assertion was the exact claim that `packInstallBytes`' KDoc was later corrected to refute from the asset-delivery bytecode. Its assertions hold under either reading, which is why nothing failed when the reason was disproved, and the KDoc now says so.

## Verification

Full unit suite 1311 tests, no failures. `:app:assembleDebugAndroidTest` builds, which is what CI does with the instrumented sources and what proves the reflection fix compiles. The bridge API spec gate, the relay harness, and the five python gates that read a document changed here all pass.