### PR TITLE
fix: correctness and build-gate fixes for 1.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,11 @@ signing.properties
 /android/.idea/
 /android/build/
 /android/app/build/
+# The Kotlin Gradle plugin's own project directory, holding compiler session
+# markers and error dumps. Written by every build, so leaving it untracked but
+# unignored means `git status` is never clean and `git add -A` sweeps compiler
+# scratch into a commit.
+/android/.kotlin/
 /android/app/release/
 /android/captures/
 .externalNativeBuild/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A file being written back to a device folder can no longer be truncated by a second writer after the editor screen is rebuilt.
 - Removing a device folder copy stays refused for the whole session the folder was open in, rather than becoming allowed as soon as the editor screen is rebuilt.
 - A directory holding exactly the copy limit is no longer reported as partly copied when every file in it arrived.
+- Installing a toolchain already being installed is declined rather than copying the tree twice, which could run a device out of space and leave a partial install.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The toolchain check finds the welcome extension by name rather than a pinned version, so the next ordinary bump of that extension no longer fails the build.
 - The translatable-text check reports the test it actually applied instead of claiming no user-facing text sits outside the string resources.
 - Two tests pinning the write-back notice no longer pass when its wiring is commented out rather than deleted.
+- The Kotlin plugin's own build directory is ignored, so a build no longer leaves compiler scratch sitting in the working tree.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The three deprecated edge-to-edge APIs Play reports are gone. Bar colours, the display cutout and bar contrast move to theme attributes; edge-to-edge and bar icons stay in code.
 - The licence check matches each copyleft component against the source offer's own entries. A deleted offer used to pass because a neighbouring entry mentioned the project by name.
 - The toolchain check finds the welcome extension by name rather than a pinned version, so the next ordinary bump of that extension no longer fails the build.
+- The translatable-text check reports the test it actually applied instead of claiming no user-facing text sits outside the string resources.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reopening a device folder now writes back an edit the watcher never carried out, instead of leaving it in the app forever.
 - A save that cannot reach the device folder now says so, once per burst, instead of failing silently and looking like a save that worked.
 - A device folder's local copy is no longer deleted when it falls off the recent list. Anything written there but never sent, a cloned repository included, was the only copy.
+- First-run setup asks for the space the unpack needs. A repair that runs before the check made it demand 113 MB more and refuse devices that had room.
 - A file being written back to a device folder can no longer be truncated by a second writer after the editor screen is rebuilt.
 - Removing a device folder copy stays refused for the whole session the folder was open in, rather than becoming allowed as soon as the editor screen is rebuilt.
 - A directory holding exactly the copy limit is no longer reported as partly copied when every file in it arrived.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The licence check matches each copyleft component against the source offer's own entries. A deleted offer used to pass because a neighbouring entry mentioned the project by name.
 - The toolchain check finds the welcome extension by name rather than a pinned version, so the next ordinary bump of that extension no longer fails the build.
 - The translatable-text check reports the test it actually applied instead of claiming no user-facing text sits outside the string resources.
+- Two tests pinning the write-back notice no longer pass when its wiring is commented out rather than deleted.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A directory holding exactly the copy limit is no longer reported as partly copied when every file in it arrived.
 - Keys on the extra row keep the space above and below their labels, which the rounded background had been replacing with none.
 - A setup failure names the real error in release builds. The shrinker renamed the type, so the screen showed a two-letter token instead.
+- The download percentage on the first-run screen comes from a string resource, so its sign and digits follow the device's language.
 - Installing a toolchain already being installed is declined rather than copying the tree twice, which could run a device out of space and leave a partial install.
 - A page can no longer bury the editor under notices about links it could not open. Only navigations you started are announced, and repeats of the same one are dropped.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A file being written back to a device folder can no longer be truncated by a second writer after the editor screen is rebuilt.
 - Removing a device folder copy stays refused for the whole session the folder was open in, rather than becoming allowed as soon as the editor screen is rebuilt.
 - A directory holding exactly the copy limit is no longer reported as partly copied when every file in it arrived.
+- Keys on the extra row keep the space above and below their labels, which the rounded background had been replacing with none.
 - Installing a toolchain already being installed is declined rather than copying the tree twice, which could run a device out of space and leave a partial install.
 - A page can no longer bury the editor under notices about links it could not open. Only navigations you started are announced, and repeats of the same one are dropped.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A save that cannot reach the device folder now says so, once per burst, instead of failing silently and looking like a save that worked.
 - A device folder's local copy is no longer deleted when it falls off the recent list. Anything written there but never sent, a cloned repository included, was the only copy.
 - A file being written back to a device folder can no longer be truncated by a second writer after the editor screen is rebuilt.
+- Removing a device folder copy stays refused for the whole session the folder was open in, rather than becoming allowed as soon as the editor screen is rebuilt.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removing a device folder copy stays refused for the whole session the folder was open in, rather than becoming allowed as soon as the editor screen is rebuilt.
 - A directory holding exactly the copy limit is no longer reported as partly copied when every file in it arrived.
 - Keys on the extra row keep the space above and below their labels, which the rounded background had been replacing with none.
+- A setup failure names the real error in release builds. The shrinker renamed the type, so the screen showed a two-letter token instead.
 - Installing a toolchain already being installed is declined rather than copying the tree twice, which could run a device out of space and leave a partial install.
 - A page can no longer bury the editor under notices about links it could not open. Only navigations you started are announced, and repeats of the same one are dropped.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A build that packages the app without the checks deciding whether its bundled tree may ship now fails, instead of producing an unchecked APK.
 - The three deprecated edge-to-edge APIs Play reports are gone. Bar colours, the display cutout and bar contrast move to theme attributes; edge-to-edge and bar icons stay in code.
 - The licence check matches each copyleft component against the source offer's own entries. A deleted offer used to pass because a neighbouring entry mentioned the project by name.
+- The toolchain check finds the welcome extension by name rather than a pinned version, so the next ordinary bump of that extension no longer fails the build.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reopening a device folder now writes back an edit the watcher never carried out, instead of leaving it in the app forever.
 - A save that cannot reach the device folder now says so, once per burst, instead of failing silently and looking like a save that worked.
 - A device folder's local copy is no longer deleted when it falls off the recent list. Anything written there but never sent, a cloned repository included, was the only copy.
+- A file being written back to a device folder can no longer be truncated by a second writer after the editor screen is rebuilt.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A device folder's local copy is no longer deleted when it falls off the recent list. Anything written there but never sent, a cloned repository included, was the only copy.
 - A file being written back to a device folder can no longer be truncated by a second writer after the editor screen is rebuilt.
 - Removing a device folder copy stays refused for the whole session the folder was open in, rather than becoming allowed as soon as the editor screen is rebuilt.
+- A directory holding exactly the copy limit is no longer reported as partly copied when every file in it arrived.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The weekly upstream patch check prints its verdict on the run summary, so a queued rebase is visible without opening the log.
 - A build that packages the app without the checks deciding whether its bundled tree may ship now fails, instead of producing an unchecked APK.
 - The three deprecated edge-to-edge APIs Play reports are gone. Bar colours, the display cutout and bar contrast move to theme attributes; edge-to-edge and bar icons stay in code.
+- The licence check matches each copyleft component against the source offer's own entries. A deleted offer used to pass because a neighbouring entry mentioned the project by name.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removing a device folder copy stays refused for the whole session the folder was open in, rather than becoming allowed as soon as the editor screen is rebuilt.
 - A directory holding exactly the copy limit is no longer reported as partly copied when every file in it arrived.
 - Installing a toolchain already being installed is declined rather than copying the tree twice, which could run a device out of space and leave a partial install.
+- A page can no longer bury the editor under notices about links it could not open. Only navigations you started are announced, and repeats of the same one are dropped.
 
 ### Security
 

--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -290,8 +290,8 @@ M6 (Release)   → Play Store release
      - Material Icon Theme, ESLint, Prettier, Python, Tailwind CSS
    - [x] 4 custom VSCodroid extensions:
      - `vscodroid.vscodroid-welcome-1.2.2`, welcome tab with quick actions
-     - `vscodroid.vscodroid-saf-bridge-1.4.0` — SAF storage integration
-     - `vscodroid.vscodroid-process-monitor-1.1.0` — phantom process monitoring
+     - `vscodroid.vscodroid-saf-bridge-1.4.0`, SAF storage integration
+     - `vscodroid.vscodroid-process-monitor-1.1.0`, phantom process monitoring
      - `vscodroid.vscodroid-serve-network-1.1.0`, serve a dev server on the LAN
    - [x] `extensions.json` manifest auto-generated on first run
 

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -25,6 +25,19 @@
 -keep class com.vscodroid.VSCodroidApp { *; }
 
 # ----------------------------------------------------------------------------
+# Exception type names that reach the user
+# ----------------------------------------------------------------------------
+# FirstRunSetup.describeFailure builds the setup-failure text the splash screen
+# shows out of error.javaClass.simpleName, so any app exception R8 renames is
+# read by the user as the obfuscated token instead of a type: a failed manifest
+# rewrite reported itself as "oo: could not write ...". The rule is written over
+# the shape rather than over the class that surfaced it, so an exception type
+# added later is legible without anyone remembering this file. -keepnames, so
+# unused classes are still removed and only the name is pinned; members stay
+# renameable because none of them is ever printed.
+-keepnames class com.vscodroid.** extends java.lang.Throwable
+
+# ----------------------------------------------------------------------------
 # WebKit
 # ----------------------------------------------------------------------------
 # Suppress warnings for optional WebKit APIs that may not be present on all

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -66,6 +66,8 @@ import com.vscodroid.webview.VSCodroidWebViewClient
 import com.vscodroid.webview.RETRY_URL
 import com.vscodroid.webview.TlsFailure
 import com.vscodroid.webview.TlsFailureReason
+import com.vscodroid.webview.HandoffFailure
+import com.vscodroid.webview.handoffFailureToAnnounce
 import com.vscodroid.webview.publishedResourceRoots
 import com.vscodroid.webview.redactToken
 import com.vscodroid.webview.sensitiveLocations
