### PR TITLE
fix(terminal): drop the folder record nothing maintained

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A terminal in a window with no folder open now starts in your projects directory, not in the last device folder you ever opened.
 - A file you edited on the device is no longer overwritten by the app's copy after a write-back that failed once and later succeeded.
 - Cancelling a toolchain download while it installs no longer deletes the files being copied out of it, which left a part-written toolchain behind.
 - A selected toolchain in the first-run picker no longer draws two check marks in the same corner.

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -758,12 +758,6 @@ class MainActivity : AppCompatActivity() {
                 safManager.startFileWatcher(mirrorDir, uri)
                 watchedSafFolder = mirrorDir to uri
 
-                // Write active folder so new terminals cd to the right place.
-                // Off the main thread: lifecycleScope dispatches on
-                // Main.immediate, so this was a file write on the UI thread
-                // inside a modal dialog. withContext suspends until it returns,
-                // so the ordering the rest of this block depends on is unchanged.
-                withContext(Dispatchers.IO) { writeActiveFolder(mirrorDir.absolutePath) }
 
                 dialog.dismiss()
 
@@ -1610,20 +1604,6 @@ class MainActivity : AppCompatActivity() {
         // the same one the webview layer uses.
         Logger.i(tag, "Loading VS Code at ${redactToken(url)}")
         wv.loadUrl(url)
-    }
-
-    /**
-     * Writes the active folder path to ~/.vscodroid_folder so new terminals
-     * can cd to the correct directory. See bashrc in FirstRunSetup.
-     */
-    private fun writeActiveFolder(folderPath: String) {
-        try {
-            val homeDir = File(Environment.getHomeDir(this))
-            File(homeDir, ".vscodroid_folder").writeText(folderPath)
-            Logger.d(tag, "Active folder: $folderPath")
-        } catch (e: Exception) {
-            Logger.d(tag, "Failed to write active folder: ${e.message}")
-        }
     }
 
     private fun injectBridgeToken() {

--- a/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
@@ -1420,9 +1420,13 @@ class FirstRunSetup(
         val content = String(bytes, Charsets.ISO_8859_1)
         if (content.contains(STARTUP_DIR_MARKER_CURRENT)) return
 
-        val start = content.indexOf(LEGACY_STARTUP_DIR_BLOCK)
-        if (start < 0) return
-        val end = start + LEGACY_STARTUP_DIR_BLOCK.length
+        // Newest first. A v1 block contains none of the v0 text, so the order does
+        // not decide anything today, and it is fixed anyway so that adding a v3 is
+        // one more entry rather than a question about which match wins.
+        val previous = listOf(LEGACY_STARTUP_DIR_BLOCK_V1, LEGACY_STARTUP_DIR_BLOCK)
+        val block = previous.firstOrNull { content.contains(it) } ?: return
+        val start = content.indexOf(block)
+        val end = start + block.length
 
         val written = writeAtomically(bashrc) {
             it.write(bytes, 0, start)
@@ -2537,6 +2541,16 @@ private const val BASH_ENV_HEADER = """# VSCodroid: sourced by NON-INTERACTIVE b
  * all three, so a terminal opened on a folder was moved somewhere else before
  * the user ever saw a prompt.
  *
+ * There is no remembered folder here, and that is the point rather than an
+ * omission. This block runs only when no workspace folder is open, so a folder
+ * remembered from an earlier session is by construction not the one the user was
+ * working in. The v1 shape read `~/.vscodroid_folder`, which was written only
+ * when a device folder was opened through the picker and was never cleared, so a
+ * device that had opened one once sent every later empty-window shell into that
+ * mirror, where a write reaches nothing until the folder is opened again.
+ * `~/projects` is where the welcome file already tells the user new terminals
+ * start.
+ *
  * `HOME` is the one directory the server never picks on purpose: it is the last
  * fallback in `getCwd`, reached only when no workspace folder is open. Landing
  * there is therefore the signal that nobody chose, and that this block still has
@@ -2553,23 +2567,17 @@ private const val BASH_ENV_HEADER = """# VSCodroid: sourced by NON-INTERACTIVE b
  * edit to the lines around it. [ensureStartupDirGuard] matches this text byte
  * for byte on devices that already have a `.bashrc`.
  */
-private const val STARTUP_DIR_VERSION = "v1"
+private const val STARTUP_DIR_VERSION = "v2"
 private const val STARTUP_DIR_BEGIN = "# >>> vscodroid startup dir"
 private const val STARTUP_DIR_END = "# <<< vscodroid startup dir"
 private const val STARTUP_DIR_MARKER_CURRENT = "$STARTUP_DIR_BEGIN $STARTUP_DIR_VERSION >>>"
 
 private val STARTUP_DIR_BLOCK = """
     $STARTUP_DIR_MARKER_CURRENT
-    # Start in the active folder ONLY when this shell was given no directory of
-    # its own. See FirstRunSetup.ensureStartupDirGuard for why the test is -ef.
+    # Start in the projects directory ONLY when this shell was given no directory
+    # of its own. See FirstRunSetup.ensureStartupDirGuard for why the test is -ef.
     if [ "${'$'}PWD" -ef "${'$'}HOME" ]; then
-        if [ -f "${'$'}HOME/.vscodroid_folder" ]; then
-            __folder="${'$'}(cat "${'$'}HOME/.vscodroid_folder" 2>/dev/null)"
-            [ -d "${'$'}__folder" ] && cd "${'$'}__folder" 2>/dev/null || cd "${'$'}PROJECTS_DIR" 2>/dev/null || true
-            unset __folder
-        else
-            cd "${'$'}PROJECTS_DIR" 2>/dev/null || true
-        fi
+        cd "${'$'}PROJECTS_DIR" 2>/dev/null || true
     fi
     $STARTUP_DIR_END $STARTUP_DIR_VERSION <<<
 """.trimIndent()
@@ -2583,6 +2591,31 @@ private val STARTUP_DIR_BLOCK = """
  * nowhere and is left exactly as they wrote it. Deriving it from the new block
  * would disarm that on the first edit to the new one.
  */
+/**
+ * The v1 block, byte for byte, markers written out rather than composed.
+ *
+ * Frozen for the reason [LEGACY_STARTUP_DIR_BLOCK] gives, and the markers are
+ * literals here rather than `$STARTUP_DIR_BEGIN` and the version constant, so
+ * that bumping the version cannot quietly rewrite what this is supposed to
+ * match. An exact match is the whole mechanism: a block the user edited matches
+ * nothing here and is left as they wrote it.
+ */
+private val LEGACY_STARTUP_DIR_BLOCK_V1 = """
+    # >>> vscodroid startup dir v1 >>>
+    # Start in the active folder ONLY when this shell was given no directory of
+    # its own. See FirstRunSetup.ensureStartupDirGuard for why the test is -ef.
+    if [ "${'$'}PWD" -ef "${'$'}HOME" ]; then
+        if [ -f "${'$'}HOME/.vscodroid_folder" ]; then
+            __folder="${'$'}(cat "${'$'}HOME/.vscodroid_folder" 2>/dev/null)"
+            [ -d "${'$'}__folder" ] && cd "${'$'}__folder" 2>/dev/null || cd "${'$'}PROJECTS_DIR" 2>/dev/null || true
+            unset __folder
+        else
+            cd "${'$'}PROJECTS_DIR" 2>/dev/null || true
+        fi
+    fi
+    # <<< vscodroid startup dir v1 <<<
+""".trimIndent()
+
 private val LEGACY_STARTUP_DIR_BLOCK = """
     # Start in the active folder (SAF or default projects dir)
     if [ -f "${'$'}HOME/.vscodroid_folder" ]; then

--- a/android/app/src/test/kotlin/com/vscodroid/setup/StartupDirGuardTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/StartupDirGuardTest.kt
@@ -115,9 +115,7 @@ class StartupDirGuardTest {
     @Test
     fun `a shell started in a folder stays in it`() {
         val workspace = File(filesDir, "workspace").apply { mkdirs() }
-        val recorded = File(filesDir, "recorded").apply { mkdirs() }
         createBashrc()
-        File(home, ".vscodroid_folder").writeText(recorded.path)
 
         assertEquals(
             workspace.canonicalPath, endsUpIn(workspace),
@@ -141,48 +139,32 @@ class StartupDirGuardTest {
         )
     }
 
+    /**
+     * A record an older release left behind must not steer a shell.
+     *
+     * `~/.vscodroid_folder` was written only when a device folder was opened
+     * through the picker, and nothing ever cleared it, so a device that opened one
+     * once sent every later empty-window shell into that mirror. A mirror with no
+     * live watcher takes writes that reach the user's device folder only when they
+     * open it again, which is the silent divergence the sync engine exists to
+     * prevent. The file is not produced any more, and this pins that a leftover one
+     * is inert.
+     *
+     * The recorded directory has to exist and has to differ from the projects
+     * directory, or the case cannot tell "ignored" from "fell back because it was
+     * missing".
+     */
     @Test
-    fun `a shell started in HOME prefers the recorded folder`() {
+    fun `a folder record left by an older release is ignored`() {
         val recorded = File(filesDir, "recorded").apply { mkdirs() }
         createBashrc()
         File(home, ".vscodroid_folder").writeText(recorded.path)
 
-        assertEquals(recorded.canonicalPath, endsUpIn(home), "the recorded folder was ignored")
-    }
-
-    @Test
-    fun `a recorded folder that no longer exists falls back to the projects directory`() {
-        createBashrc()
-        File(home, ".vscodroid_folder").writeText(File(filesDir, "deleted").path)
-
-        // endsUpIn asserts the output is exactly one line, which is the second half
-        // of this case: a failed cd that printed a diagnostic would corrupt the
-        // terminal's first prompt as surely as landing in the wrong place.
         assertEquals(
             projects.canonicalPath, endsUpIn(home),
-            "a stale recorded folder left the shell in HOME instead of falling back",
-        )
-    }
-
-    /**
-     * The case the `[ -d ]` test is actually for.
-     *
-     * Measured while checking that each clause earns its place: with the recorded
-     * folder merely deleted, dropping `[ -d ]` changes nothing, because `cd` to a
-     * missing path fails and the `||` already falls through to the projects
-     * directory. An EMPTY recorded file is different. `__folder` is then the empty
-     * string, `cd ""` succeeds in bash and moves nowhere, so without the test the
-     * shell simply stays in HOME and the fallback never runs.
-     */
-    @Test
-    fun `an empty recorded folder falls back rather than staying put`() {
-        createBashrc()
-        File(home, ".vscodroid_folder").writeText("")
-
-        assertEquals(
-            projects.canonicalPath, endsUpIn(home),
-            "an empty recorded folder left the shell in HOME: cd to the empty string " +
-                "succeeds, so only the -d test can send it to the fallback",
+            "a leftover record steered the shell into ${recorded.name}; that path is a " +
+                "mirror nothing is watching, so a write there reaches the device only " +
+                "when the folder is opened again",
         )
     }
 
@@ -233,6 +215,52 @@ class StartupDirGuardTest {
         }
         val prefix = String(before).substringBefore("# Start in the active folder")
         assertTrue(after.startsWith(prefix), "the bytes before the block did not survive unchanged")
+    }
+
+    /**
+     * A device on the previous guarded shape gets the new one.
+     *
+     * The v0 case above covers a release that never had a guard at all. This
+     * covers the one that had the guard and read the folder record, which is the
+     * shape every device carries between the guard landing and this change. It is
+     * a separate fixture rather than a parameter because the migration matches each
+     * frozen text exactly, and a test that composed the text from the constants
+     * would pass on a match that no device actually holds.
+     */
+    @Test
+    fun `a device on the v1 block is moved to v2`() {
+        val text = """
+            # VSCodroid bash configuration
+
+            export PROJECTS_DIR='${projects.path}'
+
+            # >>> vscodroid startup dir v1 >>>
+            # Start in the active folder ONLY when this shell was given no directory of
+            # its own. See FirstRunSetup.ensureStartupDirGuard for why the test is -ef.
+            if [ "${'$'}PWD" -ef "${'$'}HOME" ]; then
+                if [ -f "${'$'}HOME/.vscodroid_folder" ]; then
+                    __folder="${'$'}(cat "${'$'}HOME/.vscodroid_folder" 2>/dev/null)"
+                    [ -d "${'$'}__folder" ] && cd "${'$'}__folder" 2>/dev/null || cd "${'$'}PROJECTS_DIR" 2>/dev/null || true
+                    unset __folder
+                else
+                    cd "${'$'}PROJECTS_DIR" 2>/dev/null || true
+                fi
+            fi
+            # <<< vscodroid startup dir v1 <<<
+
+            # the user's own alias
+        """.trimIndent() + "\n"
+        bashrc.writeText(text)
+
+        FirstRunSetup(context).ensureStartupDirGuard()
+
+        val after = bashrc.readText()
+        assertTrue(after.contains("startup dir v2"), "the v1 block was not replaced")
+        assertFalse(
+            after.contains(".vscodroid_folder"),
+            "the record branch survived the migration, so an empty window still reads it",
+        )
+        assertTrue(after.contains("# the user's own alias"), "the migration lost what followed")
     }
 
     @Test


### PR DESCRIPTION
`~/.vscodroid_folder` was written only when a device folder was opened through the picker, was never updated when the workbench opened an ordinary folder, and was never cleared. Since the startup guard landed it is read only when no workspace folder is open, so a device that opened one device folder once sent **every later empty-window shell into that mirror**. A mirror with no live watcher takes writes that reach the user's device folder only when they open it again, which is the silent divergence the sync engine exists to prevent.

## Why maintaining it was the wrong shape

Correct maintenance means clearing the record when the window empties. That is the only moment it is read, so the feature disappears either way. Maintaining it without clearing promises "resume the folder you closed" and delivers a shell inside an unwatched mirror.

The app already keeps a maintained record of the open folder in memory, fed from `navigateToFolder` and from the page-load callback that `folderFromUrl` serves. The file was a second, unmaintained answer to a question the shell should not be asking.

## What changed

- The producer is deleted: the `writeActiveFolder` call in `openSafFolder` and the function itself.
- The generated block is at `v2` and reduces to a `cd` to the projects directory when the shell was given no directory of its own. That is where `docs`'s welcome file already tells the user new terminals start.
- `ensureStartupDirGuard` matches both earlier shapes. Each is frozen byte for byte with its markers written out rather than composed from the version constant, so bumping the version cannot quietly rewrite what a migration is supposed to match, and a block the user edited still matches nothing and is left exactly as they wrote it.

## Verification

Nine cases in `StartupDirGuardTest`, four of which run real `/bin/bash` against the generated file. Five negative controls, each reddening its own case: removing the `-ef` guard, removing the `cd`, putting a record branch back into `v2`, and dropping either frozen shape from the migration list.

Verified on an API 33 emulator against a real installed device, on the path that matters most, which is an update with no version change so setup does not re-run and the per-launch repair is what acts. Before: `# >>> vscodroid startup dir v1 >>>` with the record branch. After: `v2` with a single `cd`, the record branch gone, `Guarded the startup cd in .bashrc (v2)` in logcat, and the rest of the file intact, prompt block, exports, toolchain sourcing, npm and npx wrappers and aliases all still present.

Full unit suite 1359 tests, no failures.