### PR TITLE
feat(storage): let a device folder copy be seen and removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Toolchain commands now work when a program calls them, not only from bash. Tasks, `make` recipes and extensions previously failed on a correctly installed toolchain.
+- Device folder copies can now be listed by size and removed one at a time. Removing one that holds files not on the device deletes them, so it asks first.
 - Bug reports now carry the server's own output. The report always had a section for it, and nothing ever wrote the file it reads, so it was always empty.
 - The gesture trackpad now offers four accessibility actions to move the cursor. A drag was the only way to send an arrow, and a screen reader cannot drag.
 - Long pressing a key through a screen reader now opens its alternate characters. The layer needed a finger held on the key, so `'` and `\` were unreachable.

--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -290,7 +290,7 @@ M6 (Release)   → Play Store release
      - Material Icon Theme, ESLint, Prettier, Python, Tailwind CSS
    - [x] 4 custom VSCodroid extensions:
      - `vscodroid.vscodroid-welcome-1.2.2`, welcome tab with quick actions
-     - `vscodroid.vscodroid-saf-bridge-1.3.0` — SAF storage integration
+     - `vscodroid.vscodroid-saf-bridge-1.4.0` — SAF storage integration
      - `vscodroid.vscodroid-process-monitor-1.0.0` — phantom process monitoring
      - `vscodroid.vscodroid-serve-network-1.1.0`, serve a dev server on the LAN
    - [x] `extensions.json` manifest auto-generated on first run

--- a/android/app/src/main/assets/extensions/vscodroid.vscodroid-saf-bridge-1.4.0/extension.js
+++ b/android/app/src/main/assets/extensions/vscodroid.vscodroid-saf-bridge-1.4.0/extension.js
@@ -17,6 +17,7 @@
  * - vscodroid.generateSshKey       : Creates ~/.ssh/id_ed25519
  * - vscodroid.copySshPublicKey     : Copies the public key to the clipboard
  * - vscodroid.showStorageUsage     : Per-component storage breakdown
+ * - vscodroid.manageDeviceFolders  : Lists the local copies of device folders and removes one
  * - vscodroid.clearCaches          : Deletes cached data, reports bytes freed
  * - vscodroid.about                : Opens the Android About dialog
  */
@@ -276,6 +277,16 @@ function activate(context) {
                 // with.
                 if (picked.key && clearable.has(picked.key)) {
                     vscode.commands.executeCommand('vscodroid.clearCaches');
+                } else if (picked.key === 'saf_mirrors') {
+                    // The one unclearable row that has somewhere to go. It is
+                    // usually the largest, it is never freed automatically once
+                    // anything has been built inside it, and until this branch
+                    // existed choosing it produced a sentence and a dead end.
+                    // The key is compared rather than a new flag added to the
+                    // breakdown: `clearable` means "keys clearCaches empties",
+                    // and widening it to mean "keys that do something" is how
+                    // that set would come to include one this action cannot free.
+                    vscode.commands.executeCommand('vscodroid.manageDeviceFolders');
                 } else if (picked.key) {
                     vscode.window.showInformationMessage(
                         `${STORAGE_LABELS[picked.key] || picked.key} is not cached data ` +
@@ -285,6 +296,95 @@ function activate(context) {
             } catch (/** @type {*} */ err) {
                 vscode.window.showErrorMessage(
                     `Could not read storage usage: ${err.message}`
+                );
+            }
+        }
+    );
+
+    // -- Device folder storage --
+
+    /**
+     * Lists the local copy of every device folder and offers to remove one.
+     *
+     * This is the only place in the app that can name them. Opening a device
+     * folder copies it under the app's own storage, and the app keeps a grant for
+     * the ten most recently opened folders; the eleventh releases its grant, and
+     * with it the entry that carried the folder's name. The copy stays on disk.
+     * The automatic cleanup then declines to remove it whenever it holds a file
+     * the device folder does not, which is the ordinary state of any folder
+     * somebody has run a build or a clone in, so the largest copies are exactly
+     * the ones that are never reclaimed and never named anywhere else.
+     */
+    const manageDeviceFoldersCmd = vscode.commands.registerCommand(
+        'vscodroid.manageDeviceFolders',
+        async () => {
+            try {
+                const json = /** @type {string} */ (
+                    await sendBridgeCommand('listSafMirrors')
+                );
+                const mirrors = JSON.parse(json || '[]');
+
+                if (mirrors.length === 0) {
+                    vscode.window.showInformationMessage(
+                        'No device folders have been copied into VSCodroid yet.'
+                    );
+                    return;
+                }
+
+                /** @type {(vscode.QuickPickItem & { mirror?: * })[]} */
+                const items = mirrors.map((/** @type {*} */ m) => ({
+                    mirror: m,
+                    // A copy whose folder fell off the recent list has no name
+                    // left anywhere, so say that rather than showing the hash,
+                    // which reads like a folder name and is not one.
+                    label: `$(folder) ${m.name || 'Unnamed folder'}`,
+                    description:
+                        formatBytes(Number(m.bytes) || 0) +
+                        (m.granted ? '' : ' · no longer accessible'),
+                    detail: m.reclaimable
+                        ? 'Every file here is also in the device folder'
+                        : 'Holds files that are NOT in the device folder'
+                }));
+
+                const picked = await vscode.window.showQuickPick(items, {
+                    placeHolder: 'Local copies of device folders; select one to remove'
+                });
+                if (!picked || !picked.mirror) return;
+
+                const m = picked.mirror;
+                const name = m.name || 'this folder';
+                const size = formatBytes(Number(m.bytes) || 0);
+                // Two different warnings, because the two cases cost the user
+                // different things and a single wording would have to be wrong
+                // about one of them. Modal in both, since neither is undoable.
+                const message = m.reclaimable
+                    ? `Remove VSCodroid's local copy of ${name} and free ${size}? ` +
+                      'The device folder itself is not touched, and every file in ' +
+                      'the copy is already there.'
+                    : `Remove VSCodroid's local copy of ${name} and free ${size}? ` +
+                      'THIS DELETES FILES. Some files in the copy are not in the ' +
+                      'device folder, including anything under node_modules, .git, ' +
+                      '__pycache__ or .gradle, and they exist nowhere else. This ' +
+                      'cannot be undone.';
+                const confirm = await vscode.window.showWarningMessage(
+                    message, { modal: true }, 'Remove'
+                );
+                if (confirm !== 'Remove') return;
+
+                await sendBridgeCommand('reclaimSafMirror', {
+                    hash: m.hash,
+                    force: !m.reclaimable
+                });
+                // Straight back to the list: the usual reason for opening this is
+                // to free space, and one folder is rarely the whole answer.
+                vscode.commands.executeCommand('vscodroid.manageDeviceFolders');
+            } catch (/** @type {*} */ err) {
+                // The refusal reasons arrive here, and each names something that
+                // has to change before the removal can happen: a folder that is
+                // open, one still syncing, or one this session has had open,
+                // which needs a restart before its copy can be removed safely.
+                vscode.window.showErrorMessage(
+                    `Could not remove that folder's local copy: ${err.message}`
                 );
             }
         }
@@ -326,6 +426,7 @@ function activate(context) {
         generateSshKeyCmd,
         copySshPublicKeyCmd,
         storageUsageCmd,
+        manageDeviceFoldersCmd,
         clearCachesCmd,
         aboutCmd
     );

