### PR TITLE
test(a11y): cover three changes nothing would catch

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -471,8 +471,9 @@ tasks.withType<Test> {
     // reader red. Renaming a resource is NOT a control for this: it changes the
     // id, so `processDebugResources` fails first and never reaches the test.
     //
-    //   res/layout    PickerAccessibilityWiringTest
-    //   res/values    PickerAccessibilityWiringTest, ThemeEdgeToEdgeTest
+    //   res/layout    PickerAccessibilityWiringTest, TextContrastTest
+    //   res/values    PickerAccessibilityWiringTest, ThemeEdgeToEdgeTest,
+    //                 TextContrastTest
     //
     // layout/ and values/ only. Nothing reads drawable/, mipmap-*/ or xml/, and
     // the mipmaps are images whose hashes would be paid for on every run and

--- a/android/app/src/main/kotlin/com/vscodroid/SplashActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/SplashActivity.kt
@@ -421,9 +421,11 @@ class SplashActivity : AppCompatActivity() {
         val statusText = TextView(ctx).apply {
             text = getString(R.string.progress_waiting)
             setTextColor(getColor(R.color.colorOnSurface))
-            // 0.7 rather than 0.6: this text is 12sp, so WCAG AA asks 4.5:1 and
-            // dimming #CCCCCC to 0.6 on this window measures 3.62:1. At 0.7 it is
-            // 5.78:1 and still reads as secondary beside the pack name.
+            // 0.7 rather than 0.6: this text is 12sp, so WCAG AA asks 4.5:1, and
+            // dimming #CCCCCC to 0.6 on this window measures 4.58:1, clearing that
+            // line by 0.08. At 0.7 it is 5.78:1 and still reads as secondary beside
+            // the pack name. The 3.62:1 this comment used to quote is the figure for
+            // 0.5, which is what the picker's dimmed labels carried, not for 0.6.
             alpha = 0.7f
             textSize = 12f
         }

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafStorageManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafStorageManager.kt
@@ -44,22 +44,37 @@ class SafStorageManager(private val context: Context) {
      */
     fun onWriteBackFailed(announce: (File) -> Unit) {
         syncEngine.onWriteBackFailed = { file ->
-            val now = System.currentTimeMillis()
-            val last = lastFailureAnnouncedAt.get()
-            // `compareAndSet`, not read-then-write. Two threads genuinely arrive here:
-            // the `saf-writeback` daemon draining the queue, and `Dispatchers.IO`
-            // running the write-backs `initialSync` issues itself. `@Volatile` gave
-            // visibility but not atomicity, so both could read the same stale `last`,
-            // both find the interval elapsed, and both announce for one burst, which
-            // is the wall of toasts the throttle exists to prevent.
-            //
-            // The loser does not retry, deliberately. Losing means another thread has
-            // just announced this same burst, which is the answer the user needed.
-            if (shouldAnnounce(now, last) && lastFailureAnnouncedAt.compareAndSet(last, now)) {
+            if (claimAnnouncement(System.currentTimeMillis(), lastFailureAnnouncedAt.get())) {
                 announce(file)
             }
         }
     }
+
+    /**
+     * Whether the caller that read [last] off the throttle is the one that gets to speak.
+     *
+     * `compareAndSet`, not read-then-write. Two threads genuinely arrive here: the
+     * `saf-writeback` daemon draining the queue, and `Dispatchers.IO` running the
+     * write-backs `initialSync` issues itself. `@Volatile` gave visibility but not
+     * atomicity, so both could read the same stale [last], both find the interval
+     * elapsed, and both announce for one burst, which is the wall of toasts the
+     * throttle exists to prevent.
+     *
+     * The loser does not retry, deliberately. Losing means another thread has just
+     * announced this same burst, which is the answer the user needed.
+     *
+     * [last] is a parameter rather than a read taken here, and that is what makes the
+     * claim assertable: a caller can be handed a reading that another caller has already
+     * consumed, which is the losing thread's whole situation, without any threads being
+     * involved. Racing two of them is not an instrument for this. Measured on this JDK
+     * with both shapes behind a `CyclicBarrier`, the read-then-write version announced
+     * twice in 0 of 50,000 two-thread trials, 0 of 20,000 eight-thread trials and 0 of
+     * 2,000 sixteen-thread ones: the window is one read, a subtraction and one write,
+     * and the throttle confines it to the first instant of each interval, so a race test
+     * would have reported the shape this replaced as green.
+     */
+    internal fun claimAnnouncement(now: Long, last: Long): Boolean =
+        shouldAnnounce(now, last) && lastFailureAnnouncedAt.compareAndSet(last, now)
 
     /**
      * Told when a folder opened without every document reaching the mirror.

--- a/android/app/src/test/kotlin/com/vscodroid/PackStatusTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/PackStatusTest.kt
@@ -245,4 +245,139 @@ class DownloadStateWiringTest {
                 "queue one long Toast each, most of them over the editor",
         )
     }
+
+    /**
+     * Setup failure has to be spoken, because this screen has no other way to say it.
+     *
+     * Setup writes into one label for minutes, and a user who is not touching the screen
+     * hears nothing between the window opening and MainActivity arriving. Without the
+     * announcement "still extracting" and "gave up" sound identical, so the wait ends
+     * only when the user decides to check a screen that has been finished for a while.
+     * This is the only spoken channel for that transition: no layout here sets
+     * `accessibilityLiveRegion`, and the two `announceForAccessibility` calls in the app
+     * are both in this file.
+     *
+     * ⚠️ Source text, not behaviour, for the reason the two cases above are: the call
+     * lives in an Activity method and this module has no Robolectric. It proves the call
+     * is written, not that a screen reader speaks it, and `docs/DEVICE_TEST_CHECKLIST.md`
+     * is the instrument for that half.
+     */
+    @Test
+    fun `a setup failure is spoken as well as painted`() {
+        // 3,192 characters when this was written, in a file of 34,279. Bounded like the
+        // cases above, and load-bearing here for the same reason: this bodyOf counts
+        // braces raw, so an extraction that ran on would find the name in a later
+        // method and report a deleted announcement as a live one.
+        val raw = bodyOf("private fun showSetupError(")
+        check(raw.length in 500..8000) {
+            "extracted ${raw.length} characters of showSetupError, which means the " +
+                "extraction is wrong rather than the code"
+        }
+
+        // Anchored to the start of a line. Commenting a call out is how a developer
+        // disables one while debugging, and a substring search cannot tell the two
+        // apart; code() already blanks comments, and the anchor is what stops a call
+        // reappearing mid-line inside surviving text from satisfying this.
+        assertTrue(
+            Regex("""(?m)^\s*statusText\.announceForAccessibility\(""")
+                .containsMatchIn(code(raw)),
+            "showSetupError no longer speaks the failure, so a screen reader user is " +
+                "left on a screen that says nothing between the last progress step and " +
+                "a Retry button they never hear about",
+        )
+    }
+
+    /**
+     * A finished download row is repainted at full opacity, and named out loud.
+     *
+     * Two defects in one call, which is why one function owns both. The row's status
+     * text runs dimmed while it counts percentages, which is right for a number changing
+     * every second and wrong for the one word the user has to read at the end: setting
+     * only the colour left the dimming in place and "Failed" measured 3.28:1 against
+     * this window, under the 4.5:1 AA asks of 12sp text. And the row moved from a
+     * percentage to Done or Failed in silence, so a stalled download and a progressing
+     * one sounded the same.
+     *
+     * The announcement names its pack because the queue speaks several of these, and
+     * "Done" on its own says which one only to someone watching the rows.
+     */
+    @Test
+    fun `a finished download row is repainted at full opacity and named out loud`() {
+        // 998 characters when this was written. Bounded for the reason above.
+        val raw = bodyOf("private fun showResult(")
+        check(raw.length in 500..8000) {
+            "extracted ${raw.length} characters of showResult, which means the " +
+                "extraction is wrong rather than the code"
+        }
+        val body = code(raw)
+
+        assertTrue(
+            Regex("""(?m)^\s*view\.setTextColor\(""").containsMatchIn(body),
+            "showResult paints no colour, so a terminal row is left in the grey it " +
+                "counted percentages in",
+        )
+        assertTrue(
+            Regex("""(?m)^\s*view\.alpha\s*=\s*1f""").containsMatchIn(body),
+            "showResult no longer undims the row, so the result colour lands at the " +
+                "opacity the percentages ran at and \"Failed\" measures 3.28:1 against " +
+                "this window, under the 4.5:1 AA asks of 12sp text",
+        )
+        // One expression covers both halves of the scenario: the call being deleted, and
+        // the pack name being dropped from it.
+        assertTrue(
+            Regex("""(?m)^\s*view\.announceForAccessibility\([^)]*packLabel""")
+                .containsMatchIn(body),
+            "showResult no longer says which pack finished, so a queue of downloads " +
+                "either ends in silence or ends in several unattributed results",
+        )
+    }
+
+    /**
+     * And nothing paints a result beside that function.
+     *
+     * A predicate rather than a pair of named branches: the defect was a colour set
+     * without the opacity that has to go with it, so what keeps it from coming back is
+     * that the caller cannot set a colour at all, whatever branch a later result is
+     * added to.
+     */
+    @Test
+    fun `handleDownloadState paints no result colour of its own`() {
+        val raw = bodyOf("private fun handleDownloadState(")
+        check(raw.length in 500..8000) {
+            "extracted ${raw.length} characters of handleDownloadState, which means the " +
+                "extraction is wrong rather than the code"
+        }
+
+        assertFalse(
+            code(raw).contains("setTextColor"),
+            "handleDownloadState sets a text colour directly, which is how the defect " +
+                "was shipped the first time: the colour without the opacity beside it. " +
+                "Terminal rows go through showResult, which sets the pair together",
+        )
+    }
+
+    /**
+     * The control for the three extractions above, because a body that quietly ran past
+     * its own function would satisfy every assertion in them by finding the token
+     * somewhere else, and `bodyOf` here counts braces raw rather than skipping comments.
+     *
+     * Measured against the real bodies rather than guessed: `override fun onDestroy`
+     * begins 6 characters past showSetupError's closing brace, and
+     * `private fun handleDownloadState` 6 characters past showResult's. An extraction
+     * that overran by one line would already carry the name this refuses, so the control
+     * is tight rather than nominal.
+     */
+    @Test
+    fun `each extracted body stops at the declaration that follows it`() {
+        assertFalse(
+            bodyOf("private fun showSetupError(").contains("override fun onDestroy"),
+            "bodyOf ran past showSetupError and swallowed the next declaration, so its " +
+                "assertions are really a file-wide search",
+        )
+        assertFalse(
+            bodyOf("private fun showResult(").contains("private fun handleDownloadState"),
+            "bodyOf ran past showResult and swallowed the next declaration, so its " +
+                "assertions are really a file-wide search",
+        )
+    }
 }

--- a/android/app/src/test/kotlin/com/vscodroid/storage/WriteBackNoticeWiringTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/WriteBackNoticeWiringTest.kt
@@ -1,7 +1,10 @@
 package com.vscodroid.storage
 
+import android.content.Context
+import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.io.File
 
@@ -18,6 +21,21 @@ import java.io.File
 class WriteBackNoticeWiringTest {
 
     private val activity = File("../../android/app/src/main/kotlin/com/vscodroid/MainActivity.kt")
+    private val manager = File("src/main/kotlin/com/vscodroid/storage/SafStorageManager.kt")
+
+    /**
+     * A manager per case, so no case inherits a throttle another case has already moved.
+     *
+     * A relaxed [Context] is the whole of what construction needs: the constructor takes
+     * shared preferences and builds a [SafSyncEngine], and neither is touched by the
+     * claim below. [SafMirrorReclamationTest] builds one the same way.
+     */
+    private lateinit var safManager: SafStorageManager
+
+    @BeforeEach
+    fun setUp() {
+        safManager = SafStorageManager(mockk<Context>(relaxed = true))
+    }
 
     /**
      * Read from the source rather than driven through the Activity, which needs a device.
@@ -70,6 +88,106 @@ class WriteBackNoticeWiringTest {
         assertTrue(
             SafStorageManager.shouldAnnounce(now = now + interval, lastAnnouncedAt = now),
             "the notice has to come back, or a later failure is silent again",
+        )
+    }
+
+    /**
+     * The predicate above says whether a failure is far enough from the last one to be
+     * said. It cannot say who says it, and that is the half these four cover.
+     *
+     * Two threads genuinely reach the throttle: the `saf-writeback` daemon draining the
+     * queue, and `Dispatchers.IO` running the write-backs `initialSync` issues itself.
+     * With a plain read, compare and assign, both can read the same stale value, both
+     * find the interval elapsed and both announce for one burst, which is the wall of
+     * toasts the throttle exists to prevent.
+     *
+     * Driven through the reading rather than through threads, deliberately, and that is
+     * a correctness point rather than a convenience one. Racing two callers does not
+     * measure this: with both shapes released together from a `CyclicBarrier` on this
+     * JDK, the read-compare-assign version announced twice in 0 of 50,000 two-thread
+     * trials, 0 of 20,000 eight-thread trials and 0 of 2,000 sixteen-thread ones. The
+     * window is one read, a subtraction and one write, and the throttle confines it to
+     * the first instant of each interval, so a race test would have called the shape
+     * this replaced green and pinned nothing. Handing one caller a reading a previous
+     * caller has already consumed is that losing thread's exact situation, and it is
+     * decidable.
+     */
+    @Test
+    fun `the first failure of a session claims the notice`() {
+        assertTrue(
+            safManager.claimAnnouncement(now = 1_700_000_000_000L, last = 0),
+            "the first failure of a session has to be said, and nothing has claimed it",
+        )
+    }
+
+    @Test
+    fun `a second caller holding the same stale reading loses the claim`() {
+        val now = 1_700_000_000_000L
+
+        assertTrue(safManager.claimAnnouncement(now = now, last = 0), "the first caller wins")
+        assertFalse(
+            safManager.claimAnnouncement(now = now, last = 0),
+            "a caller holding a reading another caller has already consumed announced " +
+                "as well, so one burst of failures reaches the user as two toasts and " +
+                "the throttle only appears to hold",
+        )
+    }
+
+    /**
+     * The control that keeps the case above from passing for the wrong reason. A claim
+     * that refused everything after the first would satisfy it and would also silence
+     * every later failure for the rest of the session.
+     */
+    @Test
+    fun `the claim comes back once the interval has passed`() {
+        val interval = SafStorageManager.FAILURE_NOTICE_INTERVAL_MS
+        val now = 1_700_000_000_000L
+
+        assertTrue(safManager.claimAnnouncement(now = now, last = 0), "the first caller wins")
+        assertTrue(
+            safManager.claimAnnouncement(now = now + interval, last = now),
+            "a failure a full interval later was refused, so a folder that starts " +
+                "refusing again an hour on says nothing at all",
+        )
+    }
+
+    /**
+     * And the interval is still consulted. Without this a claim reduced to its
+     * `compareAndSet` would pass every case above: the reading moves each time, so the
+     * swap always succeeds and the throttle collapses into no throttle.
+     */
+    @Test
+    fun `a claim inside the interval is refused even with nothing to race`() {
+        val interval = SafStorageManager.FAILURE_NOTICE_INTERVAL_MS
+        val now = 1_700_000_000_000L
+
+        assertTrue(safManager.claimAnnouncement(now = now, last = 0), "the first caller wins")
+        assertFalse(
+            safManager.claimAnnouncement(now = now + interval - 1, last = now),
+            "a failure inside the interval was announced, so a provider that refuses " +
+                "everything buries the editor under its own error",
+        )
+    }
+
+    /**
+     * That the seam above is the one the notice actually goes through.
+     *
+     * ⚠️ Source text, because the behaviour is out of reach here: the wrapper installs
+     * itself on the manager's own [SafSyncEngine], which is private and exposed by no
+     * accessor, so a JVM test can neither read the installed lambda nor make the engine
+     * call it. Everything else about the claim is behaviour; this one line is not.
+     *
+     * Anchored to the start of a line so commenting the call out cannot satisfy it,
+     * which is how a guard of this shape passes over wiring that is already dead.
+     */
+    @Test
+    fun `the write-back notice decides through the claim rather than beside it`() {
+        assertTrue(manager.isFile, "SafStorageManager.kt is not where this test expects it")
+
+        assertTrue(
+            Regex("""(?m)^\s*if \(claimAnnouncement\(""").containsMatchIn(manager.readText()),
+            "onWriteBackFailed no longer decides through claimAnnouncement, so whatever " +
+                "the four cases above pin is not what the user's screen goes through",
         )
     }
 }

--- a/android/app/src/test/kotlin/com/vscodroid/util/TextContrastTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/util/TextContrastTest.kt
@@ -1,0 +1,557 @@
+package com.vscodroid.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.w3c.dom.Element
+import org.w3c.dom.Node
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.pow
+import kotlin.math.roundToInt
+
+/**
+ * That no text on the setup and toolchain screens is too faint to read.
+ *
+ * Six of them were. The brand blue was used as a text colour and measures 3.70:1 on the
+ * window and 3.40:1 on a card; two labels were dimmed below the line with `alpha` rather
+ * than with a colour; the picker's Continue button took its label colour from Material3,
+ * which supplies a dark violet on a dark palette; and a download row's result was painted
+ * without undimming the row it was painted on. WCAG AA asks 4.5:1 for text at these
+ * sizes, and 3:1 for text large enough to count as large.
+ *
+ * ## The ratios are computed, never read
+ *
+ * Every figure quoted in a comment beside these resources is recomputed here from the
+ * colours themselves. Asserting the number a comment states would measure the comment.
+ * The formula is WCAG 2.1's: an sRGB channel is linearised, the three are weighted into a
+ * relative luminance, and the ratio is `(lighter + 0.05) / (darker + 0.05)`. Alpha is
+ * composited in sRGB, which is where `View.setAlpha` and `android:alpha` composite, so a
+ * dimmed label is measured as the colour a screen actually shows.
+ *
+ * ## A predicate, not a list
+ *
+ * This does not name the six texts that were fixed. It walks every layout, finds every
+ * element that paints text, resolves the ground it sits on from the nearest ancestor that
+ * declares one, and measures. A seventh faint text added tomorrow reddens this without
+ * anyone remembering to add it to a list, and a colour changed in `colors.xml` reddens
+ * every text that uses it.
+ *
+ * ⚠️ What this cannot see. It reads resources, so it proves the declared colours clear the
+ * ratio, not that a device renders them that way and not that the layout puts the text on
+ * the ground this believes it does. The API 33 emulator and
+ * `docs/DEVICE_TEST_CHECKLIST.md` are the instrument for that half. It also measures only
+ * what a layout declares: a colour applied from Kotlin is out of reach here, which is why
+ * the download row's terminal result is pinned in `DownloadStateWiringTest` instead.
+ *
+ * The XML is parsed as a document rather than scanned as text, so a commented-out
+ * attribute is a comment node and can satisfy nothing. That is stricter than anchoring a
+ * search to the start of a line, and it is the reason no such anchor appears below except
+ * where Kotlin source is read.
+ */
+class TextContrastTest {
+
+    private companion object {
+        const val ANDROID_NS = "http://schemas.android.com/apk/res/android"
+        const val APP_NS = "http://schemas.android.com/apk/res-auto"
+
+        /** WCAG AA, for text below the large-text threshold. */
+        const val AA_NORMAL = 4.5
+
+        /** WCAG AA for large text: 18pt, or 14pt when bold. */
+        const val AA_LARGE = 3.0
+
+        /**
+         * The one card whose ground is swapped from Kotlin.
+         *
+         * `ToolchainPickerAdapter.bindPickerMode` repaints a selected card with
+         * `colorCardSelected`, which is translucent, so the text on a selected card sits
+         * on a different ground from the text on an unselected one. Naming the layout
+         * here rather than deriving it is a fact read out of Kotlin, and the last case in
+         * this class is what stops it going stale.
+         */
+        const val SWAPPED_GROUND_LAYOUT = "item_toolchain_card.xml"
+    }
+
+    private val layoutDir = File("src/main/res/layout")
+    private val colorsXml = File("src/main/res/values/colors.xml")
+    private val themesXml = File("src/main/res/values/themes.xml")
+    private val pickerAdapter =
+        File("src/main/kotlin/com/vscodroid/setup/ToolchainPickerAdapter.kt")
+
+    // -- The WCAG arithmetic --
+
+    private data class Rgb(val r: Int, val g: Int, val b: Int)
+
+    /** Relative luminance, WCAG 2.1 section 1.4.3. */
+    private fun luminance(c: Rgb): Double {
+        fun channel(v: Int): Double {
+            val s = v / 255.0
+            return if (s <= 0.03928) s / 12.92 else ((s + 0.055) / 1.055).pow(2.4)
+        }
+        return 0.2126 * channel(c.r) + 0.7152 * channel(c.g) + 0.0722 * channel(c.b)
+    }
+
+    private fun contrast(a: Rgb, b: Rgb): Double {
+        val la = luminance(a)
+        val lb = luminance(b)
+        return (max(la, lb) + 0.05) / (min(la, lb) + 0.05)
+    }
+
+    /**
+     * [fg] drawn at [alpha] over [bg].
+     *
+     * Composited in sRGB rather than in linear light, because that is where Android
+     * composites: `View.setAlpha` and `android:alpha` both end in a paint alpha applied
+     * to the 8-bit channel values. Compositing in linear light instead would give a
+     * different, and wrong, answer for exactly the dimmed labels this exists to measure.
+     */
+    private fun over(fg: Rgb, bg: Rgb, alpha: Double) = Rgb(
+        (alpha * fg.r + (1 - alpha) * bg.r).roundToInt(),
+        (alpha * fg.g + (1 - alpha) * bg.g).roundToInt(),
+        (alpha * fg.b + (1 - alpha) * bg.b).roundToInt(),
+    )
+
+    // -- Resolving what the resources name --
+
+    private val namedColors: Map<String, String> by lazy {
+        assertTrue(
+            colorsXml.isFile,
+            "colors.xml is not at ${colorsXml.absolutePath}; this test would otherwise " +
+                "pass by measuring nothing",
+        )
+        val found = Regex("""<color\s+name="([^"]+)"\s*>\s*(#[0-9A-Fa-f]+)\s*</color>""")
+            .findAll(colorsXml.readText())
+            .associate { it.groupValues[1] to it.groupValues[2] }
+        // The parser control. Without it a pattern that stopped matching would report
+        // every colour as unresolvable, which reads like a deleted resource rather than
+        // a broken parse, and a pattern that matched nothing at all would make the
+        // resolution below fail for the wrong reason.
+        assertTrue(
+            found.size >= 10,
+            "only ${found.size} colours were parsed out of colors.xml, so the pattern " +
+                "is not matching the file. Parsed: ${found.keys}",
+        )
+        found
+    }
+
+    /** A colour reference resolved to its opaque value and its own alpha. */
+    private fun resolve(ref: String): Pair<Rgb, Double> = when {
+        ref.startsWith("#") -> literal(ref)
+        ref == "@android:color/white" -> Rgb(255, 255, 255) to 1.0
+        ref == "@android:color/black" -> Rgb(0, 0, 0) to 1.0
+        ref.startsWith("@color/") -> {
+            val name = ref.removePrefix("@color/")
+            val value = namedColors[name]
+            // Loudly, not by skipping. A reference this cannot resolve is a text whose
+            // ratio nobody measures, and a guard that quietly declines to measure is the
+            // same as no guard.
+            checkNotNull(value) { "colors.xml declares no $name, which $ref names" }
+            literal(value)
+        }
+        else -> error(
+            "cannot resolve $ref to a colour. Teach this test how before using it on a " +
+                "text, or the text goes unmeasured while everything stays green",
+        )
+    }
+
+    private fun literal(hex: String): Pair<Rgb, Double> {
+        val digits = hex.removePrefix("#")
+        return when (digits.length) {
+            6 -> Rgb(digits.hex(0), digits.hex(2), digits.hex(4)) to 1.0
+            8 -> Rgb(digits.hex(2), digits.hex(4), digits.hex(6)) to digits.hex(0) / 255.0
+            else -> error("$hex is not a colour this test can read")
+        }
+    }
+
+    private fun String.hex(at: Int) = substring(at, at + 2).toInt(16)
+
+    /**
+     * A ground reference flattened to something opaque.
+     *
+     * A translucent ground shows the window through it, so it has to be composited before
+     * anything is measured against it. `colorCardSelected` is the one that is, and a card
+     * painted with it sits on the window on both screens that show one.
+     */
+    private fun flatten(ref: String): Rgb {
+        val (color, alpha) = resolve(ref)
+        if (alpha >= 1.0) return color
+        val (window, windowAlpha) = resolve("@color/colorBackground")
+        check(windowAlpha >= 1.0) { "the window colour is translucent; nothing is behind it" }
+        return over(color, window, alpha)
+    }
+
+    // -- Walking the layouts --
+
+    /** One text-painting element, with every ground it can be shown on. */
+    private class Painted(
+        val where: String,
+        val colorRef: String,
+        val alpha: Double,
+        val threshold: Double,
+        val grounds: List<Pair<String, Rgb>>,
+    )
+
+    private fun layouts(): List<File> {
+        assertTrue(
+            layoutDir.isDirectory,
+            "res/layout is not at ${layoutDir.absolutePath}; this test would otherwise " +
+                "pass by walking nothing",
+        )
+        val files = layoutDir.listFiles()?.filter { it.extension == "xml" }?.sortedBy { it.name }
+            .orEmpty()
+        assertTrue(files.size >= 5, "only ${files.size} layouts found, so the walk is wrong")
+        return files
+    }
+
+    private fun parse(file: File): Element =
+        DocumentBuilderFactory.newInstance()
+            .apply { isNamespaceAware = true }
+            .newDocumentBuilder()
+            .parse(file)
+            .documentElement
+
+    private fun descendants(root: Element): List<Element> {
+        val out = mutableListOf(root)
+        var i = 0
+        while (i < out.size) {
+            val children = out[i].childNodes
+            for (c in 0 until children.length) {
+                val node = children.item(c)
+                if (node.nodeType == Node.ELEMENT_NODE) out += node as Element
+            }
+            i++
+        }
+        return out
+    }
+
+    private fun Element.attr(ns: String, name: String): String? =
+        getAttributeNS(ns, name).takeIf { it.isNotEmpty() }
+
+    /**
+     * The ground an element's text sits on: the nearest ancestor, or itself, that declares
+     * one.
+     *
+     * Nearest rather than the root, because a card declares its own and a text inside it
+     * is not on the window. If nothing up the tree declares one this fails rather than
+     * guessing, since a guessed ground is a measurement of nothing.
+     */
+    private fun groundsFor(el: Element, layout: String): List<Pair<String, Rgb>> {
+        val declared = generateSequence<Node>(el) { it.parentNode }
+            .filterIsInstance<Element>()
+            .firstNotNullOfOrNull {
+                it.attr(ANDROID_NS, "background") ?: it.attr(APP_NS, "cardBackgroundColor")
+            }
+        checkNotNull(declared) {
+            "nothing from ${el.tagName} up to the root of $layout declares a background, " +
+                "so there is no ground to measure this text against"
+        }
+        val grounds = mutableListOf(declared to flatten(declared))
+        if (layout == SWAPPED_GROUND_LAYOUT) {
+            grounds += "@color/colorCardSelected (selected)" to flatten("@color/colorCardSelected")
+        }
+        return grounds
+    }
+
+    /**
+     * Whether WCAG counts this text as large, which lowers the ratio it has to clear.
+     *
+     * WCAG says 18pt, or 14pt bold, and defines a point against the CSS pixel: its own
+     * note gives 1pt as 1.333px. Android measures text in sp and has no authoritative
+     * mapping to either unit, so this reads an sp as a CSS pixel, which puts the
+     * thresholds at 24sp and 18.67sp bold. That is the stricter of the two readings in
+     * circulation, the other being to treat an sp as a point directly, and stricter is the
+     * right default for a guard. Nothing in these layouts is near the boundary, so the
+     * choice decides nothing today: the three texts it calls large all measure above 9:1.
+     *
+     * Text that declares no size is treated as normal for the same reason.
+     */
+    private fun isLarge(el: Element): Boolean {
+        val sp = el.attr(ANDROID_NS, "textSize")?.removeSuffix("sp")?.toDoubleOrNull()
+            ?: return false
+        val pt = sp * 0.75
+        val bold = el.attr(ANDROID_NS, "textStyle")?.contains("bold") == true
+        return pt >= 18.0 || (bold && pt >= 14.0)
+    }
+
+    private fun paintedTexts(): List<Painted> = layouts().flatMap { file ->
+        descendants(parse(file)).mapNotNull { el ->
+            val ref = el.attr(ANDROID_NS, "textColor") ?: el.attr(APP_NS, "titleTextColor")
+                ?: return@mapNotNull null
+            val id = el.attr(ANDROID_NS, "id")?.substringAfterLast('/') ?: el.tagName
+            Painted(
+                where = "${file.name}/$id",
+                colorRef = ref,
+                alpha = el.attr(ANDROID_NS, "alpha")?.toDouble() ?: 1.0,
+                threshold = if (isLarge(el)) AA_LARGE else AA_NORMAL,
+                grounds = groundsFor(el, file.name),
+            )
+        }
+    }
+
+    private fun measure(text: Painted, ground: Rgb): Double =
+        contrast(over(resolve(text.colorRef).first, ground, text.alpha), ground)
+
+    // Locale.ROOT, so a failure message reads the same on a machine whose default locale
+    // writes a decimal comma. Nothing here compares the string, but a reader comparing it
+    // against a comment in colors.xml would be reading two different notations.
+    private fun Double.two() = String.format(java.util.Locale.ROOT, "%.2f", this)
+
+    // -- The cases --
+
+    /**
+     * Every text these layouts paint, on every ground it can be painted on.
+     *
+     * The two failures this was written over are both in here: the brand blue used as a
+     * text colour, and `colorOnSurface` dimmed to 0.5, which is 3.62:1 on the window and
+     * 3.47:1 on a card.
+     */
+    @Test
+    fun `every text a layout paints clears the ratio WCAG asks for its size`() {
+        val texts = paintedTexts()
+
+        // The vacuity control. Everything below is a scan, and a scan that found nothing
+        // reports success in exactly the voice of a scan that found nothing wrong. 14
+        // texts across 6 layouts when this was written.
+        assertTrue(
+            texts.size >= 12,
+            "only ${texts.size} texts were found across the layouts, so the walk is " +
+                "wrong rather than the resources. Found: ${texts.map { it.where }}",
+        )
+
+        val failures = texts.flatMap { text ->
+            text.grounds.mapNotNull { (groundRef, ground) ->
+                val ratio = measure(text, ground)
+                if (ratio >= text.threshold) {
+                    null
+                } else {
+                    "${text.where}: ${text.colorRef} at alpha ${text.alpha} on " +
+                        "$groundRef measures ${ratio.two()}:1, and WCAG AA asks " +
+                        "${text.threshold}:1 for text this size"
+                }
+            }
+        }
+
+        assertEquals(
+            emptyList<String>(), failures,
+            "these texts are too faint to read. A colour or an alpha here is a decision " +
+                "about whether a sighted user can read the screen at all, and nothing " +
+                "else in this project measures one.",
+        )
+    }
+
+    /**
+     * The negative control, and the whole reason the case above is worth having.
+     *
+     * A scan that clears everything proves nothing unless the same arithmetic refuses
+     * something. Both paths are exercised, because a break in either would leave the scan
+     * green over broken resources: the colour path, with the brand blue these layouts
+     * moved away from as a text colour, and the alpha path, with `colorOnSurface` at the
+     * 0.5 the two dimmed labels used to carry. If alpha were being ignored, the scan
+     * would pass over a label restored to 0.5 and the control below is what catches that.
+     *
+     * The passing halves are asserted in the same case for the same reason: a control
+     * that only ever refuses would be satisfied by arithmetic that refuses everything.
+     */
+    @Test
+    fun `the arithmetic refuses the colours and the opacities these layouts moved off`() {
+        val window = flatten("@color/colorBackground")
+        val card = flatten("@color/colorSurface")
+        val blue = resolve("@color/colorPrimary").first
+        val onSurface = resolve("@color/colorOnSurface").first
+        val lighter = resolve("@color/colorPrimaryText").first
+
+        val refused = listOf(
+            "colorPrimary on the window" to contrast(blue, window),
+            "colorPrimary on a card" to contrast(blue, card),
+            "colorOnSurface at 0.5 on the window" to
+                contrast(over(onSurface, window, 0.5), window),
+            "colorOnSurface at 0.5 on a card" to contrast(over(onSurface, card, 0.5), card),
+        )
+        refused.forEach { (what, ratio) ->
+            assertTrue(
+                ratio < AA_NORMAL,
+                "$what measures ${ratio.two()}:1, which clears the $AA_NORMAL:1 line. " +
+                    "This is a control: it names the state these layouts were changed " +
+                    "away from, so if it passes the scan above is measuring something " +
+                    "other than what it claims",
+            )
+        }
+
+        val accepted = listOf(
+            "colorPrimaryText on the window" to contrast(lighter, window),
+            "colorPrimaryText on a card" to contrast(lighter, card),
+            "colorOnSurface at 0.7 on the window" to
+                contrast(over(onSurface, window, 0.7), window),
+            "colorOnSurface at 0.7 on a card" to contrast(over(onSurface, card, 0.7), card),
+        )
+        accepted.forEach { (what, ratio) ->
+            assertTrue(
+                ratio >= AA_NORMAL,
+                "$what measures ${ratio.two()}:1, under the $AA_NORMAL:1 line. The " +
+                    "control above would pass for arithmetic that refuses everything, " +
+                    "and this is the half that says it does not",
+            )
+        }
+    }
+
+    /**
+     * A text button has to name its own colour.
+     *
+     * The scan above measures what a layout declares, and cannot see a colour that is not
+     * there. `Widget.Material3.Button.TextButton` sets `android:textColor` to
+     * `m3_text_button_foreground_color_selector`, whose enabled, uncheckable entry is
+     * `?attr/colorOnContainer`, which `ThemeOverlay.Material3.Button.TextButton` points at
+     * `?attr/colorPrimary`. Read out of material 1.14.0, the version this app resolves. So
+     * a text button that declares nothing is labelled in the brand blue, which measures
+     * 3.70:1 on the window and 3.40:1 on a card, and deleting the attribute is a silent
+     * return to exactly that.
+     *
+     * A predicate over every such button rather than the two that exist, so the next one
+     * added cannot arrive faint.
+     */
+    @Test
+    fun `every text button names a colour of its own`() {
+        val buttons = layouts().flatMap { file ->
+            descendants(parse(file))
+                .filter { it.getAttribute("style").contains("Button.TextButton") }
+                .map { file.name to it }
+        }
+
+        assertTrue(
+            buttons.isNotEmpty(),
+            "no text buttons were found in any layout, so this case is vacuous rather " +
+                "than satisfied",
+        )
+
+        val bare = buttons.filter { (_, el) -> el.attr(ANDROID_NS, "textColor") == null }
+            .map { (layout, el) ->
+                "$layout/${el.attr(ANDROID_NS, "id")?.substringAfterLast('/') ?: el.tagName}"
+            }
+
+        assertEquals(
+            emptyList<String>(), bare,
+            "these text buttons declare no android:textColor, so their labels come from " +
+                "the theme's colorPrimary: 3.70:1 on the window and 3.40:1 on a card, " +
+                "both under the ${AA_NORMAL}:1 line",
+        )
+    }
+
+    /**
+     * The picker's Continue button, whose label colour is not in any layout.
+     *
+     * The button declares a `backgroundTint` and no `textColor`, so its label is the
+     * theme's `colorOnPrimary`. Overriding `colorPrimary` without setting that left
+     * Material3 supplying its own, a dark violet from the dark palette; white is what the
+     * theme names now.
+     *
+     * ⚠️ The margin here is 0.01. White on this blue measures 4.51:1 against a 4.5:1 line,
+     * so any darkening of the button ground breaks it, and the failure message says both
+     * numbers because "contrast too low" would not.
+     *
+     * A predicate over every tinted button that names no colour of its own, rather than
+     * over this one button by id.
+     */
+    @Test
+    fun `a tinted button's label clears the ground it is tinted with`() {
+        val onPrimary = themeItem("colorOnPrimary")
+        checkNotNull(onPrimary) {
+            "Theme.VSCodroid sets no colorOnPrimary, so Material3 supplies its own from " +
+                "the dark palette and the picker's Continue button is labelled in it"
+        }
+        val label = resolve(onPrimary).first
+
+        val tinted = layouts().flatMap { file ->
+            descendants(parse(file)).filter {
+                it.attr(ANDROID_NS, "backgroundTint") != null &&
+                    it.attr(ANDROID_NS, "textColor") == null
+            }.map { Triple(file.name, it, it.attr(ANDROID_NS, "backgroundTint")!!) }
+        }
+
+        assertTrue(
+            tinted.isNotEmpty(),
+            "no button takes its label from the theme, so this case is vacuous rather " +
+                "than satisfied",
+        )
+
+        tinted.forEach { (layout, el, tint) ->
+            val ground = flatten(tint)
+            val ratio = contrast(label, ground)
+            val threshold = if (isLarge(el)) AA_LARGE else AA_NORMAL
+            val id = el.attr(ANDROID_NS, "id")?.substringAfterLast('/') ?: el.tagName
+            assertTrue(
+                ratio >= threshold,
+                "$layout/$id is labelled in $onPrimary on $tint, which measures " +
+                    "${ratio.two()}:1 against a threshold of $threshold:1. This pair " +
+                    "clears AA by 0.01 and nothing more, so a darker tint or a dimmer " +
+                    "label breaks it",
+            )
+        }
+    }
+
+    /**
+     * That the second ground the card is measured on is still the one it gets.
+     *
+     * `colorCardSelected` is named in this file because the swap happens in Kotlin, in
+     * `ToolchainPickerAdapter.bindPickerMode`, and a layout cannot say it. That makes it
+     * the one fact here that can go stale silently: if the adapter starts painting a
+     * selected card some other colour, the scan goes on measuring a ground no card has.
+     *
+     * ⚠️ Source text, because the colour is chosen inside an Activity-scoped adapter this
+     * module cannot instantiate. Anchored to the start of a line so a commented-out call
+     * cannot satisfy it.
+     */
+    @Test
+    fun `the selected card is still painted with the colour this measures`() {
+        assertTrue(
+            pickerAdapter.isFile,
+            "${pickerAdapter.path} is not at ${pickerAdapter.absolutePath}; this test " +
+                "would otherwise pass by reading nothing",
+        )
+
+        // Anchored at the start of a line, and the character class is the anchor: nothing
+        // between the indent and the reference may be a slash, so a `//` cannot get in
+        // front of it. Without that, `^\s*.*` would match a commented-out call as
+        // readily as a live one, and commenting a line out is how a developer disables
+        // something while debugging.
+        assertTrue(
+            Regex("""(?m)^\s*[^/\n]*R\.color\.colorCardSelected""")
+                .containsMatchIn(pickerAdapter.readText()),
+            "ToolchainPickerAdapter no longer paints a selected card with " +
+                "colorCardSelected, so the second ground this class measures the card's " +
+                "text against is a colour nothing shows",
+        )
+    }
+
+    /**
+     * `name` to literal value for one item of the app's theme.
+     *
+     * A second reader of themes.xml beside [ThemeEdgeToEdgeTest], deliberately: that one
+     * asks whether the window attributes are present and equal to a literal, and this one
+     * asks what a colour measures. Sharing a parser would tie the two questions together
+     * for no gain.
+     */
+    private fun themeItem(name: String): String? {
+        assertTrue(
+            themesXml.isFile,
+            "themes.xml is not at ${themesXml.absolutePath}; this test would otherwise " +
+                "pass by reading nothing",
+        )
+        val style = Regex("""<style\s+name="Theme\.VSCodroid".*?</style>""", RegexOption.DOT_MATCHES_ALL)
+            .find(themesXml.readText())
+        checkNotNull(style) { "Theme.VSCodroid is not declared in themes.xml" }
+        val items = Regex("""<item\s+name="([^"]+)"\s*>([^<]*)</item>""")
+            .findAll(style.value)
+            .associate { it.groupValues[1] to it.groupValues[2].trim() }
+        // The parser control, in the shape ThemeEdgeToEdgeTest uses: a pattern that
+        // silently matched nothing would report every item as deleted.
+        assertTrue(
+            items.size >= 5,
+            "only ${items.size} items were parsed out of Theme.VSCodroid, so the " +
+                "pattern is not matching the file. Parsed: $items",
+        )
+        return items[name]
+    }
+}

--- a/docs/07-TESTING_STRATEGY.md
+++ b/docs/07-TESTING_STRATEGY.md
@@ -22,8 +22,8 @@ VSCodroid has unique testing challenges: it's a hybrid app (Kotlin + WebView + N
 
 ```mermaid
 flowchart TD
-  E2E["Manual / E2E Tests<br/>Real devices, UX testing<br/>14 scenarios"] --> INT["Instrumented Tests<br/>WebView + Node.js + Kotlin<br/>37 tests, run by hand on a device"]
-  INT --> UNIT["Unit Tests<br/>1307 Kotlin tests in 205 classes (JVM)<br/>8 node:assert scripts for the bundled JavaScript"]
+  E2E["Manual / E2E Tests<br/>Real devices, UX testing<br/>14 scenarios"] --> INT["Instrumented Tests<br/>WebView + Node.js + Kotlin<br/>26 tests, run by hand on a device"]
+  INT --> UNIT["Unit Tests<br/>1321 Kotlin tests in 206 classes (JVM)<br/>8 node:assert scripts for the bundled JavaScript"]
 ```
 
 ---
@@ -46,9 +46,7 @@ flowchart TD
 | SafSyncEngine | Mirror reconciliation, write-back filtering, rename pairing | `SafSyncEngineTest`, `SafWriteBackFilterTest`, `SafRenamePairingTest` |
 | VSCodroidWebViewClient | CDN interception, `vscode-remote` resource serving, downloads | `ResourceInterceptionWiringTest`, `WebviewResourceResolutionTest`, `DownloadCoordinatorTest` |
 
-The suite is **1307 tests in 205 classes**, and it is green. Both figures come from
-the XML a run writes under `app/build/test-results/testDebugUnitTest/`, one file per
-class, rather than from a figure carried forward. A test that needs a
+The suite is **1321 tests in 206 classes**, and it is green. A test that needs a
 filesystem builds its tree under a JUnit `@TempDir` rather than touching the
 checkout.
 

--- a/docs/07-TESTING_STRATEGY.md
+++ b/docs/07-TESTING_STRATEGY.md
@@ -22,8 +22,8 @@ VSCodroid has unique testing challenges: it's a hybrid app (Kotlin + WebView + N
 
 ```mermaid
 flowchart TD
-  E2E["Manual / E2E Tests<br/>Real devices, UX testing<br/>14 scenarios"] --> INT["Instrumented Tests<br/>WebView + Node.js + Kotlin<br/>26 tests, run by hand on a device"]
-  INT --> UNIT["Unit Tests<br/>1321 Kotlin tests in 206 classes (JVM)<br/>8 node:assert scripts for the bundled JavaScript"]
+  E2E["Manual / E2E Tests<br/>Real devices, UX testing<br/>14 scenarios"] --> INT["Instrumented Tests<br/>WebView + Node.js + Kotlin<br/>37 tests, run by hand on a device"]
+  INT --> UNIT["Unit Tests<br/>1360 Kotlin tests in 210 classes (JVM)<br/>8 node:assert scripts for the bundled JavaScript"]
 ```
 
 ---
@@ -46,7 +46,9 @@ flowchart TD
 | SafSyncEngine | Mirror reconciliation, write-back filtering, rename pairing | `SafSyncEngineTest`, `SafWriteBackFilterTest`, `SafRenamePairingTest` |
 | VSCodroidWebViewClient | CDN interception, `vscode-remote` resource serving, downloads | `ResourceInterceptionWiringTest`, `WebviewResourceResolutionTest`, `DownloadCoordinatorTest` |
 
-The suite is **1321 tests in 206 classes**, and it is green. A test that needs a
+The suite is **1360 tests in 210 classes**, and it is green. Both figures come from
+the XML a run writes under `app/build/test-results/testDebugUnitTest/`, one file per
+class, rather than from a figure carried forward. A test that needs a
 filesystem builds its tree under a JUnit `@TempDir` rather than touching the
 checkout.
 


### PR DESCRIPTION
Three changes shipped in this cycle with no test that would fail if they were reverted. Each is covered here, and each assertion was checked against a deliberate break of the thing it claims.

## Six hand-measured contrast ratios, with nothing reading any of them

The text-contrast corrections were computed by hand and written into comments. Nothing in the suite read a single one, and lint has no contrast check, so any of them could have been reverted silently.

`TextContrastTest` recomputes them from the resources rather than asserting the comment's number, which would measure nothing. All the original figures reproduce exactly. One comment did not: the progress-row note says alpha 0.6 measures 3.62:1, which is the figure for 0.5. It measures 4.58:1, and the comment is corrected in place with the value left where it was.

It is a predicate, not a list. It walks every layout, finds every element that paints text, resolves the ground from the nearest ancestor that declares one, composites alpha in sRGB, and compares against 4.5:1, or 3:1 for large text. It finds **14 texts across 6 layouts**, and a vacuity control refuses to pass on fewer than 12. The picker card is measured on both grounds, because the adapter swaps it on selection. Two further predicates cover what a layout does not say: every text button must name its own colour, since the Material style otherwise resolves the label to `colorPrimary`, and a tinted button that names none is measured against the theme's `colorOnPrimary`, with the message quoting both the measured ratio and the threshold because the margin there is 0.01.

The XML is DOM-parsed, so a commented-out attribute is a comment node and cannot satisfy anything.

One thing worth recording: raising the large-text threshold to 4.5 leaves the class green, so the relaxation decides nothing in this tree today. That is in the KDoc.

## A throttle whose atomicity was the whole point, with every test bypassing it

Every test that touches the write-back notice sets the engine's seam directly and never constructs the manager, so the wrapper that throttles it was uncovered.

The instrument matters here. The race was measured before the test was designed: the read-then-write shape announced twice in **0 of 50,000** two-thread trials, 0 of 20,000 eight-thread, and 0 of 2,000 sixteen-thread. A thread-race test would have called the broken code green and been worse than nothing. So the decision is made decidable instead: `claimAnnouncement(now, last)` is handed a reading another caller has already consumed, which is exactly the losing caller's situation, and answers without any timing at all.

## Two spoken transitions, invisible to a sighted reviewer

`showSetupError` is the only spoken channel for a setup failure, no layout declares a live region, and the three tests that read `SplashActivity` named neither call. Four cases in `DownloadStateWiringTest`, line-anchored on comment-stripped text so a commented-out call cannot satisfy them, including a predicate that the state handler paints no colour of its own and a scope control on the extraction.

The scope control is tight rather than nominal: both declarations that follow the extracted bodies begin six characters past the closing brace, measured, so an over-run of any size reaches them.

## Verification

Nineteen negative controls, run one at a time, each reddening the case it targets: reverting each of the eight colour or alpha values, deleting a button's colour, deleting and then breaking the theme's `colorOnPrimary`, three shapes of the throttle including the original read-compare-assign, deleting and then commenting out the setup announcement, three parts of the repaint, and a brace inside a comment for the scope control.

Two of those runs initially reported empty, because the control harness left backup files inside `res/`, which fails `mergeDebugResources`. That was a fault in the instrument rather than in the subject; it was fixed and the controls re-run.

Full unit suite **1356 tests in 210 classes**, no failures. Lint unchanged at 53 warnings. The testing strategy document is re-measured rather than incremented.