### PR TITLE
fix(scripts): stop pinning a self-check to an extension version

### DIFF
--- a/scripts/lib/bundled-extension.js
+++ b/scripts/lib/bundled-extension.js
@@ -1,0 +1,56 @@
+'use strict';
+
+// Resolving a bundled extension by its version is how a self-check rots.
+//
+// Bumping the version of a bundled extension is mandatory in this repository
+// whenever its contents change: a device only re-extracts a directory whose name
+// it does not already have. So a path pinned to one version is a path that
+// breaks on the next correct change, and the version written into it is stale
+// the moment anyone edits the extension. That is not hypothetical; it is how
+// `scripts/test-process-monitor-extension.js` came to fail on a branch whose
+// only fault was bumping the extension it tests.
+//
+// Ordered by parsed version rather than by name, because 1.10.0 sorts below
+// 1.9.0 as text. `check-welcome-claims.py` sorts its directory the same way for
+// the same reason. The comparison here is not identical to that one: it
+// zero-pads a shorter tail where Python's tuple compare would sort it first,
+// which differs only between 1.2 and 1.2.0 and does not arise in this tree.
+
+const fs = require('fs');
+const path = require('path');
+
+const EXTENSIONS_DIR = path.resolve(
+    __dirname, '../../android/app/src/main/assets/extensions',
+);
+
+function parsedVersion(name) {
+    const tail = name.slice(name.lastIndexOf('-') + 1);
+    const parts = tail.split('.').map(Number);
+    return parts.some(Number.isNaN) ? [] : parts;
+}
+
+/**
+ * The newest bundled extension directory whose name starts with `prefix`.
+ *
+ * Throws rather than returning null: every caller is a self-check, and a check
+ * that quietly examines nothing reads exactly like a check that passed.
+ */
+function newestExtensionDir(prefix) {
+    const dirs = fs.readdirSync(EXTENSIONS_DIR)
+        .filter((d) => d.startsWith(prefix))
+        .sort((a, b) => {
+            const x = parsedVersion(a);
+            const y = parsedVersion(b);
+            for (let i = 0; i < Math.max(x.length, y.length); i += 1) {
+                const d = (x[i] || 0) - (y[i] || 0);
+                if (d !== 0) return d;
+            }
+            return 0;
+        });
+    if (!dirs.length) {
+        throw new Error(`no ${prefix}* under ${EXTENSIONS_DIR}`);
+    }
+    return path.join(EXTENSIONS_DIR, dirs[dirs.length - 1]);
+}
+
+module.exports = { EXTENSIONS_DIR, newestExtensionDir };

--- a/scripts/test-bridge-relay.js
+++ b/scripts/test-bridge-relay.js
@@ -27,6 +27,7 @@ const fs = require('fs');
 const path = require('path');
 const Module = require('module');
 const vm = require('vm');
+const { EXTENSIONS_DIR, newestExtensionDir } = require('./lib/bundled-extension');
 
 const ROOT = path.join(__dirname, '..');
 const MAIN_ACTIVITY = path.join(
@@ -35,7 +36,6 @@ const MAIN_ACTIVITY = path.join(
 const ANDROID_BRIDGE = path.join(
     ROOT, 'android/app/src/main/kotlin/com/vscodroid/bridge/AndroidBridge.kt',
 );
-const EXTENSIONS_DIR = path.join(ROOT, 'android/app/src/main/assets/extensions');
 
 /**
  * One of the user-facing decline reasons, read from where it now lives.
@@ -76,22 +76,9 @@ const DOLLAR_ESCAPE = "${'$'}";
  * which only shows up between 1.2 and 1.2.0 and does not arise in this tree.
  */
 function bridgeExtension() {
-    const version = (name) => {
-        const tail = name.slice(name.lastIndexOf('-') + 1);
-        const parts = tail.split('.').map(Number);
-        return parts.some(Number.isNaN) ? [] : parts;
-    };
-    const dirs = fs.readdirSync(EXTENSIONS_DIR)
-        .filter((d) => d.startsWith('vscodroid.vscodroid-saf-bridge-'))
-        .sort((a, b) => {
-            const x = version(a), y = version(b);
-            for (let i = 0; i < Math.max(x.length, y.length); i += 1) {
-                if ((x[i] || 0) !== (y[i] || 0)) return (x[i] || 0) - (y[i] || 0);
-            }
-            return 0;
-        });
-    assert.ok(dirs.length, `no vscodroid.vscodroid-saf-bridge-* under ${EXTENSIONS_DIR}`);
-    return path.join(EXTENSIONS_DIR, dirs[dirs.length - 1], 'extension.js');
+    return path.join(
+        newestExtensionDir('vscodroid.vscodroid-saf-bridge-'), 'extension.js',
+    );
 }
 
 /**

--- a/scripts/test-process-monitor-extension.js
+++ b/scripts/test-process-monitor-extension.js
@@ -22,10 +22,14 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const Module = require('module');
+const { newestExtensionDir } = require('./lib/bundled-extension');
 
-const EXTENSION = path.resolve(
-    __dirname,
-    '../android/app/src/main/assets/extensions/vscodroid.vscodroid-process-monitor-1.0.0/extension.js',
+// Resolved by prefix rather than pinned to a version. A bundled extension's
+// version must move whenever its contents do, so a pinned path breaks on the
+// next correct change, which is how this check came to fail on a branch whose
+// only fault was bumping the extension it tests.
+const EXTENSION = path.join(
+    newestExtensionDir('vscodroid.vscodroid-process-monitor-'), 'extension.js',
 );
 
 // The extension requires 'vscode', which exists only inside the workbench.


### PR DESCRIPTION
Bumping a bundled extension's version is mandatory whenever its contents change, because a device only re-extracts a directory whose name it does not already have. A self-check that resolves the extension by a pinned path therefore breaks on the next correct change, and the version written into it is stale the moment anyone edits the extension.

`scripts/test-process-monitor-extension.js` was pinned to `-1.0.0`. It fails with `MODULE_NOT_FOUND` on any branch that bumps the extension it tests, which is exactly what a branch contributing a new setting to that extension does.

`scripts/test-bridge-relay.js` already resolved by prefix, sorted by parsed version, and its comment explained why. That resolver now lives in `scripts/lib/bundled-extension.js` and both scripts read it, so the reasoning has one home rather than one copy that rots and one that does not.

It throws rather than returning nothing when no directory matches. Every caller is a self-check, and a check that quietly examines nothing reads exactly like a check that passed.

## Verification

The control binds in both directions, run by renaming the real directories:

- With this change, renaming the extensions to `1.9.0` and `1.10.0` leaves both harnesses green, which also exercises the parsed-version ordering, since `1.10.0` sorts below `1.9.0` as text.
- With the old pinned path restored and the version bumped, the harness exits 1, reproducing the CI failure exactly.

Both harnesses pass on the tree as it stands.