### PR TITLE
feat(git): trust the developer's own CA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Toolchain commands now work when a program calls them, not only from bash. Tasks, `make` recipes and extensions previously failed on a correctly installed toolchain.
 - Device folder copies can now be listed by size and removed one at a time. Removing one that holds files not on the device deletes them, so it asks first.
 - The editor server's memory ceiling is now settable from settings. It is clamped to what the device can hold, and turns itself off after repeated crashes.
+- git now trusts certificate authorities you installed through Android Settings. The bundle is rebuilt at launch when that store changes; pages in the editor still use system roots only.
 - Bug reports now carry the server's own output. The report always had a section for it, and nothing ever wrote the file it reads, so it was always empty.
 - The gesture trackpad now offers four accessibility actions to move the cursor. A drag was the only way to send an arrow, and a screen reader cannot drag.
 - Long pressing a key through a screen reader now opens its alternate characters. The layer needed a finger held on the key, so `'` and `\` were unreachable.
@@ -21,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Every dialog, toast and spoken description now comes from a string resource, so the app can be translated. No translation ships yet; sixty-nine texts were unreachable to one.
 - A build that packages the app now fails loudly if the checks guarding its bundled tree have come unattached, instead of going quiet and shipping an unchecked tree.
 - Two accessibility guards stopped passing on code that is commented out, and one no longer loses its scope to a brace inside a comment.
-- The user guide no longer promises that certificate errors should not happen. It says which roots the bundle carries, that a private CA is not among them, and that npm does not use it.
+- The user guide no longer promises that certificate errors should not happen. It says which roots the bundle carries and that npm does not use it.
 - The picker's checked state and the Toolchains back-arrow label are now pinned by tests. Both are invisible to a sighted reviewer, so either could be deleted without a symptom.
 - Editing a layout or a string no longer leaves the unit suite up to date. Two suites read those files, and both were skipped on exactly the edits they exist to catch.
 - A test no longer states that AGP builds no release unit test task. It does build one, and it has run; what is true is that no workflow invokes it.

--- a/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
@@ -15,6 +15,10 @@ import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
 import java.nio.file.Files
+import java.security.KeyStore
+import java.security.MessageDigest
+import java.security.cert.Certificate
+import java.util.Base64
 
 /**
  * @param assetBytes how much the APK's asset tree weighs, and [largestAssetBytes]
@@ -635,16 +639,42 @@ class FirstRunSetup(
      *
      * The bundle is concatenated from the device's own trust store rather than
      * shipped, so it reflects what this device actually trusts and does not age
-     * inside the APK. Rebuilt when the store's directory is newer than the file,
-     * which is one stat rather than 143.
+     * inside the APK. Two stores, not one: the system roots, and whatever CAs
+     * the device owner installed for themselves through Settings. That second
+     * half is why the bundle exists in the form it does. A developer whose
+     * company re-signs TLS, or who runs an internal git host behind a CA they
+     * issued, has already told the device to trust it, gone through the
+     * full-screen warning and confirmed with their device credential; the
+     * bundle honouring that is the app agreeing with a decision its owner
+     * already made, not making one for them. Everything else here keeps system
+     * trust: this writes the file git's curl reads and nothing more, so the
+     * WebView and the toolchain downloader are untouched.
+     *
+     * The freshness test is two conditions rather than one, and the second is
+     * not optional. Installing a CA through Settings writes into a store of its
+     * own and never touches the mtime of the system certificate directory, so
+     * the directory-newer-than-the-file check calls the bundle fresh at exactly
+     * the moment it has gone stale. Without the fingerprint the right bundle
+     * would be built once and then never again, and a user who installs a CA
+     * would see the app ignore it for ever with nothing to indicate why. The
+     * fingerprint covers the certificates' own bytes rather than their aliases
+     * because a Conscrypt alias is a hash of the subject, so a CA re-issued
+     * under the same name keeps the alias it had.
      */
     fun setupGitCaBundle() {
-        val caDir = listOf("/apex/com.android.conscrypt/cacerts", "/system/etc/security/cacerts")
+        val caDir = systemCaCertificateDirs
             .map { File(it) }
             .firstOrNull { it.isDirectory } ?: return
 
         val bundle = File(context.filesDir, "usr/etc/tls/cert.pem")
-        if (bundle.exists() && bundle.length() > 0 && bundle.lastModified() >= caDir.lastModified()) {
+        val marker = File(context.filesDir, "usr/etc/tls/.user-ca-fingerprint")
+        val userPems = userCertificatePems()
+        val fingerprint = sha256HexOf(userPems.joinToString(""))
+
+        if (bundle.exists() && bundle.length() > 0 &&
+            bundle.lastModified() >= caDir.lastModified() &&
+            runCatching { marker.readText() }.getOrNull() == fingerprint
+        ) {
             return
         }
 
@@ -664,15 +694,116 @@ class FirstRunSetup(
                 for (cert in certs) {
                     if (cert.isFile) cert.inputStream().use { it.copyTo(out) }
                 }
+                for (pem in userPems) out.write(pem.toByteArray())
             }
             if (!written) {
                 Logger.e(tag, "Could not write the CA bundle; the previous one is unchanged")
                 return
             }
-            Logger.i(tag, "CA bundle: ${certs.size} certificates from ${caDir.path}")
+            // The marker goes last, after the bundle it vouches for is already
+            // under its final name. Written first, a crash between the two would
+            // strand a marker describing a bundle that was never built, and the
+            // freshness check would then return early on every later launch --
+            // the same permanent-staleness failure the atomic write above exists
+            // to prevent, arriving by the other door. In this order a crash
+            // anywhere leaves the marker absent or disagreeing, which is a
+            // mismatch, which is a rebuild.
+            if (!writeAtomically(marker) { it.write(fingerprint.toByteArray()) }) {
+                Logger.w(tag, "Could not record the user-CA fingerprint; the bundle will be rebuilt next launch")
+            }
+            Logger.i(
+                tag,
+                "CA bundle: ${certs.size} certificates from ${caDir.path}, " +
+                    "and ${userPems.size} user-installed CA(s)",
+            )
         } catch (e: Exception) {
             Logger.e(tag, "Failed to build CA bundle", e)
         }
+    }
+
+    /**
+     * The CAs the device owner installed themselves, PEM-encoded and sorted.
+     *
+     * Sorted because [KeyStore.aliases] promises no order, and an order that
+     * varies between launches would change the fingerprint without the trust
+     * having changed, rebuilding the whole bundle on the main thread every time
+     * the app starts.
+     *
+     * Degrades to an empty list rather than throwing, at both levels. This runs
+     * inside SplashActivity's per-launch repair block, where an exception costs
+     * the repairs that follow it, and the whole feature is worth less than
+     * [setupToolSymlinks]. So a provider that is absent or refuses to load
+     * yields no user CAs and today's system-only bundle, and one certificate
+     * whose encoding cannot be read is skipped rather than costing the other
+     * entries the store holds.
+     *
+     * The cost is paid on every launch and it is not free. Measured on an API 33
+     * emulator with one CA installed, five launches: 28 ms in the steady state,
+     * of which `KeyStore.aliases()` over 126 entries is 25 to 27 ms and the rest
+     * is under a millisecond, against 45 ms for the whole repair block around
+     * it. The first launch after an install costs 160 ms once.
+     *
+     * A cheaper signal was looked for and deliberately not taken. Measured from
+     * inside this app on the same emulator, `/data/misc/user/0/cacerts-added` is
+     * readable: `exists`, `isDirectory` and `Os.stat` all answer, and the
+     * listing has the one entry it should. So an mtime on that directory could
+     * skip the enumeration on the launches where nothing changed. It is not used
+     * because it is a hardcoded platform path with a user id baked into it, it
+     * would need the current user's id on a multi-user device, and no version of
+     * it has been checked on Android 14 or later, where the root store moved
+     * into an APEX. A path like that stops matching in silence, and the way it
+     * fails here is the expensive direction: a directory that no longer exists
+     * reads as "nothing changed". Not worth 28 ms on a screen whose next act is
+     * to start a Node server. If the cost ever stops being affordable, move this
+     * repair off the main thread beside the toolchain passes that already run
+     * there, rather than weakening the fingerprint until the store's changes go
+     * unnoticed again.
+     */
+    private fun userCertificatePems(): List<String> =
+        runCatching { userTrustedCertificates() }
+            .onFailure { Logger.w(tag, "Could not read the user CA store: ${it.message}") }
+            .getOrDefault(emptyList())
+            .mapNotNull { cert -> runCatching { pemOf(cert) }.getOrNull() }
+            .sorted()
+
+    /**
+     * Where the system trust store lives, as an injectable list so the bundle
+     * builder can be exercised against a directory a test controls.
+     *
+     * A `var` for the same reason `SafSyncEngine.usableSpaceOf` and
+     * `ProcessManager.killRecordedProcess` are: the real value is an absolute
+     * path outside the app that no test can create. Not a seam to be tidied
+     * away. The order was already the code's and is kept: the Conscrypt APEX
+     * copy is asked for first, and the legacy path answers where the APEX one is
+     * absent. Measured on an API 33 emulator, only the legacy path exists there
+     * and it holds 125 certificates, so both entries are live rather than one
+     * being a leftover.
+     */
+    internal var systemCaCertificateDirs: List<String> =
+        listOf("/apex/com.android.conscrypt/cacerts", "/system/etc/security/cacerts")
+
+    /**
+     * Reads the user half of the device trust store.
+     *
+     * `AndroidCAStore` is the platform's own merged view of both halves, and it
+     * is used here rather than the directories underneath it because it is the
+     * documented API and carries no path this app has to keep up to date.
+     * Conscrypt names its entries `system:<hash>.<n>` and `user:<hash>.<n>`, so
+     * the prefix is what separates the owner's own CAs from the roots that
+     * shipped with the device. Measured on an API 33 emulator from inside this
+     * app's process, with one CA installed through Settings: 126 aliases, of
+     * which exactly one began `user:`.
+     *
+     * A `var` for the same reason as [systemCaCertificateDirs], and more
+     * sharply: the provider does not exist on a JVM at all, so every test of
+     * the bundle builder replaces this.
+     */
+    internal var userTrustedCertificates: () -> List<Certificate> = {
+        val store = KeyStore.getInstance("AndroidCAStore")
+        store.load(null)
+        store.aliases().toList()
+            .filter { it.startsWith("user:") }
+            .mapNotNull { alias -> runCatching { store.getCertificate(alias) }.getOrNull() }
     }
 
     /**
@@ -3126,6 +3257,35 @@ internal fun writeAtomically(dest: File, write: (FileOutputStream) -> Unit): Boo
         }
         true
     }
+
+/**
+ * PEM-encodes one certificate, in the shape the concatenated bundle is made of.
+ *
+ * The files under the system trust store are already PEM, so this exists only
+ * for the user-installed half, which arrives as parsed [Certificate] objects and
+ * has to be turned back into text before it can be appended. MIME encoding with
+ * a 64-character line length and a bare newline separator gives it the shape
+ * every other entry in the file already has, since the system store's files are
+ * copied through byte for byte and OpenSSL wrote them at 64 columns. Whether
+ * the reader on the far side insists on the breaks is untested here and beside
+ * the point: matching the rest of the file costs one encoder argument, and a
+ * single unbroken run of base64 in the middle of a bundle is a difference with
+ * nothing to gain from it.
+ *
+ * `java.util.Base64` rather than `android.util.Base64` so the encoding is the
+ * same object in a unit test as it is on the device. minSdk is 33, well past
+ * the 26 that added it.
+ */
+private fun pemOf(cert: Certificate): String =
+    "-----BEGIN CERTIFICATE-----\n" +
+        Base64.getMimeEncoder(64, byteArrayOf('\n'.code.toByte())).encodeToString(cert.encoded) +
+        "\n-----END CERTIFICATE-----\n"
+
+/** SHA-256 of [text] as lower-case hex, for the user-CA freshness marker. */
+private fun sha256HexOf(text: String): String =
+    MessageDigest.getInstance("SHA-256")
+        .digest(text.toByteArray())
+        .joinToString("") { "%02x".format(it) }
 
 /**
  * One lock for every atomic write, not one per destination.

--- a/android/app/src/main/kotlin/com/vscodroid/util/Environment.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/util/Environment.kt
@@ -125,8 +125,13 @@ object Environment {
             // The bundle file curl actually reads. Its Termux build looks for
             // one at a path that does not exist here, and fails before checking
             // any certificate; CAPATH alone does not satisfy it, measured on
-            // device. setupGitCaBundle() writes this from the system trust
-            // store on every launch it has changed.
+            // device. setupGitCaBundle() writes this on every launch it has
+            // changed, from the system trust store plus any CA the device owner
+            // installed themselves through Settings. That second half reaches
+            // git and nothing else: SSL_CERT_DIR below names the system store
+            // directly, so python, ruby and curl still see system roots only,
+            // and the WebView and the toolchain downloader go through the
+            // platform trust manager, which this file cannot influence.
             "GIT_SSL_CAINFO" to "$filesDir/usr/etc/tls/cert.pem",
             "SSL_CERT_DIR" to getSystemCaCertsPath(),
             "NPM_CONFIG_PREFIX" to "$filesDir/usr",

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -96,9 +96,9 @@
          characters and a 70-character one at 74, and both times what went missing
          was the half that says what to do. So each of these stays short enough to
          render whole with a host substituted, and the advice is the shortest true
-         one rather than the fullest. Why a user-installed CA does not help is a
-         paragraph, not a toast: it is in the user guide, and the full reason is in
-         logcat on every refusal. -->
+         one rather than the fullest. Why a user-installed CA does not help a page,
+         when it does help git, is a paragraph rather than a toast: it is in the
+         user guide, and the full reason is in logcat on every refusal. -->
     <string name="tls_blocked_untrusted">Blocked %1$s: certificate not trusted. Use http instead.</string>
     <string name="tls_blocked_hostname">Blocked %1$s: its certificate is issued for a different host name.</string>
     <string name="tls_blocked_date">Blocked %1$s: its certificate is expired or not yet valid.</string>

--- a/android/app/src/test/kotlin/com/vscodroid/setup/UserCaBundleTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/UserCaBundleTest.kt
@@ -1,0 +1,415 @@
+package com.vscodroid.setup
+
+import android.content.Context
+import com.vscodroid.util.Logger
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.security.PublicKey
+import java.security.cert.Certificate
+import java.security.cert.CertificateEncodingException
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+import java.util.Base64
+
+/**
+ * Pins what [FirstRunSetup.setupGitCaBundle] puts in git's certificate bundle,
+ * and, more sharply, when it agrees to look again.
+ *
+ * The bundle used to be system roots only, rebuilt whenever the system store's
+ * directory was newer than the file. Folding in the CAs the device owner
+ * installed for themselves breaks that test, because installing a CA through
+ * Settings writes into a store of its own and leaves the system directory's
+ * mtime exactly where it was. So the launch after an install is precisely a
+ * launch on which the cheap check says "fresh" and the answer is wrong, and a
+ * naive implementation builds the right bundle once and then never again. That
+ * failure is silent in both directions -- the user sees the app ignore a
+ * certificate they installed, and nothing anywhere says why -- which is what
+ * `installing a CA rebuilds a bundle the mtime check calls fresh` exists to
+ * catch.
+ *
+ * The whole method had no unit test before this, so the system half is pinned
+ * here too: without it the new cases would be measuring one unmeasured thing
+ * against another.
+ *
+ * Certificates are supplied through the [FirstRunSetup.userTrustedCertificates]
+ * seam. `AndroidCAStore` does not exist on a JVM, so there is no version of
+ * these tests that reaches the real provider; what the seam's own body does is
+ * measured on device instead, through the user-CA count this method logs.
+ */
+class UserCaBundleTest {
+
+    @TempDir
+    lateinit var filesDir: File
+
+    @TempDir
+    lateinit var systemCaDir: File
+
+    private lateinit var context: Context
+    private lateinit var bundle: File
+
+    /** A file of the shape Android's trust store holds: PEM, one root per file. */
+    private val systemPem = "-----BEGIN CERTIFICATE-----\nc3lzdGVtcm9vdA==\n-----END CERTIFICATE-----\n"
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(Logger)
+        every { Logger.d(any(), any()) } just Runs
+        every { Logger.i(any(), any()) } just Runs
+        every { Logger.w(any(), any(), any()) } just Runs
+        every { Logger.e(any(), any(), any()) } just Runs
+
+        context = mockk(relaxed = true)
+        every { context.filesDir } returns filesDir
+
+        File(systemCaDir, "a1b2c3d4.0").writeText(systemPem)
+        bundle = File(filesDir, "usr/etc/tls/cert.pem")
+    }
+
+    @AfterEach
+    fun tearDown() = unmockkObject(Logger)
+
+    /** [FirstRunSetup] wired to the fixture store, with [certs] as the user half. */
+    private fun setupWith(certs: () -> List<Certificate>): FirstRunSetup =
+        FirstRunSetup(context).apply {
+            systemCaCertificateDirs = listOf(systemCaDir.path)
+            userTrustedCertificates = certs
+        }
+
+    private fun buildWith(vararg certs: Certificate) =
+        setupWith { certs.toList() }.setupGitCaBundle()
+
+    /**
+     * Makes the cheap freshness test say "fresh".
+     *
+     * This is the state every launch after the first is in, and the state an
+     * install through Settings does not disturb, so it is the state the user-CA
+     * cases have to start from to be measuring anything.
+     */
+    private fun makeMtimeLookFresh() {
+        assertTrue(bundle.isFile, "no bundle to age; the harness is wrong")
+        assertTrue(systemCaDir.setLastModified(1_000_000_000_000L), "could not age the store")
+        assertTrue(bundle.setLastModified(2_000_000_000_000L), "could not age the bundle")
+    }
+
+    private fun bundleText() = bundle.readText()
+
+    // -- the system half, which had no test at all before this --
+
+    @Test
+    fun `the bundle carries every file in the system store`() {
+        File(systemCaDir, "e5f6a7b8.0").writeText("-----BEGIN CERTIFICATE-----\nc2Vjb25k\n-----END CERTIFICATE-----\n")
+
+        buildWith()
+
+        assertTrue(systemPem in bundleText(), "the first system root is missing from the bundle")
+        assertTrue("c2Vjb25k" in bundleText(), "the second system root is missing from the bundle")
+    }
+
+    @Test
+    fun `an unchanged store is not rebuilt`() {
+        // The control for every "was rebuilt" assertion below. Without it they
+        // would all also hold for a method that rebuilt unconditionally, which
+        // would put a 143-file concatenation on the main thread of every launch.
+        buildWith()
+        makeMtimeLookFresh()
+        bundle.writeText("sentinel")
+
+        buildWith()
+
+        assertEquals("sentinel", bundleText(), "the bundle was rebuilt though nothing had changed")
+    }
+
+    @Test
+    fun `a store that grew a certificate is rebuilt`() {
+        // The other half of that control: the mtime test still has to work.
+        buildWith()
+        bundle.writeText("sentinel")
+        assertTrue(bundle.setLastModified(1_000_000_000_000L), "could not age the bundle")
+        assertTrue(systemCaDir.setLastModified(2_000_000_000_000L), "could not age the store")
+
+        buildWith()
+
+        assertTrue(systemPem in bundleText(), "a store newer than the bundle did not force a rebuild")
+    }
+
+    // -- the user half --
+
+    @Test
+    fun `a user CA reaches the bundle, after the system roots`() {
+        buildWith(certificateOf(byteArrayOf(1, 2, 3, 4)))
+
+        val text = bundleText()
+        assertTrue(systemPem in text, "the system roots were dropped when a user CA was folded in")
+        assertTrue("AQIDBA==" in text, "the user CA is not in the bundle git reads")
+        assertTrue(
+            text.indexOf(systemPem) < text.indexOf("AQIDBA=="),
+            "the user CA was written before the system roots; the bundle is a concatenation " +
+                "and appending is what keeps the system half byte-identical to the store",
+        )
+    }
+
+    /**
+     * The case the whole change turns on.
+     *
+     * A CA installed through Settings does not touch the mtime of the system
+     * certificate directory, so the check that guarded this method before sees
+     * a bundle newer than the store and returns. Anything that reads only that
+     * clause builds the right bundle on some earlier launch and then ignores
+     * every certificate the owner installs afterwards, for the life of the
+     * install, with nothing on screen or in the log to say so.
+     */
+    @Test
+    fun `installing a CA rebuilds a bundle the mtime check calls fresh`() {
+        buildWith()
+        makeMtimeLookFresh()
+
+        buildWith(certificateOf(byteArrayOf(9, 9, 9)))
+
+        assertTrue(
+            "CQkJ" in bundleText(),
+            "a newly installed CA never reached the bundle: the freshness test read the " +
+                "system store's mtime, which an install through Settings does not move",
+        )
+    }
+
+    @Test
+    fun `removing a CA rebuilds the bundle without it`() {
+        buildWith(certificateOf(byteArrayOf(9, 9, 9)))
+        makeMtimeLookFresh()
+
+        buildWith()
+
+        assertFalse(
+            "CQkJ" in bundleText(),
+            "a CA the owner removed is still trusted by git; the bundle is rewritten rather " +
+                "than appended to, and the fingerprint has to notice a shrinking store too",
+        )
+        assertTrue(systemPem in bundleText(), "the rebuild lost the system roots")
+    }
+
+    /**
+     * Why the fingerprint covers the certificates' bytes and not a cheaper
+     * summary of them.
+     *
+     * A Conscrypt alias is a hash of the issuer's subject, so a CA re-issued
+     * under the same name arrives under the alias the old one had, and the count
+     * does not move either. Both of those are what a shortcut would compare.
+     */
+    @Test
+    fun `a CA re-issued under the same name is noticed`() {
+        buildWith(certificateOf(byteArrayOf(1, 1, 1)))
+        makeMtimeLookFresh()
+
+        buildWith(certificateOf(byteArrayOf(2, 2, 2)))
+
+        assertTrue("AgIC" in bundleText(), "the re-issued certificate never reached the bundle")
+        assertFalse("AQEB" in bundleText(), "the superseded certificate is still trusted")
+    }
+
+    /**
+     * The store is enumerated fresh on every launch, and `KeyStore.aliases`
+     * promises no order. An order-sensitive fingerprint would therefore differ
+     * from the recorded one on launches where nothing had changed, and rebuild
+     * the whole bundle on the main thread each time.
+     */
+    @Test
+    fun `the order the store enumerates in does not force a rebuild`() {
+        val first = certificateOf(byteArrayOf(1, 1, 1))
+        val second = certificateOf(byteArrayOf(2, 2, 2))
+        setupWith { listOf(first, second) }.setupGitCaBundle()
+        makeMtimeLookFresh()
+        bundle.writeText("sentinel")
+
+        setupWith { listOf(second, first) }.setupGitCaBundle()
+
+        assertEquals(
+            "sentinel",
+            bundleText(),
+            "the same two certificates in the other order counted as a change",
+        )
+    }
+
+    // -- degrading rather than failing, inside a per-launch repair --
+
+    @Test
+    fun `one certificate that cannot be encoded does not cost the others`() {
+        buildWith(certificateOf(byteArrayOf(7, 7, 7)), certificateOf(null))
+
+        assertTrue("BwcH" in bundleText(), "a readable certificate was dropped along with a broken one")
+        assertTrue(systemPem in bundleText(), "the system roots were dropped over one broken certificate")
+    }
+
+    /**
+     * The closed-failure argument the whole feature rests on, as a property.
+     *
+     * This runs from SplashActivity's per-launch repair block, ahead of the
+     * symlink and settings repairs, so an exception escaping here costs work
+     * that matters more than this does. On a device where the provider is
+     * missing or refuses to load, the answer has to be the bundle as it was
+     * before any of this existed.
+     */
+    @Test
+    fun `a trust store that cannot be read leaves the system-only bundle`() {
+        setupWith { throw java.security.KeyStoreException("no such provider") }.setupGitCaBundle()
+
+        assertTrue(bundle.isFile, "the bundle was not written at all")
+        assertEquals(systemPem, bundleText(), "the bundle is not the system-only one")
+    }
+
+    /**
+     * Ordering, as a property rather than a comment.
+     *
+     * The marker vouches for a bundle, so it can only be written once that
+     * bundle is under its final name. Recorded first, a crash between the two
+     * writes leaves a marker describing a file that was never built, and the
+     * freshness check then returns early on every later launch: the bundle is
+     * wrong permanently and the app is certain it is right. Recorded last, the
+     * same crash leaves the marker absent, which is a mismatch, which is a
+     * rebuild.
+     *
+     * Arranged as in [BashrcAtomicityTest], by occupying the temporary path the
+     * atomic write derives from its destination: the bundle write fails, and
+     * what the next launch does about it is the property.
+     */
+    @Test
+    fun `a fingerprint is never recorded for a bundle that was not written`() {
+        buildWith()
+        val blocker = blockTheBundleWrite()
+
+        buildWith(certificateOf(byteArrayOf(5, 5, 5)))
+        assertEquals(
+            systemPem,
+            bundleText(),
+            "the blocked write modified the bundle anyway; the harness is wrong",
+        )
+
+        blocker.deleteRecursively()
+        makeMtimeLookFresh()
+
+        buildWith(certificateOf(byteArrayOf(5, 5, 5)))
+
+        assertTrue(
+            "BQUF" in bundleText(),
+            "the failed write left behind a fingerprint that vouches for it, so the freshness " +
+                "check returns early on every later launch and the CA is never picked up",
+        )
+    }
+
+    /** Non-empty, so the cleanup `delete()` cannot quietly reclaim it. */
+    private fun blockTheBundleWrite(): File {
+        bundle.parentFile?.mkdirs()
+        return File(bundle.parentFile, "${bundle.name}.tmp~").also {
+            assertTrue(it.mkdirs(), "could not stage the blocked temp path")
+            File(it, "occupied").writeText("x")
+        }
+    }
+
+    // -- the armour itself --
+
+    /**
+     * The user half is the only part of the bundle this app encodes; the system
+     * files are copied through byte for byte. So the line wrapping, the header
+     * and footer and the trailing newline are this app's to get right, and the
+     * thing that decides whether it did is a certificate parser rather than a
+     * regular expression of ours. A real self-signed certificate goes in and has
+     * to come back out of the bundle.
+     */
+    @Test
+    fun `what the bundle carries parses back as the certificate that went in`() {
+        val real = realCertificate()
+
+        buildWith(real)
+
+        val pem = bundleText().substringAfter(systemPem)
+        val parsed = CertificateFactory.getInstance("X.509")
+            .generateCertificate(pem.byteInputStream()) as X509Certificate
+        assertEquals(
+            (real as X509Certificate).subjectX500Principal,
+            parsed.subjectX500Principal,
+            "the PEM in the bundle did not parse back as the certificate it encodes",
+        )
+    }
+
+    /**
+     * The width, which the round-trip above cannot see.
+     *
+     * Java's certificate factory accepts an unbroken run of base64 quite
+     * happily, so a parser is the wrong instrument for this one: measured, an
+     * unwrapped encoder passes that test. What reads the bundle in production is
+     * a line-oriented C parser inside a libcurl this suite cannot reach, and
+     * every other entry in the file is a system root copied through byte for
+     * byte at 64 columns. The user half being the one stretch of the file with a
+     * different shape is a difference with no upside and one that costs an
+     * argument to avoid, so it is pinned rather than left to a reader to
+     * rediscover.
+     */
+    @Test
+    fun `the user half is wrapped like every other entry in the bundle`() {
+        buildWith(realCertificate())
+
+        val body = bundleText().substringAfter(systemPem)
+            .lines().filter { it.isNotBlank() && !it.startsWith("-----") }
+        assertTrue(body.size > 1, "the certificate was emitted as one unbroken run of base64")
+        assertTrue(
+            body.all { it.length <= 64 },
+            "a line ran past 64 columns: ${body.map { it.length }}",
+        )
+    }
+
+    /**
+     * A certificate whose encoding is exactly [der], or one whose encoding
+     * cannot be read when [der] is null.
+     *
+     * Only `getEncoded` is reached: [FirstRunSetup] turns each entry straight
+     * into PEM and never asks a certificate anything else. Supplying the bytes
+     * directly is what lets a re-issue be expressed as two certificates that
+     * differ in nothing a shortcut would compare.
+     */
+    private fun certificateOf(der: ByteArray?): Certificate = object : Certificate("X.509") {
+        override fun getEncoded(): ByteArray =
+            der ?: throw CertificateEncodingException("this certificate cannot be encoded")
+
+        override fun verify(key: PublicKey) = Unit
+
+        override fun verify(key: PublicKey, sigProvider: String?) = Unit
+
+        override fun getPublicKey(): PublicKey = throw UnsupportedOperationException()
+
+        override fun toString(): String = "certificateOf(${der?.size ?: "unreadable"})"
+    }
+
+    /** A self-signed CA, `O=VSCodroid Test, CN=Test CA`, valid to 2036. */
+    private fun realCertificate(): Certificate =
+        CertificateFactory.getInstance("X.509").generateCertificate(
+            Base64.getDecoder().decode(TEST_CA_DER).inputStream(),
+        )
+}
+
+private const val TEST_CA_DER =
+    "MIIDNzCCAh+gAwIBAgIUJnoYEVwNJOi5TaXU9yqNn6CeM4QwDQYJKoZIhvcNAQELBQAwKzEXMBUG" +
+        "A1UECgwOVlNDb2Ryb2lkIFRlc3QxEDAOBgNVBAMMB1Rlc3QgQ0EwHhcNMjYwODIxMTQ0NzUyWhcN" +
+        "MzYwODE4MTQ0NzUyWjArMRcwFQYDVQQKDA5WU0NvZHJvaWQgVGVzdDEQMA4GA1UEAwwHVGVzdCBD" +
+        "QTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALG+F8Gb3EA8uZQfDfZYmblmQYknv7c9" +
+        "TSzqvZPRCK1IwI3Y8oaQvOkGC5irKgcUa6qLlZ++p+Cr9mnJQrb+aj9pKFXeA1/6yniFSAnFYMxp" +
+        "P4Pxq+Az8YQYwUJgeQSQ3MWmGesXks4BrhjMfrRWnfmpzwmbEwRYWtqXWe2FD68Hy3eMjX2nVeOD" +
+        "sDVbZKlZTl2KeyYCqsHVXoww56+decfqR259+Fmf+3tvhol/AWLg0DpYZUO/MGL+AICrahHZNftN" +
+        "dLtN0f/7ohxGEtQyYTVt052N05rOizk1ZJlDj9SysE28nMoFKQlmcTyCvpMMzt6i46IPYtpwxGJA" +
+        "f6ws7ZcCAwEAAaNTMFEwHQYDVR0OBBYEFFQqDUUIUn4Pgl88bqnF9YlJWFtbMB8GA1UdIwQYMBaA" +
+        "FFQqDUUIUn4Pgl88bqnF9YlJWFtbMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEB" +
+        "ABZAbAvoeHBzeeViFam0nVWXFcNpnS3ljpTwb8nVIxIGgDVu+qNm58AbpqibPkPuYnN/oOZa2g9p" +
+        "e+FtFGfIkcor0vxuA7farq6HPGWRUyfLL68cMIubrsY/dyFxQo1E2yIERUxRseGa5IuC9ZQnWOwb" +
+        "Ig82DLAOa0RPbFsphRSwmgXE/vjgMu3GwazyK3z+VgV++OrVPaFqL1jweBpqrELHPIzWD1JRPjl3" +
+        "DF2ZOlRbVrBkyTv2UML2DkUp+boMdWGkR2Gau5PCzPZO9wdO0uYI3ovDMIP52MW692zvN8z/NgjO" +
+        "VGw9WFdevvYVYcxcdPDYRRP//2jkaPpyba8OXLc="

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -416,9 +416,11 @@ empty and there was nothing to tell that apart from a server that was not runnin
 
 Plain `http://` is the answer for a local preview: cleartext is permitted here precisely
 because that is what dev servers speak. Installing your own CA through Android Settings