--- a/android/app/src/main/assets/extensions/vscodroid.vscodroid-saf-bridge-1.4.0/package.json
+++ b/android/app/src/main/assets/extensions/vscodroid.vscodroid-saf-bridge-1.4.0/package.json
@@ -2,7 +2,7 @@
   "name": "vscodroid-saf-bridge",
   "displayName": "VSCodroid Android Bridge",
   "description": "Commands that reach Android: device folders, browser, SSH keys, storage, about",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "publisher": "vscodroid",
   "engines": {
     "vscode": "^1.96.0"
@@ -39,6 +39,10 @@
       {
         "command": "vscodroid.showStorageUsage",
         "title": "VSCodroid: Show Storage Usage"
+      },
+      {
+        "command": "vscodroid.manageDeviceFolders",
+        "title": "VSCodroid: Manage Device Folder Storage"
       },
       {
         "command": "vscodroid.clearCaches",

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -70,8 +70,10 @@ import com.vscodroid.webview.publishedResourceRoots
 import com.vscodroid.webview.redactToken
 import com.vscodroid.webview.sensitiveLocations
 import com.vscodroid.webview.tlsFailureToAnnounce
+import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
+import kotlin.concurrent.thread
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -122,7 +124,13 @@ class MainActivity : AppCompatActivity() {
      * A pair because [SafStorageManager.startFileWatcher] needs both and one is
      * useless without the other. Kept so that a failed folder switch can put the
      * previous folder's watcher back — see [restoreWatcherAfterFailure].
+     *
+     * Volatile because the removal guard reads it, and that read arrives on the
+     * WebView's "JavaBridge" thread while every write here is on the UI thread.
+     * The guard has to answer synchronously, so it cannot hop; a stale read of
+     * this field is a mirror the editor has open being reported as free.
      */
+    @Volatile
     private var watchedSafFolder: Pair<File, Uri>? = null
 
     /**
@@ -131,8 +139,40 @@ class MainActivity : AppCompatActivity() {
      * `navigateToFolder` loads `/?folder=..&tkn=..` and the server redirects, so
      * two page-finished callbacks arrive per switch. Without this, the second one
      * sees a watcher that is not yet installed and starts the same sync again.
+     *
+     * Volatile for the reason [watchedSafFolder] is: the removal guard reads it
+     * off the WebView's bridge thread and cannot hop to ask. A mirror read as not
+     * being synced while a sync is half way through it is one whose removal
+     * leaves the folder part written under a watcher that starts afterwards.
      */
+    @Volatile
     private var syncingFolder: Uri? = null
+
+    /**
+     * Every mirror this process has put a watcher on, whether or not one is on it
+     * now.
+     *
+     * Never cleared, and that is the point rather than an omission.
+     * [SafStorageManager.stopFileWatcher] stops the observers, but the engine
+     * waits only two seconds for the write-back worker to drain and then leaves
+     * it running rather than discarding writes the user expects on the device.
+     * So a folder the app considers closed can still have a thread streaming
+     * bytes out of its mirror, and every such write opens the device document
+     * with `"wt"`, which truncates at open: deleting the mirror underneath one
+     * empties the user's file rather than leaving it alone.
+     *
+     * A drain only ever touches the mirror it was started for, so refusing every
+     * mirror this process has watched is what puts it out of reach without
+     * needing to know whether a particular drain is still alive. The cost is that
+     * removing a folder opened this session needs a restart, which is a sentence
+     * the user can act on.
+     *
+     * Concurrent because it is written on the UI thread and read on the bridge
+     * thread, and a set that answers the guard cannot be one the guard may see
+     * mid-write.
+     */
+    private val mirrorsWatchedThisProcess: MutableSet<String> =
+        java.util.concurrent.ConcurrentHashMap.newKeySet()
 
     /**
      * The directories this app publishes into the WebView, resolved once.
@@ -757,7 +797,7 @@ class MainActivity : AppCompatActivity() {
                 }
 
                 safManager.startFileWatcher(mirrorDir, uri)
-                watchedSafFolder = mirrorDir to uri
+                beginWatching(mirrorDir, uri)
 
 
                 dialog.dismiss()
@@ -840,9 +880,118 @@ class MainActivity : AppCompatActivity() {
         val (mirrorDir, uri) = previous ?: return false
         if (!shouldRestorePreviousWatcher(uri.toString(), failed.toString())) return false
         safManager.startFileWatcher(mirrorDir, uri)
-        watchedSafFolder = previous
+        beginWatching(mirrorDir, uri)
         Logger.i(tag, "Restored the previous folder's watcher after a failed switch")
         return true
+    }
+
+    /**
+     * Records that a watcher is on [mirrorDir], both for now and for the rest of
+     * the process.
+     *
+     * One method rather than two assignments at each site, because the two
+     * records answer different questions and only one of them is ever cleared.
+     * [watchedSafFolder] says what is watched now and goes null on every folder
+     * switch; [mirrorsWatchedThisProcess] says what a write-back drain could
+     * still be inside, and a drain outlives the switch that stopped it. A site
+     * that set the first without the second would leave the removal guard
+     * believing a mirror was untouched while a thread was still writing out of
+     * it, and nothing about that site would look wrong.
+     */
+    private fun beginWatching(mirrorDir: File, uri: Uri) {
+        watchedSafFolder = mirrorDir to uri
+        mirrorsWatchedThisProcess.add(mirrorDir.name)
+    }
+
+    /**
+     * The local copies of device folders, as the JSON the storage screen renders.
+     *
+     * Runs on the WebView's bridge thread and walks every mirror twice, once to
+     * size it and once to ask whether the device folder holds everything in it.
+     * That is slow enough to be worth naming, and the alternative is worse: a
+     * screen that offers a removal without saying what it costs is the shape this
+     * whole feature exists to replace.
+     */
+    private fun deviceFolderCopiesAsJson(): String =
+        JSONArray().apply {
+            safManager.listMirrors().forEach { mirror ->
+                put(JSONObject().apply {
+                    put("hash", mirror.hash)
+                    // Absent rather than filled in with the hash: the extension
+                    // decides how to name a folder the app can no longer name,
+                    // and a hash rendered as a folder name reads as a real one.
+                    if (mirror.displayName != null) put("name", mirror.displayName)
+                    put("bytes", mirror.bytes)
+                    put("lastOpened", mirror.lastOpened)
+                    put("granted", mirror.granted)
+                    put("reclaimable", mirror.reclaimable)
+                })
+            }
+        }.toString()
+
+    /**
+     * Removes the local copy of one device folder, or says why it cannot be.
+     *
+     * Two refusals, in two places, because they answer different questions and
+     * only one of them can be answered here. Whether anything is still using the
+     * mirror is this Activity's to know, and
+     * [SafStorageManager.reclaimRefusal] is the rule; whether removing it would
+     * lose the user's only copy of something is the storage manager's, and
+     * [SafStorageManager.reclaimMirror] re-asks it at the moment of the removal
+     * rather than trusting the listing the user was shown, because a write-back
+     * can strand a file while a confirmation dialog is on screen.
+     *
+     * The open workspace is read from [openWorkspaceFolder] and not from
+     * `webView?.url`. This runs on the bridge thread, and `WebView.getUrl` is a
+     * View call that belongs to the UI thread; that field exists precisely
+     * because the resource interceptor has the same problem.
+     *
+     * @return the empty string when the copy was removed, and otherwise the
+     *   sentence to show. Success is the falsy value; see
+     *   [com.vscodroid.bridge.AndroidBridge.reclaimSafMirror].
+     */
+    private fun removeDeviceFolderCopy(hash: String, force: Boolean): String {
+        val mirrorsRoot = Environment.getSafMirrorsDir(this)
+        val inUse = SafStorageManager.reclaimRefusal(
+            hash = hash,
+            watchedMirror = watchedSafFolder?.first?.name,
+            syncingMirror = syncingFolder?.let { safManager.getMirrorDir(it).name },
+            openWorkspaceMirror = SafStorageManager.mirrorNameFor(
+                openWorkspaceFolder, mirrorsRoot
+            ),
+            watchedThisProcess = mirrorsWatchedThisProcess,
+        )
+        if (inUse != null) return inUse
+
+        val freed = safManager.reclaimMirror(hash, force)
+        return when (freed) {
+            SafStorageManager.RECLAIM_UNKNOWN -> getString(R.string.saf_mirror_unknown)
+            SafStorageManager.RECLAIM_REFUSED -> getString(R.string.saf_mirror_not_a_copy)
+            else -> {
+                // The mirror is already unreachable at this point; what is left is
+                // the recursive delete, which takes as long as the tree is big.
+                // Detached because nothing waits for it: the next launch pass
+                // finishes any leftover, so the worst a killed process costs is
+                // disk that is already spent.
+                thread(name = "saf-sweep", isDaemon = true) {
+                    try {
+                        safManager.sweepDiscardedMirrors()
+                    } catch (e: Exception) {
+                        Logger.w(tag, "Sweeping the removed copies failed: ${e.message}")
+                    }
+                }
+                runOnUiThread {
+                    Toast.makeText(
+                        this,
+                        getString(
+                            R.string.saf_mirror_removed, StorageManager.formatSize(freed)
+                        ),
+                        Toast.LENGTH_LONG,
+                    ).show()
+                }
+                ""
+            }
+        }
     }
 
     /**
@@ -1426,6 +1575,13 @@ class MainActivity : AppCompatActivity() {
             onDownloadNamed = { url, fileName -> downloads.onDownloadNamed(url, fileName) },
             onDownloadChunk = { requestId, base64 -> downloads.onBytes(requestId, base64) },
             onDownloadComplete = { requestId, error -> downloads.onComplete(requestId, error) },
+            // Not hopped either, and for the reason the download three are not:
+            // each returns a String the caller reads synchronously, and
+            // runOnUiThread returns Unit. Both walk the filesystem, which is
+            // correct on this thread and would not be on the UI one; the caller
+            // is a promise in the extension host with a five-second timeout.
+            onListMirrors = { deviceFolderCopiesAsJson() },
+            onReclaimMirror = { hash, force -> removeDeviceFolderCopy(hash, force) },
         )
         wv.addJavascriptInterface(bridge, "AndroidBridge")
 
@@ -2041,6 +2197,21 @@ class MainActivity : AppCompatActivity() {
                             ch.postMessage(result === ''
                                 ? {id: d.id, ok: true}
                                 : {id: d.id, ok: false, error: result});
+                        } else if (d.cmd === 'listSafMirrors') {
+                            result = AndroidBridge.listSafMirrors(token);
+                            ch.postMessage({id: d.id, ok: true, data: result});
+                        } else if (d.cmd === 'reclaimSafMirror') {
+                            // The second branch that can decline, and it follows
+                            // openExternalUrl's convention exactly: empty means it
+                            // was removed, anything else is the sentence to show.
+                            // Posting ok:true flatly here would tell the user their
+                            // disk had been freed when the removal was refused
+                            // because the folder is still open.
+                            result = AndroidBridge.reclaimSafMirror(
+                                token, d.hash, d.force === true);
+                            ch.postMessage(result === ''
+                                ? {id: d.id, ok: true}
+                                : {id: d.id, ok: false, error: result});
                         }
                     } catch(err) {
                         ch.postMessage({id: d.id, ok: false, error: String(err)});
@@ -2302,12 +2473,20 @@ class MainActivity : AppCompatActivity() {
      * Warns the user if available storage is critically low (<100 MB).
      *
      * The command name is quoted exactly as the palette lists it
-     * (`VSCodroid: Clear Caches`, contributed by the bundled Android bridge
-     * extension), because the reader's next action is to type it. This said
-     * "Clear caches in Settings" until 2026-08-14, and there is no Settings
-     * screen: the manifest declares Splash, Main and Toolchain activities and
-     * nothing else, so the sentence sent a user who was out of space looking
-     * for a place that does not exist.
+     * (`VSCodroid: Manage Device Folder Storage`, contributed by the bundled
+     * Android bridge extension), because the reader's next action is to type it.
+     * This said "Clear caches in Settings" until 2026-08-14, and there is no
+     * Settings screen: the manifest declares Splash, Main and Toolchain
+     * activities and nothing else, so the sentence sent a user who was out of
+     * space looking for a place that does not exist.
+     *
+     * It then named `VSCodroid: Clear Caches`, which exists but cannot free the
+     * directory that is usually the largest. `clearCaches` empties the npm cache,
+     * the temporary directory, the crash logs and the editor's logs, and none of
+     * those is `saf-mirrors`, where a copy of every device folder the user has
+     * opened accumulates and is never removed automatically once anything in it
+     * has been built or cloned. So the one moment the advice was given was the
+     * one moment it was wrong.
      */
     private fun checkStorageHealth() {
         if (!StorageManager.isStorageLow(this)) return

--- a/android/app/src/main/kotlin/com/vscodroid/bridge/AndroidBridge.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/bridge/AndroidBridge.kt
@@ -138,6 +138,34 @@ internal const val OPEN_URL_NO_HANDLER =
 internal const val OPEN_URL_FAILED_PREFIX = "VSCodroid could not open that link: "
 
 /**
+ * Why [AndroidBridge.reclaimSafMirror] did not remove a mirror.
+ *
+ * The convention is [AndroidBridge.openExternalUrl]'s, and it is worth stating
+ * because it reads backwards: the EMPTY STRING means it was removed, and anything
+ * else is the sentence to show. A caller testing truthiness reports every refusal
+ * as a success, which for this method means telling the user their disk was freed
+ * while it was not.
+ *
+ * A refusal here is never a suggestion to retry harder. Each one names something
+ * that has to change first, and the two below are the ones this file can decide
+ * on its own; the rest come from the Activity, which is the only place that knows
+ * what the editor currently has open.
+ */
+internal const val RECLAIM_STALE_SESSION =
+    "VSCodroid did not accept the request. Reload the window and try again."
+
+/**
+ * No Activity wired the callback, so nothing could have been removed.
+ *
+ * Distinct from a refusal with a reason, because a bridge built without the
+ * wiring is a mistake in this app rather than a state the user can act on, and
+ * reporting it as "that folder is in use" would send them looking for a folder to
+ * close.
+ */
+internal const val RECLAIM_UNAVAILABLE =
+    "VSCodroid cannot manage device folder storage right now."
+
+/**
  * The sign-in requests this app launched a browser for, and when.
  *
  * Keyed by request id rather than being a single reading, and that is the whole
@@ -299,6 +327,9 @@ class AndroidBridge(
     private val onDownloadNamed: (url: String, fileName: String) -> Unit = { _, _ -> },
     private val onDownloadChunk: (requestId: String, base64: String) -> Boolean = { _, _ -> false },
     private val onDownloadComplete: (requestId: String, error: String?) -> Unit = { _, _ -> },
+    private val onListMirrors: () -> String = { "[]" },
+    private val onReclaimMirror: (hash: String, force: Boolean) -> String =
+        { _, _ -> RECLAIM_UNAVAILABLE },
 ) {
     private val tag = "AndroidBridge"
 
@@ -605,6 +636,46 @@ class AndroidBridge(
     fun getAvailableStorage(authToken: String): Long {
         if (!security.validateToken(authToken)) return 0
         return StorageManager.getAvailableStorage(context)
+    }
+
+    /**
+     * Returns the local copies of device folders, as a JSON array.
+     *
+     * [getStorageBreakdown] reports all of them as one number under `saf_mirrors`,
+     * which is honest and unactionable: the row is correctly marked unclearable, and
+     * choosing it is a dead end. This is the row's contents, so that the user can see
+     * which folder is holding the disk and decide about that folder rather than about
+     * a total.
+     *
+     * Answers `[]` when refused and also when no SAF manager is wired up, which are
+     * indistinguishable here, as they are in [getRecentFolders].
+     */
+    @JavascriptInterface
+    fun listSafMirrors(authToken: String): String {
+        if (!security.validateToken(authToken)) return "[]"
+        return onListMirrors()
+    }
+
+    /**
+     * Removes the local copy of one device folder and says whether it went.
+     *
+     * ⚠️ **This deletes files, and with [force] it deletes files that exist nowhere
+     * else.** A mirror the app can vouch for is a copy of the device folder and
+     * removing it loses nothing. A mirror it cannot vouch for holds work the app never
+     * delivered to the device: anything under `node_modules`, `.git`, `__pycache__` or
+     * `.gradle`, which the sync excludes by construction, and anything written while no
+     * watcher was running. [force] is the user's own decision to remove it anyway, and
+     * the caller must have said what is at stake in a modal the user had to accept. It
+     * is not a retry flag.
+     *
+     * @return the empty string when the mirror was removed, and otherwise the sentence
+     *   naming why it was not. Success is the falsy value, so a truthiness test reads
+     *   backwards and claims every refusal as a removal.
+     */
+    @JavascriptInterface
+    fun reclaimSafMirror(authToken: String, hash: String, force: Boolean): String {
+        if (!security.validateToken(authToken)) return RECLAIM_STALE_SESSION
+        return onReclaimMirror(hash, force)
     }
 
     // -- Crash Reporting --

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafStorageManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafStorageManager.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.net.Uri
 import android.provider.DocumentsContract
 import com.vscodroid.util.Logger
+import com.vscodroid.util.StorageManager
 import org.json.JSONArray
 import org.json.JSONObject
 import java.io.File
@@ -352,38 +353,253 @@ class SafStorageManager(private val context: Context) {
                 return@forEach
             }
 
-            // The journal keys its entries on the mirror's real path, which is
-            // the name before this pass renames it. `removePrefix` is a no-op on
-            // the branch that has not been renamed yet, so one expression serves
-            // both. Passing the `discarded-` path instead matched no entry at
-            // all, so the records outlived the mirror they distrust, and a later
-            // re-grant of the same folder read the device's own document as this
-            // app's interrupted upload and wrote the stale mirror back over it.
-            val originalPath = File(root, name.removePrefix(DISCARD_PREFIX))
-
-            val discarded: File
-            if (alreadySetAside) {
-                discarded = entry
-            } else {
-                val target = File(root, DISCARD_PREFIX + name)
-                if (!entry.renameTo(target)) {
-                    Logger.w(tag, "Could not set $name aside; leaving it in place")
-                    return@forEach
-                }
-                discarded = target
-            }
-            if (discarded.deleteRecursively()) {
-                removed++
-                // The mirror's distrust of its own device copies goes with it; see
-                // [SafSyncEngine.clearUploadsUnder] for what an entry that outlives
-                // its mirror costs a later re-grant.
-                syncEngine.clearUploadsUnder(originalPath)
-            }
+            if (discardEntry(root, name)) removed++
         }
         if (removed > 0) {
             Logger.i(tag, "Reclaimed $removed mirror entr(ies) without a live permission")
         }
         return removed
+    }
+
+    /**
+     * Renames one entry out of the way, and answers with where it went.
+     *
+     * The rename is the commit point of every removal in this file, and the reason is
+     * in [reclaimRevokedMirrorsSync]: a delete in place rests on nothing else touching
+     * the directory while the walk is inside it, and a mirror the size of a project
+     * takes long enough for the user to re-grant the same folder and re-sync it there.
+     * The walk's remaining deletes then land on the new copy under a running watcher
+     * and go out to the device as deletions of the user's real documents. A rename is
+     * atomic and instant, so the re-granted folder gets a fresh directory this removal
+     * cannot reach.
+     *
+     * It is also what makes an interrupted removal safe to abandon. Everything after
+     * the rename is idempotent and is finished off unconditionally by the next launch
+     * pass, so a return added between here and the delete costs disk until the next
+     * launch rather than correctness. That is the property to preserve when editing
+     * either caller.
+     *
+     * @return the set-aside entry, or null when there was nothing to move or the
+     *   rename failed. An entry already carrying [DISCARD_PREFIX] is returned as it
+     *   stands: an earlier pass reached this same point and its verdict still holds.
+     */
+    private fun setAside(root: File, name: String): File? {
+        if (name.startsWith(DISCARD_PREFIX)) return File(root, name).takeIf { it.exists() }
+        val entry = File(root, name)
+        if (!entry.exists()) return null
+        val target = File(root, DISCARD_PREFIX + name)
+        if (!entry.renameTo(target)) {
+            Logger.w(tag, "Could not set $name aside; leaving it in place")
+            return null
+        }
+        return target
+    }
+
+    /**
+     * Deletes an entry [setAside] has already moved, and retires the upload records
+     * that named it.
+     *
+     * [originalPath] is the path before the rename, and passing the `discarded-` one
+     * instead matched no journal entry at all, so records outlived the mirror they
+     * distrust: a later re-grant of the same folder hashes back to the same path, and
+     * the next sync then read the device's own document as this app's interrupted
+     * upload and wrote the stale mirror back over it.
+     *
+     * The delete is [com.vscodroid.util.StorageManager.deleteRecursive] rather than
+     * `File.deleteRecursively`, which asks `isDirectory` and `listFiles` and therefore
+     * descends through a symlink pointing out of the mirror. On the launch pass that
+     * was masked by [SafSyncEngine.holdsOnlyVouchedCopies] refusing any mirror holding
+     * a link; a removal the user confirms has no such gate, and a mirror is routinely
+     * a checked-out repository, so a link inside one is ordinary.
+     *
+     * Success is read off the filesystem rather than from a return value, because the
+     * two callers need the same answer and one of them counts it.
+     */
+    private fun finishOff(discarded: File, originalPath: File): Boolean {
+        StorageManager.deleteRecursive(discarded)
+        if (discarded.exists()) {
+            Logger.w(tag, "Could not finish removing ${discarded.name}; the next launch retries")
+            return false
+        }
+        syncEngine.clearUploadsUnder(originalPath)
+        return true
+    }
+
+    /** [setAside] then [finishOff], for a caller removing one entry on its own. */
+    private fun discardEntry(root: File, name: String): Boolean {
+        val originalPath = File(root, name.removePrefix(DISCARD_PREFIX))
+        val discarded = setAside(root, name) ?: return false
+        return finishOff(discarded, originalPath)
+    }
+
+    // -- Device folder storage, as the user sees it --
+
+    /**
+     * Every mirror on disk, with its size and whether the launch pass would remove it.
+     *
+     * This exists because the count budget the app already has produces a result
+     * nobody can see. [addToRecentFolders] keeps [MAX_RECENT] folders and releases the
+     * grant of the one that falls off, which is what makes its mirror a candidate for
+     * [reclaimRevokedMirrorsSync]. But that pass then almost always declines, and it
+     * declines hardest on the mirrors worth the most disk: a mirror gets large by being
+     * worked in, and working in one creates files the sync record cannot vouch for.
+     * [SafSyncEngine.SKIP_DIRECTORIES] keeps `node_modules`, `.git`, `__pycache__` and
+     * `.gradle` out of that record by construction, so a single `npm install` inside a
+     * device folder makes its mirror permanently unreclaimable. Its recent-list entry
+     * went with its grant, so it also has no name anywhere in the app, only a hash.
+     *
+     * So the missing authority is the user's, not the app's, and this is the listing
+     * that lets them exercise it.
+     *
+     * Only entries of the shape [getMirrorDir] produces are reported, for the reason
+     * the launch pass gives: `saf-mirrors` is exported into every terminal as
+     * `SAF_MIRRORS_DIR` and published as a WebView resource root, so a person can leave
+     * a file there and some will. [isMirrorDirectoryName] is the predicate, and it is
+     * narrower than [MIRROR_ENTRY]: that pattern matches the `<hash>.synced` record
+     * too, because the launch pass has to recognise both halves of a mirror, and here
+     * the record is not a row. A `discarded-` entry fails it outright, which is what
+     * keeps a removal already in progress from being offered as a folder to remove.
+     *
+     * ⚠️ **Two full walks of every mirror**, one to size it and one to vouch for it, so
+     * this must not run on the main thread. The count is bounded by what is on disk
+     * rather than by [MAX_RECENT]: an orphan outlives its grant, which is the whole
+     * reason this method exists.
+     *
+     * The upload journal is read once for the listing rather than per mirror, as the
+     * launch pass does, so that every row is judged against one reading of it.
+     */
+    fun listMirrors(): List<MirrorInfo> {
+        val root = File(com.vscodroid.util.Environment.getSafMirrorsDir(context))
+        val entries = root.listFiles()?.filter {
+            it.isDirectory && isMirrorDirectoryName(it.name)
+        } ?: return emptyList()
+
+        val granted = context.contentResolver.persistedUriPermissions
+            .map { getMirrorDir(it.uri).name }
+            .toSet()
+        val named = getPersistedFolders().associateBy { getMirrorDir(it.uri).name }
+        val stranded = syncEngine.uploadsInFlight()
+
+        return entries.map { dir ->
+            MirrorInfo(
+                hash = dir.name,
+                displayName = named[dir.name]?.displayName,
+                bytes = StorageManager.dirSize(dir),
+                lastOpened = named[dir.name]?.lastOpened ?: 0L,
+                granted = dir.name in granted,
+                reclaimable = mayReclaim(dir.name, stranded, root.absolutePath) &&
+                    syncEngine.holdsOnlyVouchedCopies(dir),
+            )
+        }.sortedByDescending { it.bytes }
+    }
+
+    /**
+     * Gives up the grant on the folder [hash] mirrors, and drops it from the recent
+     * list.
+     *
+     * Called before a mirror is removed rather than after, so that the two records of
+     * the folder go with it. A recent-list entry that survives its mirror is an Open
+     * Recent row pointing at a directory that is not there, and a grant that survives
+     * it makes the launch pass treat the next mirror of that folder as live.
+     *
+     * A grant the system has already dropped is not an error here: the folder may have
+     * been revoked in system settings, which is one of the ways a mirror becomes an
+     * orphan in the first place.
+     */
+    fun releaseGrantFor(hash: String) {
+        context.contentResolver.persistedUriPermissions
+            .filter { getMirrorDir(it.uri).name == hash }
+            .forEach { held ->
+                try {
+                    context.contentResolver.releasePersistableUriPermission(
+                        held.uri,
+                        Intent.FLAG_GRANT_READ_URI_PERMISSION or
+                            Intent.FLAG_GRANT_WRITE_URI_PERMISSION,
+                    )
+                } catch (e: SecurityException) {
+                    Logger.d(tag, "Grant for $hash was already gone")
+                }
+            }
+        saveRecentFolders(getPersistedFolders().filterNot { getMirrorDir(it.uri).name == hash })
+    }
+
+    /**
+     * Removes one mirror the user has asked to remove, and reports what that freed.
+     *
+     * The gate is the same one [reclaimRevokedMirrorsSync] applies and is re-asked
+     * here rather than taken from [listMirrors]: the listing is rendered, read and
+     * confirmed by a person, and a write-back can strand a file in between.
+     *
+     * [force] is what the user's confirmation buys, and it is the only thing that ever
+     * passes a mirror the gate refuses. Refusing outright was the alternative and it is
+     * not one: the mirrors the gate refuses are exactly the large ones, so an
+     * unforceable removal leaves the user looking at the disk they cannot reclaim. What
+     * [force] must never become is a default, because the files it removes are the ones
+     * this app never delivered to the device. The caller is responsible for saying so
+     * in as many words before setting it, and for refusing outright when the mirror is
+     * in use, which nothing here can see.
+     *
+     * **This method only sets the mirror aside; [sweepDiscardedMirrors] does the
+     * deleting.** The split is not tidiness, it is what makes the answer honest. Both
+     * entries are renamed first, which is atomic and instant, and from that moment the
+     * mirror is unreachable: nothing can open it, a re-grant of the folder gets a fresh
+     * directory, and the next launch pass finishes the deletion whatever happens to
+     * this process. The recursive delete of a project tree is not instant, and the
+     * caller reaching this is a bridge call whose promise in the extension host times
+     * out after five seconds, so doing it here would report a failure for a removal
+     * that had in fact succeeded.
+     *
+     * Both entries go together, and it matters which way an interruption falls. A
+     * directory left behind with its record deleted can never be vouched for again; a
+     * record left behind without its directory makes a later re-grant of the same
+     * folder read the device's own document as this app's interrupted upload. Renaming
+     * both before deleting either means an exit added between the phases leaves a pair
+     * of `discarded-` entries, which is a state the existing pass already resolves.
+     *
+     * ⚠️ Walks the mirror to size it, so it must not run on the main thread.
+     *
+     * @return the bytes the removal frees, or [RECLAIM_UNKNOWN] when no such mirror
+     *   exists, or [RECLAIM_REFUSED] when the gate declined and [force] was not set.
+     */
+    fun reclaimMirror(hash: String, force: Boolean): Long {
+        val root = File(com.vscodroid.util.Environment.getSafMirrorsDir(context))
+        val dir = File(root, hash)
+        // [hash] arrives from the page, so it is judged rather than trusted, and by the
+        // same predicate that produced the listing it came from.
+        if (!isMirrorDirectoryName(hash) || !dir.isDirectory) return RECLAIM_UNKNOWN
+        if (!force &&
+            !(mayReclaim(hash, syncEngine.uploadsInFlight(), root.absolutePath) &&
+                syncEngine.holdsOnlyVouchedCopies(dir))
+        ) {
+            return RECLAIM_REFUSED
+        }
+
+        val bytes = StorageManager.dirSize(dir)
+        releaseGrantFor(hash)
+        listOf(hash, hash + SafSyncEngine.SYNCED_RECORD_SUFFIX).forEach { setAside(root, it) }
+        Logger.i(tag, "Set a device folder's local copy aside at the user's request")
+        return bytes
+    }
+
+    /**
+     * Deletes everything an earlier removal renamed out of the way, and reports how
+     * many entries went.
+     *
+     * The second half of [reclaimMirror], and safe to call at any time from any
+     * thread: a `discarded-` entry is this app's own leftover, already unreachable and
+     * already judged, so there is no gate left to apply and nothing to race with. Only
+     * names this app produces are touched, for the reason [reclaimRevokedMirrorsSync]
+     * gives about `saf-mirrors` not being private scratch space.
+     *
+     * Failing part way costs disk until the next launch rather than correctness, which
+     * is why the caller is free to run it on a thread it does not wait for.
+     */
+    fun sweepDiscardedMirrors(): Int {
+        val root = File(com.vscodroid.util.Environment.getSafMirrorsDir(context))
+        val leftovers = root.listFiles()?.map { it.name }?.filter {
+            it.startsWith(DISCARD_PREFIX) && MIRROR_ENTRY.matches(it.removePrefix(DISCARD_PREFIX))
+        } ?: return 0
+        return leftovers.count { discardEntry(root, it) }
     }
 
     // -- Sync Coordination --
@@ -565,6 +781,77 @@ class SafStorageManager(private val context: Context) {
             return strandedPaths.none { it.startsWith(prefix) }
         }
 
+        /** Answers of [reclaimMirror] that are not a byte count. */
+        internal const val RECLAIM_REFUSED = -1L
+        internal const val RECLAIM_UNKNOWN = -2L
+
+        /**
+         * Why a mirror the user asked to remove must not be removed now, or null when
+         * nothing this side knows about stands in the way.
+         *
+         * The question is "is anything still using this mirror", and it is separate
+         * from the question [mayReclaim] and [SafSyncEngine.holdsOnlyVouchedCopies]
+         * answer, which is "would removing it lose anything". Both have to be asked,
+         * and only this one needs state that lives in the Activity, which is why it
+         * takes its inputs rather than reading them.
+         *
+         * A mirror the editor still has open is not an inconvenience to delete, it is
+         * device data loss. The observers are live: a `FileObserver.DELETE` reaches
+         * `handleMirrorEvent`, becomes a DELETE write-back job and calls `deleteFromSaf`
+         * on the matching document, so a recursive delete of a watched mirror is
+         * replayed onto the user's real files through the provider. Nothing about the
+         * delete looks unusual from the watcher's side; a person deleting files is
+         * exactly what it exists to carry across.
+         *
+         * [watchedThisProcess] is the wide one and the others are narrower cases of it
+         * that produce a better sentence. It is deliberately never cleared. Closing a
+         * folder stops its observers, but `SafSyncEngine.stopWatching` waits only
+         * `DRAIN_GRACE_MS` for the write-back worker and then leaves it running rather
+         * than throwing away writes the user is expecting on the device, so a drain can
+         * still be streaming out of a mirror the app considers closed, and every write
+         * it performs opens the device document with `"wt"`, which truncates at open. A
+         * drain only ever touches the mirror it was started for, so refusing every
+         * mirror this process has watched is what puts it out of reach, and a restart
+         * is what makes the folder removable. Removing any of the three narrower checks
+         * degrades the message rather than opening the hole; removing this one opens
+         * it.
+         */
+        internal fun reclaimRefusal(
+            hash: String,
+            watchedMirror: String?,
+            syncingMirror: String?,
+            openWorkspaceMirror: String?,
+            watchedThisProcess: Set<String>,
+        ): String? = when (hash) {
+            watchedMirror -> RECLAIM_FOLDER_OPEN
+            syncingMirror -> RECLAIM_FOLDER_OPENING
+            openWorkspaceMirror -> RECLAIM_FOLDER_OPEN
+            in watchedThisProcess -> RECLAIM_FOLDER_THIS_SESSION
+            else -> null
+        }
+
+        internal const val RECLAIM_FOLDER_OPEN =
+            "That folder is open in the editor. Open a different folder first."
+        internal const val RECLAIM_FOLDER_OPENING = "That folder is still opening."
+        internal const val RECLAIM_FOLDER_THIS_SESSION =
+            "That folder was open in this session. Restart VSCodroid, then remove it."
+
+        /**
+         * The mirror [path] sits in, or null when it is not under [mirrorsRoot].
+         *
+         * The separator rule is [folderForOpenedPath]'s and is load-bearing for the
+         * same reason: mirror names are a hash prefix, so one being a prefix of another
+         * is ordinary, and a bare `startsWith` would name the wrong folder. Here the
+         * cost of naming the wrong one is refusing to remove a mirror that is free
+         * while allowing one that is open.
+         */
+        internal fun mirrorNameFor(path: String?, mirrorsRoot: String): String? {
+            val prefix = mirrorsRoot + File.separator
+            if (path == null || !path.startsWith(prefix)) return null
+            return path.removePrefix(prefix).substringBefore(File.separatorChar)
+                .takeIf { it.isNotEmpty() }
+        }
+
         /**
          * Splits the recent list into what is kept and what falls off the end.
          *
@@ -620,6 +907,26 @@ class SafStorageManager(private val context: Context) {
          */
         internal const val DISCARD_PREFIX = "discarded-"
 
+        /**
+         * Whether [name] is a mirror directory rather than anything else in
+         * `saf-mirrors`.
+         *
+         * Narrower than [MIRROR_ENTRY] by exactly one case, and the difference is why
+         * this is a predicate rather than a use of that pattern. The pattern matches
+         * both `<hash>` and `<hash>.synced`, because the reclaim pass has to recognise
+         * both halves of a mirror and remove them together. The user-facing side has
+         * the opposite need: the record is not a folder anybody opened, so listing it
+         * claims two folders where there is one, and accepting it as a removal target
+         * would set aside a record while leaving its mirror.
+         *
+         * Not covered by an `isDirectory` test at the call sites, which is the tempting
+         * simplification and was measured to be wrong: `saf-mirrors` is exported into
+         * every terminal as `SAF_MIRRORS_DIR`, so a directory can be created there
+         * under any name at all, this one included.
+         */
+        internal fun isMirrorDirectoryName(name: String): Boolean =
+            MIRROR_ENTRY.matches(name) && !name.endsWith(SafSyncEngine.SYNCED_RECORD_SUFFIX)
+
         /** How long one write-back failure notice suppresses the next. */
         internal const val FAILURE_NOTICE_INTERVAL_MS = 10_000L
 
@@ -644,4 +951,27 @@ data class SafFolderInfo(
     val displayName: String,
     val lastOpened: Long,
     val mirrorPath: String
+)
+
+/**
+ * One device folder's local copy, as the storage screen has to describe it.
+ *
+ * [displayName] and [lastOpened] come from the recent list and are therefore absent
+ * for an orphan: the grant and the list entry are released together when a folder
+ * falls off the end of [SafStorageManager.MAX_RECENT], so the mirror that survives
+ * has no name anywhere in the app. That is precisely the mirror worth showing, so
+ * the absence is carried rather than filled in with the hash.
+ *
+ * [reclaimable] is the launch pass's own verdict, not a prediction of what a removal
+ * will do. False means the mirror holds files the device folder does not, so removing
+ * it destroys the only copy of them; it is the ordinary state of any folder somebody
+ * has run a build or a clone in.
+ */
+data class MirrorInfo(
+    val hash: String,
+    val displayName: String?,
+    val bytes: Long,
+    val lastOpened: Long,
+    val granted: Boolean,
+    val reclaimable: Boolean,
 )

--- a/android/app/src/main/kotlin/com/vscodroid/util/StorageManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/util/StorageManager.kt
@@ -103,7 +103,16 @@ object StorageManager {
         return getAvailableStorage(context) < 100 * 1_048_576L
     }
 
-    private fun dirSize(dir: File): Long {
+    /**
+     * The bytes [dir] occupies, links excluded.
+     *
+     * Shared rather than private because the device-folder screen sizes each mirror
+     * with it, and a second implementation is how the mirrors would be mis-sized: a
+     * mirror is routinely a checked-out repository, so a link inside one is ordinary,
+     * and the rule below is what keeps a link's target from being charged to a
+     * directory that does not hold it.
+     */
+    internal fun dirSize(dir: File): Long {
         if (!dir.exists()) return 0
         var size = 0L
         val stack = ArrayDeque<File>()
@@ -126,7 +135,20 @@ object StorageManager {
         return size
     }
 
-    private fun deleteRecursive(dir: File): Long {
+    /**
+     * Deletes [dir] and everything under it, unlinking links rather than following
+     * them, and reports the bytes freed.
+     *
+     * Shared rather than private for the reason [dirSize] is, and here the cost of a
+     * second implementation is the user's files rather than a wrong number. The mirror
+     * reclaim in [com.vscodroid.storage.SafStorageManager] used `File.deleteRecursively`,
+     * which asks `isDirectory` and `listFiles` and so descends through a link out of the
+     * mirror. That was harmless only because the gate in front of it refuses any mirror
+     * containing a link at all; a reclaim the user confirms has no such gate, so the
+     * link-aware rule below is what stands between a forced removal and a directory
+     * somewhere else on the device.
+     */
+    internal fun deleteRecursive(dir: File): Long {
         if (!dir.exists()) return 0
         var freed = 0L
         val stack = ArrayDeque<File>()

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -182,6 +182,21 @@
         <item quantity="other">Not enough free space: %1$d files could not be copied into the editor. They are unchanged in the device folder.</item>
     </plurals>
 
+    <!-- Removing the local copy of a device folder, from the storage screen. The
+         mirror named by a hash the screen holds no longer exists: the user picked it
+         from a list this app built a moment earlier, so this means the folder was
+         removed or re-synced in between rather than that they typed something wrong. -->
+    <string name="saf_mirror_unknown">There is no local copy of that folder to remove.</string>
+    <!-- The reclaim gate declining. Worded as what is at stake rather than as a
+         refusal, because the user's next step is to confirm and remove it anyway: the
+         mirrors that hold unsynced files are exactly the ones worth the disk, since a
+         folder gets large by being worked in and working in one creates files the sync
+         excludes by construction. -->
+    <string name="saf_mirror_not_a_copy">Some files in that folder are not in the device folder. Removing the local copy would delete them.</string>
+    <!-- Said after a removal, on the Android side rather than in the editor, because
+         the recursive delete outlives the call the editor is waiting on. -->
+    <string name="saf_mirror_removed">Removed a device folder\'s local copy, freeing %1$s.</string>
+
     <!-- A folder copied out to the device that did not arrive whole. Counts entries
          rather than naming them, because the failure is usually folder-wide and forty
          separate notices is another way of telling the user nothing. Deliberately not
@@ -284,7 +299,7 @@
          quoted exactly as the palette lists it because the reader's next action
          is to type it, and it is the one part of this sentence a translator must
          leave in English. -->
-    <string name="storage_low_warning">Storage low (%1$s available). Run \"VSCodroid: Clear Caches\" from the Command Palette.</string>
+    <string name="storage_low_warning">Storage low (%1$s available). Run \"VSCodroid: Manage Device Folder Storage\" from the Command Palette.</string>
 
     <!-- An Android System WebView older than the one this app is tested against.
          Both versions are arguments: the installed one is read off the device and

--- a/android/app/src/test/kotlin/com/vscodroid/BridgeCallbackThreadHopTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/BridgeCallbackThreadHopTest.kt
@@ -66,6 +66,11 @@ class BridgeCallbackThreadHopTest {
         "onDownloadComplete" to
             "ordered against onDownloadChunk, which cannot be posted; posting only this one " +
             "would end the download before its last pieces were written",
+        "onListMirrors" to "returns a String the caller reads synchronously",
+        "onReclaimMirror" to
+            "returns a String the caller reads synchronously; the one UI call in its body " +
+            "is a Toast that hops on its own, and the filesystem work it does belongs off " +
+            "the UI thread rather than on it",
     )
 
     /**

--- a/android/app/src/test/kotlin/com/vscodroid/MirrorReclaimWiringTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/MirrorReclaimWiringTest.kt
@@ -1,0 +1,148 @@
+package com.vscodroid
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * The removal guard in `MainActivity` asks every question it has to ask.
+ *
+ * `SafStorageManager.reclaimRefusal` is the rule and `MirrorInUseTest` pins it against
+ * each input separately. What no JVM test can reach is the wiring: whether the Activity
+ * actually hands it the state it holds. A guard supplied three of its four inputs and
+ * `null` for the fourth answers "nothing is using this mirror" for a mirror that is, and
+ * the consequence is not a wrong dialog. The mirror's observers are live, a
+ * `FileObserver.DELETE` becomes a DELETE write-back job, and `deleteFromSaf` replays
+ * every delete onto the user's real documents through the provider.
+ *
+ * So this reads the source, which is the weaker kind of test in this suite and is worth
+ * naming for what it does and does not buy. It buys the presence of each input at the
+ * call site; there is no seam to extract instead, because the fields are the Activity's
+ * own and building one on the JVM is not possible. It does not check that the value
+ * passed is the right one, only that the field is named.
+ *
+ * `beginWatching` is checked in the same file because it is the other half of the same
+ * property: the guard's widest input is a set, and a site that starts a watcher without
+ * adding to it leaves the guard believing a mirror was never touched.
+ */
+class MirrorReclaimWiringTest {
+
+    private val mainActivity = File("src/main/kotlin/com/vscodroid/MainActivity.kt")
+
+    /**
+     * The body of a named method, by brace matching from its declaration.
+     *
+     * Reading to the end of some fixed number of lines was the alternative and it is
+     * the shape that rots: a body that grows past the window stops being checked and
+     * nothing says so.
+     */
+    private fun methodBody(name: String): String {
+        val source = mainActivity.readText()
+        val start = source.indexOf("private fun $name(")
+        assertTrue(start >= 0) {
+            "Could not find `private fun $name(` in ${mainActivity.path}. If it moved or " +
+                "was renamed, this test is measuring nothing; point it at the new name " +
+                "rather than deleting it."
+        }
+        val open = source.indexOf('{', start)
+        var depth = 0
+        for (i in open until source.length) {
+            when (source[i]) {
+                '{' -> depth++
+                '}' -> if (--depth == 0) return source.substring(open + 1, i)
+            }
+        }
+        error("Unbalanced braces after `private fun $name(`.")
+    }
+
+    @Test
+    fun `the removal guard is given every piece of state that decides it`() {
+        val body = methodBody("removeDeviceFolderCopy")
+
+        val missing = listOf(
+            "watchedSafFolder",
+            "syncingFolder",
+            "openWorkspaceFolder",
+            "mirrorsWatchedThisProcess",
+            "reclaimRefusal",
+        ).filterNot { body.contains(it) }
+
+        assertEquals(
+            emptyList<String>(), missing,
+            "the removal guard never reads $missing, so a mirror in use by that route is " +
+                "reported as free and deleting it replays every delete onto the user's " +
+                "device documents",
+        )
+    }
+
+    /**
+     * The extraction's own control. Every name above also appears elsewhere in this
+     * activity, so a brace match that overran into the rest of the file would satisfy
+     * the assertion above while checking nothing. `openSafFolder` is the neighbouring
+     * method that writes all four of those fields; its name must not be inside this
+     * body.
+     */
+    @Test
+    fun `the guard body is bounded to the guard`() {
+        val body = methodBody("removeDeviceFolderCopy")
+
+        assertTrue(body.isNotEmpty() && body.length < 4_000) {
+            "the extracted body is ${body.length} characters, which is not one method"
+        }
+        assertTrue("private fun " !in body) {
+            "the brace match ran past the end of the method and into the next one"
+        }
+    }
+
+    /**
+     * Starting a watcher records the mirror for the rest of the process, and it has to
+     * be one method rather than a habit at each site.
+     *
+     * `stopWatching` waits two seconds for the write-back worker and then leaves it
+     * running rather than discarding writes the user expects on the device, so a drain
+     * can still be inside a mirror the app considers closed, and each of its writes
+     * opens the device document with `"wt"`, which truncates at open. The set is what
+     * puts such a mirror out of reach of a removal; a site that assigned
+     * `watchedSafFolder` without adding to it would put it back in reach, and nothing
+     * about that site would look wrong.
+     */
+    @Test
+    fun `every watcher this activity starts is recorded for the whole process`() {
+        val source = mainActivity.readText()
+
+        // Judged by WHERE the assignment is, not by what it says. Matching the text
+        // instead was tried and does not bind: the permitted spelling is the same
+        // spelling a site that skips `beginWatching` would use, so the allowlist
+        // admitted exactly the mutation it exists to catch. Position cannot be
+        // spoofed that way.
+        val begin = methodBody("beginWatching")
+        val beginAt = source.indexOf(begin)
+        val insideBeginWatching = beginAt until (beginAt + begin.length)
+
+        val nonNull = Regex("""watchedSafFolder\s*=\s*([^\n]+)""").findAll(source)
+            .filterNot { it.groupValues[1].trim().startsWith("null") }
+            .toList()
+
+        assertTrue(nonNull.isNotEmpty()) {
+            "no assignment setting watchedSafFolder to a folder was found, so this test " +
+                "is checking nothing"
+        }
+
+        val outside = nonNull
+            .filterNot { it.range.first in insideBeginWatching }
+            .map { it.value.trim() }
+        assertEquals(
+            emptyList<String>(), outside,
+            "these set the watched folder without going through beginWatching: $outside. " +
+                "A mirror watched but not recorded can be removed while a write-back " +
+                "drain is still streaming out of it, and each of that drain's writes " +
+                "truncates the device document at open.",
+        )
+
+        assertTrue(begin.contains("mirrorsWatchedThisProcess.add")) {
+            "beginWatching no longer records the mirror, so the record is empty and the " +
+                "guard's widest check passes everything"
+        }
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/bridge/KeygenBudgetTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/bridge/KeygenBudgetTest.kt
@@ -21,9 +21,19 @@ import java.io.File
 class KeygenBudgetTest {
 
     private val bridge = File("src/main/kotlin/com/vscodroid/bridge/AndroidBridge.kt")
-    private val relay = File(
-        "src/main/assets/extensions/vscodroid.vscodroid-saf-bridge-1.3.0/extension.js"
-    )
+
+    /**
+     * Found by prefix rather than named with its version, because the version is in the
+     * directory name and moves whenever the extension is edited. A pinned path made an
+     * unrelated bump fail here with "not found", which reads as the check being broken
+     * rather than as the path being stale, and the tempting repair is to delete the
+     * check.
+     */
+    private val relay = File("src/main/assets/extensions")
+        .listFiles { f -> f.isDirectory && f.name.startsWith("vscodroid.vscodroid-saf-bridge-") }
+        ?.singleOrNull()
+        ?.let { File(it, "extension.js") }
+        ?: File("src/main/assets/extensions/vscodroid.vscodroid-saf-bridge/extension.js")
 
     private fun read(f: File): String {
         check(f.isFile) {

--- a/android/app/src/test/kotlin/com/vscodroid/storage/MirrorInUseTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/MirrorInUseTest.kt
@@ -1,0 +1,145 @@
+package com.vscodroid.storage
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * Tests for [SafStorageManager.reclaimRefusal], the question asked before a mirror the
+ * user has chosen to remove is touched at all.
+ *
+ * This is the half of the removal that the storage manager cannot answer. It knows
+ * whether removing a mirror would lose anything ([SafStorageManager.mayReclaim] and
+ * [SafSyncEngine.holdsOnlyVouchedCopies]); it does not know whether anything is still
+ * using it, and that state lives in the Activity.
+ *
+ * Getting it wrong is not an inconvenience. A mirror the editor still has open is
+ * covered by live observers, a `FileObserver.DELETE` becomes a DELETE write-back job,
+ * and `deleteFromSaf` then replays the deletion onto the user's real documents through
+ * the provider. A recursive delete of a watched mirror is a device-wide data loss event
+ * that looks, from the watcher's side, exactly like a person deleting files.
+ *
+ * Each case asserts WHICH refusal comes back rather than only that one did. The four
+ * checks overlap by design, so an outcome-only assertion would stay green with three of
+ * them deleted: the widest one, [SafStorageManager.RECLAIM_FOLDER_THIS_SESSION], covers
+ * every mirror the narrower ones name. Naming the sentence is what makes each check
+ * independently load-bearing.
+ */
+class MirrorInUseTest {
+
+    private val hash = "abc123def456"
+    private val other = "999888777666"
+    private val sep = File.separator
+    private val root = "/data/user/0/com.vscodroid/files/saf-mirrors"
+
+    private fun refusal(
+        watched: String? = null,
+        syncing: String? = null,
+        open: String? = null,
+        thisSession: Set<String> = emptySet(),
+    ) = SafStorageManager.reclaimRefusal(hash, watched, syncing, open, thisSession)
+
+    @Test
+    fun `a mirror nothing is using may be removed`() {
+        assertNull(
+            refusal(watched = other, syncing = other, open = other, thisSession = setOf(other)),
+            "every input names a different mirror, so nothing here is about this one",
+        )
+    }
+
+    @Test
+    fun `the mirror the watcher is on is refused as open`() {
+        assertEquals(
+            SafStorageManager.RECLAIM_FOLDER_OPEN,
+            refusal(watched = hash, thisSession = setOf(hash)),
+            "deleting a watched mirror replays every delete onto the device documents",
+        )
+    }
+
+    /**
+     * The mirror a sync is half way through is the one case where the files on disk are
+     * not a copy of anything yet, so it gets its own sentence: the user's action is to
+     * wait rather than to close something.
+     */
+    @Test
+    fun `the mirror being synced is refused as still opening`() {
+        assertEquals(
+            SafStorageManager.RECLAIM_FOLDER_OPENING,
+            refusal(syncing = hash, thisSession = setOf(hash)),
+        )
+    }
+
+    /**
+     * The workbench switches folders by navigating its own WebView, so it can be inside
+     * a mirror that this activity has not adopted and has no watcher on. That is the
+     * hole the watcher check alone leaves.
+     */
+    @Test
+    fun `the mirror the workbench has open is refused as open`() {
+        assertEquals(
+            SafStorageManager.RECLAIM_FOLDER_OPEN,
+            refusal(open = hash),
+            "a folder the workbench opened without going through Kotlin was removable",
+        )
+    }
+
+    /**
+     * The one that has to survive every other check being deleted.
+     *
+     * `stopWatching` waits two seconds for the write-back worker and then leaves it
+     * running rather than discarding writes the user is expecting on the device. So a
+     * closed folder can still have a thread streaming out of its mirror, and each write
+     * opens the device document with `"wt"`, which truncates at open: deleting the
+     * mirror underneath that thread empties the device file rather than leaving it
+     * alone. A drain only ever touches the mirror it was started for, which is why a
+     * set of names is the whole instrument.
+     */
+    @Test
+    fun `a mirror watched earlier in this session needs a restart`() {
+        assertEquals(
+            SafStorageManager.RECLAIM_FOLDER_THIS_SESSION,
+            refusal(thisSession = setOf(other, hash)),
+            "a write-back drain outliving its folder could still be inside this mirror",
+        )
+    }
+
+    @Test
+    fun `the mirror name is read out of the path the workbench has open`() {
+        assertEquals(hash, SafStorageManager.mirrorNameFor("$root$sep$hash", root))
+        assertEquals(
+            hash,
+            SafStorageManager.mirrorNameFor("$root$sep$hash${sep}src${sep}main.kt", root),
+            "Open Folder can point inside a mirror, and that is still that mirror",
+        )
+    }
+
+    @Test
+    fun `an ordinary project folder names no mirror`() {
+        assertNull(
+            SafStorageManager.mirrorNameFor(
+                "/data/user/0/com.vscodroid/files/home/projects/app", root
+            ),
+        )
+        assertNull(SafStorageManager.mirrorNameFor(null, root))
+        assertNull(
+            SafStorageManager.mirrorNameFor(root, root),
+            "the mirrors root itself is not a mirror",
+        )
+    }
+
+    /**
+     * The separator rule [SafStorageManager.folderForOpenedPath] and
+     * [SafStorageManager.mayReclaim] both carry, for the reason they carry it: mirror
+     * names are a hash prefix, so one being a textual prefix of another is ordinary.
+     * Here reading the wrong name means refusing to remove a mirror that is free while
+     * allowing one that is open.
+     */
+    @Test
+    fun `a sibling whose name extends this one is a different mirror`() {
+        assertEquals(
+            hash + "x",
+            SafStorageManager.mirrorNameFor("$root$sep${hash}x${sep}src", root),
+        )
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/storage/MirrorListingTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/MirrorListingTest.kt
@@ -1,0 +1,331 @@
+package com.vscodroid.storage
+
+import android.content.ContentResolver
+import android.content.Context
+import android.content.SharedPreferences
+import android.content.UriPermission
+import android.net.Uri
+import com.vscodroid.util.Logger
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+/**
+ * What [SafStorageManager.listMirrors] reports, which is the only place in the app that
+ * can name a device folder's local copy.
+ *
+ * The copies are already measured: `getStorageBreakdown` reports all of them as one
+ * number under `saf_mirrors`, correctly marked as something the cache clear cannot
+ * touch. What was missing is which folder is holding the disk, and for the copies that
+ * matter most the app had stopped being able to say. `addToRecentFolders` keeps ten
+ * folders and releases the grant of the one that falls off; the recent-list entry that
+ * carried the folder's name goes with it, and the copy stays on disk. The launch pass
+ * then declines to reclaim it whenever it holds a file the device does not, which one
+ * `npm install` guarantees for ever, because `SKIP_DIRECTORIES` keeps `node_modules`
+ * out of the sync record by construction.
+ *
+ * So the row that is invisible, nameless and unreclaimable is exactly the row worth
+ * showing, and the first case here is that one.
+ */
+class MirrorListingTest {
+
+    @TempDir
+    lateinit var filesDir: File
+
+    private lateinit var manager: SafStorageManager
+    private lateinit var resolver: ContentResolver
+    private lateinit var context: Context
+    private lateinit var mirrorsDir: File
+    private var recentJson = "[]"
+
+    private val liveUriText = "content://tree/primary%3ACurrentProject"
+    private val orphanUriText = "content://tree/primary%3AOldProject"
+    private val liveUri = mockk<Uri>()
+    private val orphanUri = mockk<Uri>()
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(Logger)
+        every { Logger.i(any(), any()) } just Runs
+        every { Logger.d(any(), any()) } just Runs
+        every { Logger.w(any(), any()) } just Runs
+        every { Logger.e(any(), any()) } just Runs
+        every { Logger.e(any(), any(), any()) } just Runs
+
+        every { liveUri.toString() } returns liveUriText
+        every { orphanUri.toString() } returns orphanUriText
+        every { liveUri.lastPathSegment } returns "primary:CurrentProject"
+        every { orphanUri.lastPathSegment } returns "primary:OldProject"
+
+        resolver = mockk(relaxed = true)
+        context = mockk<Context>(relaxed = true)
+        every { context.filesDir } returns filesDir
+        every { context.contentResolver } returns resolver
+        every { context.getSharedPreferences(any(), any()) } returns fakePrefs()
+        // The recent list is stored as JSON and read back through Uri.parse, so a
+        // fixture that writes a list has to hand the same mock back: the name and
+        // the mirror both resolve from the URI string.
+        mockkStatic(Uri::class)
+        every { Uri.parse(liveUriText) } returns liveUri
+        every { Uri.parse(orphanUriText) } returns orphanUri
+
+        manager = SafStorageManager(context)
+        mirrorsDir = File(filesDir, "saf-mirrors").apply { mkdirs() }
+    }
+
+    @AfterEach
+    fun tearDown() = unmockkAll()
+
+    /**
+     * A preferences double backed by one string, because the recent list is what
+     * supplies the display name and the whole point of the first case is a mirror
+     * whose entry is not in it.
+     */
+    private fun fakePrefs(): SharedPreferences {
+        val editor = mockk<SharedPreferences.Editor>(relaxed = true)
+        val written = slot<String>()
+        every { editor.putString(any(), capture(written)) } answers {
+            recentJson = written.captured
+            editor
+        }
+        return mockk<SharedPreferences>(relaxed = true).also { prefs ->
+            every { prefs.getString(any(), any()) } answers { recentJson }
+            every { prefs.edit() } returns editor
+        }
+    }
+
+    private fun permissionFor(granted: Uri): UriPermission = mockk<UriPermission> {
+        every { uri } returns granted
+        every { isReadPermission } returns true
+    }
+
+    /** A mirror every file of which the record vouches for, as [SafSyncEngine] writes it. */
+    private fun vouchedMirror(uri: Uri): File {
+        val dir = manager.getMirrorDir(uri).apply { mkdirs() }
+        val file = File(dir, "main.kt").apply { writeText("fun main() {}") }
+        File(dir.path + SafSyncEngine.SYNCED_RECORD_SUFFIX).writeText(
+            SafSyncEngine.RECORD_HEADER + "\n" + SafSyncEngine(context).identityLine("main.kt", file)
+        )
+        check(SafSyncEngine(context).holdsOnlyVouchedCopies(dir)) {
+            "the fixture wrote a record the engine does not accept"
+        }
+        return dir
+    }
+
+    /**
+     * The mirror the app can no longer name, which is the one the user most needs to
+     * see. Its grant was released when an eleventh folder was opened, and the recent
+     * list entry went with it.
+     */
+    @Test
+    fun `a copy with no live grant is still listed, and unnamed`() {
+        val orphan = vouchedMirror(orphanUri)
+        every { resolver.persistedUriPermissions } returns emptyList()
+
+        val listed = manager.listMirrors()
+
+        assertEquals(listOf(orphan.name), listed.map { it.hash })
+        assertFalse(listed.single().granted)
+        assertNull(
+            listed.single().displayName,
+            "an orphan has no name anywhere in the app, and inventing one hides that",
+        )
+    }
+
+    @Test
+    fun `a granted copy carries the name and time the recent list holds`() {
+        val dir = vouchedMirror(liveUri)
+        recentJson = """[{"uri":"$liveUri","name":"CurrentProject","lastOpened":1700000000}]"""
+        every { resolver.persistedUriPermissions } returns listOf(permissionFor(liveUri))
+
+        val listed = manager.listMirrors().single()
+
+        assertEquals(dir.name, listed.hash)
+        assertTrue(listed.granted)
+        assertEquals("CurrentProject", listed.displayName)
+        assertEquals(1700000000L, listed.lastOpened)
+    }
+
+    /**
+     * `saf-mirrors` is not private scratch space: first-run setup exports it into every
+     * terminal as `SAF_MIRRORS_DIR` and the WebView publishes it as a resource root, so
+     * a person can leave a file there and some will. The reclaim pass refuses to touch
+     * those and this listing must not offer them for removal either.
+     */
+    @Test
+    fun `a directory a person left beside the mirrors is not listed`() {
+        val mirror = vouchedMirror(liveUri)
+        File(mirrorsDir, "scratch").mkdirs()
+        File(mirrorsDir, "notes.md").writeText("mine")
+        every { resolver.persistedUriPermissions } returns listOf(permissionFor(liveUri))
+
+        assertEquals(
+            listOf(mirror.name), manager.listMirrors().map { it.hash },
+            "a directory this app did not create was offered for removal",
+        )
+    }
+
+    /**
+     * A mirror is two entries, `<hash>` and `<hash>.synced`. Only the first is a folder
+     * the user has any concept of; the record is an implementation detail that goes with
+     * it, and listing it makes the screen claim two folders where there is one.
+     *
+     * `MIRROR_ENTRY` matches both names on purpose, because the reclaim pass has to
+     * recognise both. What separates them here is that the record is a file: it sits
+     * beside the mirror rather than inside it, which is also why it does not defeat the
+     * gate that walks the mirror. The fixture asserts that shape before relying on it,
+     * because a test that only counted rows would pass just as happily against a filter
+     * that had stopped seeing the record at all.
+     */
+    @Test
+    fun `the record beside a copy is not a second row`() {
+        val mirror = vouchedMirror(liveUri)
+        val record = File(mirror.path + SafSyncEngine.SYNCED_RECORD_SUFFIX)
+        assertTrue(record.isFile, "the fixture did not write the record beside the mirror")
+        assertTrue(
+            SafStorageManager.MIRROR_ENTRY.matches(record.name),
+            "the record's name no longer looks like one of ours, so this case is not the " +
+                "one it is named for",
+        )
+        every { resolver.persistedUriPermissions } returns listOf(permissionFor(liveUri))
+
+        val listed = manager.listMirrors()
+
+        assertEquals(1, listed.size, "listed: ${listed.map { it.hash }}")
+        assertEquals(mirror.name, listed.single().hash)
+    }
+
+    /**
+     * The same exclusion when the record's name is worn by a directory.
+     *
+     * `saf-mirrors` is exported into every terminal as `SAF_MIRRORS_DIR`, so a
+     * directory can be created there under any name, and `isDirectory` alone is
+     * therefore not the test. Without the suffix clause this row appears as a folder
+     * the user never opened, and choosing it sets a record aside while leaving the
+     * mirror it describes behind, which is the mixed state that can never be resolved.
+     */
+    @Test
+    fun `a directory wearing the record's name is not listed as a folder`() {
+        val mirror = vouchedMirror(liveUri)
+        File(mirrorsDir, "abc123def456" + SafSyncEngine.SYNCED_RECORD_SUFFIX).mkdirs()
+        every { resolver.persistedUriPermissions } returns listOf(permissionFor(liveUri))
+
+        assertEquals(listOf(mirror.name), manager.listMirrors().map { it.hash })
+    }
+
+    @Test
+    fun `an entry set aside by an interrupted removal is not offered`() {
+        val mirror = vouchedMirror(liveUri)
+        File(mirrorsDir, SafStorageManager.DISCARD_PREFIX + "abc123def456").mkdirs()
+        every { resolver.persistedUriPermissions } returns listOf(permissionFor(liveUri))
+
+        assertEquals(
+            listOf(mirror.name), manager.listMirrors().map { it.hash },
+            "a removal already in progress was offered as a folder to remove",
+        )
+    }
+
+    /**
+     * The case that pins the root cause of the whole feature. `node_modules` is in
+     * [SafSyncEngine.SKIP_DIRECTORIES], so nothing under it is ever copied down, ever
+     * written back, or ever recorded. It is therefore invisible to the upload journal
+     * and visible to the record walk, which is what makes the mirror permanently
+     * unreclaimable the moment a user runs an install in the folder they are working in.
+     */
+    @Test
+    fun `a copy holding files the device folder lacks is listed as not reclaimable`() {
+        val dir = vouchedMirror(liveUri)
+        File(dir, "node_modules/lodash").mkdirs()
+        File(dir, "node_modules/lodash/index.js").writeText("module.exports = {}")
+        every { resolver.persistedUriPermissions } returns listOf(permissionFor(liveUri))
+
+        assertFalse(
+            manager.listMirrors().single().reclaimable,
+            "a mirror holding an npm install was reported as a disposable copy",
+        )
+    }
+
+    /** The control for the case above: the same mirror without the install. */
+    @Test
+    fun `a copy the device folder fully holds is listed as reclaimable`() {
+        vouchedMirror(liveUri)
+        every { resolver.persistedUriPermissions } returns listOf(permissionFor(liveUri))
+
+        assertTrue(manager.listMirrors().single().reclaimable)
+    }
+
+    /**
+     * The other half of the gate, and it is a separate question: the journal records a
+     * write-back this app ATTEMPTED and could not deliver, which is a file the device
+     * does not have under a name it does.
+     */
+    @Test
+    fun `a copy holding an undelivered write is listed as not reclaimable`() {
+        val dir = vouchedMirror(liveUri)
+        File(filesDir, SafSyncEngine.UPLOADS_IN_FLIGHT_FILE)
+            .writeText(File(dir, "main.kt").absolutePath + "\n")
+        every { resolver.persistedUriPermissions } returns listOf(permissionFor(liveUri))
+
+        assertFalse(
+            manager.listMirrors().single().reclaimable,
+            "a mirror holding a write that never reached the device was called a copy",
+        )
+    }
+
+    @Test
+    fun `the largest copy is listed first`() {
+        val small = vouchedMirror(liveUri)
+        val big = vouchedMirror(orphanUri)
+        File(big, "bulk.bin").writeText("x".repeat(10_000))
+        every { resolver.persistedUriPermissions } returns emptyList()
+
+        val listed = manager.listMirrors()
+
+        assertEquals(listOf(big.name, small.name), listed.map { it.hash })
+        assertTrue(
+            listed.first().bytes > listed.last().bytes,
+            "sizes: ${listed.map { it.hash to it.bytes }}",
+        )
+    }
+
+    /**
+     * A link contributes nothing to the size it is inside, because its target's bytes
+     * are not in the directory being measured. A mirror is routinely a checked-out
+     * repository, so a link in one is ordinary, and charging its target would report a
+     * figure the removal cannot possibly free.
+     */
+    @Test
+    fun `a link inside a copy is not charged to it`() {
+        val dir = vouchedMirror(liveUri)
+        val outside = File(filesDir, "outside").apply { mkdirs() }
+        File(outside, "big.bin").writeText("x".repeat(50_000))
+        java.nio.file.Files.createSymbolicLink(File(dir, "link").toPath(), outside.toPath())
+        every { resolver.persistedUriPermissions } returns emptyList()
+
+        assertTrue(
+            manager.listMirrors().single().bytes < 1_000,
+            "the size charged the target of a link that lives outside the mirror",
+        )
+    }
+
+    @Test
+    fun `an empty mirrors directory lists nothing`() {
+        every { resolver.persistedUriPermissions } returns emptyList()
+
+        assertEquals(emptyList<MirrorInfo>(), manager.listMirrors())
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/storage/MirrorReclaimTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/MirrorReclaimTest.kt
@@ -1,0 +1,366 @@
+package com.vscodroid.storage
+
+import android.content.ContentResolver
+import android.content.Context
+import android.content.SharedPreferences
+import android.content.UriPermission
+import android.net.Uri
+import com.vscodroid.util.Logger
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Files
+
+/**
+ * Removing the local copy of a device folder, at the user's own instruction.
+ *
+ * This is the only path in the app that deletes a mirror the automatic pass has refused,
+ * so it is the only path that can destroy the user's only copy of something. Four
+ * separate defects produced the gate the automatic pass applies, and none of them is
+ * relaxed here: the gate is re-asked at the moment of removal, and getting past it
+ * requires [force], which the caller may only set after a modal that says what is at
+ * stake. What this file pins is that the gate still binds without [force], and that the
+ * mechanics of the delete itself do not reach outside the mirror.
+ */
+class MirrorReclaimTest {
+
+    @TempDir
+    lateinit var filesDir: File
+
+    private lateinit var manager: SafStorageManager
+    private lateinit var resolver: ContentResolver
+    private lateinit var context: Context
+    private lateinit var mirrorsDir: File
+    private var recentJson = "[]"
+
+    private val folderUriText = "content://tree/primary%3AProject"
+    private val folderUri = mockk<Uri>()
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(Logger)
+        every { Logger.i(any(), any()) } just Runs
+        every { Logger.d(any(), any()) } just Runs
+        every { Logger.w(any(), any()) } just Runs
+        every { Logger.e(any(), any()) } just Runs
+        every { Logger.e(any(), any(), any()) } just Runs
+
+        every { folderUri.toString() } returns folderUriText
+        every { folderUri.lastPathSegment } returns "primary:Project"
+
+        resolver = mockk(relaxed = true)
+        context = mockk<Context>(relaxed = true)
+        every { context.filesDir } returns filesDir
+        every { context.contentResolver } returns resolver
+        every { context.getSharedPreferences(any(), any()) } returns fakePrefs()
+        // The recent list is stored as JSON and read back through Uri.parse, so a
+        // fixture that writes a list has to hand the same mock back: the name and
+        // the mirror both resolve from the URI string.
+        mockkStatic(Uri::class)
+        every { Uri.parse(folderUriText) } returns folderUri
+        every { resolver.persistedUriPermissions } returns emptyList()
+
+        manager = SafStorageManager(context)
+        mirrorsDir = File(filesDir, "saf-mirrors").apply { mkdirs() }
+    }
+
+    @AfterEach
+    fun tearDown() = unmockkAll()
+
+    private fun fakePrefs(): SharedPreferences {
+        val editor = mockk<SharedPreferences.Editor>(relaxed = true)
+        val written = slot<String>()
+        every { editor.putString(any(), capture(written)) } answers {
+            recentJson = written.captured
+            editor
+        }
+        return mockk<SharedPreferences>(relaxed = true).also { prefs ->
+            every { prefs.getString(any(), any()) } answers { recentJson }
+            every { prefs.edit() } returns editor
+        }
+    }
+
+    private fun permissionFor(granted: Uri): UriPermission = mockk<UriPermission> {
+        every { uri } returns granted
+        every { isReadPermission } returns true
+    }
+
+    /** A mirror whose every file the record vouches for, plus the record beside it. */
+    private fun vouchedMirror(): Pair<File, File> {
+        val dir = manager.getMirrorDir(folderUri).apply { mkdirs() }
+        File(dir, "src").mkdirs()
+        val file = File(dir, "src/main.kt").apply { writeText("fun main() {}") }
+        val record = File(dir.path + SafSyncEngine.SYNCED_RECORD_SUFFIX).apply {
+            writeText(
+                SafSyncEngine.RECORD_HEADER + "\n" +
+                    SafSyncEngine(context).identityLine("src/main.kt", file)
+            )
+        }
+        check(SafSyncEngine(context).holdsOnlyVouchedCopies(dir)) {
+            "the fixture wrote a record the engine does not accept, so every case built " +
+                "on it would fail for the wrong reason"
+        }
+        return dir to record
+    }
+
+    /** Runs the deferred half, which a live caller hands to a thread it does not wait on. */
+    private fun sweep() = manager.sweepDiscardedMirrors()
+
+    /**
+     * The gate the automatic pass applies, applied here too. Without [force] a mirror
+     * holding files the device folder does not is left exactly where it was, because
+     * removing it is not reclaiming a copy, it is deleting the only copy.
+     */
+    @Test
+    fun `a copy the gate refuses is not removed without force`() {
+        val (dir, record) = vouchedMirror()
+        File(dir, ".git").mkdirs()
+        File(dir, ".git/HEAD").writeText("ref: refs/heads/main\n")
+
+        val answer = manager.reclaimMirror(dir.name, force = false)
+        sweep()
+
+        assertEquals(SafStorageManager.RECLAIM_REFUSED, answer)
+        assertTrue(dir.isDirectory, "a repository cloned in the terminal was deleted")
+        assertTrue(File(dir, ".git/HEAD").isFile, "and its unpushed state with it")
+        assertTrue(record.isFile, "the record must not go without its mirror")
+    }
+
+    /** The same for the other half of the gate: a write this app never delivered. */
+    @Test
+    fun `a copy holding an undelivered write is not removed without force`() {
+        val (dir, _) = vouchedMirror()
+        val stranded = File(dir, "src/main.kt").absolutePath
+        File(filesDir, SafSyncEngine.UPLOADS_IN_FLIGHT_FILE).writeText(stranded + "\n")
+
+        val answer = manager.reclaimMirror(dir.name, force = false)
+        sweep()
+
+        assertEquals(SafStorageManager.RECLAIM_REFUSED, answer)
+        assertTrue(File(dir, "src/main.kt").isFile, "the only copy of an unsent edit went")
+    }
+
+    /** The control for both refusals: the same mirror with nothing unvouched in it. */
+    @Test
+    fun `a copy the device folder fully holds is removed without force`() {
+        val (dir, record) = vouchedMirror()
+
+        val freed = manager.reclaimMirror(dir.name, force = false)
+        sweep()
+
+        assertTrue(freed > 0, "the answer is the bytes the removal frees, got $freed")
+        assertFalse(dir.exists(), "a disposable copy was kept")
+        assertFalse(record.exists(), "the record must go with the mirror it describes")
+    }
+
+    /** What the confirmation buys, and the only thing that gets past the gate. */
+    @Test
+    fun `force removes a copy the gate refuses`() {
+        val (dir, record) = vouchedMirror()
+        File(dir, ".git").mkdirs()
+        File(dir, ".git/HEAD").writeText("ref: refs/heads/main\n")
+
+        val freed = manager.reclaimMirror(dir.name, force = true)
+        sweep()
+
+        assertTrue(freed > 0)
+        assertFalse(dir.exists())
+        assertFalse(record.exists())
+    }
+
+    /**
+     * The rename is the commit point of the removal, and the reason is in
+     * [SafStorageManager.reclaimRevokedMirrorsSync]: a delete in place rests on nothing
+     * else touching the directory while the walk is inside it, and a re-grant during the
+     * walk re-creates the same hash directory under a live watcher, whose remaining
+     * deletes then go out to the device as deletions of the user's real documents.
+     *
+     * Asserted as the state the call returns in, which is the property the caller
+     * depends on: the mirror is unreachable by the time the answer arrives, and the
+     * recursive delete happens afterwards.
+     */
+    @Test
+    fun `the copy is unreachable as soon as the call returns, before it is deleted`() {
+        val (dir, record) = vouchedMirror()
+
+        manager.reclaimMirror(dir.name, force = true)
+
+        assertFalse(dir.exists(), "the mirror was still reachable under its own name")
+        assertFalse(record.exists(), "the record was still reachable under its own name")
+        val setAside = mirrorsDir.listFiles()!!.map { it.name }
+        assertEquals(
+            setOf(
+                SafStorageManager.DISCARD_PREFIX + dir.name,
+                SafStorageManager.DISCARD_PREFIX + record.name,
+            ),
+            setAside.toSet(),
+            "both entries must be set aside together, or the pair can never be resolved",
+        )
+
+        assertEquals(2, sweep(), "the sweep is what actually deletes them")
+        assertTrue(mirrorsDir.listFiles()!!.isEmpty())
+    }
+
+    /**
+     * `File.deleteRecursively` asks `isDirectory` and `listFiles`, both of which answer
+     * for a link's target, so it descends out of the mirror. On the automatic pass that
+     * is masked by the gate refusing any mirror containing a link at all. A forced
+     * removal has no such mask, and a mirror is routinely a checked-out repository, so a
+     * link inside one is attacker-supplied in the ordinary case.
+     */
+    @Test
+    fun `a forced removal does not follow a link out of the copy`() {
+        val (dir, _) = vouchedMirror()
+        val outside = File(filesDir, "outside").apply { mkdirs() }
+        val keep = File(outside, "keep.txt").apply { writeText("the user's own files") }
+        Files.createSymbolicLink(File(dir, "link").toPath(), outside.toPath())
+
+        manager.reclaimMirror(dir.name, force = true)
+        sweep()
+
+        assertTrue(keep.isFile, "the removal deleted a directory outside the mirror")
+        assertTrue(outside.isDirectory)
+        assertFalse(dir.exists(), "and the mirror itself should still have gone")
+    }
+
+    /**
+     * The journal keys on the mirror's real path, which is the name before the rename.
+     * Clearing under the `discarded-` path matched no entry, so records outlived the
+     * mirror they distrust: a re-grant of the same folder hashes back to the same path,
+     * and the next sync then read the device's own document as this app's interrupted
+     * upload and wrote the stale mirror back over it.
+     */
+    @Test
+    fun `removing a copy clears the journal entries under it`() {
+        val (dir, _) = vouchedMirror()
+        val journal = File(filesDir, SafSyncEngine.UPLOADS_IN_FLIGHT_FILE)
+        val mine = File(dir, "src/main.kt").absolutePath
+        val foreign = File(mirrorsDir, "999888777666/notes.md").absolutePath
+        journal.writeText(mine + "\n" + foreign + "\n")
+
+        manager.reclaimMirror(dir.name, force = true)
+        sweep()
+
+        assertFalse(
+            journal.readLines().contains(mine),
+            "the record outlived the mirror it distrusts, so a re-grant of that folder " +
+                "will overwrite the device copy from a stale mirror",
+        )
+        assertTrue(
+            journal.readLines().contains(foreign),
+            "an unrelated mirror's record was dropped by the same clear",
+        )
+    }
+
+    /**
+     * The grant and the recent-list entry go with the copy. A grant that survives makes
+     * the launch pass treat the folder as live; an entry that survives is an Open Recent
+     * row pointing at a directory that is not there, and choosing it starts a sync that
+     * copies the whole folder down again, which is the opposite of what the user asked
+     * for.
+     */
+    @Test
+    fun `removing a copy releases its grant and drops it from the recent list`() {
+        val (dir, _) = vouchedMirror()
+        recentJson = """[{"uri":"$folderUri","name":"Project","lastOpened":1700000000}]"""
+        every { resolver.persistedUriPermissions } returns listOf(permissionFor(folderUri))
+
+        manager.reclaimMirror(dir.name, force = true)
+
+        verify { resolver.releasePersistableUriPermission(folderUri, any()) }
+        every { resolver.persistedUriPermissions } returns emptyList()
+        assertEquals(
+            emptyList<SafFolderInfo>(), manager.getPersistedFolders(),
+            "the folder still appears in Open Recent, pointing at a directory that is gone",
+        )
+    }
+
+    @Test
+    fun `a name that is not a mirror is refused rather than deleted`() {
+        val scratch = File(mirrorsDir, "scratch").apply { mkdirs() }
+        File(scratch, "wip.txt").writeText("mine")
+
+        assertEquals(SafStorageManager.RECLAIM_UNKNOWN, manager.reclaimMirror("scratch", true))
+        assertEquals(
+            SafStorageManager.RECLAIM_UNKNOWN,
+            manager.reclaimMirror("../../../databases", true),
+            "a hash is page-supplied, so a name that escapes the mirrors root must not act",
+        )
+        sweep()
+
+        assertTrue(File(scratch, "wip.txt").isFile, "a person's own directory was deleted")
+    }
+
+    /**
+     * The record is half of a mirror, never a removal target of its own. Accepting one
+     * would set the record aside while leaving the directory it describes behind, and
+     * that mirror can then never be vouched for again: the evidence that would license
+     * its removal is what the removal took away.
+     *
+     * Driven with the record's name worn by a DIRECTORY, which is the only shape where
+     * the name is what refuses it. A real record is a file, so `isDirectory` turns it
+     * away first and a case built on one would pass with the name check deleted. The
+     * shape is reachable rather than contrived: `saf-mirrors` is exported into every
+     * terminal as `SAF_MIRRORS_DIR`, so anything can be created there under any name.
+     */
+    @Test
+    fun `an entry wearing the record's name cannot be removed as a folder`() {
+        vouchedMirror()
+        val impostor = File(mirrorsDir, "abc123def456" + SafSyncEngine.SYNCED_RECORD_SUFFIX)
+        impostor.mkdirs()
+        File(impostor, "inside.txt").writeText("not a mirror")
+
+        assertEquals(
+            SafStorageManager.RECLAIM_UNKNOWN,
+            manager.reclaimMirror(impostor.name, force = true),
+        )
+        sweep()
+
+        assertTrue(File(impostor, "inside.txt").isFile, "it was removed as though a folder")
+    }
+
+    @Test
+    fun `a copy that is already gone is refused rather than reported as freed`() {
+        assertEquals(
+            SafStorageManager.RECLAIM_UNKNOWN,
+            manager.reclaimMirror("abc123def456", force = true),
+        )
+    }
+
+    /**
+     * The sweep is the resumable half, so it has to finish what a killed process left
+     * behind and has to leave everything else alone. That is the same rule the launch
+     * pass applies, and the reason is the same: `saf-mirrors` holds files this app did
+     * not write.
+     */
+    @Test
+    fun `the sweep finishes earlier removals and touches nothing else`() {
+        val leftover = File(mirrorsDir, SafStorageManager.DISCARD_PREFIX + "abc123def456")
+        leftover.mkdirs()
+        File(leftover, "stale.txt").writeText("already unreachable")
+        val impostor = File(mirrorsDir, SafStorageManager.DISCARD_PREFIX + "my-notes")
+        impostor.mkdirs()
+        File(impostor, "mine.txt").writeText("named to look like ours")
+        val (live, _) = vouchedMirror()
+
+        assertEquals(1, sweep())
+
+        assertFalse(leftover.exists(), "an interrupted removal was never finished")
+        assertTrue(File(impostor, "mine.txt").isFile, "a person's own directory was deleted")
+        assertTrue(live.isDirectory, "a live mirror was swept")
+    }
+}

--- a/docs/05-API_SPEC.md
+++ b/docs/05-API_SPEC.md
@@ -36,7 +36,7 @@ wv.addJavascriptInterface(bridge, "AndroidBridge")
 ```
 
 The injected name is `AndroidBridge` and that part was always right. The construction
-was not: `AndroidBridge(this)` does not compile. The real constructor takes nine
+was not: `AndroidBridge(this)` does not compile. The real constructor takes fourteen
 parameters, five of them required —
 
 ```kotlin
@@ -45,6 +45,9 @@ AndroidBridge(
     onBackPressed, onMinimize,             // required callbacks
     onOpenFolderPicker = {}, onOpenRecentFolder = {},
     onShowAbout = {}, safManager = null,   // defaulted
+    onDownloadNamed = { _, _ -> }, onDownloadChunk = { _, _ -> false },
+    onDownloadComplete = { _, _ -> },
+    onListMirrors = { "[]" }, onReclaimMirror = { _, _ -> "..." },
 )
 ```
 
@@ -64,9 +67,9 @@ compare.
    (`SecurityManager.generateToken`, in `bridge/`, not a `security/` package).
    `MainActivity.injectBridgeToken()` writes it to `window.__vscodroid.authToken`
    after the page loads.
-2. **Every method, not a chosen subset**: all 31 `@JavascriptInterface` methods take the
+2. **Every method, not a chosen subset**: all 33 `@JavascriptInterface` methods take the
    token and validate it before doing anything, returning without acting on refusal
-   (§2.4 records the one method whose refusal value is not an empty one).
+   (§2.4 records the three whose refusal value is not an empty one).
    `BridgeTokenUniformityTest` enumerates them by reflection and fails the build
    if one is added without the check, and a second test asserts a refused call touches
    nothing -- so the rule holds for the class, not for a list that was correct when it was
@@ -150,25 +153,29 @@ Exposed via `@JavascriptInterface`:
 
 Every method takes the session token and validates it before doing anything; a call
 with a token that does not match is refused before the method acts. Thirty of
-the thirty-one then return an empty value: `false`, `null`, `""`, `"{}"`, `"[]"`,
-`0`, or nothing. **`generateSshKey` is the exception**: it returns
-`{"success":false,"error":"unauthorized"}`, a truthy string, so a caller testing
-`if (!result)` reads a refusal as success. Test its `success` field. Read the token from
+the thirty-three then return an empty value: `false`, `null`, `""`, `"{}"`, `"[]"`,
+`0`, or nothing. **Three do not, and each is truthy on refusal.**
+`generateSshKey` returns `{"success":false,"error":"unauthorized"}`, so a caller
+testing `if (!result)` reads a refusal as success; test its `success` field.
+`openExternalUrl` and `reclaimSafMirror` return the refusal sentence itself,
+because for those two the EMPTY string is the success value, so the polarity is
+reversed and a truthiness test reads backwards in the other direction. Read the token from
 `window.__vscodroid.authToken`, which MainActivity sets once the bridge is installed.
 `BridgeTokenUniformityTest` enumerates the methods by reflection and fails if one is
 added without the check, so this holds for the class rather than for the list below.
 
 **Registered is not the same as reachable, and the difference decides what an extension
-can do.** All 31 methods below live on the `AndroidBridge` object injected into the
+can do.** All 33 methods below live on the `AndroidBridge` object injected into the
 workbench page, so anything running in that page's own realm can call them directly. An
 extension cannot: it runs in the web extension host, which does not see objects added by
 `addJavascriptInterface`. Extensions reach the bridge over the BroadcastChannel relay
 that `MainActivity.injectBridgeRelay` opens, and that relay dispatches a hand-written
-list of **12** command names — grep `d.cmd ===` in `MainActivity.kt` for the current set:
+list of **14** command names — grep `d.cmd ===` in `MainActivity.kt` for the current set:
 
 > `clearCaches`, `generateBugReport`, `generateSshKey`, `getRecentFolders`,
-> `getSshPublicKey`, `getStorageBreakdown`, `listSshKeys`, `openExternalUrl`,
-> `openFolderPicker`, `openRecentFolder`, `openToolchainSettings`, `showAboutDialog`
+> `getSshPublicKey`, `getStorageBreakdown`, `listSafMirrors`, `listSshKeys`,
+> `openExternalUrl`, `openFolderPicker`, `openRecentFolder`,
+> `openToolchainSettings`, `reclaimSafMirror`, `showAboutDialog`
 
 A method absent from that list is unreachable from any extension however correctly it is
 registered — which is the whole of why the toolchain management calls have no callers.
@@ -325,6 +332,45 @@ fun clearCaches(authToken: String): Long
 @JavascriptInterface
 fun getAvailableStorage(authToken: String): Long
 // Returns: available disk space in bytes
+
+@JavascriptInterface
+fun listSafMirrors(authToken: String): String
+// JSON array of the local copies of device folders, largest first. This is the
+// contents of the `saf_mirrors` row that getStorageBreakdown reports as one
+// number, and there is no other listing of them anywhere in the app.
+// Format: [{"hash": "abc123def456", "name": "MyProject", "bytes": N,
+//           "lastOpened": 1700000000, "granted": true, "reclaimable": false}]
+// "name" and a non-zero "lastOpened" are ABSENT for a copy whose folder fell off
+// the recent list: the grant and the list entry are released together, so the
+// copy that survives has no name left. Do not substitute the hash; it reads like
+// a folder name and is not one.
+// "reclaimable" false means the copy holds files the device folder does not, so
+// removing it destroys the only copy of them. That is the ordinary state of any
+// folder something has been built or cloned in.
+// "[]" if refused, and also "[]" when no SAF manager is wired up.
+
+@JavascriptInterface
+fun reclaimSafMirror(authToken: String, hash: String, force: Boolean): String
+// Removes the local copy of one device folder. `hash` comes from listSafMirrors.
+//
+// `force` removes a copy whose "reclaimable" is false, which DELETES FILES THAT
+// EXIST NOWHERE ELSE. Only set it after the user has confirmed a modal that says
+// so. It is not a retry flag, and nothing else in this API deletes user data.
+//
+// Returns the empty string when the copy was removed, and otherwise the reason it
+// was not. CALLERS MUST COMPARE AGAINST THE EMPTY STRING: success is the falsy
+// value here, exactly as in openExternalUrl, so a truthiness test reads backwards
+// and reports every refusal as freed disk.
+//
+// The refusals name something that has to change first: the folder is open, it is
+// still opening, or it was open in this session and VSCodroid must be restarted.
+// The last one is not caution. Closing a folder stops its watchers but leaves a
+// write-back drain running rather than discarding writes, and that drain opens
+// each device document with "wt", which truncates at open, so deleting the copy
+// underneath it empties the user's file on the device.
+//
+// The call returns as soon as the copy is unreachable; the recursive delete
+// continues afterwards and is finished by the next launch if the process dies.
 ```
 
 #### Device Info
@@ -853,7 +899,7 @@ flowchart TD
   T --> T3["ms-python.python"]
   T --> T4["dbaeumer.vscode-eslint"]
   T --> T5["bradlc.vscode-tailwindcss"]
-  O --> O1["vscodroid.vscodroid-saf-bridge (the 8 VSCodroid: commands)"]
+  O --> O1["vscodroid.vscodroid-saf-bridge (the 9 VSCodroid: commands)"]
   O --> O2["vscodroid.vscodroid-welcome (Get Started walkthrough)"]
   O --> O3["vscodroid.vscodroid-process-monitor"]
   O --> O4["vscodroid.vscodroid-serve-network (dev-server preview)"]


### PR DESCRIPTION
Opening a device folder copies it into a hash-named mirror under `filesDir`. The premise that nothing bounds the total turns out to be half wrong, and the half that is right has a different cause than a missing cap.

A count budget already exists and is already an LRU: `addToRecentFolders` splits at `MAX_RECENT` and releases the dropped folder's persisted grant. What does not bind is **bytes**, and the reason is not the absence of a cap. `reclaimRevokedMirrorsSync` requires `holdsOnlyVouchedCopies`, which walks the mirror against its sync record, while `SKIP_DIRECTORIES` keeps `node_modules`, `.git`, `__pycache__` and `.gradle` out of that record by construction. One `npm install` makes a mirror permanently unreclaimable, and its name went away with its grant, so nothing in the app could name it or remove it.

So this ships the listing and a removal the user authorises, not a cap.

## What this adds

- `SafStorageManager` gains `listMirrors`, `reclaimMirror`, `releaseGrantFor` and `sweepDiscardedMirrors`, with the decision itself as pure functions beside `mayReclaim`.
- The bridge gains `listSafMirrors` and `reclaimSafMirror`, and the bundled extension a `VSCodroid: Manage Device Folder Storage` command.
- The `saf_mirrors` row in the storage screen now opens that instead of being a dead end, and the storage health check names it rather than Clear Caches, **which cannot touch it**. `CLEARABLE_KEYS` is unchanged, deliberately: this is not a cache.

## The data-loss rule, and that it is preserved

A mirror may be deleted without the user's explicit instruction only when `mayReclaim(hash, uploadsInFlight, root)` **and** `holdsOnlyVouchedCopies(dir)` both hold. The first answers whether a write-back this app attempted failed to reach the device. The second answers the strictly larger question of whether every byte here is also on the device, which covers what the journal structurally cannot see. Both fail closed.

Preserved three ways: the launch pass's gate is byte-for-byte unchanged, with `SafMirrorReclamationTest` as its regression control; `reclaimMirror` re-asks the same conjunction rather than trusting the listing, because a write can strand while a confirmation dialog is on screen; and the only bypass is a `force` flag the extension sets only after a modal that names what is deleted.

The removal is a rename first, then a delete: both entries are renamed before either is deleted, everything after the rename is idempotent, and the existing launch pass finishes an interrupted one. An exit added between the phases costs disk until the next launch rather than correctness, which is the shape this file already needed once after a per-path claim leaked from an exit added later.

## Verification

Twenty-four negative controls, each reddening the case it targets, covering the four in-use predicates, the listing's shape, both halves of the reclaimable verdict, the rename-before-delete ordering, the journal clearing under the pre-rename path, the grant release, the sweep's name discipline, and the bridge and relay wiring.

**Two controls first stayed green, and both were real defects rather than weak tests.** The listing had dropped the sync-record exclusion on the belief that a directory check covered it; it does for a record file, but `saf-mirrors` is exported to every terminal as `SAF_MIRRORS_DIR`, so a directory wearing that name is reachable and would have been listed as a folder. And a wiring guard matched on assignment text, which permitted exactly the bypass spelling it existed to catch; it now judges by position inside the function.

No timing test is used anywhere. The concurrency properties are pinned by decidable instruments, which is what this file's own throttle recorded as the right choice after fifty thousand trials failed to reproduce its defect.

Full unit suite 1394 tests, no failures. Lint unchanged at 53 warnings. All eight python gates, all eight node gates, and `scripts/device-test.sh --self-check` pass.

Three stale claims in `docs/05-API_SPEC.md` were corrected on arrival: a method count, a constructor arity, and a statement that one bridge method is the only one whose refusal is truthy, which stopped being true when the URL hand-off started answering with a reason.

## Not settled here

The device run. This worktree has no server tree or `jniLibs`, so an APK needs about 930 MB fetched first, and the emulator has a live session on it. What a device run would settle and nothing above does: that the picker and the modal render, and that a forced removal returns the bytes to the storage breakdown.

## Left for a product decision

What the app promises about a device folder that is no longer open. This builds what all three answers need and takes a fourth: make the existing budget visible and give the user the reclaim.

- **A hard cap that refuses a new mirror** lands its refusal at the moment the user is opening a folder, and the space they would free *is* the mirrors. It is also unenforceable where it matters, because the size it would check comes from provider-reported values and a provider that omits the size column reports zero.
- **A warning only** is cheap and honest and useless alone. Half of it existed and pointed at the wrong action; that half is fixed here.
- **Automatic LRU reclaim** is the option that sounds right and is the most dangerous. Respecting the gate frees nothing on the mirrors worth freeing, because a mirror gets large by being worked in and being worked in is what makes it unvouchable. Ignoring the gate deletes the user's only copy of files the app never delivered, on a launch thread with no screen to ask from.