### PR TITLE
chore: fourteen small corrections to guards, comments and gates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,11 +168,11 @@ jobs:
           # change cannot move it again.
           cache-provider: basic
 
-      # The gates the pull request path runs, applied to the bits actually being
-      # published. They were reachable on no other trigger: lint.yml fires on
-      # pull_request alone and build.yml on pull_request and push-to-main, so a
-      # hotfix pushed straight to main and tagged went out having passed none of
-      # them -- on the one build type that also runs R8.
+      # The gates lint.yml and build.yml run, applied here to the tree actually
+      # being published. Both of those fire on pull_request and on push to main;
+      # neither fires on a tag, and a tag is free to name a commit that reached
+      # main through neither path. So a tagged build passes them only because
+      # this block runs them again, on the one build type that also runs R8.
       #
       # Before the downloads on purpose. Each reads committed source only, and
       # failing in twenty seconds beats failing after six minutes of fetching.
@@ -194,14 +194,27 @@ jobs:
       - name: Check local network access survives the targetSdk in use
         run: python3 scripts/check-local-network-permission.py
 
+      - name: Check no user-facing text is stranded in Kotlin
+        run: python3 scripts/check-translatable-strings.py
+
       - name: Check the lint baseline has not grown
         run: python3 scripts/check-lint-baseline.py
 
       - name: Check the welcome screen states nothing that goes stale
         run: python3 scripts/check-welcome-claims.py
 
+      # The committed half of it: the extension list against the notices table.
+      # The half that reads an extracted tree runs later anyway, from
+      # download-extensions.sh, so failing on a mismatched notices row costs
+      # seconds here instead of a download.
+      - name: Check the bundled extensions match the notices
+        run: python3 scripts/check-bundled-extensions.py
+
       - name: Check no document offers a withdrawn toolchain
         run: python3 scripts/check-toolchain-claims.py
+
+      - name: Check the device-test checklist accounts for its own rows
+        run: python3 scripts/check-checklist-totals.py
 
       # Needs real history, which is why it is here and not in lint.yml: that
       # workflow takes actions/checkout's default single-commit clone, where

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Re-adding a device folder while its previous copy is still being removed no longer discards the new copy's record of which files have not reached the device.
 - A registry token or proxy password in `.npmrc` survives the launch-time repair. Any byte that was not valid UTF-8 was replaced when the file was rewritten.
 - Bug reports now name the memory ceiling the server actually started with. The line existed but never reached the file the report carries.
+- The storage refusal on first run names the Retry button, so a screen reader user is told it is there.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A page can no longer bury the editor under notices about links it could not open. Only navigations you started are announced, and repeats of the same one are dropped.
 - Re-adding a device folder while its previous copy is still being removed no longer discards the new copy's record of which files have not reached the device.
 - A registry token or proxy password in `.npmrc` survives the launch-time repair. Any byte that was not valid UTF-8 was replaced when the file was rewritten.
+- Bug reports now name the memory ceiling the server actually started with. The line existed but never reached the file the report carries.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A registry token or proxy password in `.npmrc` survives the launch-time repair. Any byte that was not valid UTF-8 was replaced when the file was rewritten.
 - Bug reports now name the memory ceiling the server actually started with. The line existed but never reached the file the report carries.
 - The storage refusal on first run names the Retry button, so a screen reader user is told it is there.
+- A device folder list that fails to load says so, instead of reporting a failed removal the user never asked for.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Installing a toolchain already being installed is declined rather than copying the tree twice, which could run a device out of space and leave a partial install.
 - A page can no longer bury the editor under notices about links it could not open. Only navigations you started are announced, and repeats of the same one are dropped.
 - Re-adding a device folder while its previous copy is still being removed no longer discards the new copy's record of which files have not reached the device.
+- A registry token or proxy password in `.npmrc` survives the launch-time repair. Any byte that was not valid UTF-8 was replaced when the file was rewritten.
 
 ### Security
 

--- a/android/app/src/androidTest/kotlin/com/vscodroid/keyboard/KeyRowAccessibilityInstrumentedTest.kt
+++ b/android/app/src/androidTest/kotlin/com/vscodroid/keyboard/KeyRowAccessibilityInstrumentedTest.kt
@@ -10,6 +10,7 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import com.vscodroid.R
 import com.vscodroid.ToolchainActivity
 import org.junit.runner.RunWith
 