-does not help either. The app trusts the device's system roots only, which is the same
-wall described for git above, so a certificate you issued yourself is not trusted no
-matter where you install it.
+does not help for a page, and this is the one place where it makes a difference which
+part of the app is asking. Pages are rendered by the system WebView, which trusts the
+device's system roots and nothing else. git does read a CA you installed, because the
+app builds git's certificate bundle from both halves of the device trust store. So the
+same certificate can clone fine in the terminal and still be refused in a preview tab.
 
 #### Opening in the device's browser instead
 
@@ -795,7 +797,7 @@ If `npm install` fails with errors:
 ### Git Push/Pull Fails
 
 - **Permission denied (publickey)** -- generate an SSH key with `ssh-keygen -t ed25519` in the terminal and add it to your GitHub/GitLab account.
-- **SSL certificate error** -- the CA bundle git uses is built from your device's own system roots, so a public certificate authority is already trusted and a private or corporate one is not. Installing that CA through Android Settings does not change it either: user-installed certificates live in a separate store this app does not read. The practical answer for an internal host is an SSH remote (`git@`) instead of `https://`. Note that npm does not use that bundle at all, so a private registry behind its own CA is a different wall rather than the same one.
+- **SSL certificate error** -- the CA bundle git uses is built from your device's own trust store: the system roots, plus any certificate authority you installed yourself through Android Settings, under the CA-certificate flow in the device's security settings. So a private or corporate CA does work for git, from the next time you open the app -- the bundle is rebuilt at launch, not while the app is running. If you would rather not install a CA on the device, an SSH remote (`git@`) instead of `https://` is still the shortest route to an internal host. Two things that bundle does not reach: npm, which has its own trust store, and pages loaded inside the editor, which use the system roots only.
 
 ### App Uses Too Much Storage
 

