### PR TITLE
test(bridge): let the logging guard see the whole call

### DIFF
--- a/android/app/src/test/kotlin/com/vscodroid/bridge/PageSuppliedLoggingTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/bridge/PageSuppliedLoggingTest.kt
@@ -1,5 +1,6 @@
 package com.vscodroid.bridge
 
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.io.File
@@ -41,22 +42,55 @@ class PageSuppliedLoggingTest {
         return bridge.readText().split("@JavascriptInterface").drop(1)
     }
 
-    @Test
-    fun `every page supplied value reaching a log call is redacted`() {
-        val methods = bridgeMethods()
-        // The control for the split above. check-bridge-api-spec.py counts 31 bridge
-        // methods, so a split that returns a handful means the annotation moved or
-        // the file did, and every assertion below would then pass by examining almost
-        // nothing.
-        assertTrue(
-            methods.size >= 25,
-            "only ${methods.size} @JavascriptInterface methods were found; the scan is " +
-                "looking at the wrong thing, and passing here would mean nothing",
-        )
+    /**
+     * From [from] to the end of the statement, following an unclosed bracket onto
+     * the lines that continue it.
+     *
+     * A line-scoped read was the first shape of this scan and it had a hole with
+     * no bottom: a `Logger.…(` whose arguments all sit on continuation lines
+     * yields an empty capture, every question below is asked of nothing, and the
+     * vacuity counter still increments, so the guard reports clean over a call it
+     * never saw. Nothing in this repository forces such a wrap, since there is no
+     * ktlint and no detekt, which is exactly why it would arrive unannounced.
+     *
+     * String literals are stepped over so that an unbalanced parenthesis inside a
+     * message cannot end the statement early. Raw strings are not handled, and no
+     * log call here uses one.
+     */
+    private fun statementFrom(text: String, from: Int): String {
+        var i = from
+        var depth = 0
+        var inString = false
+        while (i < text.length) {
+            val c = text[i]
+            when {
+                inString && c == '\\' -> i++
+                c == '"' -> inString = !inString
+                inString -> {}
+                c == '(' || c == '{' -> depth++
+                c == ')' || c == '}' -> depth--
+                c == '\n' && depth <= 0 -> return text.substring(from, i)
+            }
+            i++
+        }
+        return text.substring(from)
+    }
 
+    /** What one scan found, and how much it looked at. */
+    private data class Scan(val offenders: List<String>, val examined: Int)
+
+    /**
+     * Every page-supplied value that reaches a log call in [source] unredacted,
+     * and every redacted call that hands over the exception beside it.
+     *
+     * Taken as a function of text rather than of the file, so its own correctness
+     * can be put to fixtures below. A scanner that is only ever run against a tree
+     * it reports clean has no evidence that it would report a dirty one.
+     */
+    private fun scan(source: String): Scan {
         val offenders = mutableListOf<String>()
         var examined = 0
-        for (chunk in methods) {
+        for (chunk in source.split("@JavascriptInterface").drop(1)) {
             val signature = Regex("""fun\s+(\w+)\s*\(([^)]*)\)""").find(chunk) ?: continue
             val name = signature.groupValues[1]
             // authToken is the session token the page already holds, and it is never
@@ -70,16 +104,27 @@ class PageSuppliedLoggingTest {
             // A parameter renamed on the way to the log line is the case that made
             // this necessary: `openRecentFolder` logged `uri`, a local built by
             // `Uri.parse(uriString)`, so a search for the parameter name found
-            // nothing. Locals assigned from a parameter carry its taint.
+            // nothing. Locals assigned from a parameter carry its taint, and the
+            // right-hand side is read to the end of the statement rather than the
+            // end of the line, for the reason [statementFrom] gives.
             val tainted = params.toMutableSet()
-            for (m in Regex("""val\s+(\w+)\s*=\s*([^\n]+)""").findAll(chunk)) {
-                if (tainted.any { Regex("""\b$it\b""").containsMatchIn(m.groupValues[2]) }) {
+            for (m in Regex("""val\s+(\w+)\s*=""").findAll(chunk)) {
+                val rhs = statementFrom(chunk, m.range.last + 1)
+                if (tainted.any { Regex("""\b$it\b""").containsMatchIn(rhs) }) {
                     tainted += m.groupValues[1]
                 }
             }
+            // What a catch binds. A throwable is the second channel a log line has,
+            // and redacting the first while handing over the second only looks like
+            // redaction: Log.e prints the throwable with its message, and the
+            // exceptions raised on these paths quote the whole URI or file they
+            // failed on. The message and the trace then disagree about the same
+            // value, one line apart.
+            val caught = Regex("""catch\s*\(\s*(\w+)\s*:""")
+                .findAll(chunk).map { it.groupValues[1] }.toSet()
 
-            for (call in Regex("""Logger\.[diwe]\(([^\n]*)""").findAll(chunk)) {
-                val text = call.groupValues[1]
+            for (call in Regex("""Logger\.[diwe]\(""").findAll(chunk)) {
+                val text = statementFrom(chunk, call.range.last)
                 examined++
                 for (value in tainted) {
                     val interpolated = Regex("""\$\{?$value\b""").containsMatchIn(text)
@@ -88,20 +133,159 @@ class PageSuppliedLoggingTest {
                         offenders += "$name logs $value unredacted: ${text.trim()}"
                     }
                 }
+                if (text.contains("redactToken(")) {
+                    for (binding in caught) {
+                        if (Regex(""",\s*$binding\s*\)""").containsMatchIn(text)) {
+                            offenders += "$name redacts its message and then hands over " +
+                                "$binding, whose own message repeats what was redacted: " +
+                                text.trim()
+                        }
+                    }
+                }
             }
         }
+        return Scan(offenders, examined)
+    }
 
-        // The second control. If no bridge method logs any of its own values, the
-        // loop above proves nothing, and a refactor that moved every log line out
-        // would leave this test green while removing everything it watches.
+    @Test
+    fun `every page supplied value reaching a log call is redacted`() {
+        val methods = bridgeMethods()
+        // The control for the split. check-bridge-api-spec.py counts 31 bridge
+        // methods, so a split that returns a handful means the annotation moved or
+        // the file did, and every assertion below would then pass by examining
+        // almost nothing.
         assertTrue(
-            examined > 0,
+            methods.size >= 25,
+            "only ${methods.size} @JavascriptInterface methods were found; the scan is " +
+                "looking at the wrong thing, and passing here would mean nothing",
+        )
+
+        val result = scan(bridge.readText())
+
+        // If no bridge method logs any of its own values, the scan proves nothing,
+        // and a refactor that moved every log line out would leave this green while
+        // removing everything it watches.
+        assertTrue(
+            result.examined > 0,
             "no log call inside any bridge method was examined, so this test is vacuous",
         )
         assertTrue(
-            offenders.isEmpty(),
+            result.offenders.isEmpty(),
             "a value the page supplied reaches a shipping log line in the clear:\n" +
-                offenders.joinToString("\n") { "  $it" },
+                result.offenders.joinToString("\n") { "  $it" },
+        )
+    }
+
+    /**
+     * The scanner against a call whose arguments are all on continuation lines.
+     *
+     * Without this the widening is unverified and can regress to a line-scoped read
+     * silently, because the tree it runs over is clean either way: this is the only
+     * place a wrapped call exists to be found.
+     */
+    @Test
+    fun `a wrapped log call is not invisible to the scan`() {
+        val fixture = """
+            @JavascriptInterface
+            fun openThing(uriString: String, authToken: String) {
+                Logger.w(
+                    tag,
+                    "Opening ${'$'}uriString",
+                )
+            }
+        """.trimIndent()
+
+        val result = scan(fixture)
+
+        assertEquals(1, result.examined, "the wrapped call was not counted at all")
+        assertTrue(
+            result.offenders.any { it.contains("uriString") },
+            "a page-supplied value on a continuation line was not seen: ${result.offenders}",
+        )
+    }
+
+    /**
+     * The same widening, on the other side of the scan.
+     *
+     * The taint follows a parameter into a local, and that read was line-scoped
+     * too. A wrapped assignment would leave the local untainted, so the log line
+     * below it reports clean while printing the parameter under another name,
+     * which is precisely the renaming this taint step exists for.
+     */
+    @Test
+    fun `a wrapped assignment still carries the taint`() {
+        val fixture = """
+            @JavascriptInterface
+            fun openThing(uriString: String, authToken: String) {
+                val uri = Uri.parse(
+                    uriString,
+                )
+                Logger.i(tag, "Opening ${'$'}uri")
+            }
+        """.trimIndent()
+
+        val result = scan(fixture)
+
+        assertTrue(
+            result.offenders.any { it.contains("logs uri ") },
+            "the local built from a page-supplied parameter over two lines was not " +
+                "tainted, so the log below it looked clean: ${result.offenders}",
+        )
+    }
+
+    /**
+     * The scanner against the shape that defeats a redaction from the side.
+     *
+     * The message is redacted and the exception is handed over anyway, and the
+     * exception's own message repeats the value. This is the live defect that was
+     * found one file over, in `VSCodroidWebViewClient`, which this class does not
+     * read; the rule is expressed here so a bridge method cannot acquire it.
+     */
+    @Test
+    fun `a redacted message that also hands over its exception is reported`() {
+        val fixture = """
+            @JavascriptInterface
+            fun openThing(url: String, authToken: String) {
+                try {
+                    context.startActivity(intent)
+                } catch (e: Exception) {
+                    Logger.e(tag, "Failed: ${'$'}{redactToken(url)}", e)
+                }
+            }
+        """.trimIndent()
+
+        val result = scan(fixture)
+
+        assertTrue(
+            result.offenders.any { it.contains("hands over e") },
+            "the throwable channel was not examined: ${result.offenders}",
+        )
+    }
+
+    /**
+     * The control for the case above, and the reason it is not simply "never pass a
+     * throwable". A call that redacts nothing has nothing for the trace to
+     * contradict, and one that redacts without handing anything over is the shape
+     * this whole class is asking for.
+     */
+    @Test
+    fun `a redacted message with no throwable is left alone`() {
+        val fixture = """
+            @JavascriptInterface
+            fun openThing(url: String, authToken: String) {
+                try {
+                    context.startActivity(intent)
+                } catch (e: Exception) {
+                    Logger.e(tag, "Failed: ${'$'}{redactToken(url)} (${'$'}{e.javaClass.simpleName})")
+                }
+            }
+        """.trimIndent()
+
+        val result = scan(fixture)
+
+        assertTrue(
+            result.offenders.isEmpty(),
+            "the shape this class exists to ask for was reported as an offence: ${result.offenders}",
         )
     }
 


### PR DESCRIPTION
The predicate that keeps page-supplied values out of logcat read one line per log call and one line per assignment, and asked nothing at all about the throwable beside the message. Three holes of the same shape. None of them lets a value ship today, and all three would let one arrive unannounced.

## What the guard could not see

- **A wrapped call.** `Logger\.[diwe]\(([^\n]*)` captures the empty string for a call whose arguments all sit on continuation lines, so every question is asked of nothing while the vacuity counter still increments. The guard then reports clean over a call it never examined. Nothing in this repository forces that wrap, since there is no ktlint and no detekt, which is exactly why it would arrive without warning.
- **A wrapped assignment.** The same line-scoped read is what carries a parameter into a local. `val uri = Uri.parse(` split across lines left the local untainted, and the log line below it looked clean while printing the parameter under another name. That renaming is the case the taint step exists for: it is how `openRecentFolder` hid its parameter from the sweep that missed it.
- **The throwable argument.** A message that redacts and then hands over the exception anyway. `Log.e` prints the throwable with its message, and the exceptions raised on these paths quote the whole URI or file they failed on, so the redaction and the trace disagree about the same value one line apart. That shape was live in `VSCodroidWebViewClient`, one file this class does not read; the rule is expressed here so a bridge method cannot acquire it.

## What changed

The scan reads to the end of the statement, following an unclosed bracket onto the lines that continue it and stepping over string literals so an unbalanced parenthesis in a message cannot end it early. It collects what each `catch` binds, and reports a call that redacts its message while passing one of those bindings.

It is now a function of text rather than of one file, and four fixtures put its own correctness to the question. A scanner only ever run against a tree it reports clean has no evidence that it would report a dirty one.

## Verification

Three controls, each reddening its own case and nothing else: reverting the call read to line-scoped reddens the wrapped-call fixture, reverting the assignment read reddens the wrapped-assignment fixture, and disabling the throwable check reddens the exception fixture. The fourth fixture is the control in the other direction: a redacted message with no throwable, which is the shape this class exists to ask for, must not be reported.

Full unit suite 1315 tests, no failures.