@@ -350,6 +351,18 @@ class KeyRowAccessibilityInstrumentedTest {
     @Test
     fun theTrackpadOffersOneActionPerArrow() {
         inWindow({ ctx -> GestureTrackpad(ctx) }) { _, node ->
+            // The pad draws no text, so this description is the only thing a
+            // screen reader can say when focus lands on it. Without it the four
+            // actions below hang off a node announced as an unlabelled view, and
+            // a user has no reason to open the actions menu that holds the only
+            // route to the arrows.
+            assertEquals(
+                "the trackpad node carries no usable label, so the arrow actions below " +
+                    "belong to something the user cannot identify",
+                context.getString(R.string.trackpad_description),
+                node().contentDescription?.toString(),
+            )
+
             val offered = node().actionList.mapNotNull { it.label?.toString() }
             // Resolved here rather than compared as ids: what the node carries is
             // the text the platform will read out, so this is the one place the

--- a/android/app/src/main/assets/extensions/vscodroid.vscodroid-saf-bridge-1.4.0/extension.js
+++ b/android/app/src/main/assets/extensions/vscodroid.vscodroid-saf-bridge-1.4.0/extension.js
@@ -318,11 +318,18 @@ function activate(context) {
     const manageDeviceFoldersCmd = vscode.commands.registerCommand(
         'vscodroid.manageDeviceFolders',
         async () => {
+            /** @type {*[]} */
+            let mirrors;
+            // Reading the list gets its own catch. It fails for reasons that have
+            // nothing to do with removing anything: the relay is not there, or the
+            // bridge times out. The catch below composes a sentence naming a failed
+            // removal, so sharing one with the listing told the user a folder's copy
+            // had survived a removal they were never offered and never confirmed.
             try {
                 const json = /** @type {string} */ (
                     await sendBridgeCommand('listSafMirrors')
                 );
-                const mirrors = JSON.parse(json || '[]');
+                mirrors = JSON.parse(json || '[]');
 
                 if (mirrors.length === 0) {
                     vscode.window.showInformationMessage(
@@ -330,7 +337,14 @@ function activate(context) {
                     );
                     return;
                 }
+            } catch (/** @type {*} */ err) {
+                vscode.window.showErrorMessage(
+                    `Could not read the list of device folder copies: ${err.message}`
+                );
+                return;
+            }
 
+            try {
                 /** @type {(vscode.QuickPickItem & { mirror?: * })[]} */
                 const items = mirrors.map((/** @type {*} */ m) => ({
                     mirror: m,

--- a/android/app/src/main/kotlin/com/vscodroid/keyboard/KeyMapping.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/keyboard/KeyMapping.kt
@@ -95,10 +95,19 @@ object KeyMapping {
      * the same reason [virtualKeyboardEvents] asks the layout rather than
      * carrying a table of its own.
      *
-     * This matters because the row has no `?`, `+`, `*`, `%`, `^`, `$`, `}` or
-     * `)` on any page, so a latched Shift is the only route the row offers to
+     * This matters for exactly three characters: `?`, `+` and `}`. None of them
+     * is on any page of the row, and each has an unshifted mate that is, so a
+     * latched Shift over `/`, `=` and `]` is the only route the row offers to
      * them. Dropping it types the base character, which is worse than typing
      * nothing: it is confidently wrong output.
+     *
+     * Shift is NOT a route to `*`, `%`, `^`, `$` or `)`. Those five sit on
+     * Digit8, Digit5, Digit6, Digit4 and Digit0, and the table carries no
+     * unshifted digit row at all, so the search below has nothing to match and
+     * returns null; the row carries no digits either, so there is no key to hold
+     * Shift over. Reaching one of them means putting the character itself on a
+     * page. Every other shifted character in the table is already on a page, so
+     * nothing beyond those three depends on this.
      */
     fun shiftedForm(key: String): String? {
         if (key.length == 1 && key[0].isLetter()) return key.uppercase()

--- a/android/app/src/main/kotlin/com/vscodroid/service/NodeService.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/service/NodeService.kt
@@ -824,8 +824,9 @@ class NodeService : Service() {
      * `endsUnreported` branch -- so a counter incremented there would charge one
      * kill twice and disable a value after a death and a half.
      *
-     * On this dispatcher, like every other piece of state this service keeps, and
-     * for the same reason the class header gives.
+     * Decided on this dispatcher, like every other piece of state this service
+     * keeps, and for the same reason the class header gives. Only the two touches
+     * of the preference file hop off it, and the body says why.
      *
      * The notification is raised only at the boundary, not on every kill. Before
      * the boundary the server is still being restarted with the user's value and
@@ -844,17 +845,31 @@ class NodeService : Service() {
     // `.apply()` for a source-reading guard to find, so the safer-looking spelling
     // is the one that can rot without anything going red.
     @Suppress("ApplySharedPref")
-    private fun chargeHeapOverride(exitCode: Int) {
+    private suspend fun chargeHeapOverride(exitCode: Int) {
         if (!processManager.heapOverrideInEffect()) return
-        val prefs = getSharedPreferences(HEAP_PREFS_NAME, MODE_PRIVATE)
-        val before = prefs.getInt(PREF_HEAP_KILLS, 0)
+        // Both touches of the preference file hop to IO; the decision between them
+        // and the message after them do not. `getSharedPreferences` blocks the
+        // caller until the file has been parsed, and `commit()` writes it back
+        // synchronously, so on this dispatcher they are disk work sitting in front
+        // of the notification this method may go on to raise.
+        //
+        // Suspending rather than launching, because the order is what the latch is
+        // made of: [handleServerCrash] must not reach [retryOrGiveUp] until the
+        // count is on disk, since the start that follows reads it straight back in
+        // `ProcessManager.requestedHeapCeiling` to decide whether the user's value
+        // still gets to be honoured.
+        val before = withContext(Dispatchers.IO) {
+            getSharedPreferences(HEAP_PREFS_NAME, MODE_PRIVATE).getInt(PREF_HEAP_KILLS, 0)
+        }
         val after = heapKillsAfter(exitCode, overrideInEffect = true, current = before)
         if (after == before) return
         // commit(), not apply(): the event being recorded is a SIGKILL, and the
         // kill of this app's own process often follows the one it is reacting to.
         // apply()'s deferred write is exactly what loses that race, and a latch
         // whose count does not survive is a latch that never latches.
-        prefs.edit().putInt(PREF_HEAP_KILLS, after).commit()
+        withContext(Dispatchers.IO) {
+            getSharedPreferences(HEAP_PREFS_NAME, MODE_PRIVATE).edit().putInt(PREF_HEAP_KILLS, after).commit()
+        }
         Logger.w(tag, "Server killed with a user heap ceiling in effect ($after of $HEAP_OVERRIDE_KILL_BUDGET)")
         if (heapOverrideSuspended(after)) {
             reportStartupNotice(getString(R.string.heap_override_suspended))

--- a/android/app/src/main/kotlin/com/vscodroid/service/ProcessManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/service/ProcessManager.kt
@@ -557,12 +557,19 @@ class ProcessManager(private val context: Context) {
             startWatchdog()
             // The source is named, not only the number. A ceiling in a bug report
             // that could be either a derived value or a user's is a number nobody
-            // can act on, and this line is what carries it into `server.log`.
-            Logger.i(
-                tag,
+            // can act on.
+            val summary =
                 "Server process started with PID ${getServerPid()}, heap ceiling ${heapMb}MB " +
-                    "(${if (heapOverrideActive) "user override, clamped" else "derived from device RAM"})",
-            )
+                    "(${if (heapOverrideActive) "user override, clamped" else "derived from device RAM"})"
+            Logger.i(tag, summary)
+            // And said twice on purpose. A bug report carries `server.log`, which
+            // only [ServerLog] writes, while `Logger.i` reaches logcat and in a
+            // release build stops there. Mirroring the one line makes the figure
+            // reachable from the report, next to the server output it explains.
+            // The output reader is already appending on its own thread by now;
+            // each append is a separate open in append mode, so the line lands
+            // whole either side of whatever the server has printed.
+            serverLog.append(summary)
             true
         } catch (e: Exception) {
             Logger.e(tag, "Failed to start server", e)

--- a/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
@@ -1229,14 +1229,29 @@ class FirstRunSetup(
         // nothing else is present, which keeps existing installs from seeing a
         // rewrite on the launch after this ships.
         val ownedLine = Regex("""^\s*(script-shell\s*=|os\[]\s*=\s*(linux|android)\s*$)""")
-        val carriedOver = (if (npmrc.exists()) npmrc.readText() else "")
+        // Latin-1, not UTF-8, and the charset is load-bearing for the reason
+        // [ensurePromptFix] gives: it maps all 256 byte values one to one, so
+        // every byte read here comes back out unchanged. `.npmrc` is where npm
+        // keeps a registry auth token, a proxy password and a `cafile` path, none
+        // of which is required to be valid UTF-8, and `readText` replaces every
+        // byte that is not with U+FFFD. That would destroy the credential this
+        // carry-through exists to preserve, on the first launch after the user
+        // set it, with nothing on screen and nothing in the log to say so. The
+        // three owned lines are ASCII, so encoding the result back through the
+        // same mapping is lossless as well.
+        val existing = if (npmrc.exists()) String(npmrc.readBytes(), Charsets.ISO_8859_1) else ""
+        val carriedOver = existing
             .lines()
             .filterNot { ownedLine.containsMatchIn(it) }
             .dropLastWhile { it.isBlank() }
         val expectedContent =
             (listOf("script-shell=$bashPath", "os[]=linux", "os[]=android") + carriedOver)
                 .joinToString("\n", postfix = "\n")
-        if (!npmrc.exists() || npmrc.readText() != expectedContent) {
+        // Compared against that same decoding rather than a second `readText`.
+        // A file holding one byte that is not valid UTF-8 would never compare
+        // equal to what was just written to it, so every launch would rewrite an
+        // already-correct file for ever.
+        if (existing != expectedContent) {
             // Atomically, like every other setup file this class writes. This one
             // was the exception, and it is a bad one to be: `writeText` truncates
             // before it writes, so a write that runs out of disk leaves an empty
@@ -1255,7 +1270,7 @@ class FirstRunSetup(
             // above is reached only when the content differs, and an empty file
             // does differ, but only on a launch that has room, which is the
             // launch that would not have broken it.
-            if (writeAtomically(npmrc) { it.write(expectedContent.toByteArray()) }) {
+            if (writeAtomically(npmrc) { it.write(expectedContent.toByteArray(Charsets.ISO_8859_1)) }) {
                 Logger.d(tag, "Updated .npmrc")
             } else {
                 Logger.w(tag, "Could not update .npmrc; it keeps whatever it held before")

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
@@ -364,12 +364,19 @@ class ToolchainManager(private val context: Context) {
         // behind the copy instead.
         //
         // Bounded to this instance, and that is the whole of it: `ioExecutor` is an
-        // instance field, and every construction site makes its own manager. The two
-        // callers that can reach a live download, ToolchainActivity and the first-run
-        // queue in SplashActivity, each hold one manager for the download and the
-        // cancel alike, so both are covered. `AndroidBridge.cancelToolchainInstall`
-        // builds a fresh manager per call and would not be, but nothing in this tree
-        // sends that command.
+        // instance field, and every construction site makes its own manager, so the
+        // ordering holds only between a cancel and a copy running on the SAME manager.
+        // All three callers that can reach a live download do hold one: ToolchainActivity
+        // and the first-run queue in SplashActivity each keep a manager for the download
+        // and the cancel alike, and `AndroidBridge` builds exactly one, lazily, that
+        // `installToolchain` and `cancelToolchainInstall` both go through.
+        //
+        // What stays unordered is a cancel through one manager against a copy running on
+        // another's executor, an extension cancelling what the first-run queue started
+        // being the reachable case. [installsInFlight] is process-wide and
+        // [installFromDirectory] holds a claim on it for the length of the copy, but
+        // [releasePack] does not consult it, so nothing puts the removal behind a copy
+        // that a different manager began.
         ioExecutor.execute { releasePack(info.packName) }
         Logger.i(tag, "Cancelled download of ${info.packName}")
     }

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
@@ -1249,16 +1249,6 @@ class SafSyncEngine(private val context: Context) {
     }
 
     /**
-     * Releases this writer's claim on [absolutePath], and removes the journal line only
-     * when it was the last claim.
-     *
-     * Paired with [markUploadInFlight] and called by writers alone. A second writer of
-     * the same path is reachable whenever a folder is reopened while a drain of the
-     * previous session is still streaming: the mirror is named by a hash of the folder,
-     * so both writers address one file, and before the count the first to finish removed
-     * the line the other was still inside.
-     */
-    /**
      * Drops this writer's claim while leaving standing whatever its failure recorded.
      *
      * The counterpart to [clearUploadInFlight], and deliberately not the same
@@ -1273,6 +1263,16 @@ class SafSyncEngine(private val context: Context) {
         else uploadWriters.remove(absolutePath)
     }
 
+    /**
+     * Releases this writer's claim on [absolutePath], and removes the journal line only
+     * when it was the last claim.
+     *
+     * Paired with [markUploadInFlight] and called by writers alone. A second writer of
+     * the same path is reachable whenever a folder is reopened while a drain of the
+     * previous session is still streaming: the mirror is named by a hash of the folder,
+     * so both writers address one file, and before the count the first to finish removed
+     * the line the other was still inside.
+     */
     private fun clearUploadInFlight(absolutePath: String) = synchronized(uploadJournalLock) {
         val stillWriting = (uploadWriters[absolutePath] ?: 0) - 1
         if (stillWriting > 0) {

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -52,8 +52,14 @@
          bundled asset tree, which grows with every VS Code pin. A fixed 500 MB
          outlived the tree it was measured against and sent people to free half
          of what unpacking actually needs, so they cleared space, came back, and
-         failed in the same place. See FirstRunSetup.requiredStorageMb(). -->
-    <string name="error_storage_full">Not enough storage space. Free at least %1$d MB and try again.</string>
+         failed in the same place. See FirstRunSetup.requiredStorageMb().
+
+         It ends by naming the button, like its two siblings below. The failure
+         screen adds Retry after the fact and does not move accessibility focus
+         to it, so this announcement is the only place a screen reader user is
+         told the button is there; "try again" left them looking for a gesture
+         that does not exist. -->
+    <string name="error_storage_full">Not enough storage space. Free at least %1$d MB, then tap Retry.</string>
     <string name="error_setup_failed">Setup failed. Tap Retry or reinstall the app.</string>
     <!-- The same failure when setup knows which step it died on. Names the step
          and quotes the exception, because the audience is developers and the

--- a/android/app/src/test/kotlin/com/vscodroid/MirrorReclaimWiringTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/MirrorReclaimWiringTest.kt
@@ -77,6 +77,56 @@ class MirrorReclaimWiringTest {
     }
 
     /**
+     * And it obeys the answer it is given.
+     *
+     * The case above is satisfied by the call existing. A `reclaimRefusal` whose result
+     * is dropped names every one of those fields and reads as correct at a glance, and
+     * deleting the line that returns the refusal leaves the whole suite green. What that
+     * costs is the whole point of the rule: the mirror the rule refused goes straight to
+     * `reclaimMirror`, `force` deletes it, and its live observers replay every one of
+     * those deletes onto the user's device documents.
+     *
+     * Read from the source for the reason the header of this file gives. The two
+     * spellings below are the ones it recognises; a third fails loudly, and the answer
+     * to that is to add it here rather than to loosen the pattern until anything passes.
+     */
+    @Test
+    fun `a refused removal is returned before anything is deleted`() {
+        val body = methodBody("removeDeviceFolderCopy")
+
+        val refusal = Regex("""(?m)^\s*val (\w+) = SafStorageManager\.reclaimRefusal\(""")
+            .find(body)
+        assertTrue(refusal != null) {
+            "the guard does not keep what reclaimRefusal answers, so there is no answer " +
+                "for it to obey"
+        }
+        val answer = refusal!!.groupValues[1]
+
+        // Anchored at the start of a line, so a return that has been commented out
+        // cannot satisfy it. Commenting a line out is how a developer disables
+        // something, and an unanchored search cannot tell that from live code.
+        val enforced = Regex(
+            """(?m)^\s*(?:if \($answer != null\)\s*\{?\s*return $answer\b""" +
+                """|$answer\?\.let \{ return it \})"""
+        ).find(body)
+        assertTrue(enforced != null) {
+            "the guard asks reclaimRefusal and then ignores what it says, so a mirror " +
+                "that is in use is removed anyway and every delete inside it is replayed " +
+                "onto the user's device documents"
+        }
+
+        val removal = body.indexOf("safManager.reclaimMirror(")
+        assertTrue(removal >= 0) {
+            "the removal no longer goes through safManager.reclaimMirror, so the order " +
+                "checked below is measuring nothing"
+        }
+        assertTrue(enforced!!.range.first < removal) {
+            "the refusal is returned only after the removal has already happened, which " +
+                "is not a refusal"
+        }
+    }
+
+    /**
      * The extraction's own control. Every name above also appears elsewhere in this
      * activity, so a brace match that overran into the rest of the file would satisfy
      * the assertion above while checking nothing. `openSafFolder` is the neighbouring

--- a/android/app/src/test/kotlin/com/vscodroid/bridge/ReclaimSafMirrorContractTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/bridge/ReclaimSafMirrorContractTest.kt
@@ -1,0 +1,156 @@
+package com.vscodroid.bridge
+
+import android.content.Context
+import com.vscodroid.storage.SafStorageManager
+import com.vscodroid.util.Logger
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * That [AndroidBridge.reclaimSafMirror] answers with the empty string ONLY when
+ * the copy was actually removed.
+ *
+ * The convention reads backwards, which is why it is pinned rather than left to
+ * the KDoc: success is the falsy value and every refusal is a non-empty sentence.
+ * The relay in `MainActivity.injectBridgeRelay` compares with `=== ''`, so a
+ * refusal that came back empty posts `ok: true`, the bundled saf-bridge
+ * extension resolves its promise, and the user is shown a removal that did not
+ * happen for a folder that is still on disk. The opposite mutation is just as
+ * quiet: a removal that answered with a sentence, "Removed." being the obvious
+ * one, posts `ok: false` and puts an error in front of every successful removal.
+ *
+ * Both directions are asserted here because either one alone is satisfied by a
+ * method rewritten to answer the same thing every time.
+ *
+ * Nothing about the decision is stubbed. The real [SecurityManager] and its real
+ * token are used, and the only fake is the Activity callback, which is where the
+ * decision genuinely lives: the bridge cannot know what the editor has open.
+ */
+class ReclaimSafMirrorContractTest {
+
+    /** The real one, so the token the bridge accepts is not stubbed into existence. */
+    private val security = SecurityManager()
+
+    private val context: Context = mockk(relaxed = true)
+
+    private companion object {
+        const val HASH = "a1b2c3"
+
+        /**
+         * A refusal in the shape the Activity actually produces: a sentence naming
+         * what has to change first. See `MainActivity.removeDeviceFolderCopy`.
+         */
+        const val IN_USE = "That folder is open in the editor. Close it and try again."
+    }
+
+    /**
+     * The rejected-token case logs, and `android.util.Log` throws on this
+     * classpath. Stubbed rather than the log being asserted on: what the log says
+     * is `SecurityManagerTest`'s subject, not this one's.
+     */
+    @BeforeEach
+    fun silenceRejectionLog() {
+        mockkObject(Logger)
+        every { Logger.w(any(), any()) } just Runs
+    }
+
+    @AfterEach
+    fun tearDown() = unmockkAll()
+
+    /** A bridge whose Activity callback answers [answer] and records what it was asked. */
+    private fun bridgeAnswering(answer: String): Pair<AndroidBridge, MutableList<Pair<String, Boolean>>> {
+        val asked = mutableListOf<Pair<String, Boolean>>()
+        val bridge = AndroidBridge(
+            context = context,
+            security = security,
+            clipboard = mockk(relaxed = true),
+            onBackPressed = mockk(relaxed = true),
+            onMinimize = mockk(relaxed = true),
+            safManager = mockk<SafStorageManager>(relaxed = true),
+            onReclaimMirror = { hash, force ->
+                asked += hash to force
+                answer
+            },
+        )
+        return bridge to asked
+    }
+
+    @Test
+    fun `a removal that went through comes back as the empty string`() {
+        val (bridge, asked) = bridgeAnswering("")
+
+        assertEquals(
+            "", bridge.reclaimSafMirror(security.getSessionToken(), HASH, force = false),
+            "a removal that happened must come back empty; the relay compares with === '' " +
+                "and posts ok:false on anything else, so a word here puts an error in front " +
+                "of every successful removal",
+        )
+        assertEquals(
+            listOf(HASH to false), asked,
+            "the removal never reached the Activity, so the empty answer above says nothing",
+        )
+    }
+
+    @Test
+    fun `a refusal comes back as a sentence, not as the empty string`() {
+        val (bridge, _) = bridgeAnswering(IN_USE)
+
+        val refusal = bridge.reclaimSafMirror(security.getSessionToken(), HASH, force = true)
+        assertNotEquals(
+            "", refusal,
+            "a refused removal answered the way a successful one does. The relay posts " +
+                "ok:true on the empty string, so the user is told their disk was freed while " +
+                "the copy is still there.",
+        )
+        assertEquals(
+            IN_USE, refusal,
+            "the reason has to travel unchanged: it names the one thing that has to change " +
+                "before the removal can happen, and a generic substitute is unfollowable",
+        )
+    }
+
+    @Test
+    fun `a stale session token is refused with a reason, and reaches no removal`() {
+        val (bridge, asked) = bridgeAnswering("")
+
+        val refusal = bridge.reclaimSafMirror("not the session token", HASH, force = true)
+        assertEquals(RECLAIM_STALE_SESSION, refusal, "a rejected token must say the session is stale")
+        assertTrue(
+            refusal.isNotEmpty(),
+            "the guard answered the way a completed removal does, so a caller holding no " +
+                "valid token is told the folder's copy is gone",
+        )
+        assertTrue(asked.isEmpty(), "a rejected token still reached the removal")
+    }
+
+    @Test
+    fun `a bridge with no activity behind it refuses rather than claiming a removal`() {
+        // The default constructor argument, which is what a bridge built without
+        // the SAF wiring gets. Nothing could have been removed, so answering the
+        // way a removal does would be a claim about the disk that nobody made.
+        val bridge = AndroidBridge(
+            context = context,
+            security = security,
+            clipboard = mockk(relaxed = true),
+            onBackPressed = mockk(relaxed = true),
+            onMinimize = mockk(relaxed = true),
+        )
+
+        assertEquals(
+            RECLAIM_UNAVAILABLE,
+            bridge.reclaimSafMirror(security.getSessionToken(), HASH, force = false),
+            "an unwired bridge must decline in a way the user can read; the empty string " +
+                "here reports a removal that no code path performed",
+        )
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/storage/MirrorReclaimTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/MirrorReclaimTest.kt
@@ -279,10 +279,22 @@ class MirrorReclaimTest {
         recentJson = """[{"uri":"$folderUri","name":"Project","lastOpened":1700000000}]"""
         every { resolver.persistedUriPermissions } returns listOf(permissionFor(folderUri))
 
+        // The grant stays visible to the resolver for the whole case, deliberately.
+        // Dropping it to an empty list once the removal has run answers the question
+        // the assertion below asks: [getPersistedFolders] prunes every entry whose
+        // permission is gone, so an empty answer would then be the fixture's doing and
+        // the case would hold with the recent-list drop deleted from the manager.
+        // Releasing the grant is a call on a relaxed mock and changes nothing the mock
+        // reports, which is what leaves the row visible to be dropped on its merits.
+        assertEquals(
+            1, manager.getPersistedFolders().size,
+            "the fixture never put the folder in Open Recent, so what follows is not " +
+                "measuring the removal",
+        )
+
         manager.reclaimMirror(dir.name, force = true)
 
         verify { resolver.releasePersistableUriPermission(folderUri, any()) }
-        every { resolver.persistedUriPermissions } returns emptyList()
         assertEquals(
             emptyList<SafFolderInfo>(), manager.getPersistedFolders(),
             "the folder still appears in Open Recent, pointing at a directory that is gone",

--- a/android/app/src/test/kotlin/com/vscodroid/storage/WriteBackNoticeWiringTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/WriteBackNoticeWiringTest.kt
@@ -69,6 +69,73 @@ class WriteBackNoticeWiringTest {
     }
 
     /**
+     * The same silence a folder at a time, and a seam of its own because it says
+     * something else: a folder created in the editor that reached the device short of
+     * some of its files, or that stopped at the cap this app imposes rather than at
+     * anything the device refused. Unwired, a folder that arrived incomplete is
+     * indistinguishable from one that arrived whole, and the user finds out when they
+     * open it somewhere else.
+     *
+     * Both wordings are named, and separately: the capped one exists because telling a
+     * person the device refused their folder, when the limit is ours, sends them looking
+     * at the wrong machine.
+     *
+     * Same ceiling and same anchoring as the case above.
+     */
+    @Test
+    fun `MainActivity asks to be told when a folder did not arrive whole`() {
+        assertTrue(activity.isFile, "MainActivity.kt is not where this test expects it")
+        val source = activity.readText()
+
+        assertTrue(
+            Regex("""(?m)^\s*safManager\.onUploadIncomplete\s*\{""").containsMatchIn(source),
+            "nothing wires the upload notice, so a folder that reached the device with " +
+                "files missing looks exactly like one that arrived whole",
+        )
+        assertTrue(
+            Regex("""(?m)^\s*[^/\n]*saf_upload_incomplete""").containsMatchIn(source),
+            "the notice does not name the string that says how much did not arrive",
+        )
+        assertTrue(
+            Regex("""(?m)^\s*[^/\n]*saf_upload_capped""").containsMatchIn(source),
+            "the cap this app imposes is not named, so it is announced in the wording " +
+                "for a device that refused and the user goes looking at their device",
+        )
+    }
+
+    /**
+     * The inbound direction, which is the one where the wording matters most and the
+     * one a shared seam would have got wrong: these documents are on the device and did
+     * not reach the editor, so "the only copy is inside VSCodroid" is the opposite of
+     * true for them. Running out of room is its own wording again, because that one the
+     * user can act on.
+     *
+     * The two string names are matched on separate lines rather than twice over one:
+     * `\b` refuses the longer name, so the ordinary plural cannot be satisfied by the
+     * out-of-room one and the pair stays two checks rather than one counted twice.
+     */
+    @Test
+    fun `MainActivity asks to be told when documents did not reach the editor`() {
+        assertTrue(activity.isFile, "MainActivity.kt is not where this test expects it")
+        val source = activity.readText()
+
+        assertTrue(
+            Regex("""(?m)^\s*safManager\.onDocumentsNotCopied\s*\{""").containsMatchIn(source),
+            "nothing wires the notice for documents that never arrived, so a folder " +
+                "opens missing files and says nothing about it",
+        )
+        assertTrue(
+            Regex("""(?m)^\s*[^/\n]*saf_documents_not_copied\b""").containsMatchIn(source),
+            "the notice does not name the string that says which way the copy failed",
+        )
+        assertTrue(
+            Regex("""(?m)^\s*[^/\n]*saf_documents_not_copied_no_room""").containsMatchIn(source),
+            "running out of room is announced in the wording for a provider that " +
+                "refused, so the one cause the user can fix is not the one they are told",
+        )
+    }
+
+    /**
      * The throttle belongs to the manager, so one refusing provider is one notice.
      *
      * Asserted as a rule rather than as a constant: the number is a product decision and

--- a/scripts/check-translatable-strings.py
+++ b/scripts/check-translatable-strings.py
@@ -106,7 +106,15 @@ SINK_RE = re.compile(r"\b(" + "|".join(SINKS) + r")\s*\(")
 # Not preceded by a word character, so `statusText.text` matches on `text` while
 # `contentText` and `statusText` do not. A preceding dot is allowed on purpose:
 # `row.statusText.text = "..."` is the shape this app actually writes.
-PROPERTY_RE = re.compile(r"(?<![\w])(" + "|".join(PROPERTY_SINKS) + r")\s*=(?!=)")
+#
+# `val`/`var` in front of the name is a declaration and not a sink at all:
+# `val text = "Some sentence"` names a local whose value reaches no widget, and
+# reading it as one made the check fail a line that no translator needs. The
+# keyword is matched into a group and the match dropped, rather than excluded by
+# a lookbehind, because a lookbehind has to be fixed width here and `val  text`
+# would walk straight back in.
+PROPERTY_RE = re.compile(
+    r"(?<![\w])(?:(val|var)\s+)?(" + "|".join(PROPERTY_SINKS) + r")\s*=(?!=)")
 
 # `${ ... }` first, so a `$` inside an expression is not read as a simple one.
 INTERPOLATION_RE = re.compile(r"\$\{[^{}]*\}|\$[A-Za-z_][A-Za-z0-9_]*")
@@ -268,7 +276,9 @@ def scan(path, src):
     for m in SINK_RE.finditer(masked):
         windows.append((m.group(1), *call_window(masked, m.end() - 1)))
     for m in PROPERTY_RE.finditer(masked):
-        windows.append((m.group(1), *assignment_window(masked, m.end() - 1)))
+        if m.group(1):
+            continue
+        windows.append((m.group(2), *assignment_window(masked, m.end() - 1)))
 
     findings = []
     for name, lo, hi in windows:

--- a/scripts/exec-trampoline.c
+++ b/scripts/exec-trampoline.c
@@ -127,13 +127,31 @@ int main(int argc, char **argv) {
     }
 
     char line[MAX_LINE];
-    while (fgets(line, sizeof(line), f)) {
+    for (;;) {
+        // Planted before every read, and gone only when fgets filled the
+        // buffer: fgets writes its terminator after the last character it read,
+        // so the very last byte is written by no read except one that used every
+        // byte there is. That is the question the drain below has to ask, and
+        // strlen cannot answer it. strlen stops at the first NUL, so a short
+        // record carrying one in the middle is indistinguishable from a record
+        // too long to fit, and draining for it swallows the record after it as
+        // well: fgets has already consumed this record's newline, so the drain
+        // runs to the end of the NEXT one, and a perfectly good entry
+        // disappears without a word.
+        //
+        // Planted here rather than re-armed after the read, because on a full
+        // buffer the byte it sits in holds fgets's terminator, and writing over
+        // that would leave strlen below walking off the end of the array.
+        line[sizeof(line) - 1] = '\n';
+        if (!fgets(line, sizeof(line), f)) break;
+        int filled = line[sizeof(line) - 1] == '\0';
         size_t len = strlen(line);
         if (len == 0) continue;
-        if (line[len - 1] != '\n' && !feof(f)) {
-            // The line did not fit. Drain the rest of it so the next fgets
-            // starts on a real line rather than on this one's tail, which would
-            // otherwise be read as a record of its own.
+        // The line did not fit: every byte of the buffer was used and the last
+        // of them does not end a line. Drain the rest of it so the next fgets
+        // starts on a real line rather than on this one's tail, which would
+        // otherwise be read as a record of its own.
+        if (filled && line[sizeof(line) - 2] != '\n' && !feof(f)) {
             int c;
             while ((c = fgetc(f)) != EOF && c != '\n') { }
             continue;


### PR DESCRIPTION
Fourteen small corrections, each independent. Most are guards that could not
fail and comments that describe code they do not match, so the risk in almost
all of them is a future edit landing green rather than anything a user meets
today. Three are exceptions and are worth reading first.

## The three with a user behind them

- A NUL byte anywhere in the toolchain exec table made the trampoline treat that
  record as too long to fit, and the drain that follows then ran past the newline
  `fgets` had already consumed and into the next record. One command stopped
  resolving and its neighbour disappeared with it. Measured against the previous
  behaviour with such a table: the entry after it went from unresolvable to
  resolving.
- `.npmrc` was read as UTF-8 and written back by the launch-time repair, so a
  registry token or proxy password holding a byte that was not valid UTF-8 was
  corrupted. It also meant the file differed from what had just been written to
  it, so it was rewritten on every launch.
- The device folder manage command wrapped the listing, the picker, the
  confirmation and the removal in one `try`, and its `catch` named a failed
  removal. A listing that failed told the user a removal had failed, for a
  removal they never confirmed and which never ran.

## Guards that could not fail

- Nothing pinned that `removeDeviceFolderCopy` acts on what `reclaimRefusal`
  returns. The case asserted the body names it, and a name check is satisfied by
  the call existing when its result is thrown away: deleting the line that
  returns the refusal left the whole suite green.
- A recent-list case re-stubbed the resolver to report no permissions after the
  removal and before the assertion, so it passed on its own setup rather than on
  the code.
- Two of the three device folder notices had no wiring guard, so removing either
  registration was silent.
- `reclaimSafMirror` answers with the empty string on success, inverted relative
  to ordinary truthiness, and neither direction was pinned.
- The gesture trackpad's `contentDescription` is its only label and the four
  cursor actions hang off it, with nothing pinning it.

## Comments and gates

Three comments corrected where they describe code they do not match. Two
committed-source checks now run on the release path as well as in lint, and the
comment justifying that block no longer misstates when lint fires. The
translatable-text gate stops reading a local variable named `text` as a view
sink, without weakening what it catches.

`chargeHeapOverride` moves its preference read and commit off the main thread.
The commit stays a commit: the count has to survive the SIGKILL it is reacting
to. Suspending rather than launching keeps the ordering the latch depends on.

## Verification

- 1475 unit tests, no failures, no skips.
- Every no-argument gate passes; `lintDebug` reports 0 errors.
- Each guard was proved to bite by mutating the code it guards in a throwaway
  worktree and showing it goes red, rather than by asserting it does.
- The trampoline change was compiled with `-Wall -Wextra` and exercised against a
  table holding an embedded NUL, in both the old and new shapes.
- The gate change was checked in both directions: a real sink assignment still
  fails, a local declaration no longer does.
