### PR TITLE
fix(storage): move a mirror's upload records when the mirror moves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The download percentage on the first-run screen comes from a string resource, so its sign and digits follow the device's language.
 - Installing a toolchain already being installed is declined rather than copying the tree twice, which could run a device out of space and leave a partial install.
 - A page can no longer bury the editor under notices about links it could not open. Only navigations you started are announced, and repeats of the same one are dropped.
+- Re-adding a device folder while its previous copy is still being removed no longer discards the new copy's record of which files have not reached the device.
 
 ### Security
 

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafStorageManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafStorageManager.kt
@@ -392,6 +392,13 @@ class SafStorageManager(private val context: Context) {
             Logger.w(tag, "Could not set $name aside; leaving it in place")
             return null
         }
+        // The records move with the directory, and this is the only moment they can.
+        // They are keyed by absolute path, and the name is a hash of the tree URI
+        // rather than of the session, so from here on the path this rename frees is
+        // the path the same folder gets again the moment the user re-grants it. Left
+        // behind, the departing mirror's records and the replacement's are the same
+        // strings and nothing downstream can tell them apart.
+        syncEngine.renameUploadsUnder(entry, target)
         return target
     }
 
@@ -399,11 +406,16 @@ class SafStorageManager(private val context: Context) {
      * Deletes an entry [setAside] has already moved, and retires the upload records
      * that named it.
      *
-     * [originalPath] is the path before the rename, and passing the `discarded-` one
-     * instead matched no journal entry at all, so records outlived the mirror they
-     * distrust: a later re-grant of the same folder hashes back to the same path, and
-     * the next sync then read the device's own document as this app's interrupted
-     * upload and wrote the stale mirror back over it.
+     * The records are retired under the `discarded-` path, which is the path they are
+     * filed under: [setAside] moves them when it moves the directory. Clearing under
+     * the name the mirror had *before* the rename is what this used to do, and it is
+     * wrong in the one case that matters. A mirror's directory name is a hash of the
+     * tree URI, so the path a removal frees is the path the same folder returns to when
+     * the user re-grants it, and a sweep finishing after that re-grant then retires the
+     * live mirror's records instead of the dead one's. That loses the very distrust
+     * that stops the next sync copying a truncated device document over the mirror's
+     * only complete copy. Clearing under the discarded path cannot reach a live mirror,
+     * because nothing else is ever filed there.
      *
      * The delete is [com.vscodroid.util.StorageManager.deleteRecursive] rather than
      * `File.deleteRecursively`, which asks `isDirectory` and `listFiles` and therefore
@@ -421,7 +433,18 @@ class SafStorageManager(private val context: Context) {
             Logger.w(tag, "Could not finish removing ${discarded.name}; the next launch retries")
             return false
         }
-        syncEngine.clearUploadsUnder(originalPath)
+        syncEngine.clearUploadsUnder(discarded)
+        // The second clear is for entries set aside before the records learned to move
+        // with the directory: theirs are still filed under the name the mirror had, and
+        // nothing else will ever retire them. Guarded on the path being free, because
+        // that is exactly the case this cannot tell apart. If the folder has been
+        // re-granted, the records under that name may be the new mirror's, and the two
+        // mistakes are not equal: keeping a dead record makes the next sync write a
+        // mirror over a device copy that matches it anyway, while dropping a live one
+        // lets a truncated device document overwrite the only complete copy. So the
+        // ambiguous case keeps them, and the next removal of that mirror clears them
+        // under its own discarded name.
+        if (!originalPath.exists()) syncEngine.clearUploadsUnder(originalPath)
         return true
     }
 

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
@@ -1325,6 +1325,39 @@ class SafSyncEngine(private val context: Context) {
      * read back as this app's own interrupted upload and thrown away in favour of
      * the stale copy. Reclaiming the mirror has to reclaim its distrust with it.
      */
+    /**
+     * Moves the upload records of [from] to [to], so they follow the directory a
+     * removal has just renamed out of the way.
+     *
+     * The journal is keyed by absolute path, and a mirror's directory name is a hash
+     * of the tree URI rather than of the session, so the path a removal frees is the
+     * path the same folder gets again when the user re-grants it. Without this, the
+     * records of the departing mirror and of its replacement are the same strings, and
+     * whichever side is cleared takes the other's with it: retiring them loses the live
+     * mirror's distrust, and keeping them applies a dead mirror's distrust to a live
+     * one. Both end the same way, with a stale copy written over the user's file.
+     *
+     * Renaming them at the moment the directory moves is what keeps the two apart,
+     * because that is the last moment anything can still tell them apart. It survives a
+     * process death for the same reason the rename does: both are on disk before
+     * anything else happens.
+     */
+    internal fun renameUploadsUnder(from: File, to: File) {
+        synchronized(uploadJournalLock) {
+            try {
+                val journal = uploadJournal()
+                if (!journal.isFile) return
+                val old = from.absolutePath + File.separator
+                val new = to.absolutePath + File.separator
+                val all = journal.readLines()
+                val moved = all.map { if (it.startsWith(old)) new + it.removePrefix(old) else it }
+                if (moved != all) rewriteJournal(moved)
+            } catch (e: Exception) {
+                Logger.w(tag, "Could not move the upload records of ${from.name}: ${e.message}")
+            }
+        }
+    }
+
     internal fun clearUploadsUnder(mirrorRoot: File) {
         synchronized(uploadJournalLock) {
             try {

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafMirrorReclamationTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafMirrorReclamationTest.kt
@@ -123,6 +123,51 @@ class SafMirrorReclamationTest {
     }
 
     /**
+     * The case the two paths cannot be told apart in, and the reason the records
+     * move with the directory rather than being cleared by the name the mirror had.
+     *
+     * A directory name is a digest of the tree URI, not of the session, so the path a
+     * removal frees is the path the same folder returns to the moment the user grants
+     * it again. The sweep runs on a thread that outlives the removal and takes as long
+     * as the tree is big, so a re-grant landing inside that window is ordinary rather
+     * than contrived. If the sweep then retires records by the old name, it retires the
+     * new mirror's, and those are the records that stop the next sync copying a
+     * truncated device document over the only complete copy.
+     */
+    @Test
+    fun `a re-granted mirror keeps its records when the old one is swept`() {
+        val hash = "abc123def456"
+        val original = File(mirrorsDir, hash)
+        val setAside = File(mirrorsDir, SafStorageManager.DISCARD_PREFIX + hash)
+        setAside.mkdirs()
+        File(setAside, "old.md").writeText("the copy being removed")
+        // The re-grant: the same folder, so the same digest, so the same path, live
+        // again while the sweep of its predecessor is still to run.
+        original.mkdirs()
+        File(original, "fresh.kt").writeText("written since the re-grant")
+
+        val journal = File(filesDir, SafSyncEngine.UPLOADS_IN_FLIGHT_FILE)
+        val departing = File(setAside, "old.md").absolutePath
+        val live = File(original, "fresh.kt").absolutePath
+        journal.writeText(departing + "\n" + live + "\n")
+        every { resolver.persistedUriPermissions } returns emptyList()
+
+        manager.reclaimRevokedMirrorsSync()
+
+        assertFalse(setAside.exists(), "the set-aside leftover should have gone")
+        assertFalse(
+            journal.readLines().contains(departing),
+            "the departing mirror's own record outlived it",
+        )
+        assertTrue(
+            journal.readLines().contains(live),
+            "the sweep took the live mirror's record with it, so the next sync will " +
+                "trust a device copy this app already knows is not current",
+        )
+        assertTrue(original.isDirectory, "the re-granted mirror was deleted by the sweep")
+    }
+
+    /**
      * The mirror is a copy and the device folder is the original, which is what
      * makes reclaiming safe. It stops being a copy when a write-back gave up, or
      * was refused with a SecurityException, which is exactly what a permission


### PR DESCRIPTION
A mirror's directory name is a digest of the tree URI, not of the session, so the
path a removal frees is the path the same folder returns to the moment the user
grants it again. The upload journal is keyed by absolute path, which means the
departing mirror's records and its replacement's are the same strings.

The sweep that deletes a set-aside mirror retired records by the name the mirror
had before the rename. It runs on a detached thread that outlives the removal and
takes as long as the tree is big, so a re-grant landing inside that window is
ordinary rather than contrived. What the sweep then retires is the live mirror's
records, and those are exactly what stops the next sync copying a truncated
device document down over the only complete copy.

## What changed

- `SafSyncEngine.renameUploadsUnder` moves a mirror's records to a new path prefix.
- `setAside` calls it when it renames the directory, which is the last moment
  anything can still tell the departing mirror's records from a replacement's.
  Both writes are on disk before anything else happens, so a process death between
  them changes nothing.
- `finishOff` clears under the `discarded-` name, where nothing live is ever filed.
- Entries set aside by an earlier version still have records under the old name and
  nothing else would ever retire them, so those are cleared too, guarded on the
  path being free.

## Why the guard rather than an unconditional clear

The guarded case is the one that cannot be told apart, and the two mistakes are
not equal. Keeping a dead record makes the next sync write a mirror over a device
copy that already matches it. Dropping a live one lets a truncated device document
overwrite the only complete copy. The guard chooses the first.

## Verification

- 1468 unit tests, no failures, no skips.
- The new case fails against the previous behaviour: reverting the clear to the
  pre-rename path in a throwaway worktree turns it red, so it binds the change
  rather than restating it.
- The existing case covering a leftover from an earlier pass still passes
  unmodified, which is what the second clear is there for.