@@ -101,6 +103,19 @@ class MainActivity : AppCompatActivity() {
      * a message was actually shown.
      */
     private val announcedTlsFailures = mutableSetOf<TlsFailure>()
+
+    /**
+     * The hand-off failures already put on screen, so a page driving many
+     * navigations to a scheme nothing answers is one message rather than a stream
+     * of them. See [handoffFailureToAnnounce], which owns the rule, explains why
+     * the key is the scheme and the exception type rather than the URL, and is
+     * tested without an Activity.
+     *
+     * Held here for the reason [announcedTlsFailures] is: the client has no mutable
+     * state and is worth keeping that way, and the presenter is what knows when a
+     * message was actually shown.
+     */
+    private val announcedHandoffFailures = mutableSetOf<HandoffFailure>()
 
     /**
      * Whether a workbench page is loaded and able to receive an auth callback.
@@ -1610,15 +1625,27 @@ class MainActivity : AppCompatActivity() {
             // nothing and said nothing. ActivityNotFoundException is separated
             // out because it is the one the user can act on by installing
             // something; everything else is quoted by type for a bug report.
+            //
+            // Said once per distinct failure, not once per navigation. The notice
+            // was unconditional, and a toast holds the screen for about three and
+            // a half seconds without replacing the one under it, so a page
+            // repeating a link the device cannot open covered the editor for as
+            // long as it liked. The record is consulted inside runOnUiThread, so
+            // the set has one owner thread whatever the platform guarantees about
+            // which thread the callback arrives on.
             onHandoffFailed = { uri, error ->
-                val scheme = uri.scheme ?: "external"
-                val message = if (error is android.content.ActivityNotFoundException) {
-                    getString(R.string.url_handoff_no_app, scheme)
-                } else {
-                    getString(R.string.url_handoff_failed, scheme, error.javaClass.simpleName)
-                }
+                val failure = HandoffFailure(
+                    uri.scheme ?: "external", error.javaClass.simpleName
+                )
                 runOnUiThread {
-                    Toast.makeText(this@MainActivity, message, Toast.LENGTH_LONG).show()
+                    handoffFailureToAnnounce(failure, announcedHandoffFailures)?.let {
+                        val message = if (error is android.content.ActivityNotFoundException) {
+                            getString(R.string.url_handoff_no_app, it.scheme)
+                        } else {
+                            getString(R.string.url_handoff_failed, it.scheme, it.failureType)
+                        }
+                        Toast.makeText(this@MainActivity, message, Toast.LENGTH_LONG).show()
+                    }
                 }
             },
             // A certificate the device does not trust used to produce an empty

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -149,32 +149,6 @@ class MainActivity : AppCompatActivity() {
     private var syncingFolder: Uri? = null
 
     /**
-     * Every mirror this process has put a watcher on, whether or not one is on it
-     * now.
-     *
-     * Never cleared, and that is the point rather than an omission.
-     * [SafStorageManager.stopFileWatcher] stops the observers, but the engine
-     * waits only two seconds for the write-back worker to drain and then leaves
-     * it running rather than discarding writes the user expects on the device.
-     * So a folder the app considers closed can still have a thread streaming
-     * bytes out of its mirror, and every such write opens the device document
-     * with `"wt"`, which truncates at open: deleting the mirror underneath one
-     * empties the user's file rather than leaving it alone.
-     *
-     * A drain only ever touches the mirror it was started for, so refusing every
-     * mirror this process has watched is what puts it out of reach without
-     * needing to know whether a particular drain is still alive. The cost is that
-     * removing a folder opened this session needs a restart, which is a sentence
-     * the user can act on.
-     *
-     * Concurrent because it is written on the UI thread and read on the bridge
-     * thread, and a set that answers the guard cannot be one the guard may see
-     * mid-write.
-     */
-    private val mirrorsWatchedThisProcess: MutableSet<String> =
-        java.util.concurrent.ConcurrentHashMap.newKeySet()
-
-    /**
      * The directories this app publishes into the WebView, resolved once.
      *
      * Resolved on the main thread, deliberately. [publishedResourceRoots] stats
@@ -2553,6 +2527,45 @@ class MainActivity : AppCompatActivity() {
                display:flex;align-items:center;justify-content:center;height:100vh;margin:0;">
                <div style="text-align:center"><h2 style="color:#ccc;">VSCodroid</h2>
                <p>Starting server...</p></div></body></html>"""
+
+        /**
+         * Every mirror this process has put a watcher on, whether or not one is
+         * on it now.
+         *
+         * Never cleared, and that is the point rather than an omission.
+         * [SafStorageManager.stopFileWatcher] stops the observers, but the
+         * engine waits only two seconds for the write-back worker to drain and
+         * then leaves it running rather than discarding writes the user expects
+         * on the device. So a folder the app considers closed can still have a
+         * thread streaming bytes out of its mirror, and every such write opens
+         * the device document with `"wt"`, which truncates at open: deleting the
+         * mirror underneath one empties the user's file rather than leaving it
+         * alone.
+         *
+         * A drain only ever touches the mirror it was started for, so refusing
+         * every mirror this process has watched is what puts it out of reach
+         * without needing to know whether a particular drain is still alive. The
+         * cost is that removing a folder opened this session needs a restart,
+         * which is a sentence the user can act on.
+         *
+         * In the companion, and that scope is load-bearing rather than a
+         * placement preference. The drain this guards belongs to the process,
+         * not to the Activity that started it: a rotation, a WebView recreation,
+         * or any other Activity restart hands the replacement a fresh instance
+         * while the worker is still streaming bytes out of the same mirror. Held
+         * as an instance field, the set would be empty in that replacement and
+         * would answer "never watched" for exactly the mirror it exists to put
+         * out of reach, so an Activity restart would grant the removal that
+         * [SafStorageManager.reclaimRefusal] tells the user needs a restart of
+         * VSCodroid. That refusal is also the one `force` cannot bypass, so
+         * nothing further down would catch it.
+         *
+         * Concurrent because it is written on the UI thread and read on the
+         * bridge thread, and a set that answers the guard cannot be one the
+         * guard may see mid-write.
+         */
+        private val mirrorsWatchedThisProcess: MutableSet<String> =
+            java.util.concurrent.ConcurrentHashMap.newKeySet()
 
     }
 }