--- a/scripts/device-test.sh
+++ b/scripts/device-test.sh
@@ -970,6 +970,45 @@ check_symlink "python3" "libpython.so"
 check_symlink "rg"      "libripgrep.so"
 check_symlink "ssh"     "libssh.so"
 
+# The bundle git reads, and the one place the user half of the device trust
+# store can be measured at all. Nothing in the JVM suite can reach it:
+# AndroidCAStore has no provider off a device, so the `user:` alias convention
+# that decides which certificates setupGitCaBundle folds in is checked here or
+# nowhere.
+#
+# The verdict is only that the bundle exists and holds certificates. Without one
+# every HTTPS remote dies on a trust-anchor error naming the Termux path curl
+# fell back to, which points at no install of this app and reads like a device
+# fault. Whether the device under test has a CA of its own installed is the
+# tester's choice rather than a property of the build, so the user count beside
+# it is reported and not judged. It is also arithmetic over two counts rather
+# than a parse: the system store holds one certificate per file, and the bundle
+# copies each of those files through whole, so the difference is the user half
+# unless that stops being true.
+#
+# The pattern carries no space, and that is not style. `adb shell` joins its
+# arguments and hands the result to the device's shell, so quoting applied on
+# this side never arrives: a pattern of "BEGIN CERTIFICATE" reaches grep as two
+# arguments, the second read as a filename, and the count comes back empty. The
+# anchored form is one argument however it is joined. Measured against the
+# device, which is how the split was found.
+CA_BUNDLE_REL="files/usr/etc/tls/cert.pem"
+BUNDLE_CERTS=$($ADB shell run-as "$PKG" grep -c "^-----BEGIN" "$CA_BUNDLE_REL" 2>/dev/null | tr -d '\r')
+SYSTEM_CA_DIR=/apex/com.android.conscrypt/cacerts
+if ! $ADB shell "ls $SYSTEM_CA_DIR" >/dev/null 2>&1; then
+    SYSTEM_CA_DIR=/system/etc/security/cacerts
+fi
+SYSTEM_CERTS=$($ADB shell "ls $SYSTEM_CA_DIR" 2>/dev/null | tr -d '\r' | grep -c . || true)
+if [ -n "$BUNDLE_CERTS" ] && [ "$BUNDLE_CERTS" -gt 0 ] 2>/dev/null; then
+    if [ -n "$SYSTEM_CERTS" ] && [ "$SYSTEM_CERTS" -gt 0 ] 2>/dev/null; then
+        pass "ca_bundle ($BUNDLE_CERTS certificates; $SYSTEM_CERTS in $SYSTEM_CA_DIR, so $((BUNDLE_CERTS - SYSTEM_CERTS)) came from the user store)"
+    else
+        pass "ca_bundle ($BUNDLE_CERTS certificates; system store unread, so the user half is unknown)"
+    fi
+else
+    fail "ca_bundle" "no certificates in $CA_BUNDLE_REL; every HTTPS remote fails on a trust-anchor error"
+fi
+
 # ═══════════════════════════════════════════════════════════════════
 # TESTS 15-19: Tool version checks
 # ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
