### PR TITLE
docs: date the legal notices for when they changed

### DIFF
--- a/docs/LEGAL_NOTICES.md
+++ b/docs/LEGAL_NOTICES.md
@@ -630,4 +630,4 @@ For questions about licenses, trademarks, or legal notices:
 
 ---
 
-_This document was last updated on August 20, 2026._
+_This document was last updated on August 21, 2026._


### PR DESCRIPTION
`docs/LEGAL_NOTICES.md` states the day it was settled, and its own body promises that the date moves with the policy. The OpenJDK source offer and the note about where the JDK's notices travel were added without moving it.

`scripts/check-document-dates.py` catches this, and it runs only in `release.yml`, so the stale date would have failed a release rather than a pull request. That placement is deliberate and documented in the script: `actions/checkout` clones a single commit by default, which is what the pull-request workflows take, and `git log -1 -- <file>` in that clone reports the tip commit for every file it can see and nothing for the rest. The check refuses a shallow clone outright rather than skipping, because a check that cannot run is not a check that passed.

Verified by running the gate: it now reports `ok  2 dated documents are no older than their contents`.