### PR TITLE
test: harden source-text guards against disabled code

### DIFF
--- a/android/app/src/test/kotlin/com/vscodroid/MemoryPressureTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/MemoryPressureTest.kt
@@ -183,6 +183,29 @@ class ProcessWideMemoryPressureTest {
     private val source = File("src/main/kotlin/com/vscodroid/VSCodroidApp.kt")
     private val manifest = File("src/main/AndroidManifest.xml")
 
+    /**
+     * Both source-reading cases below ask whether something is still WRITTEN in a
+     * file, and a plain search answers yes just as readily from a line someone
+     * disabled while debugging and did not put back, which is the regression they
+     * exist to catch, so the comments come out first.
+     *
+     * Which forms are stripped follows how a line is actually disabled. An editor
+     * wraps the selected statement in a block comment, so that form goes first and
+     * across lines; a developer typing it out puts `//` in front, which the line
+     * filter takes afterwards. Only a leading `//` is dropped: a trailing one
+     * cannot disable the code it sits behind, and dropping the whole line would
+     * lose that code.
+     */
+    private fun kotlinWithoutComments(file: File): List<String> =
+        file.readText()
+            .replace(Regex("""/\*.*?\*/""", RegexOption.DOT_MATCHES_ALL), "")
+            .lines()
+            .filterNot { it.trimStart().startsWith("//") }
+
+    /** The same, for the one comment form XML has. */
+    private fun xmlWithoutComments(file: File): String =
+        file.readText().replace(Regex("<!--.*?-->", RegexOption.DOT_MATCHES_ALL), "")
+
     @Test
     fun `the manifest points the process at this class`() {
         check(manifest.isFile) {
@@ -196,8 +219,13 @@ class ProcessWideMemoryPressureTest {
         // one in the tree restores the defect exactly: the process again has no
         // writer once the Activity is gone, and the two tests below stay green
         // because the class still declares the override and still calls out.
+        // Comments are taken out first. XML has no way to disable one attribute,
+        // so swapping the application class means commenting out the whole
+        // <application> element and writing another beside it. The commented-out
+        // one still holds this exact text, which is what a raw search would go on
+        // finding long after nothing read it.
         assertTrue(
-            manifest.readText().contains("android:name=\".VSCodroidApp\""),
+            xmlWithoutComments(manifest).contains("android:name=\".VSCodroidApp\""),
             "the process reports pressure through whichever class <application> names; " +
                 "VSCodroidApp is not that class, so its override is never called"
         )
@@ -219,13 +247,21 @@ class ProcessWideMemoryPressureTest {
                 "otherwise pass by looking at nothing"
         }
 
-        val body = source.readLines()
+        val body = kotlinWithoutComments(source)
             .dropWhile { !it.contains("override fun onTrimMemory(") }
             .drop(1)
             .takeWhile { !it.startsWith("    }") }
-            .filterNot { it.trimStart().startsWith("//") }
             .joinToString(" ")
             .replace(Regex("\\s+"), " ")
+
+        // Says which of the two ways this can fail happened. An override that was
+        // commented out leaves nothing to search, and "the call is not in an empty
+        // string" is a true but useless thing for a failure to report.
+        assertTrue(
+            body.isNotBlank(),
+            "${source.name} has no live onTrimMemory body, so nothing reports pressure " +
+                "for the process once the Activity is gone"
+        )
 
         // The whole call, not just the name: the directory has to be the one
         // process-monitor.js resolves TMPDIR to, and the level has to arrive

--- a/android/app/src/test/kotlin/com/vscodroid/MirrorReclaimWiringTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/MirrorReclaimWiringTest.kt
@@ -56,9 +56,28 @@ class MirrorReclaimWiringTest {
         error("Unbalanced braces after `private fun $name(`.")
     }
 
+    /**
+     * [body] with its comments blanked, so a name that survives only in prose or
+     * in a call somebody switched off cannot answer for a live one.
+     *
+     * Not optional here. Commenting a line out is how a call gets disabled while
+     * something is being debugged, and it leaves every character of that call in
+     * the file; the guard below asks whether a name is present, and raw text
+     * answers yes for the disabled call exactly as it does for the live one. The
+     * body it reads also explains the guard in prose, so the names are in reach
+     * of a search twice over.
+     *
+     * Applied to the extracted body rather than to the whole file: [methodBody]
+     * counts braces raw, and blanking a `//` inside a string literal elsewhere in
+     * this activity would take its closing brace with it and truncate the span.
+     */
+    private fun code(body: String) = body
+        .replace(Regex("""/\*.*?\*/""", RegexOption.DOT_MATCHES_ALL), " ")
+        .replace(Regex("""//[^\n]*"""), " ")
+
     @Test
     fun `the removal guard is given every piece of state that decides it`() {
-        val body = methodBody("removeDeviceFolderCopy")
+        val body = code(methodBody("removeDeviceFolderCopy"))
 
         val missing = listOf(
             "watchedSafFolder",
@@ -190,7 +209,12 @@ class MirrorReclaimWiringTest {
                 "truncates the device document at open.",
         )
 
-        assertTrue(begin.contains("mirrorsWatchedThisProcess.add")) {
+        // Anchored at the start of a line, for the reason `code()` exists: a
+        // recording that has been commented out leaves its own text behind, and a
+        // substring search reads the disabled line as the live one. The call is a
+        // statement of its own in `beginWatching`, so the anchor matches what is
+        // written today and refuses the same line behind a `//`.
+        assertTrue(Regex("""(?m)^\s*mirrorsWatchedThisProcess\.add\(""").containsMatchIn(begin)) {
             "beginWatching no longer records the mirror, so the record is empty and the " +
                 "guard's widest check passes everything"
         }

--- a/android/app/src/test/kotlin/com/vscodroid/SyncFailureNoticeTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/SyncFailureNoticeTest.kt
@@ -62,6 +62,20 @@ class SyncFailureNoticeTest {
         error("Unbalanced braces after `private fun $name(`.")
     }
 
+    /**
+     * Is the occurrence at [at] one the compiler sees?
+     *
+     * A `//` earlier on the same line makes it text rather than a call, and a
+     * doc-comment continuation makes it prose. Both read identically to a search over
+     * raw source, so without this the count below is satisfied by call sites that no
+     * longer run, and the sentence they pass is checked in dead text while the live
+     * path goes unread.
+     */
+    private fun liveAt(source: String, at: Int): Boolean {
+        val before = source.substring(source.lastIndexOf('\n', at) + 1, at)
+        return "//" !in before && !before.trimStart().startsWith("*")
+    }
+
     /** Each call's argument list, from its parenthesis to the one that closes it. */
     private fun callArguments(name: String): List<String> {
         val source = mainActivity.readText()
@@ -72,7 +86,7 @@ class SyncFailureNoticeTest {
             // The declaration wears the same spelling as a call and is not one.
             val declaredHere = from >= declaration.length &&
                 source.startsWith(declaration + name + "(", from - declaration.length)
-            if (!declaredHere) {
+            if (!declaredHere && liveAt(source, from)) {
                 val open = source.indexOf('(', from)
                 var depth = 0
                 for (i in open until source.length) {
@@ -114,14 +128,22 @@ class SyncFailureNoticeTest {
         )
     }
 
-    /** The cause half, which each caller supplies. */
+    /**
+     * The cause half, which each caller supplies.
+     *
+     * The count is the guard against this passing vacuously: with no call sites found,
+     * there are no arguments to check and the claim below is green over nothing. It
+     * counts only sites the compiler sees, so a site that has been commented out fails
+     * it rather than standing in for the live one it replaced.
+     */
     @Test
     fun `the cause of a folder that did not open comes from a resource`() {
         val calls = callArguments("reportSyncFailure")
 
         assertTrue(calls.size >= 2) {
-            "found ${calls.size} calls to reportSyncFailure, and the sync has two ways " +
-                "to fail, so this is not reading the call sites"
+            "found ${calls.size} live calls to reportSyncFailure, and the sync has two " +
+                "ways to fail, so either this is not reading the call sites or one of " +
+                "them no longer runs and that failure now reaches nobody"
         }
         assertEquals(
             emptyList<String>(), calls.flatMap { prose(it) },

--- a/android/app/src/test/kotlin/com/vscodroid/bridge/PageSuppliedLoggingTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/bridge/PageSuppliedLoggingTest.kt
@@ -39,7 +39,66 @@ class PageSuppliedLoggingTest {
             bridge.isFile,
             "${bridge.absolutePath} is missing; this test would otherwise pass by reading nothing",
         )
-        return bridge.readText().split("@JavascriptInterface").drop(1)
+        return stripComments(bridge.readText()).split("@JavascriptInterface").drop(1)
+    }
+
+    /**
+     * [source] with its comments removed and its line structure kept.
+     *
+     * Everything below reads statements as text, and text a compiler never sees
+     * answers those questions just as readily as code does. Two of them turn on
+     * it. A trailing `// redactToken(uri)` beside a live `Logger.i(tag, "…$uri")`
+     * sits inside the span [statementFrom] returns, so it answers the redaction
+     * question for the call it is written next to, and a redaction taken off
+     * while debugging, the one shape this class exists to catch, stops being
+     * reported. The other is the vacuity counter: a commented-out `Logger` call
+     * is counted as one examined, so a file whose live log lines had all been
+     * disabled would still report that the scan looked at something.
+     *
+     * Newlines are kept, because [statementFrom] ends a statement on one and a
+     * comment removed together with its line break would join the statement above
+     * it to the one below.
+     *
+     * String literals are stepped over, raw strings included, so that a `//`
+     * inside a message or a URL does not read as the start of a comment and take
+     * the rest of the call with it. Character literals are not handled and this
+     * file has none.
+     */
+    private fun stripComments(source: String): String {
+        val out = StringBuilder()
+        var i = 0
+        while (i < source.length) {
+            when {
+                source.startsWith("\"\"\"", i) -> {
+                    val end = source.indexOf("\"\"\"", i + 3)
+                    val stop = if (end < 0) source.length else end + 3
+                    out.append(source, i, stop)
+                    i = stop
+                }
+                source[i] == '"' -> {
+                    var j = i + 1
+                    while (j < source.length && source[j] != '"' && source[j] != '\n') {
+                        if (source[j] == '\\') j++
+                        j++
+                    }
+                    val stop = (if (j < source.length && source[j] == '"') j + 1 else j)
+                        .coerceAtMost(source.length)
+                    out.append(source, i, stop)
+                    i = stop
+                }
+                source.startsWith("//", i) -> {
+                    while (i < source.length && source[i] != '\n') i++
+                }
+                source.startsWith("/*", i) -> {
+                    val end = source.indexOf("*/", i + 2)
+                    val stop = if (end < 0) source.length else end + 2
+                    for (k in i until stop) if (source[k] == '\n') out.append('\n')
+                    i = stop
+                }
+                else -> out.append(source[i++])
+            }
+        }
+        return out.toString()
     }
 
     /**
@@ -90,7 +149,7 @@ class PageSuppliedLoggingTest {
     private fun scan(source: String): Scan {
         val offenders = mutableListOf<String>()
         var examined = 0
-        for (chunk in source.split("@JavascriptInterface").drop(1)) {
+        for (chunk in stripComments(source).split("@JavascriptInterface").drop(1)) {
             val signature = Regex("""fun\s+(\w+)\s*\(([^)]*)\)""").find(chunk) ?: continue
             val name = signature.groupValues[1]
             // authToken is the session token the page already holds, and it is never
@@ -286,6 +345,93 @@ class PageSuppliedLoggingTest {
         assertTrue(
             result.offenders.isEmpty(),
             "the shape this class exists to ask for was reported as an offence: ${result.offenders}",
+        )
+    }
+
+    /**
+     * The scanner against a redaction that is only written in a comment.
+     *
+     * The span [statementFrom] returns runs to the end of the line the call
+     * closes on, so a trailing comment is part of the text every question below
+     * is asked of. `redactToken(uriString)` written there answers the redaction
+     * question for a call that does not make it, and the answer is the wrong one:
+     * this is what taking a redaction off and leaving a note about it looks like,
+     * which is the exact shape the class exists to report.
+     */
+    @Test
+    fun `a redaction named only in a comment does not answer for the call`() {
+        val fixture = """
+            @JavascriptInterface
+            fun openThing(uriString: String, authToken: String) {
+                Logger.i(tag, "Opening ${'$'}uriString") // redactToken(uriString)
+            }
+        """.trimIndent()
+
+        val result = scan(fixture)
+
+        assertEquals(1, result.examined, "the live call was not examined at all")
+        assertTrue(
+            result.offenders.any { it.contains("uriString") },
+            "a comment beside the call answered the redaction question for it: ${result.offenders}",
+        )
+    }
+
+    /**
+     * What the vacuity counter is allowed to count.
+     *
+     * `examined > 0` is the only thing standing between this class and reporting
+     * clean over a file it read nothing out of, and a counter that includes
+     * disabled calls reports coverage of exactly the lines that are no longer
+     * there. Both spellings, because commenting a line out and commenting a block
+     * out are the same act.
+     */
+    @Test
+    fun `a log call that is commented out is not counted as one`() {
+        val fixture = """
+            @JavascriptInterface
+            fun openThing(uriString: String, authToken: String) {
+                // Logger.i(tag, "Opening ${'$'}uriString")
+                /* Logger.w(tag, "Opening ${'$'}uriString") */
+                onOpen(uriString)
+            }
+        """.trimIndent()
+
+        val result = scan(fixture)
+
+        assertEquals(
+            0, result.examined,
+            "a disabled log call was counted as one the scan had looked at",
+        )
+        assertTrue(
+            result.offenders.isEmpty(),
+            "a disabled log call was reported as a leak: ${result.offenders}",
+        )
+    }
+
+    /**
+     * The control for dropping comments, and the reason it cannot be done on text
+     * alone.
+     *
+     * Two slashes are ordinary inside a message: any URL has them. Cutting at the
+     * first pair without knowing a literal was open would end this call at
+     * `http:`, and both the value and the closing quote would be gone before
+     * anything was asked about them.
+     */
+    @Test
+    fun `a slash pair inside a message does not hide the rest of the call`() {
+        val fixture = """
+            @JavascriptInterface
+            fun openThing(uriString: String, authToken: String) {
+                Logger.w(tag, "Opening http://example.com from ${'$'}uriString")
+            }
+        """.trimIndent()
+
+        val result = scan(fixture)
+
+        assertEquals(1, result.examined, "the call was lost with the message it carries")
+        assertTrue(
+            result.offenders.any { it.contains("uriString") },
+            "a URL in the message hid the value beside it: ${result.offenders}",
         )
     }
 

--- a/android/app/src/test/kotlin/com/vscodroid/keyboard/KeyRowAccessibilityTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/keyboard/KeyRowAccessibilityTest.kt
@@ -43,12 +43,36 @@ class KeyRowAccessibilityTest {
         return file.readText()
     }
 
-    /** Source with comment lines dropped, so prose naming a call is not a call. */
-    private fun code(name: String): List<String> =
-        source(name).lines().filterNot {
-            val start = it.trimStart()
-            start.startsWith("//") || start.startsWith("*") || start.startsWith("/*")
+    /**
+     * Source with comment lines dropped, so prose naming a call is not a call.
+     *
+     * Both forms, because both switch code off. A line comment carries its own
+     * marker and is recognised one line at a time; a block opened at the start
+     * of a line leaves its inner lines unmarked, so the block is tracked to its
+     * close instead. Without that, wrapping a registration in one left every
+     * case below green over a view that registers nothing.
+     *
+     * A line that both opens and closes a block goes with it, whatever else it
+     * carries. Nothing in this package writes one, and the cost of being wrong
+     * about that is a red case quoting the window it read.
+     */
+    private fun code(name: String): List<String> {
+        var inBlock = false
+        return source(name).lines().filterNot { line ->
+            val start = line.trimStart()
+            when {
+                inBlock -> {
+                    if (line.indexOf("*/") >= 0) inBlock = false
+                    true
+                }
+                start.startsWith("/*") -> {
+                    if (line.indexOf("*/", line.indexOf("/*") + 2) < 0) inBlock = true
+                    true
+                }
+                else -> start.startsWith("//") || start.startsWith("*")
+            }
         }
+    }
 
     @Nested
     inner class TrackpadArrowActions {

--- a/android/app/src/test/kotlin/com/vscodroid/service/AdoptionNoteWireTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/service/AdoptionNoteWireTest.kt
@@ -1,6 +1,7 @@
 package com.vscodroid.service
 
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
 import java.io.File
 
@@ -44,6 +45,27 @@ class AdoptionNoteWireTest {
         return serverJs.readText()
     }
 
+    /**
+     * The `try` block that writes the note, from the file name to its `catch`.
+     *
+     * Scoped rather than whole-file, because the questions below are about what
+     * gets serialised and the warning inside that `catch` repeats the word `pid`
+     * in prose: `'Could not record the editor server pid: '`. A search over the
+     * whole file is answered by that sentence, so renaming the JSON key while
+     * leaving the sentence alone left the check green over a note the reader can
+     * no longer use. The sentence is outside this window on purpose.
+     */
+    private fun pidNoteWrite(): String {
+        val js = source()
+        val start = js.indexOf(EDITOR_PID_FILE)
+        assertTrue(start >= 0) {
+            "assets/server.js no longer names \"$EDITOR_PID_FILE\", so there is no write " +
+                "to scope this to. The case above reports the same thing on its own terms."
+        }
+        val end = js.indexOf("} catch", start)
+        return js.substring(start, if (end < 0) js.length else end)
+    }
+
     @Test
     fun `the bootstrap writes the file name Kotlin reads`() {
         assertTrue(source().contains(EDITOR_PID_FILE)) {
@@ -59,12 +81,39 @@ class AdoptionNoteWireTest {
         // The reader asks for these two by name (optInt("pid"), optInt("port")), and
         // a missing key answers 0 rather than throwing, so a renamed key reads as
         // "no pid" and declines adoption silently, which is the failure this pins.
-        val js = source()
+        //
+        // Asked of the object that is serialised, not of the file. Searching the
+        // whole of server.js for `pid:` is answered by the warning three lines
+        // below the write, `'Could not record the editor server pid: '`, so
+        // renaming the key while leaving that sentence alone kept this green over
+        // a note ProcessManager can no longer read. The literal is located from
+        // the JSON.stringify that feeds the write, which is the only thing whose
+        // shape the reader depends on.
+        val note = Regex("""JSON\.stringify\(\s*\{([^}]*)}""")
+            .find(pidNoteWrite())
+            ?.groupValues?.get(1)
+            ?: fail(
+                "assets/server.js no longer serialises an object literal into the pid " +
+                    "note. If the note is now built somewhere else, point this at it; " +
+                    "ProcessManager.portHeldByOurEditorServer still reads it with " +
+                    "optInt(\"pid\") and optInt(\"port\").",
+            )
+
+        // Split into keys rather than searched, because a search inside the literal
+        // has the same weakness one line down: in `{ pid: server.pid, port: PORT }`
+        // the VALUE ends in `.pid`, so a pattern looking for the word would be
+        // answered by it and a key renamed to `processId` would still read as
+        // present. Only the name before the colon is a key, and a shorthand
+        // `{ pid, port }` has no colon and is the whole segment.
+        val keys = note.split(",").map { it.substringBefore(":").trim() }
+
         for (key in listOf("pid", "port")) {
-            assertTrue(Regex("""\b$key\s*:""").containsMatchIn(js)) {
-                "assets/server.js writes no \"$key\" key. ProcessManager reads it with " +
-                    "optInt(\"$key\"), which answers 0 for a key that is absent, so this " +
-                    "fails as a refusal to adopt rather than as an error."
+            assertTrue(key in keys) {
+                "the pid note carries no \"$key\" key; it serialises {$note}, " +
+                    "whose keys are $keys. " +
+                    "ProcessManager reads it with optInt(\"$key\"), which answers 0 for " +
+                    "a key that is absent, so this fails as a refusal to adopt rather " +
+                    "than as an error."
             }
         }
     }
@@ -92,7 +141,14 @@ class AdoptionNoteWireTest {
         // Without this the note outlives the process it names, and a pid recycled
         // into another editor server, a debug build beside a release one, say,
         // could be adopted on the strength of a stale record.
-        assertTrue(source().contains("clearPidFile")) {
+        //
+        // The CALL is what is asked for, anchored to the start of a line, and
+        // both halves of that are load-bearing. Searching for the bare name was
+        // answered by the `const clearPidFile = () => {` that defines it, so the
+        // exit handler could stop calling it and nothing here would notice; and
+        // an unanchored search for the call reads `// clearPidFile();` exactly as
+        // it reads the live statement, which is how a line gets switched off.
+        assertTrue(Regex("""(?m)^\s*clearPidFile\(\)""").containsMatchIn(source())) {
             "assets/server.js no longer clears the note on the child's exit. A note that " +
                 "outlives its process is a note that vouches for the wrong one."
         }

--- a/android/app/src/test/kotlin/com/vscodroid/service/DisplayLanguageTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/service/DisplayLanguageTest.kt
@@ -64,15 +64,25 @@ class DisplayLanguageTest {
         // Both halves matter and they are separately losable: the environment
         // variable can be dropped while the literal survives in a comment, and
         // the locale can be changed while the assignment stays.
+        //
+        // The first half is anchored to the assignment at the start of a line,
+        // which is what makes "survives in a comment" something this can tell
+        // apart. Commenting the line out is how the pin gets switched off while
+        // something else is being tried, and it leaves every character in place,
+        // so a substring search reads the disabled line as the live one and
+        // reports the limit as still enforced. The variable is written once, as a
+        // statement of its own, so the anchor matches what is there today.
         assertTrue(
-            source.contains("VSCODE_NLS_CONFIG"),
+            Regex("""(?m)^\s*process\.env\.VSCODE_NLS_CONFIG\s*=""").containsMatchIn(source),
             "server.js no longer sets VSCODE_NLS_CONFIG. The editor then resolves a language " +
                 "from the environment instead of being held at English, and the Known " +
                 "Limitations entry 'The Interface Is English Only' in docs/USER_GUIDE.md is " +
-                "no longer true of the server side.",
+                "no longer true of the server side. If the assignment moved out of a " +
+                "statement of its own, retarget this deliberately rather than unanchoring it.",
         )
         assertTrue(
-            Regex("""VSCODE_NLS_CONFIG[\s\S]{0,120}?locale:\s*'en'""").containsMatchIn(source),
+            Regex("""(?m)^\s*process\.env\.VSCODE_NLS_CONFIG[\s\S]{0,120}?locale:\s*'en'""")
+                .containsMatchIn(source),
             "server.js no longer pins VSCODE_NLS_CONFIG to the 'en' locale. Rewrite the " +
                 "'The Interface Is English Only' entry in docs/USER_GUIDE.md to match whatever " +
                 "it now does.",

--- a/android/app/src/test/kotlin/com/vscodroid/service/NodeServiceTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/service/NodeServiceTest.kt
@@ -730,6 +730,9 @@ class HeapLatchCallSiteTest {
             t.startsWith("//") || t.startsWith("*") || t.startsWith("/*")
         }
 
+    /** [codeLines] as one string, for the cases that cut a window out of the file. */
+    private fun code(): String = codeLines().joinToString("\n") { it.value }
+
     /**
      * Every `SharedPreferences` edit in [file], as the text running from `.edit()`
      * to the call that ends it.
@@ -823,10 +826,15 @@ class HeapLatchCallSiteTest {
      *
      * Read off the source because the alternative is racing a teardown against a
      * crash, which would be a test that passes on a fast machine.
+     *
+     * The window is cut out of the comment-free rendering, not out of the raw
+     * text. The body of this method is mostly prose and that prose argues for
+     * the very calls named below, so raw text would let a disabled write go on
+     * satisfying the precondition that exists to prove the write is there.
      */
     @Test
     fun `the charge survives the scope being cancelled`() {
-        val body = nodeService.readText()
+        val body = code()
             .substringAfter("private suspend fun chargeHeapOverride")
             .substringBefore("\n    }")
         assertTrue(

--- a/android/app/src/test/kotlin/com/vscodroid/setup/CancelReleaseOrderingTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/CancelReleaseOrderingTest.kt
@@ -37,7 +37,17 @@ class CancelReleaseOrderingTest {
             manager.isFile,
             "${manager.absolutePath} is missing; this test would otherwise pass by reading nothing",
         )
+        // Block comments come out before anything is searched for. The `(?m)^\s*`
+        // anchors below already refuse a call disabled with `//`, and one whose
+        // whole line is wrapped in `/* */`; what they cannot refuse is a block
+        // comment opened on one line and closed on another, because the call then
+        // sits on a line of its own that carries no marker and the anchor matches
+        // it exactly as it matches live code. Measured: with the call wrapped that
+        // way and nothing else changed, both cases here passed. Nothing else in
+        // the suite covers this one, either: the race needs a real delivery, so
+        // there is no behavioural test to fall back on.
         val text = manager.readText()
+            .replace(Regex("""/\*.*?\*/""", RegexOption.DOT_MATCHES_ALL), "")
         val start = text.indexOf("fun cancel(packName: String)")
         assertTrue(start >= 0, "ToolchainManager has no cancel(packName)")
         val end = text.indexOf("\n    }\n", start)

--- a/android/app/src/test/kotlin/com/vscodroid/setup/PickerAccessibilityWiringTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/PickerAccessibilityWiringTest.kt
@@ -170,6 +170,19 @@ class PickerAccessibilityWiringTest {
     }
 
     /**
+     * The layout with its comments taken out.
+     *
+     * XML has no way to disable one attribute, so a toolbar is retired by wrapping
+     * the element in `<!-- -->` and writing another beside it. Both questions below
+     * are answered by the retired copy if it is left in the text, and the first one
+     * exists precisely to stop the second passing over an icon that is no longer
+     * there. Non-greedy and dot-matches-all, because a commented-out element spans
+     * lines.
+     */
+    private fun layoutWithoutComments(): String =
+        toolbarLayout.readText().replace(Regex("<!--.*?-->", RegexOption.DOT_MATCHES_ALL), "")
+
+    /**
      * `setSupportActionBar` is never called anywhere in this app, so the framework's
      * own "Navigate up" default never applies and no toolbar style supplies one.
      * The attribute in the layout is the only thing standing between a screen reader
@@ -182,7 +195,7 @@ class PickerAccessibilityWiringTest {
             "${toolbarLayout.path} is missing; this test would otherwise pass by " +
                 "reading nothing",
         )
-        val xml = toolbarLayout.readText()
+        val xml = layoutWithoutComments()
 
         // Anchored on the `=` rather than written as a substring. `app:navigationIcon`
         // is a prefix of `app:navigationIconTint`, which this toolbar also sets, so a
@@ -215,7 +228,7 @@ class PickerAccessibilityWiringTest {
             "${toolbarLayout.path} or ${strings.path} is missing; without this the " +
                 "reader gets a FileNotFoundException instead of the sentence above",
         )
-        val xml = toolbarLayout.readText()
+        val xml = layoutWithoutComments()
         val name = Regex("""app:navigationContentDescription="@string/(\w+)"""")
             .find(xml)?.groupValues?.get(1)
 

--- a/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainInstallClaimTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainInstallClaimTest.kt
@@ -65,6 +65,12 @@ class ToolchainInstallClaimTest {
 
     private val pack = "toolchain_java"
 
+    /**
+     * The install parked inside the guarded region, held so [tearDown] can wait
+     * for it to leave rather than only waking it.
+     */
+    private var heldInstall: Thread? = null
+
     @BeforeEach
     fun setUp() {
         mockkObject(Logger)
@@ -102,12 +108,35 @@ class ToolchainInstallClaimTest {
 
     @AfterEach
     fun tearDown() {
-        // Before unmockking, so a failed assertion cannot leave a thread parked on
+        // Two steps, both before unmockking, and neither does the other's job.
+        //
+        // Released first, so a failed assertion cannot leave a thread parked on
         // the latch holding a claim that outlives this test: the set is process
         // wide, and a claim never released refuses every later install of that
         // pack for the life of the JVM.
         letFirstProceed.countDown()
+        // Then waited out, because the claim comes back when that thread returns
+        // from `installFromDirectory`, not when it wakes. Until then the pack is
+        // still held, and the next test to touch it, in this class or any other,
+        // is declined by a claim whose owner has already finished: the install
+        // reports UNKNOWN, `downloadViaHttp` returns before it downloads
+        // anything, and both fail on assertions that name no cause. Measured with
+        // a copy of a few seconds, which is a short one for a toolchain tree: the
+        // next class began within milliseconds of the failure here and its first
+        // test failed with "the HTTP task never reported an outcome".
+        //
+        // Joining before `unmockkAll` also leaves Logger and the pack manager
+        // stubbed for the rest of that install rather than pulling them out from
+        // under it midway.
+        heldInstall?.join(TimeUnit.SECONDS.toMillis(10))
+        val stillHolding = heldInstall?.isAlive == true
+        heldInstall = null
         unmockkAll()
+        assertFalse(
+            stillHolding,
+            "an install is still inside the guarded region and still holds $pack, " +
+                "so later installs of that pack in this JVM will be declined",
+        )
     }
 
     /** A pack whose `usr/` tree has one file, so a copy leaves a trace. */
@@ -126,6 +155,18 @@ class ToolchainInstallClaimTest {
         onStateChange = { _, status, _, _ -> events.add(status) }
     }
 
+    /**
+     * Starts the install that will be held inside the guarded region, recording
+     * it so [tearDown] can wait for the claim to be given back. Every install
+     * that can still be inside that region when a test ends has to start here.
+     */
+    private fun startHeldInstall(dir: File, events: MutableList<Int>): Thread =
+        Thread({ installFromDirectory(manager(events), dir) }, "first-install")
+            .also {
+                heldInstall = it
+                it.start()
+            }
+
     /** Private, and the point at which both delivery routes converge. */
     private fun installFromDirectory(m: ToolchainManager, dir: File) =
         ToolchainManager::class.java
@@ -139,8 +180,7 @@ class ToolchainInstallClaimTest {
         val firstEvents = Collections.synchronizedList(mutableListOf<Int>())
         val secondEvents = Collections.synchronizedList(mutableListOf<Int>())
 
-        val first = Thread({ installFromDirectory(manager(firstEvents), dir) }, "first-install")
-        first.start()
+        val first = startHeldInstall(dir, firstEvents)
         assertTrue(
             firstIsHolding.await(10, TimeUnit.SECONDS),
             "the first install never reached the copy, so nothing was being raced",
@@ -189,8 +229,7 @@ class ToolchainInstallClaimTest {
         val dir = packDirectory()
         val events = Collections.synchronizedList(mutableListOf<Int>())
 
-        val first = Thread({ installFromDirectory(manager(events), dir) }, "first-install")
-        first.start()
+        val first = startHeldInstall(dir, events)
         assertTrue(firstIsHolding.await(10, TimeUnit.SECONDS), "the first install never started")
         letFirstProceed.countDown()
         first.join(TimeUnit.SECONDS.toMillis(10))

--- a/android/app/src/test/kotlin/com/vscodroid/storage/MirrorLookupTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/MirrorLookupTest.kt
@@ -81,6 +81,28 @@ class MirrorLookupTest {
     }
 
     /**
+     * Does this line carry [fragment] as something the compiler sees?
+     *
+     * A search over raw source text finds a call inside a line a `//` has
+     * disabled exactly as readily as inside a live one, and commenting a line
+     * out is how a developer turns something off while chasing something else.
+     * So a guard for wiring that must exist stays green over wiring that is
+     * already dead, which is the one shape it was written to catch. The KDoc
+     * asterisk is excluded for the same reason from the other side: this file's
+     * subject is named in the prose around the lines it checks.
+     *
+     * Covers the two forms a disabled line takes here, a leading `//` and a
+     * doc-comment continuation. A block comment opened on an earlier line is not
+     * covered; nothing in this repository disables a single call that way.
+     */
+    private fun String.carriesLive(fragment: String): Boolean {
+        val at = indexOf(fragment)
+        if (at < 0) return false
+        val before = substring(0, at)
+        return "//" !in before && !before.trimStart().startsWith("*")
+    }
+
+    /**
      * The wiring, which no JVM test can drive: the reconciliation needs a live
      * Activity, `lifecycleScope` and an `AlertDialog`. Read off the source
      * instead, the way `SyncCancellationTest` reads the same file, because the
@@ -95,11 +117,11 @@ class MirrorLookupTest {
         }
         val lines = source.readLines()
 
-        val callback = lines.indexOfFirst { it.contains("onPageLoaded = { url ->") }
+        val callback = lines.indexOfFirst { it.carriesLive("onPageLoaded = { url ->") }
         assertTrue(callback >= 0, "the page-load callback was renamed or removed")
         assertTrue(
             (callback until minOf(callback + 12, lines.size))
-                .any { lines[it].contains("adoptWorkbenchFolder(") },
+                .any { lines[it].carriesLive("adoptWorkbenchFolder(") },
             "nothing reconciles the watcher when the workbench opens a folder itself, " +
                 "so edits to it stay in the mirror and never reach the device",
         )

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafUnfetchedDocumentTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafUnfetchedDocumentTest.kt
@@ -303,18 +303,47 @@ class SafUnfetchedDocumentTest {
      * into a directory, and delivering a directory event builds a `FileObserver`, whose
      * static initializer needs native code. What holds it to the behaviour above is that
      * there is one refusal in the file, so this reads the source and pins that.
+     *
+     * Two claims, and they fail differently. The message having one home says that a
+     * second refusal cannot have been written that forgets to announce. The call count
+     * says both refusals are still there: the sentence can sit in the file, spelt exactly
+     * once, while the site that reaches it has been commented out. That site is the
+     * destructive one (with the call gone, `createOneInSaf` falls through to the write
+     * and truncates a device document this sync never read), and no behavioural test in
+     * this class can reach it.
+     *
+     * The call count counts only what the compiler sees. A plain search over raw text
+     * finds the call inside a line a `//` has disabled exactly as readily as inside a
+     * live one, which is how a guard of this shape reports wiring that is already dead
+     * as present. Excluded for the same reason: the declaration, which wears the same
+     * spelling, and a doc comment naming the helper.
      */
     @Test
     fun `the refusal message has one home, so both sites announce`() {
         val engineSource =
             File("../../android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt")
         assertTrue(engineSource.isFile, "SafSyncEngine.kt is not where this test expects it")
+        val text = engineSource.readText()
 
         assertEquals(
             1,
-            Regex("sync never read, and writing would replace it")
-                .findAll(engineSource.readText()).count(),
+            Regex("sync never read, and writing would replace it").findAll(text).count(),
             "a second copy of the refusal means a site that refuses without saying so",
+        )
+        val callSites = text.lines().count { line ->
+            val at = line.indexOf("refuseUnreadDocument(")
+            val before = if (at < 0) "" else line.substring(0, at)
+            at >= 0 && "//" !in before && !before.trimStart().startsWith("*") &&
+                "private fun " !in before
+        }
+        assertEquals(
+            2,
+            callSites,
+            "the two write paths that can find a document this sync never read are the " +
+                "event path and the directory walk, and each has to refuse through the " +
+                "announcing helper. If a third path legitimately grew one, raise this " +
+                "number; if one went away, the write it used to refuse now replaces a " +
+                "document the user has no other copy of",
         )
     }
 }

--- a/android/app/src/test/kotlin/com/vscodroid/util/NoticesTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/util/NoticesTest.kt
@@ -49,13 +49,22 @@ class NoticesTest {
      * Found by name, not by task type. The type has an assertion of its own
      * below, and a parse anchored on it would answer a change of type with
      * "the task is gone", which is a different defect and the wrong one to fix.
+     *
+     * Anchored to the start of a line, with only whitespace allowed in front.
+     * `build.gradle.kts` is Kotlin, so `//` disables a line here exactly as it
+     * does anywhere else, and a substring search reads a commented-out
+     * `from(...)` as a document the build copies. That is the shape this whole
+     * file exists to refuse: the list below would go on agreeing with
+     * [Notices.BUNDLED] while the Sync copied one document fewer and the dialog
+     * came up short on a device. Every `from(...)` in the task begins its own
+     * line, so the anchor costs nothing.
      */
     private fun copiedPaths(): List<String> {
         val script = buildScript.readText()
         val task = script.substringAfter("(\"bundleNotices\") {", "")
         assertFalse(task.isEmpty(), "bundleNotices task is gone from build.gradle.kts")
         val body = task.substringBefore("\n}")
-        return Regex("""from\(File\(repoRoot,\s*"([^"]+)"\)\)""")
+        return Regex("""(?m)^\s*from\(File\(repoRoot,\s*"([^"]+)"\)\)""")
             .findAll(body).map { it.groupValues[1] }.toList()
     }
 
@@ -81,7 +90,7 @@ class NoticesTest {
         val script = buildScript.readText()
         val body = script.substringAfter("(\"bundleNotices\") {", "")
             .substringBefore("\n}")
-        val destination = Regex("""into\(layout\.buildDirectory\.dir\("([^"]+)"\)\)""")
+        val destination = Regex("""(?m)^\s*into\(layout\.buildDirectory\.dir\("([^"]+)"\)\)""")
             .find(body)?.groupValues?.get(1)
         assertNotNull(destination, "bundleNotices names no destination directory")
 
@@ -95,9 +104,19 @@ class NoticesTest {
         // fails the build when one does not, which is a thing that happens in
         // the release graph and nowhere a pull request would see it. Pinning the
         // path spelling alone would have turned that improvement red.
-        val registersPath = Regex("assets\\.srcDir\\([^)]*" + Regex.escape(destination!!) + "[^)]*\\)")
-            .containsMatchIn(script)
-        val registersTask = Regex("""assets\.srcDir\(\s*bundleNotices\s*\)""")
+        //
+        // Both are anchored at the start of a line, and the character class in
+        // front is the anchor rather than the `^`: the live registration is
+        // `sourceSets["main"].assets.srcDir(...)`, so a receiver has to be
+        // allowed through, and what may not get through is a slash. A `//` in
+        // front of the call cannot then satisfy either alternative. Without
+        // that, commenting the registration out leaves this case green over an
+        // APK whose notices directory is copied and never packaged, which is
+        // the state the assertion exists to name.
+        val anchored = """(?m)^\s*[^/\n]*"""
+        val registersPath = Regex(anchored + "assets\\.srcDir\\([^)]*" +
+            Regex.escape(destination!!) + "[^)]*\\)").containsMatchIn(script)
+        val registersTask = Regex(anchored + """assets\.srcDir\(\s*bundleNotices\s*\)""")
             .containsMatchIn(script)
         assertTrue(
             registersPath || registersTask,
@@ -109,8 +128,11 @@ class NoticesTest {
         // And the copy has to be made to run. Nothing infers it from the source
         // directory: on a clean build the directory is simply empty, and every
         // gate stays green while the APK ships no notices at all.
+        // Line-anchored for the reason the registration above is: one of the two
+        // live wirings is `.configureEach { dependsOn(bundleNotices) }`, so the
+        // anchor has to let a receiver through and refuse a slash.
         assertTrue(
-            Regex("dependsOn\\([^)]*bundleNotices").containsMatchIn(script),
+            Regex(anchored + "dependsOn\\([^)]*bundleNotices").containsMatchIn(script),
             "Nothing depends on bundleNotices, so a clean build packages an empty " +
                 "notices directory."
         )
@@ -122,7 +144,8 @@ class NoticesTest {
         // out clean and never saw it, which is what makes it worth a gate rather
         // than a habit.
         assertTrue(
-            script.contains("tasks.register<Sync>(\"bundleNotices\")"),
+            Regex(anchored + """tasks\.register<Sync>\("bundleNotices"\)""")
+                .containsMatchIn(script),
             "bundleNotices is not a Sync, so a document removed or renamed stays " +
                 "in the notices directory and ships from any incremental build."
         )

--- a/android/app/src/test/kotlin/com/vscodroid/webview/DownloadListenerWiringTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/DownloadListenerWiringTest.kt
@@ -55,12 +55,36 @@ class DownloadListenerWiringTest {
      * Comments removed, so prose about the rule cannot satisfy a search for the
      * rule. This file's subject is discussed at length in the comments around
      * the very lines it checks.
+     *
+     * Both forms, because both disable code, and a call switched off while
+     * debugging and left that way is the state these cases exist to catch. A
+     * block counts as a comment only where it opens a line: a wildcard mime
+     * type and the CSS comments inside the scripts this file injects carry the
+     * same two characters inside a string literal and disable nothing.
      */
-    private fun withoutComments(text: String): String =
-        text.lines().joinToString("\n") { line ->
+    private fun withoutComments(text: String): String {
+        var inBlock = false
+        return text.lines().joinToString("\n") { raw ->
+            var line = raw
+            if (inBlock) {
+                val close = line.indexOf("*/")
+                if (close < 0) return@joinToString ""
+                inBlock = false
+                line = line.substring(close + 2)
+            }
+            while (line.trimStart().startsWith("/*")) {
+                val open = line.indexOf("/*")
+                val close = line.indexOf("*/", open + 2)
+                if (close < 0) {
+                    inBlock = true
+                    return@joinToString line.substring(0, open)
+                }
+                line = line.substring(0, open) + line.substring(close + 2)
+            }
             val marker = line.indexOf("//")
             if (marker >= 0) line.substring(0, marker) else line
         }
+    }
 
     @Test
     fun `every WebView gets a download listener that reaches the coordinator`() {

--- a/android/app/src/test/kotlin/com/vscodroid/webview/ExternalUrlNoticeThrottleTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/ExternalUrlNoticeThrottleTest.kt
@@ -333,8 +333,10 @@ class ExternalUrlNoticeThrottleTest {
      * Read from the source rather than driven through the Activity, which needs a
      * device. ⚠️ Its ceiling, the same one `WriteBackNoticeWiringTest` records:
      * this catches the call being deleted, not the branch being made unreachable.
-     * Anchored at the start of a line so that commenting the call out, which is how
-     * a developer disables something, does not still satisfy it.
+     * Comments come out before the search, so neither the call switched off while
+     * debugging nor the prose over the record it consults can stand in for it. The
+     * property above holds exactly that prose, one bracket away from satisfying a
+     * search of the raw text.
      */
     @Test
     fun `MainActivity puts a hand-off failure through the throttle`() {
@@ -342,9 +344,40 @@ class ExternalUrlNoticeThrottleTest {
         assertTrue(activity.isFile, "MainActivity.kt is not where this test expects it")
 
         assertTrue(
-            Regex("""(?m)^[^/\n]*handoffFailureToAnnounce\(""").containsMatchIn(activity.readText()),
+            withoutComments(activity.readText()).contains("handoffFailureToAnnounce("),
             "nothing in MainActivity consults the record of what has already been said, so " +
                 "every hand-off failure reaches the screen as its own toast",
         )
+    }
+
+    /**
+     * Both comment forms, since either one switches a call off. A line comment is
+     * cut from wherever it opens; a block is cut only where it opens a line, which
+     * is how one is written around code and how every doc comment in that file
+     * begins. A wildcard mime type and an injected CSS comment carry the same two
+     * characters inside a string literal and switch nothing off.
+     */
+    private fun withoutComments(text: String): String {
+        var inBlock = false
+        return text.lines().joinToString("\n") { raw ->
+            var line = raw
+            if (inBlock) {
+                val close = line.indexOf("*/")
+                if (close < 0) return@joinToString ""
+                inBlock = false
+                line = line.substring(close + 2)
+            }
+            while (line.trimStart().startsWith("/*")) {
+                val open = line.indexOf("/*")
+                val close = line.indexOf("*/", open + 2)
+                if (close < 0) {
+                    inBlock = true
+                    return@joinToString line.substring(0, open)
+                }
+                line = line.substring(0, open) + line.substring(close + 2)
+            }
+            val marker = line.indexOf("//")
+            if (marker >= 0) line.substring(0, marker) else line
+        }
     }
 }

--- a/docs/08-RISK_MATRIX.md
+++ b/docs/08-RISK_MATRIX.md
@@ -63,16 +63,16 @@
 
 | ID | Risk | Prob | Impact | Score | Category |
 |----|------|------|--------|-------|----------|
-| R01 | **Scope creep** — too many features before stable core | 3 | 4 | **12** | Medium |
+| R01 | **Scope creep** (too many features before stable core) | 3 | 4 | **12** | Medium |
 | R02 | **Upstream source layout** changes force patch rewrites | 2 | 4 | **8** | Medium |
 | R03 | **Solo developer burnout** (if single contributor) | 3 | 4 | **12** | Medium |
-| R04 | **Testing on real devices** — limited device access | 3 | 3 | **9** | Medium |
+| R04 | **Testing on real devices** (limited device access) | 3 | 3 | **9** | Medium |
 
 ---
 
 ## 3. Detailed Mitigation Plans
 
-### T01: Phantom Process Killing (Score: 20 — Critical)
+### T01: Phantom Process Killing (Score: 20, Critical)
 
 **Risk**: Android 12+ enforces a 32-process system-wide phantom process limit. Exceeding this causes SIGKILL to processes. VS Code architecture naturally spawns many child processes (extension host, terminals, language servers).
 
@@ -84,7 +84,7 @@
 | 2. Terminal | ptyHost as worker_thread; each terminal spawns bash directly on a real PTY | Terminal host costs no phantom process |
 | 3. Language Servers | Lazy start + idle kill after 5 min | Reduce concurrent LSP to 2-3 |
 | 4. Hard cap | Max 2-3 concurrent language servers | Predictable process count |
-| 5. Foreground Service | specialUse type — protects main process | Main app not killed |
+| 5. Foreground Service | specialUse type, protects main process | Main app not killed |
 | 6. Monitoring | Count phantoms, warn user if approaching limit | User can close terminals/extensions |
 | 7. User guidance | In-app tips: "Close unused terminals to save resources" | User awareness |
 
@@ -94,7 +94,7 @@
 
 ---
 
-### T02: Node.js ARM64 Build (Score: 15 — High)
+### T02: Node.js ARM64 Build (Score: 15, High)
 
 **Risk**: The bundled Node.js has to be ARM64, Bionic-linked, 16KB page aligned, and the same Node line the VS Code server's native modules are built against. A binary that misses any of these fails late and obscurely.
 
@@ -108,69 +108,69 @@
 
 ---
 
-### T03: VS Code Monthly Update Breaks Patches (Score: 16 — High)
+### T03: VS Code Monthly Update Breaks Patches (Score: 16, High)
 
 **Risk**: VS Code releases monthly. Each release may break our patches (conflicts, API changes, architectural changes).
 
 **Mitigation**:
-1. **Pin initial version** — Don't chase latest. Pick a VS Code version and stabilize.
-2. **Monthly rebase cadence** — Allocate 5-10 days per month for patch maintenance.
-3. **Automated patch testing** — CI job that attempts to apply patches to latest VS Code and reports failures.
-4. **Modular patches** — Keep patches small and focused. Each patch touches minimal files.
-5. **Upstream monitoring** — Watch VS Code release notes for changes to our patched areas.
+1. **Pin initial version**: Don't chase latest. Pick a VS Code version and stabilize.
+2. **Monthly rebase cadence**: Allocate 5-10 days per month for patch maintenance.
+3. **Automated patch testing**: CI job that attempts to apply patches to latest VS Code and reports failures.
+4. **Modular patches**: Keep patches small and focused. Each patch touches minimal files.
+5. **Upstream monitoring**: Watch VS Code release notes for changes to our patched areas.
 
 **Contingency**: Skip a VS Code release if patches are too broken. Two-month gap is acceptable.
 
 ---
 
-### P01: Play Store Rejection (Score: 15 — High)
+### P01: Play Store Rejection (Score: 15, High)
 
 **Risk**: Google may reject the app because it executes bundled binaries (even though bundled as .so).
 
 **Mitigation**:
 1. **Precedent**: Termux and UserLAnd are on Play Store using same .so technique.
 2. **All binaries via Play Store**: core binaries bundled as .so in the base APK, and the Ruby and Java 17 toolchains delivered as on-demand asset packs the user selects in the Language Picker, with Play handling the download. On a Play install nothing is fetched from a third party, which is the compliance story. A sideloaded install has no Play Asset Delivery, so it downloads the same toolchain ZIPs over HTTPS from this project's GitHub Releases, checked against a published sha256 manifest.
-3. **Prepare justification** — Document for Play Store review: "Educational developer tool, all binaries bundled at build time, no remote code execution."
-4. **specialUse service justification** — Clearly explain: "Local development server for code editor."
-5. **Content rating** — Properly categorize as Developer Tools.
+3. **Prepare justification**: Document for Play Store review as "Educational developer tool, all binaries bundled at build time, no remote code execution."
+4. **specialUse service justification**: Clearly explain it as "Local development server for code editor."
+5. **Content rating**: Properly categorize as Developer Tools.
 
 **Contingency**: If rejected, appeal with detailed technical explanation. If still rejected, distribute as APK via GitHub Releases and F-Droid.
 
 ---
 
-### T08: Extension Host worker_thread Patch (Score: 12 — Medium)
+### T08: Extension Host worker_thread Patch (Score: 12, Medium)
 
 **Risk**: Patching VS Code's Extension Host to run as worker_thread instead of child_process.fork() may be more complex than expected.
 
 **Mitigation**:
-1. **Research first** — Study `src/vs/workbench/api/node/extensionHostProcess.ts` thoroughly.
-2. **Prototype early** — Build proof-of-concept before committing to this approach.
-3. **code-server reference** — code-server has explored similar territory.
+1. **Research first**: Study `src/vs/workbench/api/node/extensionHostProcess.ts` thoroughly.
+2. **Prototype early**: Build proof-of-concept before committing to this approach.
+3. **code-server reference**: code-server has explored similar territory.
 
 **Contingency**: Fall back to standard child_process.fork(). Accept 1 extra phantom process. More aggressively manage terminal and LSP processes to compensate.
 
 ---
 
-### R01: Scope Creep (Score: 12 — Medium)
+### R01: Scope Creep (Score: 12, Medium)
 
 **Risk**: Adding features before the core is stable. Trying to build M3 features before M1 works.
 
 **Mitigation**:
-1. **Strict milestone gates** — Must pass test gate before advancing to next milestone.
-2. **M0 validation first** — If M0 fails, everything stops. Don't invest in M2+ features.
-3. **Feature freeze per milestone** — No new features during milestone stabilization.
-4. **PRD P0/P1/P2/P3 priorities** — Always work on P0 first.
+1. **Strict milestone gates**: Must pass test gate before advancing to next milestone.
+2. **M0 validation first**: If M0 fails, everything stops. Don't invest in M2+ features.
+3. **Feature freeze per milestone**: No new features during milestone stabilization.
+4. **PRD P0/P1/P2/P3 priorities**: Always work on P0 first.
 
 ---
 
-### P04: Foreground Service Restrictions (Score: 12 — Medium)
+### P04: Foreground Service Restrictions (Score: 12, Medium)
 
 **Risk**: Future Android versions may further restrict foreground services, making it harder to keep Node.js alive.
 
 **Mitigation**:
-1. **specialUse type** — Currently the correct type for our use case.
-2. **Justify to Google** — "Local development server" is a legitimate specialUse case.
-3. **Monitor Android beta** — Track new Android developer previews for foreground service changes.
+1. **specialUse type**: Currently the correct type for our use case.
+2. **Justify to Google**: "Local development server" is a legitimate specialUse case.
+3. **Monitor Android beta**: Track new Android developer previews for foreground service changes.
 
 **Contingency**: Explore WorkManager with long-running work, or bound service with activity lifecycle.
 
@@ -184,18 +184,18 @@ These plans cover risks that did not yet have dedicated sections above.
 |------|------------------|-------------|
 | T04 (WebView fragmentation) | **Done:** a runtime check reads the installed WebView at launch and warns when it is below Chrome 105 (`MainActivity.checkWebViewVersion`). **Not done:** no compatibility matrix in CI or a device lab, and no release gate on WebView smoke tests | Deliberately a warning, not a blocking dialog: the floor is a tested one rather than a hard incompatibility, and an editor that degrades beats one that will not open |
 | T05 (memory pressure/OOM) | Derive the V8 heap ceiling from device RAM (`ProcessManager.heapCeilingForDevice`, held between 256 MB and 768 MB), lazy-load extensions/LSP, add memory watchdog and pressure-based cleanup. **This bounds one number out of several and must not be read as bounding the app's memory.** See the note below | Auto-disable heavy extensions and reduce concurrent LSP to 1. A user-set ceiling disables itself after three `SIGKILL`s and says so |
-| T06 — node-pty failure | Build node-pty in CI for each Node.js bump, run PTY integration tests on physical device, keep pinned known-good node-pty version | Fallback terminal mode with reduced features until PTY patch is fixed |
-| T07 — 16KB page alignment | Enforce linker flags in all native build scripts, validate with `readelf` checks in CI | Block release for API 36 target until all binaries pass alignment checks |
+| T06 (node-pty failure) | Build node-pty in CI for each Node.js bump, run PTY integration tests on physical device, keep pinned known-good node-pty version | Fallback terminal mode with reduced features until PTY patch is fixed |
+| T07 (16KB page alignment) | Enforce linker flags in all native build scripts, validate with `readelf` checks in CI | Block release for API 36 target until all binaries pass alignment checks |
 | T09 (asset pack download requires internet) | Keep the core toolchain offline-ready (Node/Python/Git), clear UI states for pending downloads, retry/backoff for flaky networks | A non-Play install fetches the same toolchain ZIPs over HTTPS from GitHub Releases, checked against a published sha256 manifest |
 | T10 (Python packaging/stdlib gaps) | Take Python from the Termux package index at build time, smoke-test stdlib modules and pip in CI, and check every shared library the interpreter needs is bundled | Stay on the last known-good Termux python package |
-| P02 — Future Android binary restrictions | Track Android previews quarterly, keep alternative architecture spikes (remote execution mode) in backlog | Shift distribution toward sideload/F-Droid while redesigning runtime model |
-| P03 — Restriction of .so execution model | Keep policy documentation and precedent evidence updated, minimize dynamic execution surface, review Play policy each milestone | Prepare fast migration plan to policy-compliant delivery variant |
-| P05 — Scoped storage tightening | Already mitigated by construction: the workspace is app-private and every external folder arrives through SAF. `MANAGE_EXTERNAL_STORAGE` was never declared, so there is nothing to keep optional and nothing to document. What remains open is migration tooling for moved workspaces | Nothing to fall back to: SAF-only is what already ships |
-| L01 — Trademark risk | Keep Code-OSS attribution + disclaimer visible, prepare backup branding set, run pre-launch legal checklist | Rename app and migrate package/display name with compatibility notes |
-| L02 — Open VSX outage/API change | Cache extension metadata locally, keep retry + graceful degradation in UI, monitor Open VSX status | Support manual VSIX install for critical workflows |
-| L03 — License compliance drift | Maintain SBOM/license inventory per release, automate NOTICE generation in CI, review bundled binaries/licenses at tag time | Pull non-compliant artifact from release and republish patched build |
+| P02 (future Android binary restrictions) | Track Android previews quarterly, keep alternative architecture spikes (remote execution mode) in backlog | Shift distribution toward sideload/F-Droid while redesigning runtime model |
+| P03 (restriction of .so execution model) | Keep policy documentation and precedent evidence updated, minimize dynamic execution surface, review Play policy each milestone | Prepare fast migration plan to policy-compliant delivery variant |
+| P05 (scoped storage tightening) | Already mitigated by construction: the workspace is app-private and every external folder arrives through SAF. `MANAGE_EXTERNAL_STORAGE` was never declared, so there is nothing to keep optional and nothing to document. What remains open is migration tooling for moved workspaces | Nothing to fall back to: SAF-only is what already ships |
+| L01 (trademark risk) | Keep Code-OSS attribution + disclaimer visible, prepare backup branding set, run pre-launch legal checklist | Rename app and migrate package/display name with compatibility notes |
+| L02 (Open VSX outage/API change) | Cache extension metadata locally, keep retry + graceful degradation in UI, monitor Open VSX status | Support manual VSIX install for critical workflows |
+| L03 (license compliance drift) | Maintain SBOM/license inventory per release, automate NOTICE generation in CI, review bundled binaries/licenses at tag time | Pull non-compliant artifact from release and republish patched build |
 | R02 (upstream source layout changes) | Pin `VSCODE_VERSION`, rebuild the server once per bump, and prove every patch reached the packaged bundle with `scripts/check-patch-fingerprints.py` against `patches/fingerprints.txt` | Stay on the pinned version until the diffs are reworked |
-| R03 — burnout/single maintainer risk | Enforce milestone scope limits, reserve buffer in each milestone, document key build/release runbooks | Freeze new features and run maintenance-only cycle |
+| R03 (burnout/single maintainer risk) | Enforce milestone scope limits, reserve buffer in each milestone, document key build/release runbooks | Freeze new features and run maintenance-only cycle |
 | R04 (limited real-device access) | CI compiles the instrumented suite (`assembleDebugAndroidTest`); a person runs it on a physical device, because an arm64 emulator on hosted runners has no KVM. Define the minimum required test set per milestone | Delay milestone exit until the mandatory device matrix is met |
 
 > **T05: what the heap ceiling does and does not bound.** The mitigation above has been read as


### PR DESCRIPTION
Forty test classes pin wiring by reading production source as text. It is the
only way to reach a callback registration, a call ordering, or a value that
crosses a language boundary, and there is no compiler on either side of those.

The technique has one systematic weakness: a search over raw source finds a
string inside a commented-out line as readily as inside a live one. So a guard
written as "this call appears in the source" still passes after someone comments
the call out while debugging, which is the regression the guard exists to catch.

Every defect below was measured the same way, in a throwaway worktree: comment
the production line out, run the class, then run it again with the repair. All
of them passed on the defect beforehand.

## What was blind

- **The bridge redaction scan** proves every page-supplied value is redacted
  before it is logged. The redaction check is asked of the span a statement
  occupies, which runs to the end of the line the call closes on, so a trailing
  comment is inside it: `Logger.i(tag, "Opening $uri") // redactToken(uri)`
  answered the redaction question for a call that makes none. Its vacuity
  counter had the mirror problem, counting disabled calls as ones it had looked
  at.
- **The adoption note key check** searched all of `server.js` for `pid:`. Three
  lines below the write sits the warning `'Could not record the editor server
  pid: '`, which answers that search on its own, so renaming the key kept the
  check green over a note `ProcessManager` can no longer read. A note it cannot
  read means adoption is declined for ever, and every launch after a bootstrap
  dies spawns onto a port the surviving server still holds.
- **`adoptWorkbenchFolder(`** is what reconciles the SAF watcher when the
  workbench navigates to a folder itself. Its guard read raw text; with the call
  disabled, every save to that folder stays in the mirror.
- **The download listener and the trackpad accessibility actions** had guards
  that dropped line comments but not block comments, so wrapping the wiring in
  `/* */` was invisible to both.
- **The memory-pressure manifest check** read the XML with its comments. XML
  cannot disable one attribute, so swapping the application class means
  commenting the element out and writing another beside it, which is exactly
  what the guard could not see.
- Smaller instances of the same shape in the external-URL throttle (a call
  inside a multi-line block comment carries no slash on its middle lines), the
  heap-charge call site, the cancel/release ordering (brace matching ran through
  a comment and moved its window), and the notice, language, watcher and sync
  guards.

## What was deliberately left alone

Guards whose assertion is an **absence**: anchoring a negative makes it weaker.
Value **extractors** that pull a number or a name out of the source and assert
on the value: comment the declaration out and the extractor finds nothing, so
the test fails on its own terms. Anything matched against something that is not
production source, such as a settings document the test itself wrote or a
command line it just built. And one assertion that pins explanatory prose on
purpose, so the note travels with the code it explains.

Where a line anchor would have missed live code because of a receiver on the
same line, comments are removed from the input instead of anchoring the pattern.

## Also here

- A toolchain test parks a thread inside a process-wide claim on purpose. Its
  teardown woke that thread and unmockked immediately, without waiting for it to
  leave the guarded region, so a failing run leaked the claim into the next
  class. Injecting a plausible defect plus a slow copy produced two failures,
  the real one and an unrelated class inheriting the leak; with the join in
  place the same injection produces one.
- `docs/08-RISK_MATRIX.md` now uses the punctuation the rest of the project
  writes, in all 37 places. Row and column counts unchanged in all ten tables.

## Verification

Full unit suite with every task forced to re-run: 231 classes, 1496 tests, 0
failures, 0 errors. Android Lint clean. No production file changes; the tree is
test and documentation only.

The release bundle gate was also exercised against a real signed AAB for the
first time, which needed no change but is worth recording: base module is
270.7 MiB compressed against Play's 500 MiB cap, and all five of the gate's
refusal branches were confirmed to fire.