A developer whose company or homelab CA is installed through Android Settings could not clone over https: git reads the bundle this app writes, and that bundle carried the system roots only. The editor now says why a certificate was refused, which makes the gap visible without closing it.

## Why this is narrow, deliberately

The obvious lever is `<certificates src="user"/>` in the network security config, and it is the wrong one twice over.

It would unblock **only** the WebView subframe. npm, git, python and the extension marketplace all run through Node, which uses its own compiled-in Mozilla store: verified from the `config.gypi` embedded in `libnode.so`, which has `node_shared_openssl` true, no `node_use_openssl_ca`, no `NODE_OPENSSL_CERT_STORE`, and about 125 embedded PEM blobs. No Android configuration reaches it. VS Code's `http.systemCertificates` cannot help either, because `@vscode/proxy-agent` returns nothing for a platform that is not win32, darwin or linux, and the server's platform is `android`.

Meanwhile it is the **only** option that would also widen the trust used by `ToolchainManager`, whose five https requests fetch binaries and the digest manifest that vouches for them from the same origin over the same connection, and which then chmods and symlinks the result into `usr/bin`. That is a supply-chain boundary this repository treats as load-bearing.

So this touches the git CA bundle and nothing else: no network security config, no WebView trust, no toolchain downloader. Google Play's SSL policy is about `SslErrorHandler.proceed()`, which this app never calls on any path; a trust anchor is a different mechanism.

