### PR TITLE
fix: an uncancellable heap charge, recoverable notices, and earlier install exclusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Installing a toolchain already being installed is declined rather than copying the tree twice, which could run a device out of space and leave a partial install.
 - A page can no longer bury the editor under notices about links it could not open. Only navigations you started are announced, and repeats of the same one are dropped.
 - Re-adding a device folder while its previous copy is still being removed no longer discards the new copy's record of which files have not reached the device.
+- Installing a toolchain another install is already fetching no longer downloads and unpacks it a second time before declining.
 - A registry token or proxy password in `.npmrc` survives the launch-time repair. Any byte that was not valid UTF-8 was replaced when the file was rewritten.
 - Bug reports now name the memory ceiling the server actually started with. The line existed but never reached the file the report carries.
 - The storage refusal on first run names the Retry button, so a screen reader user is told it is there.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A page can no longer bury the editor under notices about links it could not open. Only navigations you started are announced, and repeats of the same one are dropped.
 - Re-adding a device folder while its previous copy is still being removed no longer discards the new copy's record of which files have not reached the device.
 - Installing a toolchain another install is already fetching no longer downloads and unpacks it a second time before declining.
+- The toolchain screen says an install is already running, instead of answering a tap with nothing at all.
 - A registry token or proxy password in `.npmrc` survives the launch-time repair. Any byte that was not valid UTF-8 was replaced when the file was rewritten.
 - Bug reports now name the memory ceiling the server actually started with. The line existed but never reached the file the report carries.
 - The storage refusal on first run names the Retry button, so a screen reader user is told it is there.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Re-adding a device folder while its previous copy is still being removed no longer discards the new copy's record of which files have not reached the device.
 - Installing a toolchain another install is already fetching no longer downloads and unpacks it a second time before declining.
 - The toolchain screen says an install is already running, instead of answering a tap with nothing at all.
