### PR TITLE
docs(toolchain): re-measure what the Java pack unpacks to

### DIFF
--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
@@ -564,8 +564,10 @@ class ToolchainManager(private val context: Context) {
         // A retired pack answers null from the registry -- that pass-through is
         // deliberate and keeps uninstalling one working -- and the elvis then made the
         // whole reservation the 50 MB buffer. A gate that asks for 50 MB before copying
-        // 146 MB is worse than no gate: it passes exactly the devices it exists to
-        // refuse, and reports success while doing it.
+        // 155 MB, which is what Java 17 unpacks to today, is worse than no gate: it
+        // passes exactly the devices it exists to refuse, and reports success while
+        // doing it. That figure moves with the JDK, so re-measure it rather than
+        // trusting it here: `du -sk android/toolchain_java/src/main/assets/usr`.
         val unpacked = packUnpackedBytes(packName)
         if (unpacked == null) {
             // Unknown size, so there is no honest reservation to make. Said out loud
@@ -814,8 +816,8 @@ class ToolchainManager(private val context: Context) {
                 // ⚠️ The tree copied into `usr/` above is left where it is, and
                 // nothing removes it later. Uninstall works off this manifest, so a
                 // manifest that was never written leaves the files with no record
-                // naming them: roughly the unpacked size, 146 MB for Java 17, that
-                // only clearing app data reclaims.
+                // naming them: roughly the unpacked size, about 155 MB for the Java 17
+                // this ships, that only clearing app data reclaims.
                 //
                 // Not repaired here on purpose. The copy shares `usr/` with the base
                 // install and with other toolchains, so removing it means the


### PR DESCRIPTION
Two comments in `ToolchainManager` reason about the storage reservation from the size of the unpacked Java tree, and both named 146 MB. That was accurate until the pack started carrying OpenJDK's own licence and third-party notices, which the download had been stripping. Measured now: `155,455,488` bytes, so about 155 MB.

The reasoning around both is unaffected, and that is the problem with leaving them: a reader who checks the figure and finds it wrong has no way to tell whether the argument it supports is wrong too. Both now name the measurement that produces the number, because it moves with every JDK the pack is built against.

Left alone deliberately: the same figure in `MILESTONES.md` and `docs/12-IMPLEMENTATION_PLAN.md`, which record what was built at a milestone rather than what ships today, and `ToolchainInstallSpaceTest`, whose `146_000_000` is a representative input to an arithmetic assertion and whose KDoc already says the figure is what the case was measured against, in the past tense.

Verified: full unit suite 1360 tests, no failures, and `check-toolchain-claims.py` passes.