## What it does

`setupGitCaBundle` now appends the certificates the device owner installed themselves, PEM-encoded, after the system roots. They come from `AndroidCAStore`, the platform's own merged view, filtered to the aliases Conscrypt names `user:`.

The freshness check is the part that needed care. The bundle was rebuilt only when the system store's mtime moved, and installing a CA does not touch that directory, so a user who installed one would never see it take effect. A fingerprint over the certificates' own bytes, recorded beside the bundle, is what notices. Over bytes and not aliases, because an alias is a subject hash and survives a CA re-issued under the same name.

It degrades to zero rather than throwing: this runs from the per-launch repair block, and a missing provider must not take a launch down with it.

## Verified on a device, with a real CA

A CA was installed on an API 33 emulator the way a user installs one, through Settings. From inside the app's own process, `AndroidCAStore` reports 126 aliases of which exactly one begins `user:`.

The bundle was then measured against a control build of the same commit's parent:

| Build | Certificates in `usr/etc/tls/cert.pem` | The installed CA present |
|---|---|---|
| without this change | 125 | no |
| with this change | 126 | yes, last, after the system roots |

A second launch leaves the bundle's mtime unchanged, so the freshness check holds and the per-launch repair stays cheap.

## Verification

Thirteen cases in `UserCaBundleTest`, and three negative controls run against the real source, each reddening the cases that depend on it: reading no user certificates reddens the three that assert one reaches the bundle and parses back; dropping the fingerprint from the freshness test reddens install, removal and re-issue; and recording the fingerprint for a bundle that was not written reddens the two that assert an unchanged store is not rebuilt.

Full unit suite 1421 tests, no failures. Lint 50 warnings, down from 51. `scripts/device-test.sh --self-check` passes 10 of 10.

## Left open

The general question this does not answer: when the device owner has deliberately installed a CA, which of the app's other trust stores should honour it. The WebView is one answer and Node is another, and Node's cannot be reached from Android at all without rebuilding the runtime. Both are product decisions rather than engineering ones, and neither is taken here.