+- Certificate notices pause during a burst and resume after it, so a page can no longer silence a genuine certificate fault for the rest of the session.
 - A registry token or proxy password in `.npmrc` survives the launch-time repair. Any byte that was not valid UTF-8 was replaced when the file was rewritten.
 - Bug reports now name the memory ceiling the server actually started with. The line existed but never reached the file the report carries.
 - The storage refusal on first run names the Retry button, so a screen reader user is told it is there.

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -105,6 +105,17 @@ class MainActivity : AppCompatActivity() {
     private val announcedTlsFailures = mutableSetOf<TlsFailure>()
 
     /**
+     * When the last certificate notice was shown, for the interval the record falls
+     * back on once it is past its cap.
+     *
+     * A plain field rather than an atomic, unlike the write-back throttle this
+     * borrows its shape from: that one is claimed from two threads, and this is read
+     * and written only inside the runOnUiThread below, which is the same reason the
+     * set beside it needs no synchronisation.
+     */
+    private var lastTlsNoticeAt = 0L
+
+    /**
      * The hand-off failures already put on screen, so a page driving many
      * navigations to a scheme nothing answers is one message rather than a stream
      * of them. See [handoffFailureToAnnounce], which owns the rule, explains why
@@ -1681,7 +1692,11 @@ class MainActivity : AppCompatActivity() {
             // platform guarantees about which thread the callback arrives on.
             onTlsFailure = { failure ->
                 runOnUiThread {
-                    tlsFailureToAnnounce(failure, announcedTlsFailures)?.let { reportTlsFailure(it) }
+                    val now = System.currentTimeMillis()
+                    tlsFailureToAnnounce(failure, announcedTlsFailures, now, lastTlsNoticeAt)?.let {
+                        lastTlsNoticeAt = now
+                        reportTlsFailure(it)
+                    }
                 }
             },
             onPageLoaded = { url ->

--- a/android/app/src/main/kotlin/com/vscodroid/ToolchainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/ToolchainActivity.kt
@@ -83,6 +83,18 @@ class ToolchainActivity : AppCompatActivity() {
                 if (why != null) {
                     Toast.makeText(this, getString(why.message), Toast.LENGTH_LONG).show()
                 }
+                // A decline reports UNKNOWN, and without this the screen answers a
+                // tap with nothing at all. The card cannot say it either: the pack
+                // is not installed yet and no progress belongs to this manager, so
+                // it draws the same Install it drew before, and the user taps again
+                // and gets the same silence. The install is genuinely happening,
+                // just not by this caller, so the sentence says so rather than
+                // reporting a failure.
+                if (status == AssetPackStatus.UNKNOWN && why == null) {
+                    Toast.makeText(
+                        this, getString(R.string.toolchain_already_installing), Toast.LENGTH_SHORT
+                    ).show()
+                }
                 if (status == AssetPackStatus.REQUIRES_USER_CONFIRMATION) {
                     try {
                         toolchainManager.showConfirmationDialog(this)

--- a/android/app/src/main/kotlin/com/vscodroid/service/NodeService.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/service/NodeService.kt
@@ -18,6 +18,7 @@ import com.vscodroid.util.Logger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
@@ -860,18 +861,36 @@ class NodeService : Service() {
         // count is on disk, since the start that follows reads it straight back in
         // `ProcessManager.requestedHeapCeiling` to decide whether the user's value
         // still gets to be honoured.
-        val before = withContext(Dispatchers.IO) {
-            getSharedPreferences(HEAP_PREFS_NAME, MODE_PRIVATE).getInt(PREF_HEAP_KILLS, 0)
-        }
-        val after = heapKillsAfter(exitCode, overrideInEffect = true, current = before)
-        if (after == before) return
+        // NonCancellable, and that is the half of this that is not about threads.
+        // `withContext` is a cancellation point and this scope is cancelled in
+        // `onDestroy`, so a crash arriving while the service is being torn down
+        // could reach the read and never reach the write. What is written is not
+        // work in progress a cancelled caller no longer wants: it is the record of
+        // a death that has already happened, and losing it means a ceiling that
+        // kills the server every time is never charged for the last of those kills
+        // and so is never suspended. Before these touches hopped off this
+        // dispatcher the read and the write ran to completion once entered, and
+        // this is what keeps that true.
+        //
+        // One block rather than three, so nothing can land between the read and
+        // the write that is based on it.
+        //
         // commit(), not apply(): the event being recorded is a SIGKILL, and the
         // kill of this app's own process often follows the one it is reacting to.
         // apply()'s deferred write is exactly what loses that race, and a latch
         // whose count does not survive is a latch that never latches.
-        withContext(Dispatchers.IO) {
-            getSharedPreferences(HEAP_PREFS_NAME, MODE_PRIVATE).edit().putInt(PREF_HEAP_KILLS, after).commit()
-        }
+        // Null when this death does not move the count, which is every exit that is
+        // not the kill the ceiling is charged for, and the early return it drives is
+        // what keeps the line below and the notice after it from firing on an
+        // ordinary crash.
+        val after = withContext(NonCancellable + Dispatchers.IO) {
+            val prefs = getSharedPreferences(HEAP_PREFS_NAME, MODE_PRIVATE)
+            val before = prefs.getInt(PREF_HEAP_KILLS, 0)
+            val charged = heapKillsAfter(exitCode, overrideInEffect = true, current = before)
+            if (charged == before) return@withContext null
+            prefs.edit().putInt(PREF_HEAP_KILLS, charged).commit()
+            charged
+        } ?: return
         Logger.w(tag, "Server killed with a user heap ceiling in effect ($after of $HEAP_OVERRIDE_KILL_BUDGET)")
         if (heapOverrideSuspended(after)) {
             reportStartupNotice(getString(R.string.heap_override_suspended))

--- a/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
@@ -36,6 +36,11 @@ class FirstRunSetup(
     private val context: Context,
     private val assetBytes: Long = BuildConfig.EXTRACTED_ASSET_BYTES,
     private val largestAssetBytes: Long = BuildConfig.LARGEST_ASSET_BYTES,
+    // Injected for the reason the two above are, and it is not optional here: the
+    // credit for `usr/` is capped at this figure, so a test that leaves it at a
+    // build-time zero cannot make that credit non-zero at all, and every case
+    // exercising the gate would agree with every other whatever the gate did.
+    private val bundledUsrBytes: Long = BuildConfig.BUNDLED_USR_BYTES,
 ) {
     private val tag = "FirstRunSetup"
     private val prefs = context.getSharedPreferences("vscodroid_setup", Context.MODE_PRIVATE)
@@ -192,7 +197,7 @@ class FirstRunSetup(
             val installed = extractedTreeBytes +
                 sharedTreeCredit(
                     installedBytes = installedExtractionBytes(File(context.filesDir, "usr")),
-                    bundledBytes = BuildConfig.BUNDLED_USR_BYTES,
+                    bundledBytes = bundledUsrBytes,
                     foreignBytes = installedToolchainBytes(),
                 ) +
                 sharedTreeCredit(

--- a/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
@@ -2534,9 +2534,19 @@ claude() {
          *    there. So on a genuinely fresh install `installedBytes` is already
          *    above zero, the headroom fired, and the gate asked a device with
          *    nothing unpacked for 986 MB where 873 is what the unpack needs.
-         *    Only `server/` answers the question honestly, because nothing but
-         *    extraction writes there, and it is also where the biggest file lands
-         *    (`vscode-reh` extracts to `server/vscode-reh`).
+         *    `server/` answers it honestly, and it is also where the biggest file
+         *    lands (`vscode-reh` extracts to `server/vscode-reh`). Not because
+         *    extraction is the only thing that writes there, which is not true:
+         *    `setupCopilotAndroidAliases` writes an alias `package.json` under it
+         *    on every launch, and `setupRipgrepVscodeSymlink` makes directories
+         *    and a symlink. Because neither can put a counted byte there before
+         *    extraction has run, for two different reasons. The alias manifests
+         *    sit behind `if (linuxPkg.isDirectory)`, which is the extracted tree
+         *    itself; and the ripgrep repair writes only a directory and a link,
+         *    which [installedExtractionBytes] counts as nothing, with no copying
+         *    fallback if the link fails. Check both if either is edited: a repair
+         *    that starts writing a file into `server/` unconditionally puts this
+         *    gate back where it was.
          *  - [EXTRACTION_SLACK_BYTES], for what neither of those counts.
          *
          * Takes its figures rather than reading `BuildConfig`, so the decision can
@@ -3339,8 +3349,15 @@ private val ATOMIC_WRITE_LOCK = Any()
  *
  * Only `server/` is passed in, though extraction also fills `usr/` and the
  * bundled extensions, and the asymmetry is the design rather than an omission.
- * `server/` is 700 of the tree's 810 MiB and nothing but extraction writes
- * there, so every byte counted is a byte the next unpack genuinely writes over.
+ * `server/` is 700 of the tree's 810 MiB, and near enough every byte counted
+ * there is a byte the next unpack writes over. Near enough rather than all:
+ * `setupCopilotAndroidAliases` writes an alias `package.json` beside the
+ * packages it aliases, and those are counted here without extraction replacing
+ * them. That is a credit for bytes overwriting does not give back, so it asks
+ * for less space rather than more, which is the direction the paragraph below
+ * calls the worse one. They are kilobytes against 700 MiB and the slack absorbs
+ * them many times over, so they are left rather than filtered; a repair that
+ * ever writes something substantial there would have to be.
  * The other two are shared ground: toolchains install into `usr/`, Java is
  * 146 MB unpacked, `npm install -g` lands there too, and
  * `home/.vscodroid/extensions` fills with whatever the user takes from the

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
@@ -1034,6 +1034,29 @@ class ToolchainManager(private val context: Context) {
      * Runs entirely on ioExecutor. Fires onStateChange with AssetPackStatus constants.
      */
     private fun downloadViaHttp(packName: String, url: String, estimatedSize: Long) {
+        // Asked, not claimed, and the difference is the whole of why this is here.
+        //
+        // The claim that actually excludes a second install is taken where both
+        // delivery paths converge, in [installFromDirectory], because that is the
+        // one point every route into the shared tree passes through. But this path
+        // reaches it last: it downloads the archive and expands it first, so two
+        // managers installing the same pack each spend a whole download and a
+        // whole extraction before one of them declines, on a device whose
+        // pre-flight reserved for one of them. Rotating the toolchain screen
+        // mid-download is enough to arrange it.
+        //
+        // A second claim here would be worse than the waste: it is the same key,
+        // so the install that owns it would meet its own claim further down and
+        // refuse itself. Reading the set instead cannot do that, and it cannot
+        // make anything worse either. If two callers both read it as free they
+        // proceed exactly as they do today and the real claim still decides; what
+        // this catches is the ordinary case, where one is already well into the
+        // copy by the time the other starts.
+        if (packName in installsInFlight) {
+            Logger.i(tag, "Another install already holds $packName; not downloading it again")
+            report(packName, AssetPackStatus.UNKNOWN, 0)
+            return
+        }
         // Published before the task is queued rather than reset once it starts.
         // A cancellation can arrive while this pack is still waiting behind
         // another one, and it has to survive the wait: resetting at task start

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
@@ -1515,7 +1515,7 @@ class SafSyncEngine(private val context: Context) {
      * Creates everything under [localDir] on the device, beneath [dirSafUri].
      *
      * Iterative rather than recursive through [createInSaf], and that is deliberate:
-     * [uploadableEntries] already returns parents before children, so each entry's
+     * [uploadPlan] already returns parents before children, so each entry's
      * parent document exists by the time it is reached, and the URI of every
      * directory created along the way is remembered here. Recursing instead would
      * re-query the provider for a parent it had just made.
@@ -2524,17 +2524,6 @@ class SafSyncEngine(private val context: Context) {
             return UploadPlan(if (truncated) found.take(limit) else found, truncated)
         }
 
-        /**
-         * The entries [uploadPlan] found, for a caller with no use for its answer about
-         * truncation.
-         *
-         * Separate because the two questions have separate consequences: the list
-         * decides what is created on the device, while the flag decides whether the user
-         * is told the copy came out short, and deriving the second from the first is the
-         * mistake [UploadPlan] exists to prevent.
-         */
-        internal fun uploadableEntries(root: File, limit: Int): List<File> =
-            uploadPlan(root, limit).entries
 
         /**
          * Whether [file] is a symbolic link, without following it.
@@ -2568,7 +2557,7 @@ class SafSyncEngine(private val context: Context) {
          * ones, which is where a person edits, rather than on wherever a depth-first
          * descent happened to reach first.
          *
-         * Symbolic links are not followed, for the same reason [uploadableEntries]
+         * Symbolic links are not followed, for the same reason [uploadPlan]
          * refuses them and with the same words: a mirror is routinely a checked-out
          * repository, so a link inside one is attacker-supplied in the ordinary
          * case, and inotify follows a symlinked path. Watching through one spends

--- a/android/app/src/main/kotlin/com/vscodroid/webview/VSCodroidWebViewClient.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/webview/VSCodroidWebViewClient.kt
@@ -364,6 +364,21 @@ internal fun tlsHostLabel(url: String?): String? {
 internal const val MAX_TLS_FAILURES_ANNOUNCED = 8
 
 /**
+ * How long the record goes on refusing once it is past the cap.
+ *
+ * A hard cap bounds the messages and never lets go, which is the wrong trade for
+ * a channel that is only ever advice: the page is refused by `handler.cancel()`
+ * before any of this runs, so what a muted notice costs is the explanation, and a
+ * session here is a working day rather than a page view. Eight is generous for one
+ * burst and mean for a day, so past it the record keeps refusing only until the
+ * failures stop arriving in a burst. The interval is the one the write-back notice
+ * already uses, and for the same reason: it is long enough that a wall of toasts
+ * cannot form and short enough that a fault the user has just walked into is still
+ * explained.
+ */
+internal const val TLS_NOTICE_INTERVAL_MS = 30_000L
+
+/**
  * The refusal worth putting on screen, or null when it has been said already.
  *
  * The same rule `reasonToAnnounce` applies to a failed toolchain download, for the
@@ -391,9 +406,22 @@ internal const val MAX_TLS_FAILURES_ANNOUNCED = 8
 internal fun tlsFailureToAnnounce(
     failure: TlsFailure,
     alreadySaid: MutableSet<TlsFailure>,
+    now: Long,
+    lastAnnouncedAt: Long,
 ): TlsFailure? {
-    if (alreadySaid.size >= MAX_TLS_FAILURES_ANNOUNCED) return null
-    return if (alreadySaid.add(failure)) failure else null
+    if (failure in alreadySaid) return null
+    if (alreadySaid.size >= MAX_TLS_FAILURES_ANNOUNCED) {
+        // Past the cap, and the two bounds part company here. The record must stay
+        // bounded, because a remote page picks the hostnames that fill it; the
+        // messages must stay bounded, because each one holds the screen. Refusing
+        // until the burst has stopped answers both, and clearing only then means the
+        // set is emptied at most once per interval rather than once per fresh host,
+        // which is what let a page hand back the names it had already spent.
+        if (now - lastAnnouncedAt < TLS_NOTICE_INTERVAL_MS) return null
+        alreadySaid.clear()
+    }
+    alreadySaid.add(failure)
+    return failure
 }
 
 /**

--- a/android/app/src/main/res/layout/item_toolchain_card.xml
+++ b/android/app/src/main/res/layout/item_toolchain_card.xml
@@ -124,7 +124,8 @@
             android:max="100"
             android:progressTint="@color/colorPrimary"
             android:visibility="gone"
-            app:layout_constraintEnd_toEndOf="parent"
+            android:layout_marginEnd="8dp"
+            app:layout_constraintEnd_toStartOf="@+id/actionButton"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/toolchainSize" />
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -160,6 +160,10 @@
     <string name="toolchain_failed_digest">The download did not match what the release published. Try again.</string>
     <string name="toolchain_failed_corrupt">The download was incomplete. Try again.</string>
     <string name="toolchain_failed_play">Play delivers this toolchain only to apps it installed. Install from the Play Store and try again.</string>
+    <!-- Shown when a second install of the same toolchain is declined because one is
+         already running. Not a failure: the toolchain is on its way in, by the install
+         that got there first, and the only thing the user needs is to stop tapping. -->
+    <string name="toolchain_already_installing">That toolchain is already being installed.</string>
     <string name="toolchain_failed_internal">Install failed. The app log has the details.</string>
     <string name="progress_cancel">Cancel</string>
     <string name="progress_retry">Retry</string>

--- a/android/app/src/test/kotlin/com/vscodroid/service/NodeServiceTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/service/NodeServiceTest.kt
@@ -810,6 +810,38 @@ class HeapLatchCallSiteTest {
         )
     }
 
+    /**
+     * The write has to outlive the cancellation of the scope that reaches it.
+     *
+     * The charge runs in the service's own scope, which onDestroy cancels, and it
+     * suspends on its way to the preference file. A crash arriving while the
+     * service is being torn down could otherwise reach the read and never reach
+     * the write, and what is lost is not work a cancelled caller stopped wanting:
+     * it is the record of a death that has already happened. A ceiling that kills
+     * the server every time would go uncharged for the last of those kills and so
+     * would never be suspended.
+     *
+     * Read off the source because the alternative is racing a teardown against a
+     * crash, which would be a test that passes on a fast machine.
+     */
+    @Test
+    fun `the charge survives the scope being cancelled`() {
+        val body = nodeService.readText()
+            .substringAfter("private suspend fun chargeHeapOverride")
+            .substringBefore("\n    }")
+        assertTrue(
+            body.contains("PREF_HEAP_KILLS"),
+            "chargeHeapOverride no longer writes the count, so this guard is reading " +
+                "the wrong method and would pass whatever the write does",
+        )
+        assertTrue(
+            Regex("""(?m)^\s*val \w+ = withContext\(NonCancellable""").containsMatchIn(body),
+            "the charge suspends on its way to the preference file without " +
+                "NonCancellable, so a teardown landing mid-charge drops the count " +
+                "the suspension budget is made of",
+        )
+    }
+
     @Test
     fun `the count is committed rather than deferred`() {
         // apply() is the idiomatic choice everywhere else and is wrong here. The

--- a/android/app/src/test/kotlin/com/vscodroid/setup/StoragePreflightTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/StoragePreflightTest.kt
@@ -72,6 +72,9 @@ class StoragePreflightTest {
     private val assetBytes = 8 * mb
     private val largestAssetBytes = 2 * mb
 
+    /** The cap on the `usr/` credit. Non-zero, or that credit cannot be exercised. */
+    private val bundledUsrBytes = 4 * mb
+
     /**
      * The slack the gate adds, read out of the decision rather than repeated
      * here: it is private, and a copy of it would go stale the moment it moved.
@@ -133,7 +136,7 @@ class StoragePreflightTest {
     }
 
     private fun setup(free: Long, previousVersionCode: Int = 11) =
-        FirstRunSetup(context(free, previousVersionCode), assetBytes, largestAssetBytes)
+        FirstRunSetup(context(free, previousVersionCode), assetBytes, largestAssetBytes, bundledUsrBytes)
 
     /**
      * Writes [bytes] of server tree, spread over a few files so the walk has
@@ -357,6 +360,36 @@ class StoragePreflightTest {
             result,
             "an install already holding the tree was told to free the size of the tree again, " +
                 "which is the state no Retry can reach and no in-app cleanup can fix",
+        )
+    }
+
+    /**
+     * The gate itself, on the state a real fresh install is actually in.
+     *
+     * The arithmetic is pinned elsewhere, but the defect this closes lived at the
+     * call site: the headroom was decided from the whole credit, and SplashActivity
+     * writes into `usr/` before the gate is ever reached, so a device with nothing
+     * unpacked was charged for a rewrite it was not about to do. Every other case
+     * here leaves `usr/` empty, so passing the credit again instead of the
+     * extracted tree would satisfy all of them.
+     *
+     * Sized so the two answers differ: enough room for the tree and the slack, not
+     * enough for the rewrite headroom on top.
+     */
+    @Test
+    fun `a fresh install is not charged the headroom for a file the repairs left in usr`() {
+        File(filesDir, "usr/etc/tls").mkdirs()
+        File(filesDir, "usr/etc/tls/cert.pem").writeText("a repair wrote this before the gate ran")
+
+        val result = runBlocking {
+            setup(free = assetBytes + slack, previousVersionCode = 0).runSetup()
+        }
+
+        assertNotEquals(
+            FirstRunSetup.SetupResult.LOW_STORAGE,
+            result,
+            "a device with room for the whole tree was refused because a launch-time " +
+                "repair had left a file in usr/, which the rewrite headroom must not read",
         )
     }
 

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafUploadPlanTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafUploadPlanTest.kt
@@ -9,7 +9,7 @@ import java.io.File
 import java.nio.file.Files
 
 /**
- * Tests for [SafSyncEngine.uploadableEntries], which decides what gets created on the
+ * Tests for [SafSyncEngine.uploadPlan], which decides what gets created on the
  * device when a directory appears in the mirror.
  *
  * The case that matters is a rename. inotify reports it as MOVED_FROM on the old name
@@ -39,7 +39,7 @@ class SafUploadPlanTest {
         val root = File(tmp, "helpers").apply { mkdirs() }
         tree(root)
 
-        val names = SafSyncEngine.uploadableEntries(root, limit = 1000)
+        val names = SafSyncEngine.uploadPlan(root, limit = 1000).entries
             .map { it.relativeTo(root).path }
 
         // Every file that existed under the old name has to be created under the new
@@ -59,7 +59,7 @@ class SafUploadPlanTest {
         val root = File(tmp, "helpers").apply { mkdirs() }
         tree(root)
 
-        val names = SafSyncEngine.uploadableEntries(root, limit = 1000)
+        val names = SafSyncEngine.uploadPlan(root, limit = 1000).entries
             .map { it.relativeTo(root).path }
 
         // A document cannot be created before the directory that holds it exists, so
@@ -80,7 +80,7 @@ class SafUploadPlanTest {
         File(root, "node_modules/left-pad/index.js").writeText("x")
         File(root, "keep.txt").writeText("k")
 
-        val names = SafSyncEngine.uploadableEntries(root, limit = 1000)
+        val names = SafSyncEngine.uploadPlan(root, limit = 1000).entries
             .map { it.relativeTo(root).path }
 
         assertTrue(names.contains("keep.txt"))
@@ -96,7 +96,7 @@ class SafUploadPlanTest {
         File(root, "own.txt").writeText("o")
         Files.createSymbolicLink(File(root, "escape").toPath(), outside.toPath())
 
-        val names = SafSyncEngine.uploadableEntries(root, limit = 1000)
+        val names = SafSyncEngine.uploadPlan(root, limit = 1000).entries
             .map { it.relativeTo(root).path }
 
         assertTrue(names.contains("own.txt"))
@@ -114,7 +114,7 @@ class SafUploadPlanTest {
         File(root, "deep").mkdirs()
         repeat(20) { File(root, "deep/f$it.txt").writeText("$it") }
 
-        val names = SafSyncEngine.uploadableEntries(root, limit = 3)
+        val names = SafSyncEngine.uploadPlan(root, limit = 3).entries
             .map { it.relativeTo(root).path }
 
         assertEquals(3, names.size)
@@ -172,7 +172,7 @@ class SafUploadPlanTest {
         File(root, "session.tmp").writeText("x")
         File(root, "copy.vscodroid-partial").writeText("x")
 
-        val names = SafSyncEngine.uploadableEntries(root, limit = 1000)
+        val names = SafSyncEngine.uploadPlan(root, limit = 1000).entries
             .map { it.name }
 
         assertTrue(names.contains("real.kt"), "the real file must still go: $names")
@@ -198,7 +198,7 @@ class SafUploadPlanTest {
 
         assertTrue(link.isDirectory, "fixture check: the link does look like a directory")
         assertTrue(
-            SafSyncEngine.uploadableEntries(link, limit = 1000).isEmpty(),
+            SafSyncEngine.uploadPlan(link, limit = 1000).entries.isEmpty(),
             "a symlinked root must not be walked; its target is outside the folder " +
                 "the user granted",
         )
@@ -207,8 +207,8 @@ class SafUploadPlanTest {
     @Test
     fun `a file, a missing directory and a zero cap all yield nothing`(@TempDir tmp: File) {
         val file = File(tmp, "plain.txt").apply { writeText("x") }
-        assertTrue(SafSyncEngine.uploadableEntries(file, 1000).isEmpty())
-        assertTrue(SafSyncEngine.uploadableEntries(File(tmp, "gone"), 1000).isEmpty())
-        assertTrue(SafSyncEngine.uploadableEntries(tmp, 0).isEmpty())
+        assertTrue(SafSyncEngine.uploadPlan(file, 1000).entries.isEmpty())
+        assertTrue(SafSyncEngine.uploadPlan(File(tmp, "gone"), 1000).entries.isEmpty())
+        assertTrue(SafSyncEngine.uploadPlan(tmp, 0).entries.isEmpty())
     }
 }

--- a/android/app/src/test/kotlin/com/vscodroid/webview/TlsFailureNoticeTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/TlsFailureNoticeTest.kt
@@ -210,9 +210,9 @@ class TlsFailureNoticeTest {
         val said = mutableSetOf<TlsFailure>()
         val failure = TlsFailure("dev.example.com", TlsFailureReason.UNTRUSTED)
 
-        assertEquals(failure, tlsFailureToAnnounce(failure, said))
+        assertEquals(failure, tlsFailureToAnnounce(failure, said, now = 0L, lastAnnouncedAt = 0L))
         assertNull(
-            tlsFailureToAnnounce(failure, said),
+            tlsFailureToAnnounce(failure, said, now = 0L, lastAnnouncedAt = 0L),
             "a second image from the same host adds nothing the user can act on",
         )
     }
@@ -226,16 +226,16 @@ class TlsFailureNoticeTest {
     @Test
     fun `a different host or a different reason is still announced`() {
         val said = mutableSetOf<TlsFailure>()
-        tlsFailureToAnnounce(TlsFailure("dev.example.com", TlsFailureReason.UNTRUSTED), said)
+        tlsFailureToAnnounce(TlsFailure("dev.example.com", TlsFailureReason.UNTRUSTED), said, now = 0L, lastAnnouncedAt = 0L)
 
         assertEquals(
             TlsFailure("other.example.com", TlsFailureReason.UNTRUSTED),
-            tlsFailureToAnnounce(TlsFailure("other.example.com", TlsFailureReason.UNTRUSTED), said),
+            tlsFailureToAnnounce(TlsFailure("other.example.com", TlsFailureReason.UNTRUSTED), said, now = 0L, lastAnnouncedAt = 0L),
             "a different host is a fact the user has not been told",
         )
         assertEquals(
             TlsFailure("dev.example.com", TlsFailureReason.DATE),
-            tlsFailureToAnnounce(TlsFailure("dev.example.com", TlsFailureReason.DATE), said),
+            tlsFailureToAnnounce(TlsFailure("dev.example.com", TlsFailureReason.DATE), said, now = 0L, lastAnnouncedAt = 0L),
             "the same host failing a different way needs a different answer from the reader",
         )
     }
@@ -260,7 +260,7 @@ class TlsFailureNoticeTest {
 
         for (i in 0 until MAX_TLS_FAILURES_ANNOUNCED * 4) {
             tlsFailureToAnnounce(
-                TlsFailure("host$i.example.com", TlsFailureReason.UNTRUSTED), said,
+                TlsFailure("host$i.example.com", TlsFailureReason.UNTRUSTED), said, now = 0L, lastAnnouncedAt = 0L,
             )?.let { shown += it }
         }
 
@@ -275,13 +275,52 @@ class TlsFailureNoticeTest {
                 "count above a cap rather than a mute that started somewhere else",
         )
         assertNull(
-            tlsFailureToAnnounce(first, said),
+            tlsFailureToAnnounce(first, said, now = 0L, lastAnnouncedAt = 0L),
             "a host already announced was announced a second time, so the record was " +
                 "forgotten rather than closed",
         )
         assertTrue(
             said.size <= MAX_TLS_FAILURES_ANNOUNCED,
             "the record grew past the cap on hosts a remote page chooses: ${said.size}",
+        )
+    }
+
+    /**
+     * The reason the cap became an interval, and the property a hard cap did not have.
+     *
+     * The page is refused by `handler.cancel()` before any of this runs, so a notice
+     * nobody sees costs the explanation and not the protection. But a session here is
+     * a working day, not a page view, and eight is a number a developer with a few
+     * internal hosts reaches without anything hostile happening. A cap that never let
+     * go would leave the rest of that day silent, including the certificate fault the
+     * user walks into an hour later.
+     */
+    @Test
+    fun `a new fault after the burst has passed is still announced`() {
+        val said = mutableSetOf<TlsFailure>()
+        var last = 0L
+        for (i in 0 until MAX_TLS_FAILURES_ANNOUNCED * 4) {
+            tlsFailureToAnnounce(
+                TlsFailure("host$i.example.com", TlsFailureReason.UNTRUSTED),
+                said, now = 0L, lastAnnouncedAt = last,
+            )?.let { last = 0L }
+        }
+        val later = TlsFailure("much-later.example.com", TlsFailureReason.UNTRUSTED)
+
+        assertNull(
+            tlsFailureToAnnounce(later, said, now = 0L, lastAnnouncedAt = 0L),
+            "the burst is still arriving, so this is the wall of toasts the record exists " +
+                "to stop and the case below would prove nothing",
+        )
+        assertEquals(
+            later,
+            tlsFailureToAnnounce(later, said, now = TLS_NOTICE_INTERVAL_MS, lastAnnouncedAt = 0L),
+            "a fault met after the burst had passed was never explained, because the " +
+                "record had spent its budget on hosts a page chose",
+        )
+        assertTrue(
+            said.size <= MAX_TLS_FAILURES_ANNOUNCED,
+            "letting go of the budget also let go of the bound on the record: ${said.size}",
         )
     }
 


### PR DESCRIPTION
Seven changes closing the follow-ups, three of which are consequences of earlier
changes in this series rather than of code that was already there.

## A write that could be cancelled

Moving the heap-kill charge off the main dispatcher gave it two cancellation
points, and the scope it runs in is cancelled in onDestroy. A crash arriving as
the service is torn down could reach the read and never reach the write. What is
lost is the record of a death that already happened, so a ceiling that kills the
server every time goes uncharged for the last of those kills and is never
suspended. The read, the decision and the write are one NonCancellable block now.
The early return is kept: every exit that is not the kill being charged for
leaves the count alone, and without it the log line and the notice would fire on
ordinary crashes.

## Two bounds that were really one

The certificate notice was bounded by count, which stopped a page burying the
editor and left the channel silent for the rest of the session once the count was
spent. A session here is a working day, and eight is a number a developer with a
few internal hosts reaches without anything hostile happening. Past the cap the
record now refuses only until the failures stop arriving in a burst, on the
interval the write-back notice already uses. The record is cleared at most once
per interval rather than once per fresh host, so it stays bounded and a page
cannot hand back names it has already spent.

Resetting on a main-frame navigation was the other candidate. There is one
loadUrl in the app and the workbench switches folders through it, so an editing
session has almost no navigations and the budget would never come back.

## Toolchain installs

The claim that excludes a second install sits where both delivery paths converge,
which is right, but the HTTP path reaches it after downloading and expanding the
archive: two managers installing the same pack each spend a whole download and a
whole extraction before one declines. That path now reads the claim before it
starts. Reading, not claiming, because a second claim on the same key would meet
itself further down and refuse the install that owns it.

A declined install also reported a status the card cannot draw, so a tap got no
answer and a second tap got the same silence. The screen says the install is
already running.

## Smaller

The storage gate is pinned at the call site, not only at the arithmetic, since
that is where the defect lived. It could not have worked as written: the usr/
credit is capped at a figure a test cannot set, so it was always zero and the case
agreed with itself whatever the gate did. That figure is now injected the way the
other two already are.

The upload walk's second entry point had no production caller and the one caller's
documentation still named it. The toolchain card's progress bar is constrained to
end where the action button begins, which the badge already was and it was not.

And the comment claiming nothing but extraction writes under server/ now says what
actually makes that measurement reliable, because two repairs do write there.

## Verification

- 1493 unit tests, no failures, no skips. Lint 0 errors. Every no-argument gate passes.
- Each new or changed guard was proved to bite by mutating the code it guards in a
  throwaway worktree, including the two that did not bite when first written.