--- a/android/app/src/main/kotlin/com/vscodroid/SplashActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/SplashActivity.kt
@@ -507,7 +507,10 @@ class SplashActivity : AppCompatActivity() {
         when (status) {
             AssetPackStatus.DOWNLOADING, AssetPackStatus.TRANSFERRING -> {
                 row.progressBar.progress = percent
-                row.statusText.text = "$percent%"
+                // Through the resource, not "$percent%": the sign's position and
+                // the digit glyphs are both locale-dependent, and getString
+                // formats with the configuration's locale.
+                row.statusText.text = getString(R.string.progress_percent, percent)
             }
             AssetPackStatus.COMPLETED -> {
                 row.progressBar.progress = 100

--- a/android/app/src/main/kotlin/com/vscodroid/keyboard/ExtraKeyButton.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/keyboard/ExtraKeyButton.kt
@@ -175,10 +175,6 @@ class ExtraKeyButton @JvmOverloads constructor(
         maxLines = 1
         minWidth = dpToPx(48)
         minimumHeight = dpToPx(56)
-        // Horizontal padding carries the inset as well as the old padding, so
-        // the distance from the text to the edge of the drawn key is what it
-        // was before the gap moved off the layout params.
-        setPadding(dpToPx(4 + KEY_GAP_DP), dpToPx(6), dpToPx(4 + KEY_GAP_DP), dpToPx(6))
         isClickable = true
         isFocusable = false
 
@@ -194,7 +190,9 @@ class ExtraKeyButton @JvmOverloads constructor(
             this, 8, 13, 1, TypedValue.COMPLEX_UNIT_SP
         )
 
-        // Rounded corner background
+        // Rounded corner background. This is also what applies the key's
+        // padding, and the comment in applyRoundedBackground says why the two
+        // cannot be separated.
         applyRoundedBackground(context.getColor(R.color.colorExtraKeyBg))
 
         setOnTouchListener { _, event ->
@@ -249,6 +247,28 @@ class ExtraKeyButton @JvmOverloads constructor(
             },
             dpToPx(KEY_GAP_DP), 0, dpToPx(KEY_GAP_DP), 0,
         )
+        // After the assignment, never before it, and that order is the whole
+        // reason the padding lives in a method rather than in one line of init.
+        // setBackground asks the drawable for its padding and writes whatever
+        // it reports onto the view, and an InsetDrawable reports its insets, so
+        // the assignment above replaces the key's padding with the two insets
+        // horizontally and zero vertically. That silently dropped the 6dp that
+        // keeps the label off the top and bottom edges for as long as the
+        // background was assigned last. It has to run on every repaint, not
+        // only the first: updateToggleAppearance repaints on every latch and
+        // KeyPageAdapter calls in here on every bind.
+        applyKeyPadding()
+    }
+
+    /**
+     * The distance from the label to the edge of the key.
+     *
+     * Horizontal padding carries the inset as well as the old padding, so the
+     * distance from the text to the edge of the drawn key is what it was before
+     * the gap moved off the layout params.
+     */
+    private fun applyKeyPadding() {
+        setPadding(dpToPx(4 + KEY_GAP_DP), dpToPx(6), dpToPx(4 + KEY_GAP_DP), dpToPx(6))
     }
 
     private fun dpToPx(dp: Int): Int =

--- a/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
@@ -3437,7 +3437,7 @@ internal fun bundledIdsToRelist(
  *
  * Bundled extensions are extracted to `publisher.name-version` directories, so
  * bumping a version extracts a new directory beside the old one. The scanner
- * shows only what `extensions.json` — the default profile's manifest — lists,
+ * shows only what `extensions.json` (the default profile's manifest) lists,
  * not what sits on disk, so the deletion here is half of the swap: it is what
  * lets reconcileExtensionsManifest drop the old entry and list the new version
  * in its place. The other stake is disk, which never comes back on its own:
@@ -3446,7 +3446,7 @@ internal fun bundledIdsToRelist(
  * extensions by listing directories; the manifest is what it reads.)
  *
  * Only strictly older copies are named. A user who installed a newer build of the
- * same extension from the marketplace keeps it — that is their copy, and the
+ * same extension from the marketplace keeps it: that is their copy, and the
  * scanner already prefers it. A version that is not purely numeric is left alone
  * rather than guessed at.
  */
@@ -3487,7 +3487,7 @@ internal fun supersededExtensionDirs(present: List<String>, bundled: List<String
  * Two of the jobs are about paths. `git.path` still embeds `nativeLibraryDir`,
  * which a reinstall moves, so it is re-pointed whenever it has gone stale. The
  * terminal profile is instead migrated *off* it and onto `usr/bin/bash`, which
- * `setupToolSymlinks()` already repairs on every launch — after that move the
+ * `setupToolSymlinks()` already repairs on every launch, and after that move the
  * pattern no longer matches and the profile never goes stale again.
  *
  * The move carries the other two halves of the shell-integration fix with it,

--- a/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
@@ -183,7 +183,13 @@ class FirstRunSetup(
             // with a Retry button that measures the same thing for ever and a
             // MainActivity that never runs, so nothing the app offers can free a byte.
             val available = context.filesDir.usableSpace
-            val installed = installedExtractionBytes(File(context.filesDir, "server")) +
+            // Kept on its own because two different questions read it. It counts
+            // toward what is already on disk, and it is also the only honest
+            // answer to "is the extracted tree here at all", which is what
+            // decides the rewrite headroom. `usr/` cannot answer the second: the
+            // per-launch repair block writes into it before this gate ever runs.
+            val extractedTreeBytes = installedExtractionBytes(File(context.filesDir, "server"))
+            val installed = extractedTreeBytes +
                 sharedTreeCredit(
                     installedBytes = installedExtractionBytes(File(context.filesDir, "usr")),
                     bundledBytes = BuildConfig.BUNDLED_USR_BYTES,
@@ -196,7 +202,8 @@ class FirstRunSetup(
                     bundledBytes = BuildConfig.BUNDLED_EXTENSION_BYTES,
                     foreignBytes = 0,
                 )
-            val required = requiredExtractionBytes(assetBytes, largestAssetBytes, installed)
+            val required =
+                requiredExtractionBytes(assetBytes, largestAssetBytes, installed, extractedTreeBytes)
             if (available < required) {
                 lastRefusedBytes = required
                 Logger.e(
@@ -2497,12 +2504,24 @@ claude() {
          *    install already holding the tree is not about to write it again from
          *    nothing. Clamped at zero: `installedBytes` can exceed the asset total
          *    when a pin drops files that extraction never removes.
-         *  - the room to rewrite one file, charged only when something is already
-         *    there. [writeAtomically] writes `<dest>.tmp~` and renames, so while
-         *    the biggest file is being replaced both copies exist, 113 MiB of
+         *  - the room to rewrite one file, charged only when the extracted tree is
+         *    already there. [writeAtomically] writes `<dest>.tmp~` and renames, so
+         *    while the biggest file is being replaced both copies exist, 113 MiB of
          *    Copilot runtime, currently. On an install with nothing on disk there
          *    is no second copy to hold, and charging for one would refuse fresh
          *    installs that fit.
+         *
+         *    [extractedTreeBytes] and not [installedBytes] decides that, and the
+         *    two are not interchangeable. `installedBytes` also carries the credit
+         *    for `usr/` and the extensions directory, and SplashActivity's
+         *    per-launch repair block writes into `usr/` before this gate is ever
+         *    reached: `setupGitCaBundle` alone leaves `usr/etc/tls/cert.pem`
+         *    there. So on a genuinely fresh install `installedBytes` is already
+         *    above zero, the headroom fired, and the gate asked a device with
+         *    nothing unpacked for 986 MB where 873 is what the unpack needs.
+         *    Only `server/` answers the question honestly, because nothing but
+         *    extraction writes there, and it is also where the biggest file lands
+         *    (`vscode-reh` extracts to `server/vscode-reh`).
          *  - [EXTRACTION_SLACK_BYTES], for what neither of those counts.
          *
          * Takes its figures rather than reading `BuildConfig`, so the decision can
@@ -2513,9 +2532,10 @@ claude() {
             assetBytes: Long,
             largestAssetBytes: Long,
             installedBytes: Long,
+            extractedTreeBytes: Long,
         ): Long {
             val missing = (assetBytes - installedBytes).coerceAtLeast(0)
-            val rewriteHeadroom = if (installedBytes > 0) largestAssetBytes else 0L
+            val rewriteHeadroom = if (extractedTreeBytes > 0) largestAssetBytes else 0L
             return missing + rewriteHeadroom + EXTRACTION_SLACK_BYTES
         }
 
@@ -2581,6 +2601,7 @@ claude() {
                         BuildConfig.EXTRACTED_ASSET_BYTES,
                         BuildConfig.LARGEST_ASSET_BYTES,
                         installedBytes = 0,
+                        extractedTreeBytes = 0,
                     )
                 ) / 1_048_576L
 

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
@@ -213,6 +213,41 @@ class ToolchainManager(private val context: Context) {
          * what keeps such a reader from ever seeing a half-written file even so.
          */
         private val stateLock = Any()
+
+        /**
+         * Pack names whose copy into the shared `usr/` tree is running right now.
+         *
+         * On the companion for the same reason [stateLock] is: every call site
+         * builds its own [ToolchainManager], and `ioExecutor` is an instance
+         * field, so the executors serialise each manager's own work and nothing
+         * serialises theirs against each other. Two managers installing one pack
+         * is reachable without trying: `ToolchainActivity` declares no
+         * `configChanges`, so a rotation mid-install recreates it with a second
+         * manager, and the card it rebuilds knows nothing of the install still
+         * running, so it offers Install again.
+         *
+         * What that costs is space and bookkeeping rather than the bytes
+         * themselves. Both copies carry identical source bytes, so the
+         * overlapping writes do not corrupt anything. But neither install's
+         * pre-flight reserves for the other, so a device whose free space sits
+         * between one install's reservation and two installs' real peak passes
+         * both checks and then hits ENOSPC partway through the second copy. That
+         * leaves a truncated tree under a record the first install has already
+         * written as installed, and `repairInstalledToolchains` does not
+         * re-examine a pack the record calls installed, so nothing ever puts it
+         * right.
+         *
+         * The second install declines rather than waits, which is the call
+         * `SafSyncEngine.documentWritesInFlight` already makes for this shape:
+         * waiting on an unbounded filesystem operation turns a race into a stall
+         * behind whatever the user is looking at, and here there is nothing to
+         * wait for anyway. The pack is being installed; the caller that declines
+         * has nothing to add to that.
+         *
+         * Ceiling: one process, exactly as above. Another process copying into
+         * `usr/` is outside this entirely, and nothing does today.
+         */
+        private val installsInFlight = ConcurrentHashMap.newKeySet<String>()
     }
 
     private val listener = AssetPackStateUpdateListener { state ->
@@ -619,8 +654,15 @@ class ToolchainManager(private val context: Context) {
                 return
             }
         }
-        installFromDirectory(packName, assetsDir)
-        releasePack(packName)
+        // Released only by the call that did the install. A false here means
+        // another install of this pack is copying out of `assetsDir` at this
+        // moment, and `removePack` is a real recursive delete of that directory:
+        // releasing it would pull the source out from under the reader, which is
+        // the hazard [cancel] documents from the other direction. The install
+        // that holds the pack releases it when it is done with it.
+        if (installFromDirectory(packName, assetsDir)) {
+            releasePack(packName)
+        }
     }
 
     /**
@@ -702,7 +744,72 @@ class ToolchainManager(private val context: Context) {
 
     // -- File operations --
 
-    private fun installFromDirectory(packName: String, assetsDir: File) {
+    /**
+     * Copies a pack into the shared `usr/` tree, unless another install of the
+     * same pack is already doing exactly that.
+     *
+     * The claim is taken here rather than at either entry point because this is
+     * where the two of them meet: [installDeliveredPack] arrives from Play, the
+     * background task in [downloadViaHttp] arrives from a release ZIP, and the
+     * copy below is the part they share. One claim site is also what keeps a
+     * single install from claiming twice.
+     *
+     * A decliner touches nothing the install that holds the claim owns: it does
+     * not release the pack, does not delete a staging directory, and does not
+     * write the record. The staging directory is per download already
+     * ([toolchainTempDir]), so the HTTP path's own cleanup stays correct without
+     * knowing about any of this; the Play pack is not, which is why the return
+     * value exists.
+     *
+     * @return false when this call declined because another install holds the
+     *   pack. [installDeliveredPack] has to ask, because `removePack` is a real
+     *   recursive delete of the very directory the other install is copying out
+     *   of.
+     */
+    private fun installFromDirectory(packName: String, assetsDir: File): Boolean {
+        if (!installsInFlight.add(packName)) {
+            Logger.i(tag, "Another install already holds $packName; leaving it to that one")
+            // Neither COMPLETED nor FAILED, because both would be untrue in a way
+            // something acts on. COMPLETED is the word this class uses for "the
+            // record is written and the toolchain is usable", which this call did
+            // not do and cannot promise the other one will. FAILED carries a
+            // reason the user is asked to act on, and there is nothing here for
+            // them to act on.
+            //
+            // Reported at all, rather than returning in silence, because the
+            // first-run queue advances on reported state and `isTerminalPackStatus`
+            // counts anything outside the five in-progress statuses as finished.
+            // A silent return would leave that queue waiting on a pack that this
+            // manager has stopped working on, with every pack behind it.
+            //
+            // UNKNOWN and specifically NOT the neighbouring NOT_INSTALLED, which
+            // reads as terminal just as well and is wrong for a different reason.
+            // That one is this class's word for a completed uninstall, written at
+            // the end of `uninstallSync`, and `ToolchainCardState.updateState`
+            // reads it as exactly that and drops the pack from its installed set.
+            // The rotation this claim exists for is where that bites: the manager
+            // still holding the claim belongs to the destroyed Activity, so its
+            // COMPLETED reaches nothing, while this decline reaches the live card
+            // and would leave it offering Install for a toolchain that is on its
+            // way in. UNKNOWN carries no such meaning to any reader here.
+            report(packName, AssetPackStatus.UNKNOWN, 0)
+            return false
+        }
+        try {
+            installFromDirectoryHoldingPack(packName, assetsDir)
+        } finally {
+            // In a finally rather than at each exit: the body reports FAILED and
+            // returns from four places and throws from more, and a claim dropped
+            // on only the path its author had in mind is never released at all,
+            // which would refuse every later install of that pack for the life
+            // of the process.
+            installsInFlight.remove(packName)
+        }
+        return true
+    }
+
+    /** The install itself, with the pack already claimed by the caller. */
+    private fun installFromDirectoryHoldingPack(packName: String, assetsDir: File) {
         // Both of these report FAILED before returning, and that is load-bearing
         // rather than tidy. Every other way out of this function ends in a state
         // being reported -- success at the end, and the caller's catch on a throw
@@ -965,6 +1072,12 @@ class ToolchainManager(private val context: Context) {
                 zipFile.delete()
 
                 // Install from extracted directory (same path as Play Asset Delivery)
+                //
+                // The answer is not read here, unlike the Play path: a decline
+                // leaves this task with nothing to undo. The finally below
+                // deletes a staging directory this download owns alone, so it
+                // cannot reach whatever the install that holds the pack is
+                // reading.
                 installFromDirectory(packName, extractDir)
 
             } catch (e: MissingFromRelease) {

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafStorageManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafStorageManager.kt
@@ -152,7 +152,7 @@ class SafStorageManager(private val context: Context) {
      *
      * Pruning the list is all this does. Deleting the mirror of a pruned folder used to
      * happen here too, which put a recursive delete of the user's files inside a method
-     * the workbench calls whenever it wants the recent list — and made a permission that
+     * the workbench calls whenever it wants the recent list, and made a permission that
      * read as absent for a moment enough to take the mirror of the folder currently open
      * in the editor out from under it. That reclamation lives in [reclaimRevokedMirrors]
      * alone now.
@@ -895,7 +895,7 @@ class SafStorageManager(private val context: Context) {
          * six bytes of a digest, so twelve hex characters. Pinned by
          * `SafMirrorReclamationTest`, because the length lives there and the consequence
          * of the two drifting apart is a reclamation pass that stops recognising its own
-         * mirrors — or starts recognising files it did not write.
+         * mirrors, or starts recognising files it did not write.
          */
         internal val MIRROR_ENTRY =
             Regex("^[0-9a-f]{12}(${Regex.escape(SafSyncEngine.SYNCED_RECORD_SUFFIX)})?$")

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
@@ -1033,37 +1033,6 @@ class SafSyncEngine(private val context: Context) {
     }
 
     /**
-     * Documents a write is streaming into right now, keyed by document URI.
-     *
-     * `openOutputStream(uri, "wt")` truncates at open, so two writers of one document
-     * produce a file that is neither of their inputs. Two writers are reachable: the
-     * mirror is named by a hash of the folder rather than by the session, so reopening
-     * a folder while the previous session's drain is still streaming puts [initialSync]
-     * on the IO dispatcher and that drain on the same document.
-     *
-     * A set rather than a lock, and that is the whole design. The obvious fix, a
-     * per-document lock the second writer waits on, was rejected for a measured reason:
-     * a `ContentResolver` stream to a network or MTP provider has no timeout, so
-     * waiting converts today's race into an unbounded stall of [initialSync], behind a
-     * dialog built with `setCancelable(false)`. A trade of corruption for a hang is not
-     * a fix. `add` returns false when someone already holds the document, and the loser
-     * declines instead of waiting.
-     *
-     * What the loser gives up is one write, and both writers copy the same local file,
-     * so the bytes it would have written are the bytes the winner is writing. If the
-     * mirror changed in between, the watcher raises MODIFY again and the queue carries
-     * it; [processWriteBack] already drops a job a newer one supersedes.
-     *
-     * Keyed by document rather than by local path deliberately, though the two coincide
-     * today: the mirror is one directory per folder, so one local path resolves to one
-     * document and nothing distinguishes the keys. Measured, and stated because it is a
-     * coincidence rather than a guarantee. The thing being protected is the document
-     * that `"wt"` truncates, so that is what the key names; a local path is a proxy that
-     * happens to agree.
-     */
-    private val documentWritesInFlight = ConcurrentHashMap.newKeySet<String>()
-
-    /**
      * Writes a local file's contents back to its corresponding SAF document.
      *
      * Declines outright when another write already holds the document, so two streams
@@ -2082,6 +2051,49 @@ class SafSyncEngine(private val context: Context) {
          * what the journal is for.
          */
         private val uploadWriters = mutableMapOf<String, Int>()
+
+        /**
+         * Documents a write is streaming into right now, keyed by document URI.
+         *
+         * `openOutputStream(uri, "wt")` truncates at open, so two writers of one
+         * document produce a file that is neither of their inputs. Two writers are
+         * reachable: the mirror is named by a hash of the folder rather than by the
+         * session, so reopening a folder while the previous session's drain is still
+         * streaming puts [SafSyncEngine.initialSync] on the IO dispatcher and that
+         * drain on the same document.
+         *
+         * In this object rather than on the engine, next to [uploadJournalLock] and
+         * [uploadWriters] and for the reason those give: the engine is one per
+         * [SafStorageManager] and the manager one per activity, while
+         * [SafSyncEngine.stopWatching] waits [DRAIN_GRACE_MS] and then deliberately
+         * leaves a drain it could not join to finish on its own. The two writers above
+         * are therefore routinely in two different engines, an activity recreated while
+         * a drain is still streaming being the ordinary way there, and a set held per
+         * instance is empty in exactly the engine that has to see the departing drain's
+         * claim. Process scope is what makes the claim mean anything at all.
+         *
+         * A set rather than a lock, and that is the whole design. The obvious fix, a
+         * per-document lock the second writer waits on, was rejected for a measured
+         * reason: a `ContentResolver` stream to a network or MTP provider has no
+         * timeout, so waiting converts today's race into an unbounded stall of
+         * [SafSyncEngine.initialSync], behind a dialog built with
+         * `setCancelable(false)`. A trade of corruption for a hang is not a fix. `add`
+         * returns false when someone already holds the document, and the loser declines
+         * instead of waiting.
+         *
+         * What the loser gives up is one write, and both writers copy the same local
+         * file, so the bytes it would have written are the bytes the winner is writing.
+         * If the mirror changed in between, the watcher raises MODIFY again and the
+         * queue carries it; the write-back already drops a job a newer one supersedes.
+         *
+         * Keyed by document rather than by local path deliberately, though the two
+         * coincide today: the mirror is one directory per folder, so one local path
+         * resolves to one document and nothing distinguishes the keys. Measured, and
+         * stated because it is a coincidence rather than a guarantee. The thing being
+         * protected is the document that `"wt"` truncates, so that is what the key
+         * names; a local path is a proxy that happens to agree.
+         */
+        private val documentWritesInFlight = ConcurrentHashMap.newKeySet<String>()
 
         /**
          * Suffix of the sibling file recording what the last complete sync found.

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
@@ -1492,7 +1492,8 @@ class SafSyncEngine(private val context: Context) {
      * to put the child would file it somewhere the user did not put it.
      */
     private fun createChildrenInSaf(localDir: File, dirSafUri: Uri, treeUri: Uri) {
-        val entries = uploadableEntries(localDir, MAX_UPLOAD_ENTRIES)
+        val plan = uploadPlan(localDir, MAX_UPLOAD_ENTRIES)
+        val entries = plan.entries
         if (entries.isEmpty()) return
 
         val created = mutableMapOf(localDir.absolutePath to dirSafUri)
@@ -1508,7 +1509,11 @@ class SafSyncEngine(private val context: Context) {
                 made++
             }
         }
-        val capped = entries.size >= MAX_UPLOAD_ENTRIES
+        // The walk's own answer, not `entries.size >= MAX_UPLOAD_ENTRIES`. That test
+        // reported a directory holding exactly the cap as incompletely copied when every
+        // entry of it had just been created, because the walk stops at the cap and so
+        // can never return more than it.
+        val capped = plan.truncated
         if (capped) {
             Logger.w(tag, "Stopped at $MAX_UPLOAD_ENTRIES entries under ${localDir.name}; " +
                 "the rest were not copied to the device")
@@ -2425,11 +2430,15 @@ class SafSyncEngine(private val context: Context) {
          * construction, which the caller needs: a child cannot be created until its
          * parent document exists.
          *
+         * [UploadPlan.truncated] is how the caller learns the cap bit at all. The list
+         * cannot say so on its own, which is what the walk below collects one entry past
+         * the cap to answer.
+         *
          * Symbolic links are not followed. A mirror is routinely a checked-out
          * repository, so a link inside one is attacker-supplied in the ordinary case,
          * and following it would copy files from outside the folder the user granted.
          */
-        internal fun uploadableEntries(root: File, limit: Int): List<File> {
+        internal fun uploadPlan(root: File, limit: Int): UploadPlan {
             // [root] is tested for being a link before anything else, and that is not
             // symmetry with the children loop below -- it is the case that reaches
             // outside the folder the user granted. `File.isDirectory` follows links,
@@ -2439,17 +2448,27 @@ class SafSyncEngine(private val context: Context) {
             // would list the *target's* contents and copy them onto the device: point
             // one at a home directory inside a synced folder and the whole of it
             // uploads.
-            if (limit <= 0 || isLink(root) || !root.isDirectory) return emptyList()
+            if (limit <= 0 || isLink(root) || !root.isDirectory) {
+                return UploadPlan(emptyList(), truncated = false)
+            }
 
             val found = mutableListOf<File>()
             val pending = ArrayDeque<File>()
             pending.addLast(root)
 
-            while (pending.isNotEmpty() && found.size < limit) {
+            // One entry past the cap, which is what makes the truncation answer exact:
+            // a walk that stops at exactly [limit] cannot tell a directory that ends
+            // there from one with a thousand more files below it, and the extra entry
+            // exists only in the second case.
+            //
+            // Written as `<= limit` rather than as a `limit + 1` ceiling because a
+            // caller passing Int.MAX_VALUE would overflow that into a negative one and
+            // get an empty plan for a folder full of files.
+            while (pending.isNotEmpty() && found.size <= limit) {
                 val dir = pending.removeFirst()
                 val children = dir.listFiles() ?: continue
                 for (child in children.sortedBy { it.name }) {
-                    if (found.size >= limit) break
+                    if (found.size > limit) break
                     if (isLink(child)) continue
                     val isDir = child.isDirectory
                     if (isDir && shouldSkip(child.name, isDir = true)) continue
@@ -2465,8 +2484,24 @@ class SafSyncEngine(private val context: Context) {
                     if (isDir) pending.addLast(child)
                 }
             }
-            return found
+            // The extra entry is reported and then dropped: what the caller creates is
+            // still capped at [limit], and a prefix of a breadth-first walk keeps
+            // parents ahead of their children, which is what the caller creates by.
+            val truncated = found.size > limit
+            return UploadPlan(if (truncated) found.take(limit) else found, truncated)
         }
+
+        /**
+         * The entries [uploadPlan] found, for a caller with no use for its answer about
+         * truncation.
+         *
+         * Separate because the two questions have separate consequences: the list
+         * decides what is created on the device, while the flag decides whether the user
+         * is told the copy came out short, and deriving the second from the first is the
+         * mistake [UploadPlan] exists to prevent.
+         */
+        internal fun uploadableEntries(root: File, limit: Int): List<File> =
+            uploadPlan(root, limit).entries
 
         /**
          * Whether [file] is a symbolic link, without following it.
@@ -2626,6 +2661,17 @@ internal data class SyncJob(
 internal enum class SyncType {
     MODIFY, CREATE, DELETE, RENAME
 }
+
+/**
+ * What [SafSyncEngine.uploadPlan] found under a directory, and whether the cap stopped
+ * the walk short of the tree.
+ *
+ * The flag is carried rather than derived because the two part company at exactly the
+ * cap: [entries] is capped at the limit, so its size reads as "there was more" for a
+ * directory that ends there naturally as readily as for one with a thousand more files
+ * below.
+ */
+internal data class UploadPlan(val entries: List<File>, val truncated: Boolean)
 
 /**
  * A directory that left the mirror and has not been accounted for yet.

--- a/android/app/src/main/kotlin/com/vscodroid/webview/VSCodroidWebViewClient.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/webview/VSCodroidWebViewClient.kt
@@ -386,6 +386,64 @@ internal fun tlsFailureToAnnounce(
     return if (alreadySaid.add(failure)) failure else null
 }
 
+/**
+ * One hand-off this app could not complete, reduced to the two things a notice
+ * about it can say.
+ *
+ * The scheme, and never the address. `url_handoff_no_app` already names only a
+ * scheme, for the reason [TlsFailure] gives: the failing URL is whatever the open
+ * page asked for, and a sign-in or a dev server's address can carry an OAuth code
+ * or an API key in its query, so repeating it back would put a credential into a
+ * toast and into logcat.
+ *
+ * [failureType] is the exception's simple class name, which is the only other
+ * thing the two message forms print: `ActivityNotFoundException` is the one the
+ * user can act on by installing something, and every other type is quoted for a
+ * bug report.
+ *
+ * So the pair is exactly what determines the sentence, which is what makes it the
+ * right key for [handoffFailureToAnnounce].
+ */
+internal data class HandoffFailure(val scheme: String, val failureType: String)
+
+/**
+ * How many distinct hand-off failures are remembered before the record starts over.
+ *
+ * Same bound and same trade as [MAX_TLS_FAILURES_ANNOUNCED]: the schemes that end
+ * up in the record are chosen by whatever page is open, so an unbounded record is
+ * an allocation a page controls, and clearing at the cap costs a message that may
+ * repeat once past eight distinct failures.
+ */
+internal const val MAX_HANDOFF_FAILURES_ANNOUNCED = 8
+
+/**
+ * The hand-off failure worth putting on screen, or null when it has been said
+ * already.
+ *
+ * The same rule as [tlsFailureToAnnounce] and for the same measured reason: toasts
+ * stack rather than replace, each one holds the screen for about three and a half
+ * seconds, and one page can drive many navigations with nothing in between.
+ *
+ * Keyed on [HandoffFailure], which is to say on the scheme and the exception type
+ * and deliberately NOT on the URL. Two reasons, and the second is the load-bearing
+ * one. A second `ssh:` link that no app answers is the same fact and the same
+ * sentence, so it adds nothing to act on. And a URL-keyed record would be one the
+ * content can defeat at will: a page navigating to `ssh://a1`, `ssh://a2` and so on
+ * mints a fresh key per navigation while producing an identical message, which is
+ * a throttle that throttles nothing and a set that grows on strings a page chooses.
+ *
+ * [alreadySaid] belongs to the presenter, which keeps this class free of mutable
+ * state, and its lifetime falls out of that: it dies with the Activity, so a fresh
+ * launch says everything again.
+ */
+internal fun handoffFailureToAnnounce(
+    failure: HandoffFailure,
+    alreadySaid: MutableSet<HandoffFailure>,
+): HandoffFailure? {
+    if (alreadySaid.size >= MAX_HANDOFF_FAILURES_ANNOUNCED) alreadySaid.clear()
+    return if (alreadySaid.add(failure)) failure else null
+}
+
 class VSCodroidWebViewClient(
     private val allowedPort: Int,
     private val resourceRoots: List<String>,
@@ -411,6 +469,10 @@ class VSCodroidWebViewClient(
      * `resolveActivity` would answer null for handlers that do exist under
      * package-visibility filtering, and enumerating schemes to make it work is a
      * destination allowlist under another name. The exception is the signal.
+     *
+     * Not told about every failure, and the call site says which ones it keeps to
+     * itself. The presenter still owes this a second filter: see
+     * [handoffFailureToAnnounce], which holds the record of what has been said.
      */
     private val onHandoffFailed: (Uri, Throwable) -> Unit = { _, _ -> },
     /**
@@ -512,7 +574,40 @@ class VSCodroidWebViewClient(
                 "Failed to open external URL: ${redactToken(url.toString())} " +
                     "(${e.javaClass.simpleName})"
             )
-            onHandoffFailed(url, e)
+            // The launch above is attempted for every frame, and that stays true:
+            // a link in a preview or in the simple browser still leaves for a
+            // browser. What is gated here is only the notice.
+            //
+            // It has to be, because this callback receives subframe navigations
+            // and the frames are not all ours. A script can navigate an iframe to
+            // a scheme nothing on the device answers, with no user gesture and as
+            // often as it likes, and each failure was an unconditional
+            // `Toast.LENGTH_LONG` -- about three and a half seconds of screen,
+            // stacking rather than replacing. That is a rendered page holding a
+            // sustained stream of notices over a live editor, and the content that
+            // reaches this client includes the bundled simple browser holding an
+            // arbitrary remote site plus previews and notebook output built from
+            // workspace files.
+            //
+            // `hasGesture()` is the request's own record of whether a user gesture
+            // was associated with the navigation, so it answers the question a
+            // notice depends on: did the user do this. It is a disjunction with the
+            // frame test rather than a conjunction, and the asymmetry is deliberate.
+            // The main frame is the workbench, the one document here this app
+            // serves, and it is also where both routes this channel backs up
+            // navigate: `injectWindowOpenOverride` falls through to a plain
+            // navigation, and the workbench's own opener assigns `location.href`
+            // for every scheme that is not http or https. Whether user activation
+            // survives those chains is not measured here, and losing the notice on
+            // them would silence exactly the case it was added for, a sign-in or an
+            // `ssh:` clone link that no app answers. So the main frame keeps its
+            // notice unconditionally, and the gesture is what still earns one for a
+            // link the user genuinely tapped inside a preview. Only a navigation
+            // that is neither our own page nor something the user did is silent,
+            // and it stays in the log line above.
+            if (request.isForMainFrame || request.hasGesture()) {
+                onHandoffFailed(url, e)
+            }
         }
         return true  // Don't navigate WebView to external URL
     }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -134,6 +134,12 @@
     <!-- Toolchain download progress -->
     <string name="progress_title">Installing toolchains\u2026</string>
     <string name="progress_waiting">Waiting\u2026</string>
+    <!-- How much of a download has arrived. The number is an argument rather than
+         part of a literal built in Kotlin because neither half of a percentage is
+         fixed across locales: the sign sits before the number in some of them, and
+         the digits are drawn with a different set of glyphs in others. Passing it
+         through the resource lets both follow the device's locale. -->
+    <string name="progress_percent">%1$d%%</string>
     <string name="progress_installing">Installing\u2026</string>
     <string name="progress_done">Done</string>
     <string name="progress_failed">Failed</string>

--- a/android/app/src/test/kotlin/com/vscodroid/setup/SharedTreeCreditTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/SharedTreeCreditTest.kt
@@ -154,10 +154,10 @@ class SharedTreeCreditTest {
         val assetBytes = server + usr + extensions
         val largest = 113 * mb
 
-        val before = FirstRunSetup.requiredExtractionBytes(assetBytes, largest, server)
+        val before = FirstRunSetup.requiredExtractionBytes(assetBytes, largest, server, server)
         val credit = FirstRunSetup.sharedTreeCredit(usr, usr, 0) +
             FirstRunSetup.sharedTreeCredit(extensions, extensions, 0)
-        val after = FirstRunSetup.requiredExtractionBytes(assetBytes, largest, server + credit)
+        val after = FirstRunSetup.requiredExtractionBytes(assetBytes, largest, server + credit, server)
 
         assertTrue(after < before, "crediting the shared trees must lower the demand")
         assertEquals(

--- a/android/app/src/test/kotlin/com/vscodroid/setup/StoragePreflightTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/StoragePreflightTest.kt
@@ -77,7 +77,7 @@ class StoragePreflightTest {
      * here: it is private, and a copy of it would go stale the moment it moved.
      * With nothing on disk and nothing in the APK it is the whole answer.
      */
-    private val slack = FirstRunSetup.requiredExtractionBytes(0, 0, 0)
+    private val slack = FirstRunSetup.requiredExtractionBytes(0, 0, 0, 0)
 
     /**
      * A `filesDir` that reports a fixed amount of free space.
@@ -173,17 +173,57 @@ class StoragePreflightTest {
     fun `a fresh install has to fit the whole tree`() {
         assertEquals(
             assetBytes + slack,
-            FirstRunSetup.requiredExtractionBytes(assetBytes, largestAssetBytes, installedBytes = 0),
+            FirstRunSetup.requiredExtractionBytes(
+                assetBytes,
+                largestAssetBytes,
+                installedBytes = 0,
+                extractedTreeBytes = 0,
+            ),
             "an install with nothing on disk must still be asked for the whole tree; the room " +
                 "to hold a second copy of one file is not part of it, because there is no " +
                 "first copy to hold",
         )
     }
 
+    /**
+     * The case the gate got wrong, and the reason the headroom reads a tree of its
+     * own rather than the total.
+     *
+     * A fresh install is not a device with an empty `filesDir`. SplashActivity's
+     * per-launch repair block runs before this gate, and `setupGitCaBundle` writes
+     * `usr/etc/tls/cert.pem` on the way through, so `installedBytes` already
+     * carries a few hundred KB of credit by the time the gate is asked. Charged
+     * off that, the rewrite headroom fired on an install with nothing unpacked and
+     * the gate demanded 986 MB where the unpack needs 873, refusing devices that
+     * fit on a screen whose only other control is a Retry that measures the same
+     * thing again.
+     */
+    @Test
+    fun `a repair file under usr does not make a fresh install pay the rewrite headroom`() {
+        val repairBytes = 320L * 1024
+
+        assertEquals(
+            assetBytes - repairBytes + slack,
+            FirstRunSetup.requiredExtractionBytes(
+                assetBytes,
+                largestAssetBytes,
+                installedBytes = repairBytes,
+                extractedTreeBytes = 0,
+            ),
+            "a launch-time repair writing into usr/ must not be read as an extracted tree; " +
+                "charging the headroom for it refuses fresh installs that fit",
+        )
+    }
+
     @Test
     fun `an install that already holds the tree asks only for the room to rewrite one file`() {
         val required =
-            FirstRunSetup.requiredExtractionBytes(assetBytes, largestAssetBytes, installedBytes = assetBytes)
+            FirstRunSetup.requiredExtractionBytes(
+                assetBytes,
+                largestAssetBytes,
+                installedBytes = assetBytes,
+                extractedTreeBytes = assetBytes,
+            )
 
         assertEquals(largestAssetBytes + slack, required)
         assertTrue(
@@ -199,11 +239,14 @@ class StoragePreflightTest {
             assetBytes,
             largestAssetBytes,
             installedBytes = assetBytes / 2,
+            extractedTreeBytes = assetBytes / 2,
         )
 
         assertEquals(assetBytes / 2 + largestAssetBytes + slack, required)
         assertTrue(
-            required > FirstRunSetup.requiredExtractionBytes(assetBytes, largestAssetBytes, assetBytes),
+            required > FirstRunSetup.requiredExtractionBytes(
+                assetBytes, largestAssetBytes, assetBytes, assetBytes,
+            ),
             "a damaged tree is treated like a complete one, so the gate waves through a device " +
                 "that then runs out of disk mid-unpack",
         )
@@ -217,6 +260,7 @@ class StoragePreflightTest {
                 assetBytes,
                 largestAssetBytes,
                 installedBytes = assetBytes * 2,
+                extractedTreeBytes = assetBytes * 2,
             ),
             "a pin that drops files leaves more on disk than it ships, and the surplus must " +
                 "not be subtracted from the headroom the rewrite needs",

--- a/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainInstallClaimTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainInstallClaimTest.kt
@@ -1,0 +1,211 @@
+package com.vscodroid.setup
+
+import android.content.Context
+import com.google.android.play.core.assetpacks.AssetPackManager
+import com.google.android.play.core.assetpacks.AssetPackManagerFactory
+import com.google.android.play.core.assetpacks.model.AssetPackStatus
+import com.vscodroid.util.Logger
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.util.Collections
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Two installs of one pack, overlapping, and what the second one is allowed to do.
+ *
+ * `installFromDirectory` copies into `filesDir/usr`, which every toolchain and the
+ * base install share. Nothing serialises two of those against each other: each
+ * call site builds its own [ToolchainManager] and `ioExecutor` is an instance
+ * field, and `ToolchainActivity` declares no `configChanges`, so rotating the
+ * screen mid-install recreates it with a second manager whose card offers Install
+ * again for a pack that is already being installed.
+ *
+ * The bytes are identical on both sides, so the overlap does not corrupt the tree.
+ * What it costs is the space pre-flight: neither install reserves for the other, so
+ * a device between one install's reservation and two installs' real peak passes
+ * both checks and then runs out of room partway through the second copy, leaving a
+ * truncated tree under a record the first install has already written as installed.
+ * The repair pass at launch does not re-examine a pack the record calls installed.
+ *
+ * The sequencing here is real rather than simulated: the log line immediately
+ * before the copy is stubbed to hold the first install there, so the second one
+ * runs while the first genuinely holds the pack and has not yet written a byte.
+ */
+class ToolchainInstallClaimTest {
+
+    @TempDir
+    lateinit var filesDir: File
+
+    private lateinit var context: Context
+    private lateinit var packManager: AssetPackManager
+
+    /** Set by whichever thread reaches the copy, so it is counted atomically. */
+    private val entered = AtomicInteger(0)
+
+    /** Counts down when an install has taken the pack and is held before its copy. */
+    private val firstIsHolding = CountDownLatch(1)
+
+    /** Releases the held install once the second one has had its turn. */
+    private val letFirstProceed = CountDownLatch(1)
+
+    private val pack = "toolchain_java"
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(Logger)
+        every { Logger.d(any(), any()) } just Runs
+        every { Logger.i(any(), any()) } just Runs
+        every { Logger.w(any(), any()) } just Runs
+        every { Logger.w(any(), any(), any()) } just Runs
+        every { Logger.e(any(), any(), any()) } just Runs
+
+        // The last statement before the tree is copied, and the only point at
+        // which an install both holds the pack and has changed nothing yet.
+        // Stubbed after the general Logger.i above so this narrower one wins.
+        every { Logger.i(any(), match { it.startsWith("Installing toolchain:") }) } answers {
+            if (entered.incrementAndGet() == 1) {
+                firstIsHolding.countDown()
+                // Only the first entrant waits. An install that reaches here while
+                // the claim is meant to have refused it must run to completion
+                // rather than deadlock, or removing the claim would hang this test
+                // instead of failing it.
+                letFirstProceed.await(10, TimeUnit.SECONDS)
+            }
+        }
+
+        packManager = mockk(relaxed = true)
+        mockkStatic(AssetPackManagerFactory::class)
+        every { AssetPackManagerFactory.getInstance(any()) } returns packManager
+
+        context = mockk(relaxed = true)
+        every { context.filesDir } returns filesDir
+        every { context.cacheDir } returns File(filesDir, "cache")
+        every { context.packageName } returns "com.vscodroid"
+
+        File(filesDir, "home/.vscodroid").mkdirs()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        // Before unmockking, so a failed assertion cannot leave a thread parked on
+        // the latch holding a claim that outlives this test: the set is process
+        // wide, and a claim never released refuses every later install of that
+        // pack for the life of the JVM.
+        letFirstProceed.countDown()
+        unmockkAll()
+    }
+
+    /** A pack whose `usr/` tree has one file, so a copy leaves a trace. */
+    private fun packDirectory(): File {
+        val dir = File(filesDir, "delivered-$pack").apply { mkdirs() }
+        File(dir, "$pack.json").writeText("""{"name":"java","installRoot":"usr/opt/java"}""")
+        File(dir, "usr/opt/java/bin").mkdirs()
+        File(dir, "usr/opt/java/bin/java").writeText("payload")
+        return dir
+    }
+
+    /** Where [packDirectory]'s one file lands, and the evidence a copy ran. */
+    private fun copiedFile() = File(filesDir, "usr/opt/java/bin/java")
+
+    private fun manager(events: MutableList<Int>) = ToolchainManager(context).apply {
+        onStateChange = { _, status, _, _ -> events.add(status) }
+    }
+
+    /** Private, and the point at which both delivery routes converge. */
+    private fun installFromDirectory(m: ToolchainManager, dir: File) =
+        ToolchainManager::class.java
+            .getDeclaredMethod("installFromDirectory", String::class.java, File::class.java)
+            .apply { isAccessible = true }
+            .invoke(m, pack, dir)
+
+    @Test
+    fun `a second install of a pack already being installed copies nothing`() {
+        val dir = packDirectory()
+        val firstEvents = Collections.synchronizedList(mutableListOf<Int>())
+        val secondEvents = Collections.synchronizedList(mutableListOf<Int>())
+
+        val first = Thread({ installFromDirectory(manager(firstEvents), dir) }, "first-install")
+        first.start()
+        assertTrue(
+            firstIsHolding.await(10, TimeUnit.SECONDS),
+            "the first install never reached the copy, so nothing was being raced",
+        )
+
+        installFromDirectory(manager(secondEvents), dir)
+
+        assertEquals(
+            1, entered.get(),
+            "the second install copied the tree on top of the first one's copy",
+        )
+        assertFalse(
+            copiedFile().exists(),
+            "the first install is still held before its copy, so this file can only " +
+                "have been written by the install that was supposed to decline",
+        )
+        assertEquals(
+            listOf(AssetPackStatus.UNKNOWN), secondEvents,
+            "an install that copied nothing has to say so, and must not say COMPLETED",
+        )
+        // Named rather than left to the assertion above, because the two statuses are
+        // interchangeable to everything that only asks whether the pack is finished,
+        // and differ to the one reader that matters: NOT_INSTALLED is what a completed
+        // uninstall reports, and ToolchainCardState drops the pack from its installed
+        // set on it. A decline is not an uninstall.
+        assertFalse(
+            secondEvents.contains(AssetPackStatus.NOT_INSTALLED),
+            "declining an install must not report the status that means it was removed",
+        )
+
+        letFirstProceed.countDown()
+        first.join(TimeUnit.SECONDS.toMillis(10))
+        assertFalse(first.isAlive, "the first install never finished")
+        assertEquals(
+            listOf(AssetPackStatus.COMPLETED), firstEvents,
+            "the install that held the pack did not finish it",
+        )
+        assertTrue(copiedFile().exists(), "the tree was never copied at all")
+    }
+
+    @Test
+    fun `a pack installs normally once the install holding it has finished`() {
+        // The claim is only correct if it is given back. Released on every exit
+        // rather than on the one the happy path takes, or the first install of a
+        // pack would be the last one this process ever performs.
+        val dir = packDirectory()
+        val events = Collections.synchronizedList(mutableListOf<Int>())
+
+        val first = Thread({ installFromDirectory(manager(events), dir) }, "first-install")
+        first.start()
+        assertTrue(firstIsHolding.await(10, TimeUnit.SECONDS), "the first install never started")
+        letFirstProceed.countDown()
+        first.join(TimeUnit.SECONDS.toMillis(10))
+        assertFalse(first.isAlive, "the first install never finished")
+
+        copiedFile().delete()
+        events.clear()
+
+        installFromDirectory(manager(events), dir)
+
+        assertEquals(
+            2, entered.get(),
+            "the later install was refused, so the claim was never given back",
+        )
+        assertEquals(listOf(AssetPackStatus.COMPLETED), events)
+        assertTrue(copiedFile().exists(), "the later install reported success and copied nothing")
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafUploadPlanTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafUploadPlanTest.kt
@@ -124,6 +124,41 @@ class SafUploadPlanTest {
         assertTrue(names.contains("b.txt"), "got $names")
     }
 
+    /**
+     * The two directories the count cannot tell apart, which is why the walk carries
+     * the answer instead of the caller deriving it.
+     *
+     * A walk that stops at the cap can never return more than the cap, so
+     * `entries.size >= limit` reads "there was more below" for a directory that ends
+     * exactly at the limit just as readily as for one with a thousand files under it.
+     * The first of those is a complete copy, and reporting it as truncated tells the
+     * user files were left behind when every one of them arrived.
+     */
+    @Test
+    fun `a directory ending exactly at the cap is not reported as truncated`(@TempDir tmp: File) {
+        val root = File(tmp, "exact").apply { mkdirs() }
+        repeat(3) { File(root, "f$it.txt").writeText("$it") }
+
+        val plan = SafSyncEngine.uploadPlan(root, limit = 3)
+
+        assertEquals(3, plan.entries.size, "every entry must still be offered: ${plan.entries}")
+        assertFalse(
+            plan.truncated,
+            "a directory holding exactly the cap was copied whole, so nothing was left behind",
+        )
+    }
+
+    @Test
+    fun `one entry past the cap is reported as truncated`(@TempDir tmp: File) {
+        val root = File(tmp, "over").apply { mkdirs() }
+        repeat(4) { File(root, "f$it.txt").writeText("$it") }
+
+        val plan = SafSyncEngine.uploadPlan(root, limit = 3)
+
+        assertEquals(3, plan.entries.size, "the cap still bounds what is created: ${plan.entries}")
+        assertTrue(plan.truncated, "a file below the cap was left behind and the user is owed the notice")
+    }
+
     @Test
     fun `machine-temporary files are not uploaded`(@TempDir tmp: File) {
         // The same filter shouldWriteBack applies to single-file events. The

--- a/android/app/src/test/kotlin/com/vscodroid/storage/WriteBackNoticeWiringTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/WriteBackNoticeWiringTest.kt
@@ -51,13 +51,19 @@ class WriteBackNoticeWiringTest {
         assertTrue(activity.isFile, "MainActivity.kt is not where this test expects it")
         val source = activity.readText()
 
+        // Anchored at the start of a line, and for the second pattern the character
+        // class is the anchor: nothing between the indent and the string name may be a
+        // slash, so a `//` cannot get in front of it. Unanchored, a substring search
+        // finds `// safManager.onWriteBackFailed { file ->` as readily as the call
+        // itself, and commenting a line out is how a developer disables something, so
+        // wiring that is already dead is the one shape these two could not see.
         assertTrue(
-            Regex("""safManager\.onWriteBackFailed\s*\{""").containsMatchIn(source),
+            Regex("""(?m)^\s*safManager\.onWriteBackFailed\s*\{""").containsMatchIn(source),
             "nothing wires the write-back notice, so a save that never reached the " +
                 "device folder is silent again",
         )
         assertTrue(
-            Regex("""saf_write_back_failed""").containsMatchIn(source),
+            Regex("""(?m)^\s*[^/\n]*saf_write_back_failed""").containsMatchIn(source),
             "the notice does not name the string that tells the user what happened",
         )
     }

--- a/android/app/src/test/kotlin/com/vscodroid/webview/ExternalUrlNoticeThrottleTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/ExternalUrlNoticeThrottleTest.kt
@@ -1,0 +1,340 @@
+package com.vscodroid.webview
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.SystemClock
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import com.vscodroid.util.Logger
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * How often a hand-off this app could not complete may put something on screen.
+ *
+ * The notice itself is covered by `ExternalUrlHandoffTest`, which pins that each
+ * of the three exceptions landing in that catch produces one. What is pinned here
+ * is the other side of it: the notice was unconditional, and both of the things
+ * that makes it are cheap for a page to drive.
+ *
+ * A toast holds the screen for about three and a half seconds at `LENGTH_LONG`
+ * and stacks rather than replaces, and `shouldOverrideUrlLoading` receives
+ * subframe navigations as well as top-level ones. A script may navigate an iframe
+ * to a scheme no app on the device answers with no user gesture at all and as
+ * often as it likes, and the content that reaches this client is not this app's:
+ * the bundled simple browser holds an arbitrary remote site, and previews and
+ * notebook output are built from whatever the workspace holds. So a rendered page
+ * could hold a sustained stream of long toasts over an editor the user is working
+ * in, and before the notice existed that path only logged.
+ *
+ * Two rules, both needed, and each of the cases below fails on its own if the
+ * other is the only one present. The gate asks whether the navigation is
+ * attributable to the user or to this app's own page; the throttle asks whether
+ * the message has already been said. The gate alone still lets a page the user
+ * taps once per link speak once per link; the throttle alone still lets a page
+ * spend its first eight silent navigations on eight distinct schemes.
+ *
+ * The launch is NOT gated, and one case exists to keep it that way. A link in a
+ * preview still leaves for a browser exactly as it did.
+ */
+class ExternalUrlNoticeThrottleTest {
+
+    private val ALLOWED_PORT = 13337
+
+    private lateinit var context: Context
+    private lateinit var view: WebView
+    private lateinit var client: VSCodroidWebViewClient
+
+    /** Every hand-off failure the client passed to its presenter, in order. */
+    private val announced = mutableListOf<HandoffFailure>()
+
+    /**
+     * The clock the main-frame branch reads before arming a callback window. The
+     * stub `android.jar` throws, and the catch below the launch would turn that
+     * into a failure that never happened.
+     */
+    private val launchedAt = 1_700_222L
+
+    private fun request(
+        scheme: String,
+        address: String,
+        fromMainFrame: Boolean,
+        withGesture: Boolean,
+    ): WebResourceRequest {
+        val uri = mockk<Uri>(relaxed = true)
+        every { uri.scheme } returns scheme
+        // No host on these addresses, so `isLocalhost` answers false without the
+        // port being consulted and every case here reaches the hand-off.
+        every { uri.host } returns null
+        every { uri.toString() } returns address
+        val req = mockk<WebResourceRequest>(relaxed = true)
+        every { req.url } returns uri
+        // Both stated rather than left to the relaxed mock, which answers false
+        // for each and would quietly make every case a silent one.
+        every { req.isForMainFrame } returns fromMainFrame
+        every { req.hasGesture() } returns withGesture
+        return req
+    }
+
+    @BeforeEach
+    fun setUp() {
+        announced.clear()
+        mockkObject(Logger)
+        every { Logger.i(any(), any()) } just Runs
+        every { Logger.e(any(), any(), any()) } just Runs
+        every { Logger.d(any(), any()) } just Runs
+
+        mockkConstructor(Intent::class)
+        every { anyConstructed<Intent>().addFlags(any()) } returns mockk(relaxed = true)
+
+        mockkStatic(SystemClock::class)
+        every { SystemClock.elapsedRealtime() } returns launchedAt
+
+        context = mockk(relaxed = true)
+        view = mockk(relaxed = true)
+        every { view.context } returns context
+        // The case this whole file is about: nothing on the device answers the
+        // scheme, so the launch throws and the catch runs.
+        every { context.startActivity(any()) } throws ActivityNotFoundException("no handler")
+
+        client = VSCodroidWebViewClient(
+            allowedPort = ALLOWED_PORT,
+            resourceRoots = emptyList(),
+            sensitiveLocations = emptyList(),
+            openFolder = { null },
+            connectionToken = { null },
+            onCrash = {},
+            onPageLoaded = {},
+            onRetryServer = {},
+            onHandoffFailed = { uri, error ->
+                announced += HandoffFailure(uri.scheme ?: "external", error.javaClass.simpleName)
+            },
+        )
+    }
+
+    @AfterEach
+    fun releaseMocks() {
+        unmockkAll()
+    }
+
+    /**
+     * The defect, driven end to end: a source this app does not vouch for, given
+     * no user gesture, may not produce a message per navigation.
+     *
+     * The addresses differ on purpose. A gate that let these through would be
+     * caught by any of them; what the varying address adds is that a throttle
+     * keyed on the URL would not have helped here either, since each navigation
+     * would mint a fresh key while producing the identical sentence.
+     */
+    @Test
+    fun `a script-driven subframe cannot drive a notice per navigation`() {
+        repeat(20) { i ->
+            client.shouldOverrideUrlLoading(
+                view,
+                request("ssh", "ssh://git@example.com/repo$i.git", false, withGesture = false),
+            )
+        }
+
+        assertTrue(
+            announced.isEmpty(),
+            "a page in an iframe drove $announced. Each one is about three and a half " +
+                "seconds of toast over a live editor, and toasts stack rather than replace",
+        )
+    }
+
+    /**
+     * The launch is not what is gated, and this is the case that says so.
+     *
+     * A link in a markdown preview or in the simple browser still leaves for a
+     * browser. Withholding the launch as well would be a destination filter on
+     * frame identity, which is a different decision and not this one;
+     * `ExternalUrlHandoffTest` pins the same property for a sign-in address.
+     */
+    @Test
+    fun `a subframe navigation the notice is withheld from still leaves for a browser`() {
+        val handled = client.shouldOverrideUrlLoading(
+            view, request("ssh", "ssh://git@example.com/repo.git", false, withGesture = false)
+        )
+
+        assertTrue(handled, "the WebView was left to navigate to a scheme it cannot load")
+        verify(exactly = 1) { context.startActivity(any()) }
+        assertTrue(announced.isEmpty(), "the silent case announced $announced")
+    }
+
+    /**
+     * The control that keeps the two cases above from passing on a channel that is
+     * simply dead.
+     *
+     * The main frame is the workbench, the one document here this app serves, and
+     * it is where both routes this channel backs up navigate. It keeps its notice
+     * whether or not the gesture bit survived the workbench's opener chain, which
+     * is the case the notice was added for: a sign-in or a clone link that no app
+     * answers, where the WebView does not navigate either and the tap otherwise
+     * did nothing and said nothing.
+     */
+    @Test
+    fun `a main-frame hand-off is still announced`() {
+        client.shouldOverrideUrlLoading(
+            view, request("ssh", "ssh://git@example.com/repo.git", true, withGesture = false)
+        )
+
+        assertEquals(listOf(HandoffFailure("ssh", "ActivityNotFoundException")), announced)
+    }
+
+    /**
+     * The other control, and the one that makes the gate a question about the user
+     * rather than about frames.
+     *
+     * A link the user actually tapped inside a preview is something they did, and
+     * `hasGesture()` is the request's own record of it. Silencing that would take
+     * the notice away from a real tap on a real link, which is the same silence
+     * this channel exists to end.
+     */
+    @Test
+    fun `a link the user tapped in a subframe is still announced`() {
+        client.shouldOverrideUrlLoading(
+            view, request("ssh", "ssh://git@example.com/repo.git", false, withGesture = true)
+        )
+
+        assertEquals(listOf(HandoffFailure("ssh", "ActivityNotFoundException")), announced)
+    }
+
+    /**
+     * The gate is not the whole answer, which is why the throttle exists too.
+     *
+     * A page may hold one gesture per link, and every one of them is attributable.
+     * Ten taps on ten different `ssh:` addresses are one fact and one sentence,
+     * because the message names the scheme and never the address.
+     */
+    @Test
+    fun `many attributable failures of one kind are one message`() {
+        val said = mutableSetOf<HandoffFailure>()
+        val shown = mutableListOf<HandoffFailure>()
+
+        repeat(10) { i ->
+            client.shouldOverrideUrlLoading(
+                view,
+                request("ssh", "ssh://git@example.com/repo-$i.git", false, withGesture = true),
+            )
+        }
+        announced.forEach { failure ->
+            handoffFailureToAnnounce(failure, said)?.let { shown += it }
+        }
+
+        assertEquals(10, announced.size, "the gate let fewer through than this case needs")
+        assertEquals(
+            listOf(HandoffFailure("ssh", "ActivityNotFoundException")), shown,
+            "one scheme failing one way is one sentence, however many addresses carry it",
+        )
+    }
+
+    /** One page failing the same way twice is one message. */
+    @Test
+    fun `the same failure twice is announced once`() {
+        val said = mutableSetOf<HandoffFailure>()
+        val failure = HandoffFailure("ssh", "ActivityNotFoundException")
+
+        assertEquals(failure, handoffFailureToAnnounce(failure, said))
+        assertNull(
+            handoffFailureToAnnounce(failure, said),
+            "a second link on the same scheme adds nothing the user can act on",
+        )
+    }
+
+    /**
+     * The half that makes the rule above a filter rather than a mute.
+     *
+     * Keyed on the scheme and the failure type together, which is exactly what the
+     * two message forms print: a different scheme needs a different app installed,
+     * and the same scheme failing a different way is quoted by type for a bug
+     * report rather than as something to install.
+     */
+    @Test
+    fun `a different scheme or a different failure type is still announced`() {
+        val said = mutableSetOf<HandoffFailure>()
+        handoffFailureToAnnounce(HandoffFailure("ssh", "ActivityNotFoundException"), said)
+
+        assertEquals(
+            HandoffFailure("git", "ActivityNotFoundException"),
+            handoffFailureToAnnounce(HandoffFailure("git", "ActivityNotFoundException"), said),
+            "a second scheme is a fact the user has not been told",
+        )
+        assertEquals(
+            HandoffFailure("ssh", "SecurityException"),
+            handoffFailureToAnnounce(HandoffFailure("ssh", "SecurityException"), said),
+            "the same scheme failing a different way needs a different answer from the reader",
+        )
+    }
+
+    /**
+     * The record cannot grow without bound.
+     *
+     * The schemes in it are chosen by whatever page is open, so an unbounded set is
+     * an allocation a page controls. What this case also documents is the residual:
+     * past the cap a message may be said a second time, and that is the intended
+     * trade rather than a defect.
+     */
+    @Test
+    fun `the record is bounded and starts over at the cap`() {
+        val said = mutableSetOf<HandoffFailure>()
+        val first = HandoffFailure("scheme0", "ActivityNotFoundException")
+
+        // One short of the cap, so the record is still whole.
+        for (i in 0 until MAX_HANDOFF_FAILURES_ANNOUNCED - 1) {
+            val failure = HandoffFailure("scheme$i", "ActivityNotFoundException")
+            assertEquals(failure, handoffFailureToAnnounce(failure, said), "distinct failure $i")
+        }
+        assertNull(
+            handoffFailureToAnnounce(first, said),
+            "below the cap nothing is forgotten, which is what makes the assertion below a " +
+                "reset rather than a set that never remembered anything",
+        )
+
+        val atCap = HandoffFailure("atcap", "ActivityNotFoundException")
+        assertEquals(atCap, handoffFailureToAnnounce(atCap, said))
+
+        assertEquals(
+            first, handoffFailureToAnnounce(first, said),
+            "the record clears once it holds the cap, so an old failure is said a second time " +
+                "rather than the set growing on schemes a page chooses",
+        )
+    }
+
+    /**
+     * The presenter is the only owner of the record, so an unwired presenter is a
+     * throttle that throttles nothing while every case above stays green.
+     *
+     * Read from the source rather than driven through the Activity, which needs a
+     * device. ⚠️ Its ceiling, the same one `WriteBackNoticeWiringTest` records:
+     * this catches the call being deleted, not the branch being made unreachable.
+     * Anchored at the start of a line so that commenting the call out, which is how
+     * a developer disables something, does not still satisfy it.
+     */
+    @Test
+    fun `MainActivity puts a hand-off failure through the throttle`() {
+        val activity = File("src/main/kotlin/com/vscodroid/MainActivity.kt")
+        assertTrue(activity.isFile, "MainActivity.kt is not where this test expects it")
+
+        assertTrue(
+            Regex("""(?m)^[^/\n]*handoffFailureToAnnounce\(""").containsMatchIn(activity.readText()),
+            "nothing in MainActivity consults the record of what has already been said, so " +
+                "every hand-off failure reaches the screen as its own toast",
+        )
+    }
+}

--- a/docs/05-API_SPEC.md
+++ b/docs/05-API_SPEC.md
@@ -117,7 +117,7 @@ from. `isTextEntry` decides which route a press takes and `typeCharacter` is the
 first of them; both live in the `keyboard` package beside `KeyInjector`.
 
 Nothing needs to be defined on the page for either route to work, and defining a
-hook by that name — which is what following the old text led to — leaves a function
+hook by that name (which is what following the old text led to) leaves a function
 nothing ever calls.
 
 ```javascript
@@ -170,7 +170,7 @@ workbench page, so anything running in that page's own realm can call them direc
 extension cannot: it runs in the web extension host, which does not see objects added by
 `addJavascriptInterface`. Extensions reach the bridge over the BroadcastChannel relay
 that `MainActivity.injectBridgeRelay` opens, and that relay dispatches a hand-written
-list of **14** command names — grep `d.cmd ===` in `MainActivity.kt` for the current set:
+list of **14** command names. Grep `d.cmd ===` in `MainActivity.kt` for the current set:
 
 > `clearCaches`, `generateBugReport`, `generateSshKey`, `getRecentFolders`,
 > `getSshPublicKey`, `getStorageBreakdown`, `listSafMirrors`, `listSshKeys`,

--- a/scripts/check-library-attribution.py
+++ b/scripts/check-library-attribution.py
@@ -659,6 +659,43 @@ def attributed_in(text):
     return names
 
 
+def normalised(name):
+    """A component name reduced to what two spellings of it have in common.
+
+    The keys in LIBRARIES and the bold names in the source offer are written by
+    hand in two different files, so they agree on the words without always
+    agreeing on the case or on a trailing full stop. Folding both sides through
+    here keeps a cosmetic difference from reading as a missing source offer,
+    which would be a false alarm nobody could act on. It deliberately stops
+    there: anything looser is a substring test again, and a substring test is
+    what let one component's bullet answer for another's.
+    """
+    return " ".join(name.split()).strip("*_ .,:;").casefold()
+
+
+def offered_in(section):
+    """The set of component names the source-offer section's bullets declare.
+
+    A set, tested for membership, rather than a search for the name inside the
+    section's text, and the difference is not academic. The libiconv bullet ends
+    "linked by Bash and by every Git executable", so with the substring test in
+    place both Bash's and Git's own bullets could be deleted and the section
+    still read as offering source for both: the two GPL tools with the widest
+    reach here were exactly the two whose loss the check could not see. Only
+    deleting libiconv as well, which nothing else in the section names, turned it
+    red.
+
+    A bullet is `- **Name** (LICENCE): where the source is`. The bold name is
+    what a reader of the document looks for, so it is what is matched, whole. A
+    component that cannot be matched by name is reported as unoffered rather than
+    waved through, so a bullet rewritten out of that shape fails loudly.
+    """
+    return {
+        normalised(m.group(1))
+        for m in re.finditer(r"^\s*[-*]\s+\*\*(.+?)\*\*\s*\(", section, re.MULTILINE)
+    }
+
+
 def main():
     names = shipped()
     nest = nested()
@@ -695,6 +732,10 @@ def main():
         print("FAIL no '## GPL Source Code Availability' section in LEGAL_NOTICES.md",
               file=sys.stderr)
         return 1
+    # Parsed into the set of names its bullets declare, because isolating the
+    # section only stops a mention elsewhere in the file from counting; it does
+    # nothing about one bullet mentioning another bullet's component.
+    offered = offered_in(offer)
 
     unknown, unattributed, unoffered, unlicensed = [], [], [], []
     # Toolchain payloads are checked alongside the base tree. They ship to fewer
@@ -788,7 +829,7 @@ def main():
         short = [doc for doc, known in docs.items() if component not in known]
         if short:
             unattributed.append(f"{name} ({component}), absent from {', '.join(short)}")
-        if any(c in licence.upper() for c in COPYLEFT) and component not in offer:
+        if any(c in licence.upper() for c in COPYLEFT) and normalised(component) not in offered:
             unoffered.append(f"{name} ({component}, {licence})")
 
     for label, items, hint in (

--- a/scripts/check-toolchain-claims.py
+++ b/scripts/check-toolchain-claims.py
@@ -41,7 +41,46 @@ import sys
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 
 MANAGER = ROOT / "android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt"
-WELCOME = ROOT / "android/app/src/main/assets/extensions/vscodroid.vscodroid-welcome-1.2.2"
+EXTENSIONS = ROOT / "android/app/src/main/assets/extensions"
+
+
+def welcome_dir():
+    """The bundled welcome extension, whatever version it is at.
+
+    Resolved by prefix, the same way `check-welcome-claims.py` does it, because
+    the version in the directory name moves with the extension's manifest and
+    the name written out here does not follow. A spelled-out version turns the
+    next ordinary bump into a failure of this check for a reason that has
+    nothing to do with what it tests, while the other gate over the same two
+    files keeps reading the tree, so the pair disagree about which directory
+    exists.
+
+    Ordered by parsed version rather than by name, again matching that script:
+    lexically 1.10.0 sorts below 1.9.0, and a name sort would then read the
+    older directory and report on a file that is not shipping.
+
+    Absence is fatal rather than an empty answer. With no directory the
+    walkthrough and its illustration simply drop out of OFFER_FILES, and those
+    are the two files in the set that every new user is shown.
+    """
+    def version(path):
+        tail = path.name.rsplit("-", 1)[-1]
+        try:
+            return tuple(int(part) for part in tail.split("."))
+        except ValueError:
+            return ()
+
+    found = sorted(EXTENSIONS.glob("vscodroid.vscodroid-welcome-*"), key=version)
+    if not found:
+        sys.exit(
+            "FAIL no vscodroid.vscodroid-welcome-* directory under "
+            f"{EXTENSIONS.relative_to(ROOT)}; the Get Started walkthrough and "
+            "its illustration would be checked by nothing"
+        )
+    return found[-1]
+
+
+WELCOME = welcome_dir()
 
 # Files that describe what the product CONTAINS, whether a user or a maintainer
 # reads them. The split is what a file is for, not who opens it.

--- a/scripts/check-translatable-strings.py
+++ b/scripts/check-translatable-strings.py
@@ -317,8 +317,17 @@ def main():
     # rename that moved the sources, or an edge case that made scan_string
     # swallow a file, would report zero findings over zero literals and read
     # exactly like a clean tree.
+    # The sentence says what the scan establishes, which is narrower than what a
+    # reader wants it to say. Two classes pass it while being read by a user: a
+    # sink this file does not list, and a literal is_prose judges to be formatting
+    # rather than language. `row.statusText.text = "$percent%"` was the second of
+    # those; is_prose needs a letter to survive the interpolation strip, and no
+    # letter survives that one. Widening is_prose is not the answer either, since
+    # it would flag every numeric format string in the app. So the line reports the
+    # predicate that was actually evaluated, and the docstring above says what sits
+    # outside it.
     print(f"ok: {len(files)} Kotlin sources, {literals_seen} string literals, "
-          f"no user-facing text outside strings.xml")
+          "no prose literal at a recognised sink")
     return 0
 
 


### PR DESCRIPTION
Fifteen fixes ahead of 1.2.0, across device-folder storage, first-run setup,
toolchain installs, and the checks that gate a packaged build. Each commit is
independent and carries its own test and changelog line.

## Storage

- `documentWritesInFlight` and the device-folder removal guard both lived on an
  object that does not outlive what they guard. There is one sync engine per
  activity, while `stopWatching` waits two seconds for the write-back worker and
  then leaves a drain it could not join to finish on its own, so an activity
  recreated mid-drain gave the replacement an empty guard. Both now sit in the
  companion, beside `uploadJournalLock`, whose own documentation already named
  this case. Without it, a file written back to a device folder could be opened
  `"wt"` by a second writer and end up holding neither input.
- Upload truncation is reported by the walk that found it rather than inferred
  from `entries.size >= cap`. The walk stops at the cap, so it can never return
  more than the cap, and a directory ending exactly there was reported as partly
  copied when every file had arrived.

## Setup and toolchains

- The first-run storage gate charged the rewrite headroom from the total already
  installed, which also credits `usr/`. The per-launch repair block writes there
  before the gate runs, so a genuinely fresh install was asked for 986 MB where
  the unpack needs 873, and the refusal quotes that figure. It now reads
  `server/`, which nothing but extraction writes to.
- Two toolchain installs of the same pack could copy into `filesDir/usr` at once:
  a rotation rebuilds `ToolchainActivity` with a second manager, and the card
  offers Install again. Both copy identical bytes, so the cost is space, and
  neither pre-flight reserves for the other. A process-wide claim now declines
  the second, and hands Play's copy back only when the install actually ran.
- App exception names survive R8, so a setup failure names the real type instead
  of a shortened one.

## Interface

- The notice for a link the device cannot open is bounded and gated on a gesture.
  It fired from every frame with no record of what had been said, and a page
  driving iframe navigations could hold the editor under toasts. The hand-off
  itself is unchanged: a subframe's external link still leaves for a browser.
- Extra key row labels keep the vertical padding the rounded background replaced.
- The download percentage comes from a string resource, so its sign and digits
  follow the device's language.

## Gates

- The copyleft check matches components against the source offer's own entries.
  It tested for the name anywhere in that section, and one entry mentions two
  other components by name, so those two offers could be deleted with the check
  still green.
- The toolchain check resolves the welcome extension by prefix, so the next
  ordinary version bump no longer fails it.
- The translatable-text check reports the predicate it evaluated rather than a
  stronger claim its own header already disclaims.
- Two guards over MainActivity's source are anchored to a line start, so a
  commented-out registration no longer satisfies them.

## Risk

Behaviour changes worth knowing about. A device folder copy now stays
unremovable for the whole process the folder was opened in, where an activity
restart used to release it; the refusal already told the user a restart was
needed. A second install of a pack already installing is declined rather than
run, reported as `UNKNOWN` rather than `NOT_INSTALLED`, since the latter is what
a finished uninstall reports and the toolchain card reads it as one. The storage
gate asks for 113 MB less on a fresh install.

## Verification

- 1467 unit tests, no failures, no skips (1453 before; fourteen added here).
- Every gate run with the arguments CI uses, plus the nine bundled extensions and
  both node harnesses: no failures.
- `lintDebug` 0 errors, 52 warnings, one fewer than before.
- R8 and `lintVitalRelease` build clean, and `ManifestWriteFailed` maps to itself
  in the release mapping instead of a two-letter token.
- Each fix has a test that goes red when the fix is reverted, checked in a
  throwaway worktree rather than argued. The five commits that split a file were
  each compiled on their own so bisect stays usable.
