### PR TITLE
fix: close the deferred items and two defects seen on device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Long pressing a key through a screen reader now opens its alternate characters. The layer needed a finger held on the key, so `'` and `\` were unreachable.
 
 ### Changed
+- The toolchain picker is offered until you answer it. An interrupted first run used to skip it permanently, leaving the launcher shortcut as the only way to add a language.
+- Packaging now checks every bundled binary is 16 KB page aligned, so a build that could not load on Android 16 fails at build time instead of on a device.
+- Toolchain cards now quote sizes in the same unit as the rest of the app, so a card and the storage screen no longer disagree by five percent.
+- The editor now opens with the chat panel closed on a phone, so the walkthrough and the file tree are not squeezed into half the width on a first run.
+- The process counter no longer shows a warning on an untouched install. Its threshold sat exactly on what the app costs when idle, so it was always lit.
 - Download outcome messages and the About dialog's unknown-version wording are now translatable; both were written in code and stayed English in every language.
 - Long-press alternates now carry spoken, translatable names, so a screen reader can tell the apostrophe from the backtick instead of reading the bare glyph.
 - The key row now says which of its five pages is showing, and announces the change on a swipe, instead of leaving five unlabelled indicator dots.
@@ -77,6 +82,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The Kotlin plugin's own build directory is ignored, so a build no longer leaves compiler scratch sitting in the working tree.
 
 ### Fixed
+- The setup screen now keeps the display awake while it unpacks the app, so a screen timeout can no longer strand a first run part-way through an 800 MB extraction.
+- Toolchain screen: a download already running is now shown with its progress and a Cancel button instead of an Install button that started nothing.
+- Clearing caches now frees the toolchain download staging directories it was already counting, leaving alone any directory a running download is still using.
+- Saving a download no longer stops working after the page reloads or the workspace folder changes; the abandoned transfer is released and its part-written file removed.
+- The copied crash report is marked sensitive, so Android no longer draws a preview of the server log and crash text over the editor.
+- The storage and device-folder screens no longer time out on installs with many files: the commands that walk the disk now get a deadline that fits.
+- Refusals the bridge shows in the editor, a link that would not open or a folder copy still in use, moved to string resources so they can be translated.
+- Every install, new or upgraded, now opens with the secondary side bar closed, so a phone-width editor is not half covered by a chat view with no provider.
+- Settings files written before this release now gain the secondary side bar default, which previously reached clean installs only and left every upgraded device on the upstream layout.
+- A workspace whose saved layout still opens the chat view is corrected once, on the next launch. Opening the bar yourself is remembered and is never undone again.
+- The process list now names the program behind each entry, so several rows no longer read identically as the bundled Node runtime and its heap setting.
+- The chat agent's model backend is now recognised as a language server, so both the idle reclaim under memory pressure and Kill Idle Servers can reach it.
 - Git helper setup no longer follows its own symlinks when setting the execute bit, ending refused permission changes on every launch.
 - Extra key row: a Shift latched and then left unused while typing on the soft keyboard no longer changes which character the next row key inserts.
 - The first-run toolchain picker subtitle now uses plain punctuation; the escaped dash it carried was expanded into the compiled resource and shown to users.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -658,6 +658,75 @@ val verifyNativeAddons = tasks.register<Exec>("verifyNativeAddons") {
     }
 }
 
+/**
+ * Refuses a packaged asset tree carrying a binary Android 16 will not map.
+ *
+ * The page-size rule is enforced everywhere a binary is produced and nowhere a
+ * binary is packaged, for everything except `jniLibs/`. Each download script
+ * checks the one file it just placed, and `verifyBundledBinaries` sweeps
+ * `jniLibs/` as a directory, so the ~150 aarch64 binaries under `assets/` were
+ * answered for at fetch time and never again. Three ordinary routes reach
+ * packaging with no fetch having run: a cache restore in CI, a local build after
+ * an old fetch, and `package-assets.sh` copying `server/vscode-reh` over the
+ * tree wholesale. The server tree also arrives from a release as a tarball,
+ * where only ripgrep is examined on the way in.
+ *
+ * What it costs when it goes wrong is a `dlopen` that fails on a 16 KB-page
+ * device and nowhere else, which is the shape of failure the whole checker
+ * exists for: the file is present, the build is green, and the feature the addon
+ * backs is simply missing on the devices that ship today.
+ *
+ * Alignment only. The tree is packaged rather than built here, so it
+ * legitimately holds payloads for other platforms and dependencies nothing
+ * loads, and asking the full question of it would fail a correct build; the
+ * script's `alignment_sweep` names both cases and the measurements behind them.
+ * The dependency half of the question is already asked of these same
+ * directories by `verifyNativeAddons`.
+ *
+ * Armed by the same file as its two neighbours, and skipped with them: the lint
+ * and unit-test jobs stub an empty assets tree so Gradle will configure, and a
+ * tree that was never downloaded has nothing to judge.
+ *
+ * Measured on the real tree: 158 aarch64 binaries, 4 skipped as another ABI or
+ * not loadable, 0.8s.
+ */
+val verifyPackagedAlignment = tasks.register<Exec>("verifyPackagedAlignment") {
+    group = "verification"
+    description = "Checks every packaged aarch64 binary is 16 KB page aligned."
+
+    val entryPoint = file("src/main/assets/vscode-reh/out/server-main.js")
+
+    workingDir = rootProject.projectDir.parentFile
+    commandLine(
+        "python3", "scripts/verify-android-elf.py",
+        "--tree", "android/app/src/main/assets",
+    )
+
+    onlyIf { entryPoint.isFile }
+
+    isIgnoreExitValue = true
+    val alignResult = executionResult
+    doLast {
+        if (alignResult.get().exitValue != 0) {
+            throw GradleException(
+                "A binary in the packaged asset tree is not 16 KB page aligned.\n" +
+                    "The FAIL line above names the file and the alignment it has.\n" +
+                    "\n" +
+                    "Android 16 refuses to map it, so whatever loads it fails on a\n" +
+                    "current device and works everywhere older. Re-run the script that\n" +
+                    "places the file: scripts/build-native-addons.sh for an addon under\n" +
+                    "vscode-reh/node_modules, scripts/download-termux-tools.sh or\n" +
+                    "download-python.sh for anything under assets/usr, and\n" +
+                    "scripts/fetch-vscode-oss.sh for the server tree itself.\n" +
+                    "\n" +
+                    "A file that arrives misaligned from upstream is not fixable here:\n" +
+                    "it has to be rebuilt with -Wl,-z,max-page-size=16384, which is what\n" +
+                    "build-native-addons.sh already passes."
+            )
+        }
+    }
+}
+
 val verifyServerTree = tasks.register<Exec>("verifyServerTree") {
     group = "verification"
     description = "Checks the server tree in assets/ is one this app can run."
@@ -1148,15 +1217,16 @@ tasks.matching { it.name.contains("Lint") || it.name.contains("lint") }
 // A dependency of the merge, not of the package or the assemble: the point is
 // to stop the wrong tree getting into an APK rather than to describe one that
 // already did.
-// The nine, once. They were written twice before, here as task providers and
-// again below as a list of strings for the graph check, with nothing keeping the
-// two in step. The dangerous drift is one-directional and quiet: add a tenth gate
-// here and forget the other list, and the new gate is wired but never verified,
-// which is the state the check exists to make impossible.
+// The set, once. It was written twice before, here as task providers and again
+// below as a list of strings for the graph check, with nothing keeping the two in
+// step. The dangerous drift is one-directional and quiet: add a gate here and
+// forget the other list, and the new gate is wired but never verified, which is
+// the state the check exists to make impossible.
 val packagingGates = listOf(
     checkPatchFingerprints, verifyServerTree, verifyBundledBinaries,
     verifyRequiredBinaries, verifyBundledShellPaths, verifyRubyPackShellPaths,
-    verifyNativeAddons, checkPackOverlap, verifyPythonPlatform,
+    verifyNativeAddons, verifyPackagedAlignment, checkPackOverlap,
+    verifyPythonPlatform,
 )
 
 tasks.matching { it.name.startsWith("merge") && it.name.endsWith("Assets") }
@@ -1165,7 +1235,7 @@ tasks.matching { it.name.startsWith("merge") && it.name.endsWith("Assets") }
         dependsOn(bundleNotices)
     }
 
-// The same nine, by name, so the graph can be asked whether they are in it.
+// The same set, by name, so the graph can be asked whether they are in it.
 //
 // The wiring above is by name SHAPE, which is right: AGP has moved this family
 // between versions and matching two literal names would fail the build at

--- a/android/app/src/androidTest/kotlin/com/vscodroid/SplashActivityTest.kt
+++ b/android/app/src/androidTest/kotlin/com/vscodroid/SplashActivityTest.kt
@@ -35,10 +35,15 @@ class SplashActivityTest {
 
     @Before
     fun setUp() {
-        // Clear setup_version so SplashActivity runs first-run extraction.
-        getSetupPrefs().edit().remove("setup_version").commit()
-        // Keep toolchain_picker_shown=true to prevent the picker UI from
-        // blocking (it waits for user interaction).
+        // Both version keys, through the shared helper. Removing setup_version
+        // alone does force extraction, because the staleness test is an OR, but
+        // it leaves a version code behind that names a build no record here
+        // agrees with, for whatever runs next in the same session to read.
+        ServerReadyHelper.clearSetupState(context)
+        // After the clear, which also removes this: keep toolchain_picker_shown
+        // true to prevent the picker UI from blocking (it waits for user
+        // interaction, and it is now offered on any launch that has not answered
+        // it rather than only on the first).
         getAppPrefs().edit().putBoolean("toolchain_picker_shown", true).commit()
     }
 
@@ -103,6 +108,7 @@ class SplashActivityTest {
         )
         val before = serverJs.lastModified()
         val versionBefore = getSetupPrefs().getString("setup_version", null)
+        val codeBefore = getSetupPrefs().getInt("setup_version_code", 0)
 
         val scenario = ActivityScenario.launch(SplashActivity::class.java)
         Thread.sleep(3000)  // give it time to transition
@@ -110,6 +116,14 @@ class SplashActivityTest {
         val version = getSetupPrefs().getString("setup_version", null)
         assertNotNull("setup_version should still be set after skip", version)
         assertEquals("setup_version changed across a launch that skipped setup", versionBefore, version)
+        // The other half of the pair, which is what the skip is decided on: either
+        // one differing re-runs the whole of setup, so a launch that rewrote only
+        // the code would look identical to this test while having extracted 810 MB.
+        assertEquals(
+            "setup_version_code changed across a launch that skipped setup",
+            codeBefore,
+            getSetupPrefs().getInt("setup_version_code", 0),
+        )
         assertEquals(
             "server.js was rewritten, so extraction ran instead of being skipped",
             before,

--- a/android/app/src/main/assets/extensions/vscodroid.vscodroid-process-monitor-1.1.0/extension.js
+++ b/android/app/src/main/assets/extensions/vscodroid.vscodroid-process-monitor-1.1.0/extension.js
@@ -65,12 +65,20 @@ function updateStatusBar(snapshot) {
 
     statusBarItem.text = `$(pulse) ${total}`;
 
-    // Color thresholds (soft budget = 5, system hard limit = 32)
-    if (total >= 10) {
+    // Read from the snapshot rather than repeated here. These two numbers used
+    // to be literals in this file with a comment naming a third literal in
+    // process-monitor.js, and nothing made the three agree: when the idle set
+    // grew, the warning threshold stayed where it was and the item went amber on
+    // a fresh install with nothing open. The fallbacks cover a snapshot written
+    // before the budget carried them, which is only ever a stale file on disk.
+    const budget = snapshot.budget || {};
+    const soft = budget.soft || 8;
+    const error = budget.error || 14;
+    if (total >= error) {
         statusBarItem.backgroundColor = new vscode.ThemeColor(
             'statusBarItem.errorBackground'
         );
-    } else if (total >= 5) {
+    } else if (total >= soft) {
         statusBarItem.backgroundColor = new vscode.ThemeColor(
             'statusBarItem.warningBackground'
         );
@@ -259,7 +267,9 @@ function showProcessTree() {
     const tree = s.tree || [];
     const langservers = tree.filter(p => p.type === 'langserver');
     const terminals = tree.filter(p => p.type === 'terminal' || p.type === 'tmux');
-    if (s.total >= 5) {
+    // The same threshold the status item colours on, from the same place, so
+    // advice appears exactly when the count is worth acting on.
+    if (s.total >= ((s.budget && s.budget.soft) || 8)) {
         outputChannel.appendLine('');
         outputChannel.appendLine('Recommendations:');
         if (terminals.length > 2) {

--- a/android/app/src/main/assets/extensions/vscodroid.vscodroid-saf-bridge-1.4.0/extension.js
+++ b/android/app/src/main/assets/extensions/vscodroid.vscodroid-saf-bridge-1.4.0/extension.js
@@ -49,12 +49,43 @@ function getChannel() {
 }
 
 /**
+ * How long to wait for a command that only has to be relayed.
+ *
+ * The relay posts back from the page's main thread as soon as the bridge method
+ * returns, and for most commands that is a field read or a hand-off to an
+ * Activity, so anything past a moment means the relay is not there at all.
+ */
+const BRIDGE_TIMEOUT_MS = 5000;
+
+/**
+ * How long to wait for a command whose cost is the size of the user's disk.
+ *
+ * Four of the bridge methods walk directory trees before they can answer:
+ * `getStorageBreakdown` sizes every component of the app's storage and the whole
+ * of `filesDir` on top; `listSafMirrors` walks every copied device folder twice,
+ * once to size it and once to ask whether the device folder holds everything in
+ * it; `reclaimSafMirror` re-asks that second question and sizes the copy before
+ * removing it; and `clearCaches` deletes trees. The app's own extracted tree is
+ * around 875 MB before a single project is opened, so on any real install those
+ * walks run for far longer than the deadline above, and until this existed they
+ * were all given it: the storage screen and the device-folder screen, the only
+ * two places in the app that can reclaim disk, answered "Bridge timeout: is the
+ * app running on Android?" for every user who had enough files to need them.
+ *
+ * The number is not a guess about how long a walk takes; it cannot be, since it
+ * is the user's disk. It is the point at which "still working" stops being a
+ * plausible explanation and a relay that is not answering at all becomes one.
+ */
+const DISK_WALK_TIMEOUT_MS = 120000;
+
+/**
  * Sends a command to the main page relay and returns a promise for the response.
  * @param {string} cmd
  * @param {Record<string, *>} [extra]
+ * @param {number} [timeoutMs]
  * @returns {Promise<*>}
  */
-function sendBridgeCommand(cmd, extra = {}) {
+function sendBridgeCommand(cmd, extra = {}, timeoutMs = BRIDGE_TIMEOUT_MS) {
     return new Promise((resolve, reject) => {
         const id = Math.random().toString(36).slice(2);
         _pending[id] = { resolve, reject };
@@ -67,13 +98,12 @@ function sendBridgeCommand(cmd, extra = {}) {
             return;
         }
 
-        // Timeout after 5 seconds (relay should respond almost instantly)
         setTimeout(() => {
             if (_pending[id]) {
                 delete _pending[id];
                 reject(new Error('Bridge timeout: is the app running on Android?'));
             }
-        }, 5000);
+        }, timeoutMs);
     });
 }
 
@@ -227,7 +257,7 @@ function activate(context) {
         async () => {
             try {
                 const json = /** @type {string} */ (
-                    await sendBridgeCommand('getStorageBreakdown')
+                    await sendBridgeCommand('getStorageBreakdown', {}, DISK_WALK_TIMEOUT_MS)
                 );
                 const b = JSON.parse(json || '{}');
 
@@ -327,7 +357,7 @@ function activate(context) {
             // had survived a removal they were never offered and never confirmed.
             try {
                 const json = /** @type {string} */ (
-                    await sendBridgeCommand('listSafMirrors')
+                    await sendBridgeCommand('listSafMirrors', {}, DISK_WALK_TIMEOUT_MS)
                 );
                 mirrors = JSON.parse(json || '[]');
 
@@ -388,7 +418,7 @@ function activate(context) {
                 await sendBridgeCommand('reclaimSafMirror', {
                     hash: m.hash,
                     force: !m.reclaimable
-                });
+                }, DISK_WALK_TIMEOUT_MS);
                 // Straight back to the list: the usual reason for opening this is
                 // to free space, and one folder is rarely the whole answer.
                 vscode.commands.executeCommand('vscodroid.manageDeviceFolders');
@@ -408,7 +438,7 @@ function activate(context) {
         'vscodroid.clearCaches',
         async () => {
             try {
-                const freed = Number(await sendBridgeCommand('clearCaches')) || 0;
+                const freed = Number(await sendBridgeCommand('clearCaches', {}, DISK_WALK_TIMEOUT_MS)) || 0;
                 // Say the number. A command that claims to free space without saying how
                 // much is indistinguishable from one that did nothing, and "already
                 // clear" is a useful answer rather than a failure.

--- a/android/app/src/main/assets/extensions/vscodroid.vscodroid-welcome-1.2.2/extension.js
+++ b/android/app/src/main/assets/extensions/vscodroid.vscodroid-welcome-1.2.2/extension.js
@@ -7,9 +7,71 @@ const path = require('path');
 
 const WALKTHROUGH_ID = 'vscodroid.vscodroid-welcome#vscodroid.welcome';
 
+// Set on a workspace once its secondary side bar has been put where this
+// device's settings ask for it.
+//
+// Workspace-scoped rather than global because the layout record it corrects is
+// workspace-scoped too, and it lives in the same browser storage as that record:
+// clear one and the other goes with it, so a profile that loses its stored
+// layout is realigned rather than left open with a marker saying it was handled.
+const SIDE_BAR_ALIGNED = 'vscodroid.secondarySideBar.aligned';
+
+/**
+ * Puts the secondary side bar where this device's settings ask for it, once per
+ * workspace.
+ *
+ * `workbench.secondarySideBar.defaultVisibility` cannot do this on its own here,
+ * however plainly its name reads. The setting decides a workspace that has no
+ * recorded layout, and by the time it is readable the record exists. The
+ * workbench reaches this device's settings over the remote connection and does
+ * not wait for them: it starts from a copy in browser storage, which the first
+ * load in a profile has not written yet, so that load falls back to upstream's
+ * `visibleInWorkspace`, opens the bar, and
+ * stores `workbench.auxiliaryBar.hidden: false` against the workspace. Every
+ * later load reads the stored value and never consults the default again, so the
+ * bar stays open for the life of the workspace however the setting reads.
+ *
+ * On a phone that is roughly 45 percent of the width, spent on a chat view whose
+ * provider this build prunes, while the walkthrough beside it wraps to one word
+ * per line.
+ *
+ * Runs at most once per workspace, so the bar stays where the user leaves it:
+ * opening it is a choice, and nothing here runs again to undo it. `hidden` is
+ * the only value acted on; any other means the user asked for the bar and gets
+ * it. The marker is written only after the command has run, so a launch that
+ * fails to close the bar tries again on the next one instead of recording a job
+ * it did not do.
+ */
+function alignSecondarySideBar(context) {
+    if (context.workspaceState.get(SIDE_BAR_ALIGNED)) {
+        return;
+    }
+    const visibility = vscode.workspace
+        .getConfiguration()
+        .get('workbench.secondarySideBar.defaultVisibility');
+    if (visibility !== 'hidden') {
+        return;
+    }
+    // closeAuxiliaryBar hides the part outright rather than toggling it, so a
+    // workspace that already agrees costs nothing and still gets marked.
+    Promise.resolve(
+        vscode.commands.executeCommand('workbench.action.closeAuxiliaryBar')
+    ).then(
+        () => context.workspaceState.update(SIDE_BAR_ALIGNED, true),
+        () => {}
+    );
+}
+
 function activate(context) {
-    // File-based marker: survives force-stop (globalState does not,
-    // because SIGKILL prevents VS Code from flushing its state DB)
+    // File-based marker, kept because it outlives the workbench profile: a
+    // cleared WebView data directory takes extension state with it, and the
+    // walkthrough should not reappear for that.
+    //
+    // The reason recorded here used to be that extension state does not survive
+    // a force-stop at all, because SIGKILL stops VS Code flushing its state DB.
+    // Measured on API 33: a counter in globalState and one in workspaceState both
+    // came back incremented across five force-stop and relaunch cycles, so that
+    // reason was wrong and [alignSecondarySideBar] relies on the opposite.
     const markerFile = path.join(
         process.env.HOME || process.env.USERPROFILE || '/tmp',
         '.vscodroid_welcome_shown'
@@ -32,6 +94,12 @@ function activate(context) {
             // Completion event fires automatically when command runs
         })
     );
+
+    // Deliberately outside the marker below. That marker records that the
+    // walkthrough has been shown, and every device upgrading into this release
+    // already has it, which is exactly the population whose stored layout needs
+    // correcting.
+    alignSecondarySideBar(context);
 
     // Auto-open walkthrough on first activation only
     if (!fs.existsSync(markerFile)) {

--- a/android/app/src/main/assets/process-monitor.js
+++ b/android/app/src/main/assets/process-monitor.js
@@ -13,6 +13,32 @@ const path = require('path');
 
 const SCAN_INTERVAL_MS = 10_000;
 const IDLE_KILL_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
+
+// What this app costs when nothing is happening, measured rather than guessed:
+// on a cold start left untouched, /proc under the app's own uid holds the
+// bootstrap, the editor server, the file watcher, the agent host, and the chat
+// agent's model backend. Five, on API 33 and on API 37 alike.
+//
+// The number matters because the thresholds below are read against it. The soft
+// budget used to be 5, chosen when the idle set was smaller, so a fresh install
+// sat exactly on its own warning with nothing open and the status item was amber
+// from the first paint. A warning that is always lit is one nobody reads, which
+// costs more than the warning was worth.
+const IDLE_BASELINE = 5;
+
+// Idle, plus a terminal and two language servers: a session with real work in
+// it. Below this the count says nothing a user could act on.
+const SOFT_BUDGET = 8;
+
+// Far enough above the soft budget to mean something has gone wrong rather than
+// that the user is busy, and still well short of the hard limit, so there is
+// room to act. This used to live in the status bar extension as a bare 10 with
+// no relation to anything; both numbers now come from here, so they cannot
+// drift apart in two languages with nothing to make them agree.
+const ERROR_BUDGET = 14;
+
+// Android's system-wide phantom process limit, shared with every other app.
+const HARD_LIMIT = 32;
 // The severities that justify shedding idle language servers, as words written
 // by the Android side. It used to be a number compared with >= against Android's
 // trim levels, which are not ordered by severity: TRIM_MEMORY_UI_HIDDEN is 20
@@ -404,7 +430,13 @@ function scan() {
         const snapshot = {
             timestamp: now,
             total: tree.length,
-            budget: { current: tree.length, soft: 5, hard: 32 },
+            budget: {
+                current: tree.length,
+                idle: IDLE_BASELINE,
+                soft: SOFT_BUDGET,
+                error: ERROR_BUDGET,
+                hard: HARD_LIMIT,
+            },
             tree,
             warnings
         };

--- a/android/app/src/main/assets/process-monitor.js
+++ b/android/app/src/main/assets/process-monitor.js
@@ -239,6 +239,38 @@ function namesProgram(name, needle) {
 }
 
 /**
+ * The name the details view prints for a process.
+ *
+ * This was the basename of argv[0] followed by argv[1], and on this device that
+ * is the same string for nearly everything: every process the app owns is the
+ * one bundled Node binary, and the first argument it is given is the heap
+ * ceiling. Measured on an API 33 emulator sitting idle, five of the six rows
+ * rendered as `libnode.so --max-old-space-size=488`, so the view whose whole job
+ * is to say what is running distinguished none of them, and neither did the
+ * counter's tooltip.
+ *
+ * What identifies a process is the first argument that is not an option: the
+ * script the runtime was asked to run. `--type=` is carried along beside it
+ * because `bootstrap-fork` is launched more than once with different ones and is
+ * otherwise several rows sharing one name. A script called `index.js` is named
+ * by the directory holding it rather than by itself, which is how a Node
+ * package's entry point is spelled.
+ */
+function shortCommand(cmdline) {
+    const parts = cmdline.split(' ').filter(Boolean);
+    const program = path.basename(parts[0] || '');
+    const script = parts.slice(1).find((arg) => !arg.startsWith('-'));
+    const type = parts.find((arg) => arg.startsWith('--type='));
+
+    let name = script ? path.basename(script) : '';
+    if (name === 'index.js') {
+        const pkg = path.basename(path.dirname(script));
+        if (pkg && pkg !== '.' && pkg !== path.sep) name = `${pkg}/${name}`;
+    }
+    return [program, name, type].filter(Boolean).join(' ');
+}
+
+/**
  * Classify a process by its cmdline.
  */
 function classify(cmdline) {
@@ -273,6 +305,27 @@ function classify(cmdline) {
     // No "and not bash" guard needed once this is an exact name rather than a
     // substring: 'bash' is simply not 'sh'.
     if (names.includes('sh')) return 'terminal';
+
+    // The agent host's model backend, which `bootstrap-fork --type=agentHost`
+    // launches as node_modules/@github/copilot-<platform>/index.js. No
+    // LANG_SERVER_PATTERNS entry can reach it, because the basename every rule
+    // above compares is `index.js`: that names the package's entry point and not
+    // the program, so a bare word would miss it and a substring would claim every
+    // index.js on the device, the user's own included. Matched on the package path
+    // instead, the exception the saf paths above already take, and the
+    // node_modules segment is what keeps the needle off a directory someone chose
+    // themselves.
+    //
+    // Being unclassified was not cosmetic here. Measured idle on an API 33 and an
+    // API 37 emulator, signed out, nothing but the Welcome tab open: 226 MB
+    // resident, the largest process this app owns after the Android process
+    // itself, and one of only five counted against the phantom budget. As
+    // 'unknown' it was in neither reclaim path -- not lsCpuTracker, so the idle
+    // kill could not shed it under critical memory pressure, and not the
+    // 'Kill Idle Servers' command, which filters on this very type. Both exist for
+    // a lazily started, idle-killable server forked by a host, which is what this
+    // is.
+    if (cmd.includes('node_modules/@github/copilot-')) return 'langserver';
 
     for (const pattern of LANG_SERVER_PATTERNS) {
         const needle = pattern.toLowerCase();
@@ -322,10 +375,7 @@ function scan() {
             // command line matches no pattern and would come out 'unknown'.
             const type = pid === process.pid ? 'bootstrap' : classify(cmdline);
             if (type === 'app') continue; // main Android process, not a phantom
-            const parts = cmdline.split(' ');
-            const shortCmd = path.basename(parts[0]) + (parts[1] ? ' ' + parts[1] : '');
-
-            tree.push({ pid, ppid: info.ppid, type, cmd: shortCmd });
+            tree.push({ pid, ppid: info.ppid, type, cmd: shortCommand(cmdline) });
 
             if (type === 'langserver') {
                 activeLsPids.add(pid);

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -1104,6 +1104,10 @@ class MainActivity : AppCompatActivity() {
      */
     private fun removeDeviceFolderCopy(hash: String, force: Boolean): String {
         val mirrorsRoot = Environment.getSafMirrorsDir(this)
+        // The refusal is resolved here because this is the side that has a Context.
+        // The predicate answers WHICH refusal applies and deliberately not what it
+        // says, which is what keeps it pure and reachable from a JVM test with no
+        // Activity. See SafStorageManager.RECLAIM_FOLDER_OPEN.
         val inUse = SafStorageManager.reclaimRefusal(
             hash = hash,
             watchedMirror = watchedSafFolder?.first?.name,
@@ -1112,7 +1116,7 @@ class MainActivity : AppCompatActivity() {
                 openWorkspaceFolder, mirrorsRoot
             ),
             watchedThisProcess = mirrorsWatchedThisProcess,
-        )
+        )?.let { getString(it) }
         if (inUse != null) return inUse
 
         val freed = safManager.reclaimMirror(hash, force)
@@ -1855,6 +1859,26 @@ class MainActivity : AppCompatActivity() {
                     openWorkspaceFolder = it
                     adoptWorkbenchFolder(it)
                 }
+                // A main-frame load is a new document, and the document that owed a
+                // download's bytes went with the old one. [recreateWebView] used to
+                // be the only site that said so, which covered a renderer crash and
+                // nothing else: `reload()` on the way back from the background, the
+                // `loadUrl` in [navigateToFolder], the server-gave-up page, and the
+                // folder switches the workbench performs on its own all replace the
+                // page without passing through it. After any of those the
+                // coordinator was left holding a transfer nothing could finish, the
+                // stream open on the user's chosen document and that document never
+                // discarded, and because it runs one download at a time every later
+                // Download tap queued behind it until the queue filled and the rest
+                // were refused. The feature was dead for the life of the Activity.
+                //
+                // Unconditional, and it can be: a page cannot both have just
+                // finished loading and be the one already pushing bytes. The capture
+                // script is injected below, from this same callback, so no download
+                // can even be named before a page has finished loading. A picker
+                // still on screen is untouched by this; its result is matched by
+                // request id and the document it created is removed.
+                downloads.onPageGone()
                 // Only for a page the server served. onPageFinished fires for
                 // every main-frame load under this client, and one of them is the
                 // server-gave-up page, which is a local `about:blank` document
@@ -2701,7 +2725,24 @@ class MainActivity : AppCompatActivity() {
             .setNeutralButton(getString(R.string.crash_copy_report)) { _, _ ->
                 val report = CrashReporter.generateBugReport(this)
                 val clipboard = getSystemService(android.content.ClipboardManager::class.java)
-                clipboard.setPrimaryClip(android.content.ClipData.newPlainText("VSCodroid Bug Report", report))
+                val clip = android.content.ClipData.newPlainText("VSCodroid Bug Report", report)
+                // Marked sensitive before it goes anywhere, because of what this
+                // clip holds: [CrashReporter.generateBugReport] gathers the last
+                // 200 lines of server output and the text of the three most recent
+                // crash logs. Android 13 and later draw a preview of whatever is
+                // copied, so without this a crashing session's log is rendered
+                // over the editor for anyone looking at the screen, and the
+                // clipboard is readable by every app the user pastes into next.
+                // The preview is suppressed; the paste is unaffected.
+                //
+                // Deliberately not applied to the editor's own copy in
+                // [ClipboardBridge]. There the preview confirms what was copied,
+                // which is the whole affordance, and the text is a line the user
+                // selected rather than a log they never read.
+                clip.description.extras = android.os.PersistableBundle().apply {
+                    putBoolean(android.content.ClipDescription.EXTRA_IS_SENSITIVE, true)
+                }
+                clipboard.setPrimaryClip(clip)
                 Toast.makeText(this, getString(R.string.crash_report_copied), Toast.LENGTH_SHORT).show()
                 CrashReporter.clearCrashLogs()
             }

--- a/android/app/src/main/kotlin/com/vscodroid/SplashActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/SplashActivity.kt
@@ -139,12 +139,12 @@ class SplashActivity : AppCompatActivity() {
                 findViewById<TextView>(R.id.statusText).text = getString(R.string.status_updating_python)
                 lifecycleScope.launch {
                     withContext(Dispatchers.IO) { setup.reconcilePythonRuntime() }
-                    launchMain()
+                    continueAfterSetup()
                 }
                 return
             }
-            Logger.i(tag, "Not first run, launching main activity")
-            launchMain()
+            Logger.i(tag, "Not first run, setup is already behind this launch")
+            continueAfterSetup()
             return
         }
 
@@ -197,7 +197,7 @@ class SplashActivity : AppCompatActivity() {
             val result = setup.runSetup()
             when (result) {
                 FirstRunSetup.SetupResult.SUCCESS -> {
-                    if (shouldShowPicker()) showToolchainPicker() else launchMain()
+                    continueAfterSetup()
                 }
                 FirstRunSetup.SetupResult.LOW_STORAGE -> {
                     val message = getString(
@@ -290,6 +290,39 @@ class SplashActivity : AppCompatActivity() {
     }
 
     // -- Picker phase --
+
+    /**
+     * Where a launch goes once setup is behind it: the picker, or the editor.
+     *
+     * The single place that decision is made, and that is the fix rather than a
+     * tidy-up. It used to live in the continuation of the coroutine that ran
+     * setup, which is the one place it cannot survive: `runSetupLocked`'s body is
+     * blocking with no suspension point in it, so a relaunch part-way through
+     * cancels the coroutine while the extraction runs on to `markSetupComplete()`.
+     * `isFirstRun()` then goes false with the continuation never resumed, and the
+     * offer was only ever made inside the `isFirstRun()` branch, so the picker was
+     * gone for the life of that install. The way back is a launcher long-press,
+     * which nothing tells the user about.
+     *
+     * Not a corner case. Locale, font scale and display size are all undeclared in
+     * this activity's `configChanges` on purpose, so changing any of them during
+     * an extraction that runs for minutes relaunches the activity, and the
+     * manifest says as much where it lists them.
+     *
+     * Asking on every launch rather than only after setup costs nothing on an
+     * install that answered the picker, because answering it is what writes the
+     * preference: both the Continue and the Skip buttons call [markPickerShown].
+     * An upgrade is unaffected either way, since a new versionName makes
+     * `isFirstRun()` true and that route already passed through here.
+     */
+    private fun continueAfterSetup() {
+        if (shouldShowPicker()) {
+            Logger.i(tag, "The toolchain picker has not been answered yet; offering it")
+            showToolchainPicker()
+        } else {
+            launchMain()
+        }
+    }
 
     private fun shouldShowPicker(): Boolean {
         val prefs = getSharedPreferences("vscodroid", MODE_PRIVATE)

--- a/android/app/src/main/kotlin/com/vscodroid/ToolchainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/ToolchainActivity.kt
@@ -111,6 +111,14 @@ class ToolchainActivity : AppCompatActivity() {
         toolchainManager.registerListener()
         // Refresh installed state on resume (user may have installed from terminal)
         adapter.setInstalled(toolchainManager.getInstalledToolchains())
+        // And what is downloading, which this screen is not told about at all when
+        // another manager began the transfer. A rotation destroys this Activity and
+        // rebuilds it with a new manager, and opening the screen while the first-run
+        // queue is still working never had one; either way the cards started empty
+        // and offered Install for a pack already downloading, with no progress and
+        // no Cancel. Play's own downloads are not in this map and do not need to be:
+        // registerListener above makes Play re-deliver their state.
+        adapter.setDownloading(ToolchainManager.packsDownloading())
     }
 
     override fun onStop() {

--- a/android/app/src/main/kotlin/com/vscodroid/bridge/AndroidBridge.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/bridge/AndroidBridge.kt
@@ -9,8 +9,10 @@ import android.net.Uri
 import android.os.Build
 import android.os.SystemClock
 import android.webkit.JavascriptInterface
+import androidx.annotation.StringRes
 import androidx.browser.customtabs.CustomTabsIntent
 import com.google.android.play.core.assetpacks.model.AssetPackStatus
+import com.vscodroid.R
 import com.vscodroid.setup.ToolchainManager
 import com.vscodroid.setup.ToolchainRegistry
 import com.vscodroid.storage.SafStorageManager
@@ -120,23 +122,39 @@ internal fun authRequestIdsIn(url: String): List<String> =
  * reason belongs to which failure without pinning the wording, which is not the
  * contract. The wording is user facing: the extension's "Open in Browser" puts
  * whichever of these comes back straight into a `showErrorMessage`.
+ *
+ * A string resource and no longer the sentence itself, and the difference is what
+ * a translator can reach. These leave this app through a return value and are
+ * drawn by the editor, so `check-translatable-strings.py` cannot see them: it is
+ * a predicate over call shapes and finds a literal only where the literal is
+ * written at the sink, which its own docstring names as the hole it has. Written
+ * in Kotlin they stayed English under a translated editor for ever, and nothing
+ * anywhere reported it.
+ *
+ * The identity is what the constant carries, exactly as before; only the text
+ * moved. `res/values/strings.xml` holds the wording and the reasoning for it.
  */
-internal const val OPEN_URL_STALE_SESSION =
-    "VSCodroid did not accept the request. Reload the window and try again."
+@StringRes
+internal val OPEN_URL_STALE_SESSION = R.string.bridge_stale_session
 
 /** The reason that is worth acting on, and the only one the relay used to give. */
-internal const val OPEN_URL_NO_HANDLER =
-    "VSCodroid did not open it. No app on this device handles that link."
+@StringRes
+internal val OPEN_URL_NO_HANDLER = R.string.open_url_no_handler
 
 /**
- * Everything else, with the exception's class name appended.
+ * Everything else, with the exception's class name substituted into it.
  *
  * The class name and not its message: `ActivityNotFoundException` quotes the
  * whole Intent it could not match, and `FileUriExposedException` quotes the
  * file, so a message here would hand the URL to the page that supplied it and,
  * through the extension, to a notification a user may screenshot.
+ *
+ * A format string with the name as its one argument, rather than the prefix this
+ * used to be. A sentence assembled by concatenation puts the cause in the same
+ * place in every language and no translation can move it.
  */
-internal const val OPEN_URL_FAILED_PREFIX = "VSCodroid could not open that link: "
+@StringRes
+internal val OPEN_URL_FAILED = R.string.open_url_failed
 
 /**
  * Why [AndroidBridge.reclaimSafMirror] did not remove a mirror.
@@ -147,13 +165,22 @@ internal const val OPEN_URL_FAILED_PREFIX = "VSCodroid could not open that link:
  * as a success, which for this method means telling the user their disk was freed
  * while it was not.
  *
+ * That convention is worth one warning for whoever writes the next test here:
+ * a relaxed `Context` mock answers `getString` with the empty string, which is
+ * this method's answer for "it was removed". Stub the resource rather than
+ * asserting on what a relaxed mock returns.
+ *
  * A refusal here is never a suggestion to retry harder. Each one names something
  * that has to change first, and the two below are the ones this file can decide
  * on its own; the rest come from the Activity, which is the only place that knows
  * what the editor currently has open.
+ *
+ * The same resource as [OPEN_URL_STALE_SESSION], kept under its own name: it is
+ * one situation with one instruction, and the two names are what let a test say
+ * which call it is pinning.
  */
-internal const val RECLAIM_STALE_SESSION =
-    "VSCodroid did not accept the request. Reload the window and try again."
+@StringRes
+internal val RECLAIM_STALE_SESSION = R.string.bridge_stale_session
 
 /**
  * No Activity wired the callback, so nothing could have been removed.
@@ -163,8 +190,8 @@ internal const val RECLAIM_STALE_SESSION =
  * reporting it as "that folder is in use" would send them looking for a folder to
  * close.
  */
-internal const val RECLAIM_UNAVAILABLE =
-    "VSCodroid cannot manage device folder storage right now."
+@StringRes
+internal val RECLAIM_UNAVAILABLE = R.string.bridge_reclaim_unavailable
 
 /**
  * The sign-in requests this app launched a browser for, and when.
@@ -330,7 +357,7 @@ class AndroidBridge(
     private val onDownloadComplete: (requestId: String, error: String?) -> Unit = { _, _ -> },
     private val onListMirrors: () -> String = { "[]" },
     private val onReclaimMirror: (hash: String, force: Boolean) -> String =
-        { _, _ -> RECLAIM_UNAVAILABLE },
+        { _, _ -> context.getString(RECLAIM_UNAVAILABLE) },
 ) {
     private val tag = "AndroidBridge"
 
@@ -387,7 +414,7 @@ class AndroidBridge(
      */
     @JavascriptInterface
     fun openExternalUrl(url: String, authToken: String): String {
-        if (!security.validateToken(authToken)) return OPEN_URL_STALE_SESSION
+        if (!security.validateToken(authToken)) return context.getString(OPEN_URL_STALE_SESSION)
         // Empty until the launch arms something, and then the ids to take back if
         // the launch that armed them throws. Arming has to precede the launch, so
         // without this a launch nothing accepted still left the callback relay
@@ -443,8 +470,8 @@ class AndroidBridge(
             // inside the trace would only look like a redaction. The frames behind
             // it are all framework, so the class name is what was being read for.
             Logger.e(tag, "Failed to open a URL at ${urlLogLabel(url)} (${e.javaClass.simpleName})")
-            if (e is ActivityNotFoundException) OPEN_URL_NO_HANDLER
-            else OPEN_URL_FAILED_PREFIX + e.javaClass.simpleName
+            if (e is ActivityNotFoundException) context.getString(OPEN_URL_NO_HANDLER)
+            else context.getString(OPEN_URL_FAILED, e.javaClass.simpleName)
         }
     }
 
@@ -679,7 +706,7 @@ class AndroidBridge(
      */
     @JavascriptInterface
     fun reclaimSafMirror(authToken: String, hash: String, force: Boolean): String {
-        if (!security.validateToken(authToken)) return RECLAIM_STALE_SESSION
+        if (!security.validateToken(authToken)) return context.getString(RECLAIM_STALE_SESSION)
         return onReclaimMirror(hash, force)
     }
 

--- a/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
@@ -1948,14 +1948,24 @@ claude() {
             // neither value is a preference.
             //
             // The secondary side bar starts hidden, and on a phone that is not a
-            // preference either. Upstream's default is "visibleInWorkspace" and a
-            // brand-new profile opens it regardless of that, so the first screen a
-            // user ever sees gives a large share of its width to the chat view
-            // while what is beside it wraps mid-word. The provider that view
-            // exists for is not in this build, the Copilot extension being pruned
-            // from it, so the width buys nothing back. It is only a default and
-            // the view's own title menu reverses it, so a user who opens the bar
-            // keeps it open.
+            // preference either: it takes roughly 45 percent of the width for a
+            // chat view whose provider this build prunes, and what is beside it
+            // then wraps mid-word.
+            //
+            // Writing the key here does not by itself close the bar, however
+            // plainly its name reads. It decides a workspace with no recorded
+            // layout, and by the time this file reaches the web client that
+            // record exists: the workbench starts from a copy of these settings
+            // in browser storage that the first load in a profile has not
+            // written yet, falls back to
+            // upstream's "visibleInWorkspace", opens the bar and stores
+            // `workbench.auxiliaryBar.hidden: false` against the workspace. Every
+            // later load reads the record and never consults the default again.
+            // The bundled welcome extension is what corrects the record, once per
+            // workspace; this is the value it reads to decide whether to.
+            //
+            // Still only a default, and the view's own title menu reverses it, so
+            // a user who opens the bar keeps it open.
             val defaults = """
                 {
                     "workbench.secondarySideBar.defaultVisibility": "hidden",
@@ -3062,6 +3072,14 @@ private val CLAUDE_WRAPPER_KEY = Regex(""""claudeCode\.claudeProcessWrapper"\s*:
 private val VERIFY_SIGNATURE = Regex(""""extensions\.verifySignature"\s*:""")
 
 /**
+ * Whether the user's settings already mention the secondary side bar's default.
+ *
+ * Presence alone, either value, for the reason [VERIFY_SIGNATURE] gives: the bar
+ * open is a working window and a user who asked for it meant to.
+ */
+private val SECONDARY_SIDE_BAR = Regex(""""workbench\.secondarySideBar\.defaultVisibility"\s*:""")
+
+/**
  * The two settings that route Python environment discovery through `pet`, the
  * Python extension's native locator.
  *
@@ -3772,8 +3790,8 @@ private fun isOlderVersion(a: String, b: String): Boolean {
  * than only refreshed, so they reach installs made before the setting existed:
  * `claudeCode.claudeProcessWrapper`, itself a `nativeLibraryDir` path and so
  * refreshed too, but left alone when it points somewhere the user chose;
- * `extensions.verifySignature`; and the two Python pins [PYTHON_LOCATOR] and
- * [PYTHON_ENV_EXTENSION].
+ * `extensions.verifySignature`; `workbench.secondarySideBar.defaultVisibility`;
+ * and the two Python pins [PYTHON_LOCATOR] and [PYTHON_ENV_EXTENSION].
  *
  * Substitutes values in place and leaves every other byte untouched.
  * settings.json is JSONC: comments and trailing commas are legal there, so
@@ -3825,6 +3843,25 @@ internal fun refreshManagedPaths(
     // switching it back on is a decision worth keeping.
     if (!VERIFY_SIGNATURE.containsMatchIn(updated)) {
         updated = insertSetting(updated, "extensions.verifySignature", "false")
+    }
+
+    // Same reach, and it is the whole point here: v1.1.0 shipped no such key, and
+    // createDefaultSettings() writes only when settings.json is absent, so every
+    // device upgrading into this release would otherwise never see the value at
+    // all. Inserted when absent and never rewritten, in company with
+    // [VERIFY_SIGNATURE].
+    //
+    // The key is not on its own enough to close the bar, and was never expected
+    // to be: it decides a workspace that has no recorded layout, and the record
+    // is written before this file reaches the web client. What acts on the record
+    // is the bundled welcome extension, once per workspace. This is what gives it
+    // something to read.
+    if (!SECONDARY_SIDE_BAR.containsMatchIn(updated)) {
+        updated = insertSetting(
+            updated,
+            "workbench.secondarySideBar.defaultVisibility",
+            "\"hidden\"",
+        )
     }
 
     // Reaches installs that already have a settings.json, which is every device

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainCardState.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainCardState.kt
@@ -1,6 +1,7 @@
 package com.vscodroid.setup
 
 import com.google.android.play.core.assetpacks.model.AssetPackStatus
+import com.vscodroid.util.StorageManager
 
 /** Which screen the cards are on. */
 enum class ToolchainCardMode {
@@ -16,6 +17,15 @@ enum class ToolchainAction { INSTALL, REMOVE, CANCEL, RETRY }
 
 /** What a card's status line says. */
 enum class ToolchainBadge { NONE, INSTALLED, FAILED }
+
+/**
+ * The two sizes a card quotes, already formatted.
+ *
+ * Two fields rather than one, because they answer different questions and the
+ * card was showing only the second: what the download costs on mobile data, and
+ * what it occupies once unpacked.
+ */
+data class SizeFigures(val download: String, val installed: String)
 
 /**
  * Everything one toolchain card shows, decided without a View.
@@ -55,6 +65,19 @@ class ToolchainCardState(private val mode: ToolchainCardMode) {
     private val downloadStatus = mutableMapOf<String, Int>()
     private val downloadPercent = mutableMapOf<String, Int>()
 
+    /**
+     * Downloads the process knows about that this screen was never told of, as
+     * pack name to percentage.
+     *
+     * Kept apart from [downloadStatus] rather than folded into it, because the
+     * two have opposite lifetimes. A report is this screen's own and stays until
+     * the next one replaces it; a seed is a snapshot of what some other manager
+     * is doing and is replaced wholesale by the next [setDownloading]. Folding a
+     * seed into [downloadStatus] would leave a card offering Cancel for a
+     * download that finished, since nothing ever reports its end here.
+     */
+    private val seededDownloads = mutableMapOf<String, Int>()
+
     /** Position of [packName] among [items], or -1 when no card shows it. */
     fun positionOf(packName: String): Int = items.indexOfFirst { it.packName == packName }
 
@@ -70,6 +93,26 @@ class ToolchainCardState(private val mode: ToolchainCardMode) {
         installed.addAll(packNames.map { name ->
             if (name.startsWith("toolchain_")) name else "toolchain_$name"
         })
+    }
+
+    /**
+     * Replaces what the process is downloading with [percentByPack].
+     *
+     * A download reports its progress to the manager that began it and to
+     * nothing else, so a screen built after the transfer started hears nothing:
+     * rotating the toolchain screen rebuilds it, and so does opening it while
+     * the first-run queue is still working. With an empty state the card fell
+     * through to Install for a pack that was already downloading, offering no
+     * progress and, worse, no Cancel, which is the only way to stop a 56 MB
+     * transfer once it is running.
+     *
+     * Replaces rather than adds, so a download that has since finished stops
+     * being drawn as running. That matters because its end is not reported here
+     * either.
+     */
+    fun setDownloading(percentByPack: Map<String, Int>) {
+        seededDownloads.clear()
+        seededDownloads.putAll(percentByPack)
     }
 
     /**
@@ -101,6 +144,31 @@ class ToolchainCardState(private val mode: ToolchainCardMode) {
     /** A snapshot of what is ticked, safe to hold while the user carries on tapping. */
     fun selectedPackNames(): Set<String> = selected.toSet()
 
+    /**
+     * The two figures the size line shows, both spelled the way the rest of the
+     * app spells them.
+     *
+     * Here rather than in [ToolchainPickerAdapter] for the reason the rest of
+     * this class is: it is part of what the card says, and it is the part that
+     * was wrong without anything failing. The registry used to format these
+     * itself, dividing by 1,000,000, while the low-storage warning, the
+     * first-run pre-flight, the storage breakdown and the device-folder screen
+     * all divide by 1,048,576 and write the same "MB". The card therefore
+     * quoted a toolchain 4.9% larger than the number the user had just read on
+     * the screen they came from.
+     *
+     * The convention kept is 1,048,576, for two reasons. It is what `du -h` and
+     * `df -h` report in this app's own terminal, which is where its users check
+     * a size, and it is what every other figure here already uses, so it is the
+     * one that can be made consistent without changing what a free-space gate
+     * appears to promise. Nothing computes with these strings: every pre-flight
+     * works in raw bytes.
+     */
+    fun sizeFigures(info: ToolchainRegistry.ToolchainInfo): SizeFigures = SizeFigures(
+        download = StorageManager.formatSize(info.downloadSize),
+        installed = StorageManager.formatSize(info.estimatedSize),
+    )
+
     /** The card to draw for [packName] on this screen. */
     fun card(packName: String): ToolchainCard = when (mode) {
         ToolchainCardMode.PICKER -> ToolchainCard(selected = packName in selected)
@@ -109,9 +177,18 @@ class ToolchainCardState(private val mode: ToolchainCardMode) {
 
     private fun managerCard(packName: String): ToolchainCard {
         val status = downloadStatus[packName]
+        // A report always wins over a seed, and only a pack with no report at
+        // all is read from the seeds. A report is this screen's own and keeps
+        // arriving; a seed is a one-off snapshot and would otherwise outlive the
+        // download it describes, since nothing reports that download's end here.
+        val seeded = if (status == null) seededDownloads[packName] else null
         return when {
             status in IN_FLIGHT -> ToolchainCard(
                 progressPercent = downloadPercent[packName] ?: 0,
+                action = ToolchainAction.CANCEL,
+            )
+            seeded != null -> ToolchainCard(
+                progressPercent = seeded,
                 action = ToolchainAction.CANCEL,
             )
             status == AssetPackStatus.FAILED -> ToolchainCard(

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
@@ -138,6 +138,19 @@ class ToolchainManager(private val context: Context) {
      */
     private class HttpDownload {
         @Volatile var cancelled = false
+
+        /**
+         * How far the transfer has got, kept on the token as well as reported.
+         *
+         * The report goes to `onStateChange`, which belongs to the manager that
+         * began the download and to nothing else. A screen rebuilt while the
+         * transfer runs holds a different manager and hears none of it, so
+         * without a figure the process itself can be asked for, the only card
+         * such a screen could draw would be a progress bar frozen at zero.
+         * Volatile because the download thread writes it and the main thread
+         * reads it through [packsDownloading].
+         */
+        @Volatile var percent = 0
     }
 
     /**
@@ -276,6 +289,29 @@ class ToolchainManager(private val context: Context) {
          * `remove` in the download's `finally` keeps the later one cancellable.
          */
         private val httpDownloads = ConcurrentHashMap<String, HttpDownload>()
+
+        /**
+         * Every pack with an HTTP transfer outstanding right now, and how far
+         * each has got.
+         *
+         * Asked of the process rather than of one manager, because progress is
+         * reported only to the manager that began the download. Two readers need
+         * the answer and neither holds that manager. The toolchain screen rebuilds
+         * its cards from nothing on every `onCreate` -- a rotation, or simply
+         * opening it while the first-run queue is still working -- and a card with
+         * no report to go on drew Install for a pack that was already downloading:
+         * no progress, and no Cancel, which is the one button that stops a 56 MB
+         * transfer on mobile data. [com.vscodroid.util.StorageManager.clearCaches]
+         * needs it for the opposite reason: to leave a running download's staging
+         * directory alone while it clears the abandoned ones.
+         *
+         * The Play path is not here and does not need to be. Play Core re-delivers
+         * state for a pack it is still fetching once [registerListener] runs, which
+         * the activities do in `onStart`, so a rebuilt screen learns about that
+         * download on its own. The HTTP path has no such redelivery.
+         */
+        internal fun packsDownloading(): Map<String, Int> =
+            httpDownloads.mapValues { (_, download) -> download.percent }
     }
 
     private val listener = AssetPackStateUpdateListener { state ->
@@ -1260,6 +1296,7 @@ class ToolchainManager(private val context: Context) {
                 Logger.i(tag, "$packName matches the digest the release publishes")
 
                 // Extract: report as TRANSFERRING (file copy phase)
+                download.percent = 90
                 report(packName, AssetPackStatus.TRANSFERRING, 90)
                 extractDir.deleteRecursively()
                 extractDir.mkdirs()
@@ -1691,6 +1728,10 @@ class ToolchainManager(private val context: Context) {
                     val percent = if (totalBytes > 0) {
                         ((bytesRead * 85) / totalBytes).toInt().coerceAtMost(85)
                     } else 0
+                    // On the token as well as in the report: the report reaches
+                    // only the manager that began this download, and a screen
+                    // rebuilt mid-transfer holds a different one.
+                    download.percent = percent
                     report(packName, AssetPackStatus.DOWNLOADING, percent)
                 }
             }

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainPickerAdapter.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainPickerAdapter.kt
@@ -43,6 +43,18 @@ class ToolchainPickerAdapter(
         notifyDataSetChanged()
     }
 
+    /**
+     * MANAGER mode: replaces the downloads this screen was never told about.
+     *
+     * See [ToolchainCardState.setDownloading]. Called when the screen starts,
+     * because that is the moment a rebuilt one holds no reports at all.
+     */
+    @SuppressLint("NotifyDataSetChanged")
+    fun setDownloading(percentByPack: Map<String, Int>) {
+        cards.setDownloading(percentByPack)
+        notifyDataSetChanged()
+    }
+
     fun updateState(packName: String, status: Int, percent: Int) {
         val pos = cards.updateState(packName, status, percent)
         if (pos >= 0) notifyItemChanged(pos)
@@ -64,10 +76,11 @@ class ToolchainPickerAdapter(
         // used to be here. The single figure was the unpacked size, so a card
         // offered "179 MB" for a 59 MB download, and the person most likely to
         // read it is the one deciding whether to spend mobile data.
+        val sizes = cards.sizeFigures(info)
         holder.size.text = ctx.getString(
             R.string.toolchain_size_download_and_installed,
-            ToolchainRegistry.formatSize(info.downloadSize),
-            ToolchainRegistry.formatSize(info.estimatedSize),
+            sizes.download,
+            sizes.installed,
         )
 
         when (mode) {

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainRegistry.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainRegistry.kt
@@ -115,11 +115,13 @@ object ToolchainRegistry {
     fun find(nameOrPack: String): ToolchainInfo? =
         available.find { it.packName == nameOrPack || it.packName == "toolchain_$nameOrPack" }
 
-    /** Format byte count as human-readable size (e.g. "9 MB"). */
-    fun formatSize(bytes: Long): String = when {
-        bytes >= 1_000_000_000 -> "${bytes / 1_000_000_000} GB"
-        bytes >= 1_000_000 -> "${bytes / 1_000_000} MB"
-        bytes >= 1_000 -> "${bytes / 1_000} KB"
-        else -> "$bytes B"
-    }
+    // There was a `formatSize` here, dividing by 1,000,000 and writing "MB".
+    // Every other byte figure the app shows divides by 1,048,576 and writes the
+    // same word: the low-storage warning, the first-run pre-flight, the storage
+    // breakdown and the device-folder screen. So "MB" meant one thing on the
+    // toolchain cards and another, 4.9% larger, everywhere the user could
+    // compare it against, with nothing on either screen saying which. The cards
+    // go through [com.vscodroid.util.StorageManager.formatSize] now, like
+    // everything else; [ToolchainCardState.sizeFigures] records why that is the
+    // convention kept.
 }

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafStorageManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafStorageManager.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.provider.DocumentsContract
+import androidx.annotation.StringRes
+import com.vscodroid.R
 import com.vscodroid.util.Logger
 import com.vscodroid.util.StorageManager
 import org.json.JSONArray
@@ -878,8 +880,9 @@ class SafStorageManager(private val context: Context) {
         internal const val RECLAIM_FAILED = -3L
 
         /**
-         * Why a mirror the user asked to remove must not be removed now, or null when
-         * nothing this side knows about stands in the way.
+         * Why a mirror the user asked to remove must not be removed now, as the string
+         * resource that says so, or null when nothing this side knows about stands in
+         * the way.
          *
          * The question is "is anything still using this mirror", and it is separate
          * from the question [mayReclaim] and [SafSyncEngine.holdsOnlyVouchedCopies]
@@ -908,13 +911,14 @@ class SafStorageManager(private val context: Context) {
          * degrades the message rather than opening the hole; removing this one opens
          * it.
          */
+        @StringRes
         internal fun reclaimRefusal(
             hash: String,
             watchedMirror: String?,
             syncingMirror: String?,
             openWorkspaceMirror: String?,
             watchedThisProcess: Set<String>,
-        ): String? = when (hash) {
+        ): Int? = when (hash) {
             watchedMirror -> RECLAIM_FOLDER_OPEN
             syncingMirror -> RECLAIM_FOLDER_OPENING
             openWorkspaceMirror -> RECLAIM_FOLDER_OPEN
@@ -922,11 +926,27 @@ class SafStorageManager(private val context: Context) {
             else -> null
         }
 
-        internal const val RECLAIM_FOLDER_OPEN =
-            "That folder is open in the editor. Open a different folder first."
-        internal const val RECLAIM_FOLDER_OPENING = "That folder is still opening."
-        internal const val RECLAIM_FOLDER_THIS_SESSION =
-            "That folder was open in this session. Restart VSCodroid, then remove it."
+        /**
+         * The three refusals above, as string resources rather than sentences.
+         *
+         * They cross the bridge and the bundled extension shows whichever comes
+         * back verbatim, so they are user-facing text, and a sentence written in
+         * Kotlin is the same in every locale for ever. Nothing reported that:
+         * `check-translatable-strings.py` finds a literal only where the literal
+         * is written at the sink, and these leave through a return value, which
+         * its own docstring names as the hole it has.
+         *
+         * The ids and not the text, so this stays a pure predicate a JVM test can
+         * exercise with no Context: what belongs to which case is decided here and
+         * the words are resolved by the Activity that has one. Resource ids are
+         * never zero, so null still means "no refusal".
+         */
+        @StringRes
+        internal val RECLAIM_FOLDER_OPEN = R.string.saf_mirror_folder_open
+        @StringRes
+        internal val RECLAIM_FOLDER_OPENING = R.string.saf_mirror_folder_opening
+        @StringRes
+        internal val RECLAIM_FOLDER_THIS_SESSION = R.string.saf_mirror_folder_this_session
 
         /**
          * The mirror [path] sits in, or null when it is not under [mirrorsRoot].

--- a/android/app/src/main/kotlin/com/vscodroid/util/StorageManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/util/StorageManager.kt
@@ -1,6 +1,7 @@
 package com.vscodroid.util
 
 import android.content.Context
+import com.vscodroid.setup.ToolchainManager
 import org.json.JSONArray
 import org.json.JSONObject
 import java.io.File
@@ -14,7 +15,7 @@ import java.nio.file.Files
  * - Extensions (marketplace + bundled)
  * - User data (settings, state, logs)
  * - Tools (usr/: bash, git, python, npm, etc.)
- * - Cache (npm-cache, tmp, crash-logs)
+ * - Cache (npm-cache, tmp, crash-logs, toolchain staging directories)
  */
 object StorageManager {
     private const val TAG = "StorageManager"
@@ -61,7 +62,8 @@ object StorageManager {
     internal val CLEARABLE_KEYS = setOf("logs", "cache")
 
     /**
-     * Clears caches: npm-cache, tmp dir, crash logs, VS Code logs.
+     * Clears caches: npm-cache, tmp dir, crash logs, VS Code logs, and the
+     * toolchain staging directories no download is using.
      * Returns the number of bytes freed.
      */
     fun clearCaches(context: Context): Long {
@@ -85,7 +87,58 @@ object StorageManager {
         freed += deleteRecursive(vscodeLogs)
         vscodeLogs.mkdirs() // recreate
 
+        // Toolchain staging directories
+        freed += clearAbandonedToolchainDownloads(context)
+
         Logger.i(TAG, "Caches cleared: ${formatSize(freed)} freed")
+        return freed
+    }
+
+    /**
+     * Removes the toolchain staging directories no download is using, and reports
+     * the bytes that went.
+     *
+     * These sit under `cacheDir`, so [getStorageBreakdown] has always counted them
+     * in the `cache` row, and [CLEARABLE_KEYS] offers that row to [clearCaches].
+     * Leaving them out meant the Clear action reported success and left the figure
+     * on the same screen unmoved, and it is by some way the largest thing here: an
+     * abandoned Java download is roughly 155 MB of expanded tree, against a few MB
+     * for the other four directories put together. The user who opens that screen
+     * is the one who is out of space.
+     *
+     * A directory belonging to a running download is left alone, and that is the
+     * whole reason this is not one more line beside the others. `toolchainTempDir`
+     * gives each transfer a directory of its own and the download writes its
+     * archive, expands it and copies out of it there; pulling it out mid-flight
+     * fails the transfer at best, and at worst leaves the copy into `usr/` reading
+     * a tree that is being deleted underneath it. The name carries the pack and a
+     * timestamp only the download itself knows, so the test is on the pack: every
+     * directory of a pack being fetched stays, including an older abandoned one.
+     * That keeps at most one extra directory for the length of one download, and
+     * the launch sweep takes it a day later.
+     *
+     * The listing is taken before the in-flight set is read, not after. A download
+     * publishes its pack name before it queues the task that creates the directory,
+     * so anything already on disk at listing time is named in a set read afterwards.
+     * The other order has a window: a download starting in between would have its
+     * directory in the listing and its name in neither set.
+     *
+     * `ToolchainManager` also sweeps these on every launch, but only once they are a
+     * day old, deliberately: nothing there can tell a stalled download from a
+     * finished one. This is the user asking, so it takes everything it safely can.
+     */
+    private fun clearAbandonedToolchainDownloads(context: Context): Long {
+        val root = File(context.cacheDir, "toolchain-download")
+        val entries = root.listFiles() ?: return 0
+        val inFlight = ToolchainManager.packsDownloading().keys
+        var freed = 0L
+        for (entry in entries) {
+            if (inFlight.any { entry.name.startsWith("$it-") }) {
+                Logger.i(TAG, "Keeping ${entry.name}: a download is still using it")
+                continue
+            }
+            freed += deleteRecursive(entry)
+        }
         return freed
     }
 

--- a/android/app/src/main/res/layout/activity_splash.xml
+++ b/android/app/src/main/res/layout/activity_splash.xml
@@ -1,8 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- keepScreenOn is load-bearing, and the manifest points here for it. First-run
+     setup unpacks over 800 MB and takes minutes with nothing for the user to
+     touch, so the display times out partway through every time. What that costs
+     is not the drawing: the window stops being visible, the activity is stopped,
+     and a process holding nothing but a stopped activity is what the system
+     reclaims first, in the middle of a write that has no skip-if-present branch
+     to make the next attempt cheaper.
+
+     On the root view rather than as a window flag, so it lasts exactly as long as
+     this screen does. setContentView swaps in the picker next, which waits on a
+     person and could hold the display awake until the battery is flat; a window
+     flag would keep burning through that wait, and this drops the moment the
+     view is detached. -->
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:keepScreenOn="true"
     android:background="@color/colorBackground">
 
     <!-- App icon. Decorative: the TextView below carries the same @string/app_name

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -229,6 +229,39 @@
          the recursive delete outlives the call the editor is waiting on. -->
     <string name="saf_mirror_removed">Removed a device folder\'s local copy, freeing %1$s.</string>
 
+    <!-- The refusals the removal guard raises before anything is deleted. They travel
+         back across the bridge and the bundled extension shows them verbatim, so they
+         are the user's whole explanation for a removal that did not happen. Each names
+         the thing that has to change first; none of them invites a bare retry. -->
+    <string name="saf_mirror_folder_open">That folder is open in the editor. Open a different folder first.</string>
+    <string name="saf_mirror_folder_opening">That folder is still opening.</string>
+    <!-- The widest of the three. A write-back drain outlives the folder switch that
+         stopped it and can still be streaming out of the copy, so a restart is what
+         makes the copy safe to remove rather than closing the folder. -->
+    <string name="saf_mirror_folder_this_session">That folder was open in this session. Restart VSCodroid, then remove it.</string>
+
+    <!-- Reasons a bridge call did not do what it was asked. These are returned to the
+         page and rendered by the bundled extension's showErrorMessage, which is the
+         only reason they are resources at all: the gate over translatable strings is a
+         predicate over call shapes and cannot see a sentence that leaves through a
+         return value. -->
+    <!-- The caller's session token did not match. Used by both the external-URL and
+         the folder-removal calls; one string because it is one situation and one
+         instruction. -->
+    <string name="bridge_stale_session">VSCodroid did not accept the request. Reload the window and try again.</string>
+    <!-- No Activity wired the removal callback, so nothing could have been removed.
+         Distinct from a refusal with a reason: this is a mistake in the app rather
+         than a state the user can act on, and saying "that folder is in use" would
+         send them looking for a folder to close. -->
+    <string name="bridge_reclaim_unavailable">VSCodroid cannot manage device folder storage right now.</string>
+    <!-- Nothing on the device claimed the link. The one refusal the user can act on. -->
+    <string name="open_url_no_handler">VSCodroid did not open it. No app on this device handles that link.</string>
+    <!-- Every other launch failure, with the class name of the exception substituted. The
+         class name and never its message: ActivityNotFoundException quotes the whole
+         Intent and FileUriExposedException quotes the file, so the message would hand
+         the address back to the page that supplied it. -->
+    <string name="open_url_failed">VSCodroid could not open that link: %1$s</string>
+
     <!-- A folder copied out to the device that did not arrive whole. Counts entries
          rather than naming them, because the failure is usually folder-wide and forty
          separate notices is another way of telling the user nothing. Deliberately not

--- a/android/app/src/test/kotlin/com/vscodroid/BridgeCommandDeadlineTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/BridgeCommandDeadlineTest.kt
@@ -1,0 +1,157 @@
+package com.vscodroid
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * That the two screens which reclaim disk are allowed to finish.
+ *
+ * Every command the bundled bridge extension sends is answered synchronously by
+ * the relay in the page, and four of the bridge methods behind them walk
+ * directory trees before they can answer: `getStorageBreakdown` sizes each
+ * component of the app's storage and then the whole of `filesDir` again for the
+ * total, `listSafMirrors` walks every copied device folder twice (once to size
+ * it, once to ask whether the device folder holds everything in it),
+ * `reclaimSafMirror` re-asks that second question and sizes the copy, and
+ * `clearCaches` deletes trees. Both `SafStorageManager.listMirrors` and
+ * `SafStorageManager.reclaimMirror` carry a warning in their own documentation
+ * that they walk the mirror.
+ *
+ * All four were sent under one five-second deadline written for a relay hop. The
+ * extracted server tree alone is around 875 MB before a project is opened, so on
+ * a real install the walk outruns the deadline, the promise rejects, and the user
+ * is told "Bridge timeout: is the app running on Android?" by the only two
+ * screens in the app that can free space. The answer they were waiting for
+ * arrives afterwards and is dropped, because the pending entry is already gone.
+ *
+ * The deadline is checked rather than the walk, because the walk is the user's
+ * disk and nothing here can bound it. What can be pinned is that these four are
+ * not given the deadline meant for a command that only has to be relayed.
+ *
+ * Read out of the shipped script, as `DeviceFolderPayloadTest` reads it: the
+ * extension runs in the web extension host inside a WebView, so there is no
+ * harness in this suite that can execute it.
+ */
+class BridgeCommandDeadlineTest {
+
+    /**
+     * The bundled extension, found by prefix rather than by version, for the
+     * reason `DeviceFolderPayloadTest` gives: the directory name carries the
+     * extension's version and moves with every release of it.
+     */
+    private fun script(): String {
+        val root = File("src/main/assets/extensions")
+        val matches = root.listFiles { entry: File ->
+            entry.isDirectory && entry.name.startsWith("vscodroid.vscodroid-saf-bridge-")
+        }?.toList().orEmpty()
+
+        assertEquals(
+            1, matches.size,
+            "expected exactly one bundled SAF bridge extension under ${root.absolutePath}; " +
+                "found ${matches.map { it.name }}",
+        )
+        val file = File(matches.single(), "extension.js")
+        assertTrue(file.isFile) { "no extension.js in ${matches.single().name}" }
+        return file.readText()
+    }
+
+    /**
+     * The text of every `sendBridgeCommand` call for [command], from the command
+     * name to the closing parenthesis of the call.
+     *
+     * Balanced rather than read to the next `)`, because two of these calls pass
+     * an object literal whose own parentheses and braces sit between the command
+     * name and the deadline.
+     */
+    private fun callsTo(source: String, command: String): List<String> {
+        val opener = "sendBridgeCommand('$command'"
+        val found = mutableListOf<String>()
+        var from = source.indexOf(opener)
+        while (from >= 0) {
+            var depth = 0
+            var i = source.indexOf('(', from)
+            while (i < source.length) {
+                if (source[i] == '(') depth += 1
+                if (source[i] == ')') {
+                    depth -= 1
+                    if (depth == 0) {
+                        found.add(source.substring(from, i + 1))
+                        break
+                    }
+                }
+                i += 1
+            }
+            from = source.indexOf(opener, from + opener.length)
+        }
+        return found
+    }
+
+    /** The commands whose cost is the size of what the user has on disk. */
+    private val diskWalking = listOf(
+        "getStorageBreakdown",
+        "listSafMirrors",
+        "reclaimSafMirror",
+        "clearCaches",
+    )
+
+    /**
+     * Commands the relay answers out of a field or by handing an intent to an
+     * Activity. They are the negative control: if they carried the long deadline
+     * too, this file would be pinning "everything waits two minutes" rather than
+     * "the disk walks are not held to a relay hop", and a bridge that had stopped
+     * answering at all would keep the user waiting for it.
+     */
+    private val instant = listOf("openFolderPicker", "getRecentFolders", "showAboutDialog")
+
+    @Test
+    fun `a command that walks the disk is not held to the relay deadline`() {
+        val source = script()
+
+        assertTrue(source.contains("const DISK_WALK_TIMEOUT_MS")) {
+            "the bundled extension has no separate deadline for the commands that walk " +
+                "the disk, so all of them are held to the relay hop's five seconds and the " +
+                "storage screens report a timeout on any install with files on it."
+        }
+
+        val missing = diskWalking.filter { command ->
+            val calls = callsTo(source, command)
+            assertTrue(calls.isNotEmpty()) {
+                "no sendBridgeCommand('$command') call left in the bundled extension, so " +
+                    "this test is measuring nothing for it. If the command was renamed, " +
+                    "rename it here."
+            }
+            calls.any { !it.contains("DISK_WALK_TIMEOUT_MS") }
+        }
+
+        assertEquals(
+            emptyList<String>(), missing,
+            "these commands walk the user's disk before they can answer and are still sent " +
+                "under the deadline meant for a relay hop. The promise rejects while the " +
+                "walk is still running, the user is told the app may not be running on " +
+                "Android, and the answer is discarded when it arrives.",
+        )
+    }
+
+    @Test
+    fun `a command the relay answers at once keeps the short deadline`() {
+        val source = script()
+
+        val overlong = instant.filter { command ->
+            val calls = callsTo(source, command)
+            assertTrue(calls.isNotEmpty()) {
+                "no sendBridgeCommand('$command') call left in the bundled extension, so " +
+                    "this control is measuring nothing"
+            }
+            calls.any { it.contains("DISK_WALK_TIMEOUT_MS") }
+        }
+
+        assertEquals(
+            emptyList<String>(), overlong,
+            "a command the relay answers out of a field is waiting on the disk-walk " +
+                "deadline. A bridge that is not there at all would then take two minutes " +
+                "to say so instead of five seconds, which is what the short deadline is for.",
+        )
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/BugReportClipTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/BugReportClipTest.kt
@@ -1,0 +1,113 @@
+package com.vscodroid
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * That the bug report is not drawn on screen on its way to the clipboard.
+ *
+ * `CrashReporter.generateBugReport` gathers the last 200 lines of server output
+ * and the text of the three most recent crash logs, and the crash dialog offers
+ * to copy all of it. Android 13 and later render a preview of whatever is put on
+ * the clipboard, so without `ClipDescription.EXTRA_IS_SENSITIVE` that material is
+ * shown over the editor at the one moment the user is most likely to be handing
+ * the device to somebody or taking a screenshot of it. `minSdk` is 33, so every
+ * device this ships to draws that preview and no version guard is involved.
+ *
+ * Read out of the source, which is the weaker kind of test in this suite and is
+ * used here for the reason `DownloadListenerWiringTest` gives: there is no seam.
+ * The clip is built inline inside a dialog button handler on a private method of
+ * an Activity, `ClipData.newPlainText` is static and `ClipboardManager` is a
+ * system service, so a unit test has no way to reach the call and read back what
+ * was put on the clipboard.
+ *
+ * The order is asserted as well as the presence. Setting the flag on a
+ * `ClipDescription` after the clip has already been handed to the clipboard
+ * changes nothing that has been shown, and it would read exactly like this test
+ * passing.
+ */
+class BugReportClipTest {
+
+    private val source = File("src/main/kotlin/com/vscodroid/MainActivity.kt").readText()
+
+    /** The body of a `private fun name(` declaration, to its closing brace. */
+    private fun body(name: String): String {
+        val start = source.indexOf("private fun $name(")
+        assertTrue(start >= 0) {
+            "$name is gone from MainActivity.kt, so this test is measuring nothing. If it " +
+                "moved or was renamed, point this at the new site rather than deleting it."
+        }
+        val open = source.indexOf('{', start)
+        var depth = 0
+        var i = open
+        while (i < source.length) {
+            if (source[i] == '{') depth += 1
+            if (source[i] == '}') {
+                depth -= 1
+                if (depth == 0) return source.substring(open, i + 1)
+            }
+            i += 1
+        }
+        throw AssertionError("Could not find the end of $name in MainActivity.kt")
+    }
+
+    /**
+     * Comments removed, so prose about the rule cannot satisfy a search for the
+     * rule. The lines this file checks are surrounded by a comment that names
+     * both `EXTRA_IS_SENSITIVE` and `setPrimaryClip`.
+     */
+    private fun withoutComments(text: String): String {
+        var inBlock = false
+        return text.lines().joinToString("\n") { raw ->
+            var line = raw
+            if (inBlock) {
+                val close = line.indexOf("*/")
+                if (close < 0) return@joinToString ""
+                inBlock = false
+                line = line.substring(close + 2)
+            }
+            while (line.trimStart().startsWith("/*")) {
+                val open = line.indexOf("/*")
+                val close = line.indexOf("*/", open + 2)
+                if (close < 0) {
+                    inBlock = true
+                    return@joinToString line.substring(0, open)
+                }
+                line = line.substring(0, open) + line.substring(close + 2)
+            }
+            val marker = line.indexOf("//")
+            if (marker >= 0) line.substring(0, marker) else line
+        }
+    }
+
+    @Test
+    fun `the copied bug report is marked sensitive before it reaches the clipboard`() {
+        val dialog = withoutComments(body("checkPreviousCrash"))
+
+        // Control. Without it a scan that stopped finding the copy action at all
+        // would report green over a dialog that still puts the log on screen.
+        assertTrue(dialog.contains("generateBugReport")) {
+            "checkPreviousCrash no longer builds a bug report, so this test is measuring " +
+                "nothing. If the copy action moved, point this at the new site."
+        }
+
+        val flagged = dialog.indexOf("EXTRA_IS_SENSITIVE")
+        assertTrue(flagged >= 0) {
+            "the bug report goes on the clipboard with no ClipDescription.EXTRA_IS_SENSITIVE, " +
+                "so Android 13 and later draw a preview of it: the last 200 lines of server " +
+                "output and three crash logs, rendered over the editor."
+        }
+
+        val handedOver = dialog.indexOf("setPrimaryClip")
+        assertTrue(handedOver >= 0) {
+            "checkPreviousCrash no longer puts the report on the clipboard; this test is " +
+                "measuring nothing"
+        }
+        assertTrue(flagged < handedOver) {
+            "the clip is marked sensitive after it has already been handed to the " +
+                "clipboard, which is after the preview has been drawn. Set the flag on the " +
+                "description before setPrimaryClip."
+        }
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/SplashLifetimeTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/SplashLifetimeTest.kt
@@ -1,0 +1,133 @@
+package com.vscodroid
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.w3c.dom.Element
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+
+/**
+ * What has to hold for the screen that unpacks the app.
+ *
+ * First-run setup writes out some 810 MB with nothing for the user to touch, and
+ * `extractAssetFile` has no skip-if-present branch, so an interruption is not a
+ * pause: the next attempt starts from zero. Two things decide whether it is
+ * interrupted and what it costs, and neither is visible from the code that does
+ * the extracting.
+ *
+ * Source and layout reading, which is the weaker layer in this suite. It is what
+ * is available: both subjects are an Activity's lifecycle and a resource
+ * attribute, and no plain JVM test can build either.
+ */
+class SplashLifetimeTest {
+
+    private val source = File("src/main/kotlin/com/vscodroid/SplashActivity.kt")
+    private val layout = File("src/main/res/layout/activity_splash.xml")
+
+    /**
+     * The source with comments dropped.
+     *
+     * Prose about a rule must not be able to satisfy a search for the rule: this
+     * file explains at length what it does and why, so a check over raw text
+     * would read its own justification as its implementation.
+     */
+    private fun code(): List<String> {
+        check(source.isFile) {
+            "SplashActivity.kt not found at ${source.absolutePath}; this test would " +
+                "otherwise pass by looking at nothing"
+        }
+        return source.readLines().filterNot {
+            val t = it.trimStart()
+            t.startsWith("//") || t.startsWith("*") || t.startsWith("/*")
+        }
+    }
+
+    /** One method's body, from its declaration to the next one at class level. */
+    private fun body(name: String): List<String> {
+        val lines = code()
+        val start = lines.indexOfFirst { it.contains("fun $name(") }
+        check(start >= 0) { "$name is gone from SplashActivity; this test is measuring nothing" }
+        val boundary = Regex("^ {4}(private |internal |public |protected |override )*fun ")
+        val rest = lines.drop(start + 1)
+        val end = rest.indexOfFirst { boundary.containsMatchIn(it) || it == "}" }
+        return if (end < 0) rest else rest.take(end)
+    }
+
+    private fun layoutRoot(): Element {
+        check(layout.isFile) {
+            "activity_splash.xml not found at ${layout.absolutePath}; this test would " +
+                "otherwise pass by looking at nothing"
+        }
+        return DocumentBuilderFactory.newInstance().newDocumentBuilder()
+            .parse(layout).documentElement
+    }
+
+    @Test
+    fun `the extraction screen holds the display awake`() {
+        // The display timing out is not a cosmetic event here. It stops the
+        // window being visible, which stops the activity, and a process holding
+        // nothing but a stopped activity is the first thing the system reclaims
+        // while it is part-way through writing 810 MB.
+        //
+        // Either implementation satisfies this: the attribute on the layout the
+        // extraction is drawn in, or the window flag raised for the duration. What
+        // must not happen is neither.
+        val root = layoutRoot()
+        val onLayout = root.getAttribute("android:keepScreenOn") == "true"
+        val onWindow = code().any { it.contains("FLAG_KEEP_SCREEN_ON") }
+
+        assertTrue(onLayout || onWindow) {
+            "nothing holds the display awake while first-run setup runs. It takes " +
+                "minutes with no reason for the user to touch the screen, so the " +
+                "timeout stops the activity and the extraction becomes a process the " +
+                "system may reclaim mid-write, with no partial progress to resume from."
+        }
+    }
+
+    @Test
+    fun `every launch that is past setup asks whether the picker was answered`() {
+        // The picker is offered once and answering it is what records the answer,
+        // so a launch that reaches the editor without asking spends the only offer
+        // there is. It used to be asked from the continuation of the setup
+        // coroutine alone, which a relaunch cancels while the extraction runs on to
+        // completion, and the pref that gates it stays false for good.
+        val onCreate = body("onCreate")
+        assertTrue(onCreate.isNotEmpty()) { "onCreate is empty; this test is measuring nothing" }
+
+        val direct = onCreate.filter { it.contains("launchMain()") }
+        assertTrue(direct.isEmpty()) {
+            "onCreate reaches the editor without asking whether the toolchain picker " +
+                "has been answered:\n${direct.joinToString("\n")}\nA launch that skips " +
+                "the question can never ask it again: the only other way in is a " +
+                "launcher long-press nothing tells the user about."
+        }
+
+        val asks = onCreate.count { it.contains("continueAfterSetup()") }
+        assertEquals(2, asks) {
+            "both routes out of the already-set-up branch have to go through the one " +
+                "place that decides, the Python reconcile and the plain launch; found " +
+                "$asks call(s)"
+        }
+    }
+
+    @Test
+    fun `the picker decision is made in one place`() {
+        // The control for the case above, and the half that rots first. Two
+        // callers is how it started: the question was asked in the setup
+        // continuation and nowhere else, and the second site added later is what
+        // makes a check on the first look satisfied.
+        val callers = code().filter {
+            it.contains("shouldShowPicker()") && !it.contains("fun shouldShowPicker")
+        }
+        assertEquals(1, callers.size) {
+            "shouldShowPicker() has ${callers.size} call sites:\n" +
+                "${callers.joinToString("\n")}\nOne of them will be forgotten when a " +
+                "route is added. It belongs in continueAfterSetup() alone."
+        }
+        assertTrue(body("continueAfterSetup").any { it.contains("shouldShowPicker()") }) {
+            "the one caller is no longer continueAfterSetup(), which is what every " +
+                "route out of onCreate calls"
+        }
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/bridge/BridgeRefusalLanguageTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/bridge/BridgeRefusalLanguageTest.kt
@@ -1,0 +1,101 @@
+package com.vscodroid.bridge
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * That a refusal leaving through a return value is still something a translator
+ * can reach.
+ *
+ * These sentences are as user-facing as anything in a Toast: `openExternalUrl`
+ * and `reclaimSafMirror` answer with the reason they refused, the relay posts it
+ * as the error of a rejected promise, and the bundled bridge extension puts it
+ * straight into `showErrorMessage`. `SafStorageManager.reclaimRefusal` produces
+ * three more that travel the same way. Written as Kotlin they are the same in
+ * every locale for ever, so the app would half-translate and the English half
+ * would read as an oversight by the translator rather than as a defect here.
+ *
+ * Nothing else can see this. `check-translatable-strings.py` is a predicate over
+ * call shapes and finds a literal only where the literal is written at the sink;
+ * its own docstring names a string that reaches the screen through a helper or a
+ * return value as the biggest hole it has, and every one of these does. Lint's
+ * `HardcodedText`, the other half of that gate, reads layouts only.
+ *
+ * Read out of the source, because what is being checked is where the text lives
+ * rather than what any call returns. The identities stay named constants for the
+ * reason their own documentation gives, so this asks only that what they hold is
+ * a resource id.
+ */
+class BridgeRefusalLanguageTest {
+
+    /**
+     * The two files that declare a refusal a bridge caller is shown, with the
+     * name prefixes each one uses.
+     *
+     * Prefixes rather than a list of constant names: a refusal added later to
+     * either family is covered without anyone remembering this file, which is the
+     * failure mode a written list has.
+     */
+    private val sources = mapOf(
+        "src/main/kotlin/com/vscodroid/bridge/AndroidBridge.kt" to
+            listOf("OPEN_URL_", "RECLAIM_"),
+        "src/main/kotlin/com/vscodroid/storage/SafStorageManager.kt" to
+            listOf("RECLAIM_FOLDER_"),
+    )
+
+    /**
+     * `NAME = value` for every `internal val` or `internal const val` in [text]
+     * whose name starts with one of [prefixes], with the value read to the end of
+     * the statement.
+     *
+     * The value may sit on the following line, which is how the longer ones are
+     * written, so this takes the rest of the declaration rather than the rest of
+     * the line.
+     */
+    private fun declarations(text: String, prefixes: List<String>): Map<String, String> {
+        val pattern = Regex(
+            """(?m)^\s*internal (?:const )?val (\w+)\s*=\s*((?:.|\n)*?)(?=\n\s*\n|\n\s*/\*|\n\s*@|\n\s*internal |\n})"""
+        )
+        return pattern.findAll(text)
+            .filter { match -> prefixes.any { match.groupValues[1].startsWith(it) } }
+            .associate { it.groupValues[1] to it.groupValues[2].trim() }
+    }
+
+    @Test
+    fun `every refusal the editor renders is a string resource`() {
+        val written = mutableListOf<String>()
+        var seen = 0
+
+        for ((path, prefixes) in sources) {
+            val file = File(path)
+            assertTrue(file.isFile) {
+                "$path not found at ${file.absolutePath}; this test would otherwise pass " +
+                    "by looking at nothing"
+            }
+            for ((name, value) in declarations(file.readText(), prefixes)) {
+                seen += 1
+                if (!value.contains("R.string.")) written += "$name in $path = $value"
+            }
+        }
+
+        // Control, and not a formality: every assertion below is satisfied by an
+        // empty scan, so a regex that stopped matching would leave this file
+        // reporting green over sentences nobody can translate. Eight is what the
+        // two families hold; a refusal added later only raises it.
+        assertTrue(seen >= 8) {
+            "only found $seen refusal declaration(s); the scan is no longer reading them, " +
+                "so this test is measuring nothing"
+        }
+
+        assertEquals(
+            emptyList<String>(), written,
+            "a refusal a bridge caller is shown is written in Kotlin, so it stays English " +
+                "whatever language the editor is in. It leaves through a return value and " +
+                "is drawn by the bundled extension's showErrorMessage, which is a shape " +
+                "check-translatable-strings.py cannot see. Move the sentence into " +
+                "res/values/strings.xml and let the constant name the resource.",
+        )
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/bridge/BridgeTokenUniformityTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/bridge/BridgeTokenUniformityTest.kt
@@ -11,6 +11,7 @@ import io.mockk.Runs
 import io.mockk.clearMocks
 import io.mockk.confirmVerified
 import io.mockk.every
+import io.mockk.excludeRecords
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -87,6 +88,21 @@ class BridgeTokenUniformityTest {
 
         init {
             every { security.validateToken(any()) } returns false
+            // Reading a string resource is not acting, and two methods have to do it
+            // on the refusal path: openExternalUrl and reclaimSafMirror answer with
+            // the sentence naming why they refused, and those sentences are string
+            // resources so a translator can reach them. Left recorded, the guard
+            // below would read composing a refusal as reaching past the token.
+            //
+            // Narrow on purpose: only the two getString overloads are excluded, and
+            // getString has no effect beyond returning text, so a method that touches
+            // nothing else has not acted. Everything a bridge method could actually
+            // DO through this Context -- startActivity, the content resolver, the
+            // package manager -- is still watched.
+            excludeRecords {
+                context.getString(any())
+                context.getString(any(), *anyVararg())
+            }
         }
     }
 

--- a/android/app/src/test/kotlin/com/vscodroid/bridge/KeygenBudgetTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/bridge/KeygenBudgetTest.kt
@@ -17,6 +17,12 @@ import java.io.File
  *
  * Read off both sources rather than restated here, because a third copy of the
  * number is the defect this is about.
+ *
+ * The relay side is read as the SMALLEST deadline it declares. It declares more
+ * than one now: the commands that walk the user's disk before they can answer
+ * cannot be held to the deadline written for a relay hop. The keygen command is
+ * not one of those, so the short one is what it gets, and taking the minimum
+ * stays right if that ever changes.
  */
 class KeygenBudgetTest {
 
@@ -46,7 +52,14 @@ class KeygenBudgetTest {
     fun `the keygen timeout is shorter than the relay that waits on it`() {
         val kotlinSeconds = Regex("""KEYGEN_TIMEOUT_SECONDS = (\d+)L""")
             .find(read(bridge))?.groupValues?.get(1)?.toLong()
-        val relayMillis = Regex("""\}, (\d+)\);""")
+        // Every deadline the relay declares, and the smallest of them, because that
+        // is the one this side has to beat. The relay used to have a single literal
+        // in its `setTimeout`, which is what this read; it now names its deadlines so
+        // the commands that walk the user's disk are not held to the one meant for a
+        // relay hop, and a read of the literal found nothing at all and said so.
+        // Taking the minimum keeps the answer conservative whichever deadline the
+        // keygen command ends up under.
+        val relayMillis = Regex("""const \w*TIMEOUT_MS = (\d+);""")
             .findAll(read(relay))
             .map { it.groupValues[1].toLong() }
             .minOrNull()

--- a/android/app/src/test/kotlin/com/vscodroid/bridge/OpenExternalUrlRefusalTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/bridge/OpenExternalUrlRefusalTest.kt
@@ -79,6 +79,18 @@ class OpenExternalUrlRefusalTest {
         /** Named so a failure says the launch was attempted, not that something broke. */
         const val UNREACHABLE = "a browser launch is not reachable from a JVM test"
 
+        /**
+         * What the stubbed resources answer, one recognisable sentinel each.
+         *
+         * The refusals are string resources now, so a `Context` is what turns an id
+         * into a sentence and the test has to say what its own Context returns.
+         * Distinct values, because two refusals answering with the same text would
+         * let a method that always returns the wrong one satisfy both cases.
+         */
+        const val STALE = "stale-session-resource"
+        const val NO_HANDLER = "no-handler-resource"
+        const val FAILED_OTHER = "launch-failed-resource"
+
         const val LOCAL = "http://localhost:3000"
 
         /**
@@ -138,6 +150,13 @@ class OpenExternalUrlRefusalTest {
         every { SystemClock.elapsedRealtime() } returns 1L
 
         context = mockk(relaxed = true)
+        // Stubbed rather than left to the relaxed mock, and not as bookkeeping. A
+        // relaxed Context answers getString with the EMPTY STRING, which is this
+        // method's answer for "it opened". Unstubbed, every refusal below would come
+        // back as a success and each case would pass by agreeing with itself.
+        every { context.getString(OPEN_URL_STALE_SESSION) } returns STALE
+        every { context.getString(OPEN_URL_NO_HANDLER) } returns NO_HANDLER
+        every { context.getString(OPEN_URL_FAILED, *anyVararg()) } returns FAILED_OTHER
         bridge = AndroidBridge(
             context = context,
             security = security,
@@ -160,7 +179,7 @@ class OpenExternalUrlRefusalTest {
         // from "turned away at the door"; the reason now says which happened, so
         // the two assertions corroborate each other instead of one carrying both.
         assertNotEquals(
-            OPEN_URL_STALE_SESSION,
+            STALE,
             bridge.openExternalUrl(LOCAL, security.getSessionToken()),
             "a valid token was treated as a stale one, so the call never reached the launch",
         )
@@ -458,7 +477,7 @@ class OpenExternalUrlRefusalTest {
         every { context.startActivity(any()) } throws ActivityNotFoundException("nothing handles it")
 
         assertEquals(
-            OPEN_URL_NO_HANDLER,
+            NO_HANDLER,
             bridge.openExternalUrl(LOCAL, security.getSessionToken()),
             "nothing claimed the intent, which is the one cause the user can act on",
         )
@@ -467,20 +486,24 @@ class OpenExternalUrlRefusalTest {
         val refused = bridge.openExternalUrl(LOCAL, security.getSessionToken())
 
         assertNotEquals(
-            OPEN_URL_NO_HANDLER, refused,
+            NO_HANDLER, refused,
             "a launch Android refused on its own terms was reported as a missing app, which " +
                 "sends the user to install something that cannot help",
         )
-        assertTrue(
-            refused.startsWith(OPEN_URL_FAILED_PREFIX) && refused.endsWith("SecurityException"),
-            "the reason has to name what actually failed, got: " + refused,
+        assertEquals(
+            FAILED_OTHER, refused,
+            "the reason has to come from the catch-all resource, got: " + refused,
         )
+        // And carrying the class name, which is the whole of what that resource has
+        // to say. Asserting on the returned text cannot show this: the stub above
+        // answers the same sentence whatever it is handed.
+        verify { context.getString(OPEN_URL_FAILED, "SecurityException") }
     }
 
     @Test
     fun `a rejected token is refused before the URL is even looked at`() {
         assertEquals(
-            OPEN_URL_STALE_SESSION,
+            STALE,
             bridge.openExternalUrl(LOCAL, "not the session token"),
             "a URL that would otherwise open must still be refused with a bad token, and " +
                 "the reason has to say so: blaming a missing app sends the user to install " +

--- a/android/app/src/test/kotlin/com/vscodroid/bridge/ReclaimSafMirrorContractTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/bridge/ReclaimSafMirrorContractTest.kt
@@ -41,7 +41,18 @@ class ReclaimSafMirrorContractTest {
     /** The real one, so the token the bridge accepts is not stubbed into existence. */
     private val security = SecurityManager()
 
-    private val context: Context = mockk(relaxed = true)
+    /**
+     * Answers the two refusal resources with recognisable sentinels.
+     *
+     * Not bookkeeping. A relaxed `Context` answers `getString` with the EMPTY
+     * STRING, which is this method's answer for "the copy was removed", so an
+     * unstubbed mock would turn both refusals below into claims that the user's
+     * disk had been freed, and each case would then pass by agreeing with itself.
+     */
+    private val context: Context = mockk(relaxed = true) {
+        every { getString(RECLAIM_STALE_SESSION) } returns STALE
+        every { getString(RECLAIM_UNAVAILABLE) } returns UNAVAILABLE
+    }
 
     private companion object {
         const val HASH = "a1b2c3"
@@ -51,6 +62,13 @@ class ReclaimSafMirrorContractTest {
          * what has to change first. See `MainActivity.removeDeviceFolderCopy`.
          */
         const val IN_USE = "That folder is open in the editor. Close it and try again."
+
+        /**
+         * What the stubbed refusal resources answer. Distinct from each other, so a
+         * method that always returns the wrong one cannot satisfy both cases.
+         */
+        const val STALE = "stale-session-resource"
+        const val UNAVAILABLE = "reclaim-unavailable-resource"
     }
 
     /**
@@ -124,7 +142,7 @@ class ReclaimSafMirrorContractTest {
         val (bridge, asked) = bridgeAnswering("")
 
         val refusal = bridge.reclaimSafMirror("not the session token", HASH, force = true)
-        assertEquals(RECLAIM_STALE_SESSION, refusal, "a rejected token must say the session is stale")
+        assertEquals(STALE, refusal, "a rejected token must say the session is stale")
         assertTrue(
             refusal.isNotEmpty(),
             "the guard answered the way a completed removal does, so a caller holding no " +
@@ -147,7 +165,7 @@ class ReclaimSafMirrorContractTest {
         )
 
         assertEquals(
-            RECLAIM_UNAVAILABLE,
+            UNAVAILABLE,
             bridge.reclaimSafMirror(security.getSessionToken(), HASH, force = false),
             "an unwired bridge must decline in a way the user can read; the empty string " +
                 "here reports a removal that no code path performed",

--- a/android/app/src/test/kotlin/com/vscodroid/setup/FirstRunEditorDefaultsTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/FirstRunEditorDefaultsTest.kt
@@ -23,20 +23,28 @@ import java.io.File
  * What the editor looks like on the first screen a user ever sees.
  *
  * The secondary side bar is upstream's home for the chat view, its default is
- * `visibleInWorkspace`, and a brand-new profile opens it regardless of that
- * value. On a desktop that costs a quarter of the width; on the phone this app
- * exists for it takes a large share of a narrow window, and it does it beside
- * whatever the walkthrough opened, which then wraps mid-word.
- *
+ * `visibleInWorkspace`, and on a phone it takes roughly 45 percent of the width,
+ * beside whatever the walkthrough opened, which then wraps to one word per line.
  * The provider the view exists for is not in this build: the Copilot extension
- * is pruned from the server tree, so the panel is an onboarding pane for
- * something that cannot be onboarded. The width buys nothing back.
+ * is pruned from the server tree, so the width buys nothing back.
  *
- * Written into the first-run defaults rather than anywhere else, which decides
- * who it reaches: a clean install, once. `createDefaultSettings` writes only
- * when `settings.json` is absent, so an upgrading user keeps the window they
- * already arranged, and this is a default rather than a lock, so a user who
- * opens the bar keeps it open.
+ * Three things have to hold together, and this file covers all three because
+ * only the first of them used to, while the bar stayed open on the device.
+ *
+ * 1. A clean install carries `workbench.secondarySideBar.defaultVisibility`.
+ * 2. So does an install that predates the key. `createDefaultSettings` writes
+ *    only when `settings.json` is absent, so on its own it reaches nobody who
+ *    already has one, and v1.1.0 shipped no such key. [refreshManagedPaths] is
+ *    what closes that gap, and leaves a value the user chose alone.
+ * 3. Something acts on it. The setting decides a workspace with no recorded
+ *    layout, and by the time the web client can read it the record exists: the
+ *    workbench starts from a copy of these settings held in browser storage,
+ *    which the first load in a profile has not written yet, so that load falls
+ *    back to `visibleInWorkspace`, opens the bar and stores
+ *    `workbench.auxiliaryBar.hidden: false` against the workspace. Later loads
+ *    read the record and never consult the default again. The bundled welcome
+ *    extension corrects the record once per workspace; that call is the third
+ *    check here.
  *
  * Runs the real writer rather than asserting on the string it embeds, the way
  * `PythonLocatorDefaultTest` and `TerminalShellPathTest` do: the point is the
@@ -82,6 +90,110 @@ class FirstRunEditorDefaultsTest {
             written.contains(""""workbench.secondarySideBar.defaultVisibility": "hidden""""),
             "the first screen gives a large share of a phone-width window to a chat view " +
                 "whose provider is pruned from this build:\n$written",
+        )
+    }
+
+    @Test
+    fun `an install that predates the key gains it`() {
+        // The shape v1.1.0 left behind: a settings.json with no mention of the
+        // secondary side bar at all.
+        val existing = """
+            {
+                "editor.fontSize": 14,
+                "workbench.colorTheme": "Default Dark Modern"
+            }
+        """.trimIndent()
+
+        val updated = refreshManagedPaths(existing, "/bin/bash", "/lib/libgit.so", "/lib/libldmusl.so")
+
+        assertTrue(
+            updated != null &&
+                updated.contains(""""workbench.secondarySideBar.defaultVisibility": "hidden""""),
+            "every device upgrading from a release without the key keeps upstream's " +
+                "visibleInWorkspace, so the chat view keeps the width:\n$updated",
+        )
+    }
+
+    @Test
+    fun `a bar the user asked for is left alone`() {
+        val chosen = """
+            {
+                "workbench.secondarySideBar.defaultVisibility": "visible"
+            }
+        """.trimIndent()
+
+        val updated = refreshManagedPaths(chosen, "/bin/bash", "/lib/libgit.so", "/lib/libldmusl.so")
+
+        assertTrue(
+            updated == null || !updated.contains(""""defaultVisibility": "hidden""""),
+            "a user who opened the secondary side bar had the choice taken back:\n$updated",
+        )
+    }
+
+    /**
+     * The half that acts on the setting, read out of the extension this app
+     * bundles.
+     *
+     * Three properties, and each one was a way to get this wrong:
+     *
+     * - The command must be `closeAuxiliaryBar`, which hides the part outright.
+     *   `toggleAuxiliaryBar` reads as the same fix and is the opposite one: on a
+     *   workspace that already agrees it opens the bar.
+     * - The marker must be workspace-scoped. A global one would align the first
+     *   workspace a user opens and leave every other one as it found it.
+     * - The call must be reached without the walkthrough's own marker file,
+     *   which every device upgrading into this release already has, and which is
+     *   therefore exactly the population whose stored layout needs correcting.
+     *   Position is what settles that: a call sited before the marker gate
+     *   cannot be inside it.
+     */
+    @Test
+    fun `the bundled welcome extension corrects the stored layout`() {
+        val welcome = File("src/main/assets/extensions")
+            .listFiles { f -> f.isDirectory && f.name.startsWith("vscodroid.vscodroid-welcome-") }
+            ?.singleOrNull()
+        check(welcome != null) {
+            "no single bundled welcome extension under src/main/assets/extensions; this test " +
+                "would otherwise pass by finding nothing to read"
+        }
+
+        val source = File(welcome, "extension.js").readText()
+
+        assertTrue(
+            source.contains("'workbench.action.closeAuxiliaryBar'"),
+            "nothing closes the secondary side bar, so the setting decides a layout record " +
+                "that the first load has already written",
+        )
+        assertTrue(
+            !source.contains("toggleAuxiliaryBar"),
+            "toggling reopens the bar on a workspace that already agrees",
+        )
+        // Both halves named in full, and against the code rather than the word.
+        // "workspaceState" on its own is satisfied by the comment above the
+        // walkthrough marker, which names it while saying nothing about scope:
+        // swapping the two reads for globalState left that check green.
+        assertTrue(
+            source.contains("context.workspaceState.get(SIDE_BAR_ALIGNED)") &&
+                source.contains("context.workspaceState.update(SIDE_BAR_ALIGNED"),
+            "the marker has to be workspace-scoped, or only the first workspace is aligned",
+        )
+
+        // The call, not the declaration. `function alignSecondarySideBar(context)`
+        // contains the same text and sits near the top of the file, so an
+        // unqualified search found it and reported an ordering that held however
+        // the call itself was moved. The trailing semicolon is what tells them
+        // apart.
+        val call = source.indexOf("alignSecondarySideBar(context);")
+        val walkthroughGate = source.indexOf("existsSync(markerFile)")
+        assertTrue(
+            call >= 0 && walkthroughGate >= 0,
+            "neither anchor was found, so the ordering below is checking nothing: " +
+                "call=$call gate=$walkthroughGate",
+        )
+        assertTrue(
+            call < walkthroughGate,
+            "the alignment sits inside the walkthrough's once-ever gate, so every device " +
+                "that has already seen the walkthrough keeps the bar open",
         )
     }
 

--- a/android/app/src/test/kotlin/com/vscodroid/setup/SettingsPathsTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/SettingsPathsTest.kt
@@ -44,9 +44,10 @@ class SettingsPathsTest {
         verifySignature: Boolean = true,
         pythonLocator: String? = "js",
         envExtension: String? = "false",
+        secondarySideBar: String? = "hidden",
     ) = """
         {
-        $preamble    "editor.fontSize": 14,${claudeWrapper?.let { "\n    \"claudeCode.claudeProcessWrapper\": \"$it\"," } ?: ""}${if (verifySignature) "\n        \"extensions.verifySignature\": false," else ""}${pythonLocator?.let { "\n        \"python.locator\": \"$it\"," } ?: ""}${envExtension?.let { "\n        \"python.useEnvironmentsExtension\": $it," } ?: ""}
+        $preamble    "editor.fontSize": 14,${claudeWrapper?.let { "\n    \"claudeCode.claudeProcessWrapper\": \"$it\"," } ?: ""}${if (verifySignature) "\n        \"extensions.verifySignature\": false," else ""}${pythonLocator?.let { "\n        \"python.locator\": \"$it\"," } ?: ""}${envExtension?.let { "\n        \"python.useEnvironmentsExtension\": $it," } ?: ""}${secondarySideBar?.let { "\n        \"workbench.secondarySideBar.defaultVisibility\": \"$it\"," } ?: ""}
             "terminal.integrated.profiles.linux": {
                 "bash": {
                     "path": "$bashPath",
@@ -307,7 +308,9 @@ class SettingsPathsTest {
         fun `returns null when git path is absent rather than inventing one`() {
             val noGit = """{ "claudeCode.claudeProcessWrapper": "$wrapper", """ +
                 """"extensions.verifySignature": false, "python.locator": "js", """ +
-                """"python.useEnvironmentsExtension": false, "editor.fontSize": 14 }"""
+                """"python.useEnvironmentsExtension": false, """ +
+                """"workbench.secondarySideBar.defaultVisibility": "hidden", """ +
+                """"editor.fontSize": 14 }"""
 
             assertNull(refreshManagedPaths(noGit, shell, git, wrapper))
         }
@@ -321,6 +324,7 @@ class SettingsPathsTest {
                     "extensions.verifySignature": false,
                     "python.locator": "js",
                     "python.useEnvironmentsExtension": false,
+                    "workbench.secondarySideBar.defaultVisibility": "hidden",
                     "terminal.integrated.profiles.linux": {
                         "zsh": { "path": "$oldDir/libzsh.so" }
                     }

--- a/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainCardStateTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainCardStateTest.kt
@@ -1,6 +1,7 @@
 package com.vscodroid.setup
 
 import com.google.android.play.core.assetpacks.model.AssetPackStatus
+import com.vscodroid.util.StorageManager
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
@@ -192,6 +193,126 @@ class ToolchainCardStateTest {
             val card = state.card(go)
             assertEquals(ToolchainAction.RETRY, card.action)
             assertEquals(ToolchainBadge.FAILED, card.badge)
+        }
+    }
+
+    @Nested
+    inner class DownloadsThisScreenWasNotTold {
+
+        /**
+         * A download reports only to the manager that started it, and a manager
+         * belongs to whoever built it. Two ordinary things build a second one:
+         * rotating this screen, which has no `configChanges` and so is destroyed
+         * and rebuilt, and opening it from the launcher shortcut while the
+         * first-run queue is still working. In both, the cards start with no
+         * reports at all and fell through to Install for a pack that was already
+         * downloading, offering no progress and no way to stop a 56 MB transfer.
+         */
+        @Test
+        fun `a download begun elsewhere is drawn as running, with a way to stop it`() {
+            val state = manager()
+            state.setDownloading(mapOf(ruby to 42))
+
+            val card = state.card(ruby)
+            assertEquals(
+                ToolchainAction.CANCEL, card.action,
+                "a download already running was offered as a fresh Install",
+            )
+            assertEquals(42, card.progressPercent)
+        }
+
+        @Test
+        fun `this screen's own report wins over what it was told at the start`() {
+            // The report keeps arriving; the seed is a single snapshot taken when
+            // the screen opened. Letting the stale one win freezes the bar.
+            val state = manager()
+            state.setDownloading(mapOf(ruby to 42))
+            state.updateState(ruby, AssetPackStatus.DOWNLOADING, 77)
+
+            assertEquals(77, state.card(ruby).progressPercent)
+        }
+
+        @Test
+        fun `a download that has since finished stops being drawn as running`() {
+            // Its end is not reported here either, so a seed that only ever
+            // accumulated would leave the card offering Cancel for a transfer
+            // that is over, and Cancel is destructive.
+            val state = manager()
+            state.setDownloading(mapOf(ruby to 42))
+            state.setDownloading(emptyMap())
+            state.setInstalled(listOf("ruby"))
+
+            assertEquals(ToolchainAction.REMOVE, state.card(ruby).action)
+            assertNull(state.card(ruby).progressPercent)
+        }
+
+        @Test
+        fun `a completed report ends the seed as well`() {
+            val state = manager()
+            state.setDownloading(mapOf(ruby to 42))
+            state.updateState(ruby, AssetPackStatus.COMPLETED, 100)
+
+            val card = state.card(ruby)
+            assertEquals(ToolchainAction.REMOVE, card.action)
+            assertEquals(ToolchainBadge.INSTALLED, card.badge)
+            assertNull(card.progressPercent)
+        }
+
+        @Test
+        fun `the picker draws no download at all`() {
+            // First-run cards carry a tick and nothing else. A Cancel button
+            // there would take the tap that selects the toolchain.
+            val state = picker()
+            state.setDownloading(mapOf(ruby to 42))
+
+            val card = state.card(ruby)
+            assertNull(card.action)
+            assertNull(card.progressPercent)
+        }
+    }
+
+    @Nested
+    inner class SizeLine {
+
+        private val rubyInfo = ToolchainRegistry.find("toolchain_ruby")
+
+        /**
+         * The card used to format these itself, dividing by 1,000,000, while the
+         * low-storage warning, the first-run pre-flight and the storage
+         * breakdown all divide by 1,048,576 and write the same "MB". So the same
+         * quantity read 4.9% differently depending on which screen the user was
+         * on, with nothing to tell them which reading they were looking at.
+         */
+        @Test
+        fun `the card quotes sizes the way the rest of the app quotes them`() {
+            val info = requireNotNull(rubyInfo) { "the registry no longer lists Ruby" }
+            val figures = manager().sizeFigures(info)
+
+            assertEquals(StorageManager.formatSize(info.downloadSize), figures.download)
+            assertEquals(StorageManager.formatSize(info.estimatedSize), figures.installed)
+        }
+
+        /**
+         * The convention itself, pinned separately from the agreement above: if
+         * both sides were moved to 1,000,000 together the case above would still
+         * pass, and every free-space figure in the app would then be quoting a
+         * different "MB" from the one this card quotes.
+         */
+        @Test
+        fun `a hundred mebibytes is what the card calls a hundred MB`() {
+            // A hundred and not one: 1,048,576 divided by 1,000,000 rounds to
+            // "1.0 MB" as well, so a one-mebibyte case reads as a test of the
+            // convention while agreeing with both of them.
+            val info = ToolchainRegistry.ToolchainInfo(
+                packName = "toolchain_test",
+                displayName = "Test",
+                shortLabel = "Test",
+                descriptionRes = 0,
+                estimatedSize = 100L * 1_048_576,
+                downloadSize = 100L * 1_048_576,
+            )
+
+            assertEquals("100.0 MB", manager().sizeFigures(info).installed)
         }
     }
 

--- a/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainDownloadTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainDownloadTest.kt
@@ -93,6 +93,11 @@ class ToolchainDownloadTest {
             .apply { isAccessible = true }
             .newInstance()
 
+    private fun setPercent(token: Any, percent: Int) =
+        token.javaClass.getDeclaredField("percent")
+            .apply { isAccessible = true }
+            .setInt(token, percent)
+
     private fun isCancelled(token: Any): Boolean =
         token.javaClass.getDeclaredField("cancelled")
             .apply { isAccessible = true }
@@ -204,6 +209,27 @@ class ToolchainDownloadTest {
             "a manager built after the screen was recreated could not reach the download " +
                 "the first one started, so nothing short of a force-stop ends it",
         )
+    }
+
+    /**
+     * What the toolchain screen has to be able to ask when it opens.
+     *
+     * A transfer reports its progress to the manager that began it and to
+     * nothing else, so a screen rebuilt while one is running -- a rotation, or
+     * the launcher shortcut opened while the first-run queue is still working --
+     * hears nothing about it. Its cards then fell through to Install for a pack
+     * already downloading: no progress, and no Cancel, which is the only way to
+     * stop a 56 MB transfer on mobile data.
+     *
+     * Putting the map or the percentage back on an instance turns this red.
+     */
+    @Test
+    fun `the process can be asked what is downloading and how far along it is`() {
+        val token = newDownloadToken()
+        setPercent(token, 42)
+        outstanding()["toolchain_java"] = token
+
+        assertEquals(mapOf("toolchain_java" to 42), ToolchainManager.packsDownloading())
     }
 
     /**

--- a/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainRegistryTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainRegistryTest.kt
@@ -14,7 +14,7 @@ import org.junit.jupiter.params.provider.ValueSource
 import java.io.File
 
 /**
- * Tests for [ToolchainRegistry]: catalog lookups and size formatting.
+ * Tests for [ToolchainRegistry]: the catalog and its lookups.
  */
 class ToolchainRegistryTest {
 
@@ -186,37 +186,9 @@ class ToolchainRegistryTest {
         }
     }
 
-    // ── formatSize() ─────────────────────────────────────────────────────
-
-    @Nested
-    inner class FormatSizeTest {
-
-        @Test
-        fun `formats bytes`() {
-            assertEquals("500 B", ToolchainRegistry.formatSize(500))
-        }
-
-        @Test
-        fun `formats kilobytes`() {
-            assertEquals("1 KB", ToolchainRegistry.formatSize(1_000))
-            assertEquals("512 KB", ToolchainRegistry.formatSize(512_000))
-        }
-
-        @Test
-        fun `formats megabytes`() {
-            assertEquals("1 MB", ToolchainRegistry.formatSize(1_000_000))
-            assertEquals("179 MB", ToolchainRegistry.formatSize(179_000_000))
-        }
-
-        @Test
-        fun `formats gigabytes`() {
-            assertEquals("1 GB", ToolchainRegistry.formatSize(1_000_000_000))
-            assertEquals("2 GB", ToolchainRegistry.formatSize(2_500_000_000))
-        }
-
-        @Test
-        fun `formats zero`() {
-            assertEquals("0 B", ToolchainRegistry.formatSize(0))
-        }
-    }
+    // ToolchainRegistry.formatSize was here, and with it a nested class pinning
+    // its 1,000,000 divisor. Sizes are formatted by
+    // com.vscodroid.util.StorageManager.formatSize now, like every other byte
+    // figure the app shows, and the card's use of it is pinned by
+    // ToolchainCardStateTest.SizeLine.
 }

--- a/android/app/src/test/kotlin/com/vscodroid/util/ClearableStorageTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/util/ClearableStorageTest.kt
@@ -1,6 +1,7 @@
 package com.vscodroid.util
 
 import android.content.Context
+import com.vscodroid.setup.ToolchainManager
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -110,6 +111,58 @@ class ClearableStorageTest {
             )
             planted.delete()
         }
+    }
+
+    /**
+     * The staging directory a toolchain download expands into sits under
+     * `cacheDir`, so the `cache` row has always counted it and the screen has
+     * always offered that row to the clear action. Nothing cleared it: an
+     * abandoned Java download is roughly 155 MB, against a few MB for everything
+     * else the action reaches, so the button reported success and left the
+     * largest number on the screen exactly where it was.
+     */
+    @Test
+    fun `the toolchain staging bytes the cache row counts are bytes the clear frees`() {
+        val staging = File(cacheDir, "toolchain-download/toolchain_java-1700000000/payload.bin")
+        staging.parentFile?.mkdirs()
+        staging.writeText("x".repeat(8192))
+
+        val counted = StorageManager.getStorageBreakdown(context).getLong("cache")
+        assertTrue(
+            counted >= 8192,
+            "the cache row does not even count these bytes, so this proves nothing",
+        )
+
+        val freed = StorageManager.clearCaches(context)
+
+        assertTrue(!staging.exists(), "$staging survived a clear that counted it")
+        assertTrue(freed >= 8192, "only $freed bytes were reported freed")
+    }
+
+    /**
+     * And the directory a download is still using is left alone, which is why
+     * this is not one more line beside the other four. Each transfer writes its
+     * archive, expands it and copies out of it in a directory of its own;
+     * removing that under a running download fails the transfer, and can leave
+     * the copy into `usr/` reading a tree being deleted beneath it. The storage
+     * screen is exactly where a user goes while a large download is running.
+     */
+    @Test
+    fun `a staging directory a running download owns survives the clear`() {
+        mockkObject(ToolchainManager.Companion)
+        every { ToolchainManager.packsDownloading() } returns mapOf("toolchain_java" to 40)
+
+        val live = File(cacheDir, "toolchain-download/toolchain_java-1700000000/payload.bin")
+        live.parentFile?.mkdirs()
+        live.writeText("x".repeat(8192))
+        val abandoned = File(cacheDir, "toolchain-download/toolchain_ruby-1600000000/payload.bin")
+        abandoned.parentFile?.mkdirs()
+        abandoned.writeText("x".repeat(8192))
+
+        StorageManager.clearCaches(context)
+
+        assertTrue(live.exists(), "$live was pulled out from under a running download")
+        assertTrue(!abandoned.exists(), "$abandoned belongs to no download and should have gone")
     }
 
     @Test

--- a/android/app/src/test/kotlin/com/vscodroid/webview/DownloadListenerWiringTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/DownloadListenerWiringTest.kt
@@ -188,6 +188,53 @@ class DownloadListenerWiringTest {
         }
     }
 
+    /**
+     * That a download in flight is released whenever the main frame is replaced,
+     * and not only when a renderer crash replaces the whole WebView.
+     *
+     * `recreateWebView` was the only site that told the coordinator, which left
+     * every ordinary page replacement wedging it: `reload()` on the way back from
+     * a long absence, the `loadUrl` in `navigateToFolder`, the server-gave-up
+     * page, and the folder switches the workbench performs on its own without
+     * going through Kotlin. The page that owed the bytes is gone in every one of
+     * those, so nothing further arrives, the request stays live with its stream
+     * open, the document the picker created is never discarded, and because the
+     * coordinator runs one download at a time every later Download tap queues
+     * behind it until the queue fills and the rest are refused. Nothing in
+     * `DownloadCoordinatorTest` can see this: it calls `onPageGone` itself.
+     *
+     * The callback is what all four have in common, so that is where it is
+     * checked. Asserting the position and not just the presence, because the
+     * whole point is that the coordinator hears about a page it did not replace.
+     */
+    @Test
+    fun `every main-frame replacement releases the download the old page owed`() {
+        val bridge = withoutComments(body("initBridge"))
+
+        val loaded = bridge.indexOf("onPageLoaded")
+        assertTrue(loaded >= 0) {
+            "the page-loaded callback is gone from initBridge, so this test is measuring " +
+                "nothing. If the client's callbacks moved, point this at the new site."
+        }
+        val nextCallback = bridge.indexOf("onRetryServer", loaded)
+        assertTrue(nextCallback > loaded) {
+            "cannot find the end of the page-loaded callback; this test would otherwise " +
+                "accept a call made anywhere in initBridge"
+        }
+
+        val pageLoaded = bridge.substring(loaded, nextCallback)
+        assertTrue(pageLoaded.contains("downloads.onPageGone()")) {
+            "a finished main-frame load does not tell the download coordinator that the " +
+                "page owing the bytes is gone. Reload, folder switch, the server-gave-up " +
+                "page and a workbench-driven folder switch all replace the page without " +
+                "passing through recreateWebView, and each one leaves the coordinator " +
+                "holding a transfer nothing can finish: the user's chosen document stays " +
+                "as a part-written file and Download does nothing for the rest of the " +
+                "session. Found in the callback: " +
+                pageLoaded.lines().filter { it.contains("downloads.") }.joinToString("; ")
+        }
+    }
+
     @Test
     fun `the page that answers the listener is given the script that answers it`() {
         val inject = withoutComments(body("injectBridgeToken"))

--- a/docs/05-API_SPEC.md
+++ b/docs/05-API_SPEC.md
@@ -182,6 +182,20 @@ registered, which is the whole of why the toolchain management calls have no cal
 Adding a method to `AndroidBridge` does not publish it; the relay branch is a second,
 separate edit, and nothing fails if you forget it.
 
+**A bridge call blocks the page's main thread for as long as the method runs, and four of
+them run for as long as the disk is big.** The relay answers from the workbench page, and
+a call made through `addJavascriptInterface` does not return to JavaScript until the
+Kotlin method has finished. `getStorageBreakdown`, `listSafMirrors`, `reclaimSafMirror`
+and `clearCaches` all walk directory trees before they can answer, and the app's own
+extracted tree is around 875 MB before a project is opened, so on any real install those
+walks take far longer than the moment every other command takes. A caller that puts a
+deadline on the promise must give those four one of their own. The bundled bridge
+extension declares two, `BRIDGE_TIMEOUT_MS` for a command the relay answers at once and
+`DISK_WALK_TIMEOUT_MS` for these four; read the values out of its `extension.js` rather
+than from here, because a copy of a number in a document is how the two drift. Held to
+the short one the four reject while the walk is still running, the user is told the app
+may not be running on Android, and the answer is discarded when it arrives.
+
 #### Clipboard
 
 ```kotlin
@@ -323,11 +337,17 @@ fun getStorageBreakdown(authToken: String): String
 // Returns JSON with per-component disk usage in bytes:
 // {"vscode_server": N, "extensions": N, "user_data": N, "logs": N,
 //  "tools": N, "saf_mirrors": N, "cache": N, "total": N}
+//
+// TAKES AS LONG AS THE DISK. Every figure is a directory walk and "total" walks
+// filesDir again on top, so on an install carrying the extracted server tree
+// (~875 MB before a project is opened) this runs for far longer than a relay
+// hop. See the deadline note at the head of this section.
 
 @JavascriptInterface
 fun clearCaches(authToken: String): Long
 // Clears npm-cache, tmp dir, crash logs, VS Code logs
 // Returns: number of bytes freed
+// Deletes trees, so it takes as long as the disk. Same deadline note.
 
 @JavascriptInterface
 fun getAvailableStorage(authToken: String): Long
@@ -348,6 +368,9 @@ fun listSafMirrors(authToken: String): String
 // removing it destroys the only copy of them. That is the ordinary state of any
 // folder something has been built or cloned in.
 // "[]" if refused, and also "[]" when no SAF manager is wired up.
+//
+// TAKES AS LONG AS THE DISK: every copy is walked twice, once for "bytes" and
+// once for "reclaimable". Same deadline note.
 
 @JavascriptInterface
 fun reclaimSafMirror(authToken: String, hash: String, force: Boolean): String
@@ -371,6 +394,9 @@ fun reclaimSafMirror(authToken: String, hash: String, force: Boolean): String
 //
 // The call returns as soon as the copy is unreachable; the recursive delete
 // continues afterwards and is finished by the next launch if the process dies.
+//
+// It is still not quick: without `force` the copy is walked to re-ask the gate,
+// and it is walked again to report the bytes freed. Same deadline note.
 ```
 
 #### Device Info

--- a/scripts/check-plain-punctuation.py
+++ b/scripts/check-plain-punctuation.py
@@ -15,6 +15,23 @@ Every one of the three is named here by its codepoint rather than written
 out. A checker that spells its own subject is a file that fails itself, and
 the local editing hook refuses to write it at all.
 
+The second spelling, in the XML the resource compiler reads
+-----------------------------------------------------------
+Comparing codepoints answers "does this file hold the character", which is
+the same question as "will a user see it" everywhere except one place. An
+Android resource can hold any of the three in a form that is plain ASCII on
+disk and the character itself by the time it is drawn: the `\\uXXXX` escape
+aapt2 processes inside a string value, and an XML character reference in
+either notation. One of those had been sitting in the first-run picker's
+subtitle, on screen for every user who installs the app, while this gate
+reported a clean tree because the bytes really were clean.
+
+So every XML aapt2 compiles, meaning anything under a `res/` directory plus
+the manifests, is read for those two forms as well. A named entity is not
+among them on purpose: XML predefines five and `&mdash;` is not one, so a
+resource carrying it fails the build out loud rather than reaching a screen,
+which is the opposite of the failure this section exists for.
+
 Why a gate rather than a habit
 ------------------------------
 857 of them accumulated across 118 files before anyone counted, in prose, in
@@ -40,6 +57,7 @@ repository has shipped that mistake before.
 """
 
 import pathlib
+import re
 import subprocess
 import sys
 
@@ -47,6 +65,22 @@ BANNED = {
     chr(0x2014): "U+2014 EM DASH",
     chr(0x2013): "U+2013 EN DASH",
     chr(0x2015): "U+2015 HORIZONTAL BAR",
+}
+
+# The same three characters in the spellings an Android resource can hold
+# without any of them appearing in the file as itself: the escape aapt2
+# expands inside a string value, and an XML character reference in hex or in
+# decimal, with the leading zeros that notation allows.
+#
+# Built from the codepoints rather than written out, for the reason the module
+# docstring gives. Case-insensitive because the hex digits and the `u` may be
+# written either way and both compile to the same character.
+ESCAPED = {
+    char: re.compile(
+        rf"\\u{ord(char):04x}|&#x0*{ord(char):04x};|&#0*{ord(char)};",
+        re.IGNORECASE,
+    )
+    for char in BANNED
 }
 
 SKIP_PREFIXES = ("licenses/",)
@@ -75,6 +109,23 @@ def checkable_lines(path, text):
     return enumerate(lines, start=1)
 
 
+def compiled_by_aapt2(path):
+    """Whether the resource compiler reads this file and expands its escapes.
+
+    Everything under a `res/` directory, in any module, plus the manifests: a
+    literal `android:label` is drawn in the launcher exactly as an escape in
+    `strings.xml` is drawn on screen. Path shape rather than a list of files,
+    so a resource directory added later is covered by existing.
+
+    A directory component rather than a substring, so `res/values/strings.xml`
+    is recognised when the path has no leading directory at all, which is what
+    `git ls-files` prints when this runs from inside a module.
+    """
+    if not path.endswith(".xml"):
+        return False
+    return "res" in pathlib.PurePosixPath(path).parts[:-1] or path.endswith("AndroidManifest.xml")
+
+
 def offences(path):
     try:
         text = pathlib.Path(path).read_text(encoding="utf-8")
@@ -84,10 +135,24 @@ def offences(path):
         # problem that a different gate should report.
         return []
     found = []
+    # Only where a compiler expands them. Elsewhere `\\u2014` is six characters
+    # a reader sees as six characters, and this gate is about what reaches a
+    # user rather than about how a file spells things.
+    escaped = ESCAPED if compiled_by_aapt2(path) else {}
     for number, line in checkable_lines(path, text):
         for column, char in enumerate(line, start=1):
             if char in BANNED:
                 found.append((number, column, BANNED[char], line.strip()))
+        for char, pattern in escaped.items():
+            for hit in pattern.finditer(line):
+                found.append((
+                    number, hit.start() + 1,
+                    f"{BANNED[char]}, escaped; the resource compiler expands it",
+                    line.strip(),
+                ))
+    # Both passes walk the same line, so a file holding one of each would
+    # otherwise report the second line before the first column of the first.
+    found.sort(key=lambda offence: offence[:2])
     return found
 
 
@@ -99,6 +164,19 @@ def main(argv) -> int:
     if sum(probe.count(c) for c in BANNED) != 3:
         print("  FAIL   the character table is wrong; this gate cannot see its own subject")
         return 2
+
+    # The same proof for the escaped spelling, and it earns its place twice
+    # over: a table that cannot see a form reports exactly what a clean tree
+    # reports, and this form was invisible here for as long as the gate has
+    # existed. The three codepoints are written again rather than read back
+    # from the table, so a wrong number in one place is a disagreement rather
+    # than a shared assumption.
+    for code in (0x2014, 0x2013, 0x2015):
+        forms = (rf"\u{code:04x}", rf"&#x{code:04x};", rf"&#{code};")
+        seen = sum(len(p.findall(form)) for form in forms for p in ESCAPED.values())
+        if seen != len(forms):
+            print(f"  FAIL   the escape table cannot see U+{code:04X} written as an escape")
+            return 2
 
     paths = argv[1:] or ["."]
     files = [f for f in tracked(paths) if not f.startswith(SKIP_PREFIXES)]

--- a/scripts/test-bridge-relay.js
+++ b/scripts/test-bridge-relay.js
@@ -36,6 +36,9 @@ const MAIN_ACTIVITY = path.join(
 const ANDROID_BRIDGE = path.join(
     ROOT, 'android/app/src/main/kotlin/com/vscodroid/bridge/AndroidBridge.kt',
 );
+const STRINGS_XML = path.join(
+    ROOT, 'android/app/src/main/res/values/strings.xml',
+);
 
 /**
  * One of the user-facing decline reasons, read from where it now lives.
@@ -48,13 +51,38 @@ const ANDROID_BRIDGE = path.join(
  */
 function bridgeReason(name) {
     const src = fs.readFileSync(ANDROID_BRIDGE, 'utf8');
-    const m = src.match(new RegExp('const val ' + name + '\\s*=\\s*"([^"]*)"'));
+    // Two hops, because the words moved once already. The bridge now names a
+    // resource rather than carrying the sentence, so that a translation can
+    // reach it; the sentence itself lives in strings.xml. Following both hops
+    // keeps this asking the question it has always asked, which is about the
+    // words a user is shown, not about where they happen to be declared.
+    const ref = src.match(new RegExp('val ' + name + '\\s*=\\s*R\\.string\\.(\\w+)'));
     assert.ok(
-        m,
+        ref,
         name + ' is gone from AndroidBridge.kt, so this check has nothing to read. If the ' +
         'reasons moved, point this at their new home rather than deleting the check.',
     );
-    return m[1];
+    const strings = fs.readFileSync(STRINGS_XML, 'utf8');
+    const text = strings.match(
+        new RegExp('<string name="' + ref[1] + '"[^>]*>([\\s\\S]*?)</string>'),
+    );
+    assert.ok(
+        text,
+        name + ' points at R.string.' + ref[1] + ', which strings.xml does not declare. ' +
+        'The bridge would then fail at getString rather than showing the reason.',
+    );
+    // What a user reads, not what the file stores: the resource compiler
+    // unescapes these, and a format argument is filled before the sentence is
+    // shown, so the assertions below would otherwise compare against text that
+    // never appears on screen.
+    return text[1]
+        .replace(/%\d+\$s/g, '')
+        .replace(/\\'/g, "'")
+        .replace(/\\"/g, '"')
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .trim();
 }
 
 /** How a literal dollar is written inside a Kotlin raw string. */

--- a/scripts/test-process-monitor.js
+++ b/scripts/test-process-monitor.js
@@ -52,6 +52,11 @@ const REH = '/data/user/0/com.vscodroid/files/server/vscode-reh';
 // Marketplace and bundled-by-us extensions are extracted here, which is a
 // different tree from the editor's own extensions under REH.
 const EXT = '/data/user/0/com.vscodroid/files/home/.vscodroid/extensions';
+// The ceiling ProcessManager derives from device RAM and puts on the command
+// line. It is on the real processes and it belongs on the fixtures, because it
+// is the argument that used to be the only thing the details view printed.
+const HEAP = '--max-old-space-size=488';
+const DATA = '/data/user/0/com.vscodroid/files/home/.vscodroid/data';
 
 const MAIN_ACTIVITY = path.join(
     __dirname, '../android/app/src/main/kotlin/com/vscodroid/MainActivity.kt',
@@ -116,6 +121,51 @@ function checkLabelCoverage(snapshot) {
         `them, so the tooltip would offer the reader an internal identifier: ${unlabelled.join(', ')}`,
     );
     return types;
+}
+
+/**
+ * Every row says which program it is.
+ *
+ * The details view and the counter's tooltip are the only places a person can
+ * find out what is holding a slot, and both print this string. It used to be
+ * argv[0] plus argv[1], which on this device is the bundled Node binary plus the
+ * heap ceiling for nearly every process the app owns: on an idle API 33 emulator
+ * five of six rows read `libnode.so --max-old-space-size=488` and the view named
+ * nothing.
+ *
+ * The pairs matter as much as the strings. `bootstrap-fork` is launched twice
+ * with different `--type=`, so a rule that keeps only the program name leaves two
+ * rows sharing one identity, and a rule that keeps only the first argument leaves
+ * every row sharing the heap flag. Both failures are asserted for, and the
+ * expectations are compared as a set so that a pid dropping out of the snapshot
+ * cannot quietly empty the check.
+ */
+function checkCommandNames(snapshot, byPid) {
+    const expected = new Map([
+        [process.pid, 'libnode.so server.js'],
+        [1001, 'libnode.so server-main.js'],
+        [1007, 'libnode.so bootstrap-fork --type=fileWatcher'],
+        [1029, 'libnode.so bootstrap-fork --type=agentHost'],
+        [1030, 'libnode.so copilot-android-arm64/index.js'],
+        [1004, 'libbash.so'],
+    ]);
+    for (const [pid, want] of expected) {
+        const got = byPid.get(pid);
+        assert.ok(got, `pid ${pid} never reached the snapshot, so its name was never compared`);
+        assert.strictEqual(
+            got.cmd, want,
+            `pid ${pid} is printed as ${JSON.stringify(got.cmd)}; a reader cannot tell it ` +
+            `from the other rows built on the same runtime`,
+        );
+    }
+
+    const names = snapshot.tree.map((entry) => entry.cmd);
+    assert.ok(
+        !names.includes(`libnode.so ${HEAP}`),
+        'a row is named after the runtime and its heap ceiling, which every process here ' +
+        'shares, so the details view says nothing about it',
+    );
+    return expected.size;
 }
 
 /**
@@ -294,7 +344,7 @@ function main() {
         [1004, ['/data/data/com.vscodroid/lib/arm64/libbash.so', '-l'], 'terminal'],
         [1005, [NODE, '/data/user/0/com.vscodroid/files/home/projects/my-eslint-tool/index.js'], 'unknown'],
         [1006, [NODE, '/data/user/0/com.vscodroid/files/usr/share/reporter/index.js'], 'unknown'],
-        [1007, [NODE, `${REH}/out/bootstrap-fork.js`, '--type=fileWatcher'], 'fileWatcher'],
+        [1007, [NODE, HEAP, `${REH}/out/bootstrap-fork`, '--type=fileWatcher'], 'fileWatcher'],
         [1008, [NODE, '/data/user/0/com.vscodroid/files/saf-mirrors/a1b2c3/sync.js'], 'safSync'],
         // A marketplace language server, not one of the three bundled with the
         // editor, and the reason it is here: check-langserver-patterns.py globs
@@ -387,6 +437,22 @@ function main() {
         // user's. It is gone, and this is what its absence has to keep true.
         [1028, [NODE, '/data/user/0/com.vscodroid/files/home/projects/vscode-eslint-shim.js'],
             'unknown'],
+        // The two processes a signed-out, untouched editor leaves running on this
+        // device beyond its own core, measured on an API 33 and an API 37
+        // emulator: the agent host, and the model backend it forks. The backend
+        // is the one that was invisible. Its basename is `index.js`, so no
+        // pattern above can name it, and as 'unknown' it was outside both the
+        // idle kill and the command that sheds language servers by hand.
+        [1029, [NODE, HEAP, `${REH}/out/bootstrap-fork`, '--type=agentHost',
+            '--logsPath', `${DATA}/logs`], 'system'],
+        [1030, [NODE, `${REH}/node_modules/@github/copilot-android-arm64/index.js`,
+            '--headless', '--no-auto-update', '--stdio', '--no-auto-login'], 'langserver'],
+        // The other direction for that needle. It carries the node_modules and
+        // scope segments precisely so a name merely containing 'copilot' stays
+        // the user's, and being classified 'langserver' is what makes a process
+        // eligible to be killed.
+        [1031, [NODE, '/data/user/0/com.vscodroid/files/home/projects/copilot-demo/index.js'],
+            'unknown'],
     ];
     for (const [pid, argv] of cases) {
         writeProc(proc, pid, argv);
@@ -423,11 +489,13 @@ function main() {
 
     const contract = checkPressureContract(tmp);
     const labelled = checkLabelCoverage(snapshot);
+    const named = checkCommandNames(snapshot, byPid);
 
     fs.rmSync(tmp, { recursive: true, force: true });
     console.log(
         `ok -- ${snapshot.total} processes counted, ${cases.length} classifications checked, ` +
         `${labelled.length} types all labelled by the status bar extension, ` +
+        `${named} rows named after the program they run, ` +
         `pressure contract agrees on ${JSON.stringify(contract.critical)} in ${contract.filename}`,
     );
 }

--- a/scripts/test-process-monitor.js
+++ b/scripts/test-process-monitor.js
@@ -485,6 +485,30 @@ function main() {
 
     assert.strictEqual(snapshot.total, snapshot.tree.length, 'total disagrees with the tree it summarises');
     assert.strictEqual(snapshot.budget.current, snapshot.total, 'budget.current disagrees with total');
+
+    // The thresholds have to stand clear of what the app costs when nothing is
+    // happening. They did not: the soft budget was chosen when the idle set was
+    // smaller, the idle set grew to meet it, and a fresh install came up with
+    // its own warning already lit and nothing open. An always-on warning is one
+    // nobody reads, so this pins the relation rather than the numbers.
+    const budget = snapshot.budget;
+    for (const key of ['idle', 'soft', 'error', 'hard']) {
+        assert.ok(
+            Number.isInteger(budget[key]),
+            `budget.${key} is missing, so the status bar has nothing to colour against ` +
+            'and falls back to numbers of its own, which is the split this replaced',
+        );
+    }
+    assert.ok(
+        budget.soft > budget.idle,
+        `the soft budget (${budget.soft}) is not above the idle baseline (${budget.idle}), ` +
+        'so an untouched install shows a warning it can do nothing about',
+    );
+    assert.ok(
+        budget.error > budget.soft && budget.hard > budget.error,
+        `thresholds out of order: idle ${budget.idle}, soft ${budget.soft}, ` +
+        `error ${budget.error}, hard ${budget.hard}`,
+    );
     assert.strictEqual(snapshot.total, cases.length + 1, 'the count moved');
 
     const contract = checkPressureContract(tmp);

--- a/scripts/verify-android-elf.py
+++ b/scripts/verify-android-elf.py
@@ -2,6 +2,8 @@
 """Check that an ELF binary can actually load on Android.
 
     verify-android-elf.py <file> [--lib-dir DIR]...
+    verify-android-elf.py --dir DIR [--lib-dir DIR]...
+    verify-android-elf.py --tree DIR
 
 Three things, each of which fails the same quiet way at runtime (the file is
 present, the build is green, and the process dies or the addon refuses to load
@@ -13,12 +15,18 @@ with a message nobody sees):
   * every LOAD segment aligned to at least 16 KB, which Android 16 requires and
     NDK 27 does not do by default.
 
+`--tree` asks the third question only, of a whole directory tree. What it is
+for is written at [alignment_sweep]; the short version is that the first two
+cannot be asked of a tree this app packages without failing it for files that
+are correct.
+
 Pure Python on purpose: the NDK's readelf is not available everywhere this runs,
 and having one implementation means the addon build and the runtime download
 cannot drift apart in what they consider acceptable.
 """
 
 import argparse
+import os
 import pathlib
 import stat
 import struct
@@ -26,6 +34,11 @@ import sys
 
 ELF_MAGIC = b"\x7fELF"
 EM_AARCH64 = 0xB7
+# A relocatable object, which is the one ELF the loader never maps: it has no
+# LOAD segment to align, and the alignment sweep would read that absence as an
+# alignment of zero. Python's build ships one, usr/lib/python3.x/config-*/
+# python.o, and it is the only one in the packaged tree (measured).
+ET_REL = 1
 PT_LOAD, PT_DYNAMIC = 1, 2
 DT_NULL, DT_NEEDED, DT_STRTAB, DT_STRSZ = 0, 1, 5, 10
 MIN_ALIGN = 16384
@@ -56,6 +69,7 @@ def read_elf(path: pathlib.Path):
     if data[4] != 2:
         raise NotAnElf(f"{path.name} is not 64-bit")
 
+    e_type = struct.unpack_from("<H", data, 16)[0]
     machine = struct.unpack_from("<H", data, 18)[0]
     phoff, = struct.unpack_from("<Q", data, 32)
     phentsize, phnum = struct.unpack_from("<HH", data, 54)
@@ -98,7 +112,7 @@ def read_elf(path: pathlib.Path):
                     end = table.index(b"\0", val)
                     needed.append(table[val:end].decode())
 
-    return machine, needed, [a for *_, a in loads]
+    return machine, e_type, needed, [a for *_, a in loads]
 
 
 def resolvable_names(lib_dirs: list):
@@ -141,7 +155,7 @@ def verify(path: pathlib.Path, bundled: set) -> bool:
     # that tells its reader "the FAIL line above names the file" would be lying.
     # Caught per file so the sweep finishes and still fails.
     try:
-        machine, needed, aligns = read_elf(path)
+        machine, _e_type, needed, aligns = read_elf(path)
     # ValueError covers the two that read_elf can raise out of a corrupt dynamic
     # string table: bytes.index() when a DT_NEEDED offset has no NUL after it, and
     # .decode() on a non-UTF-8 name (UnicodeDecodeError is a ValueError). Those
@@ -179,6 +193,81 @@ def verify(path: pathlib.Path, bundled: set) -> bool:
     return not failed
 
 
+def alignment_sweep(root: pathlib.Path) -> int:
+    """Ask one question of every ELF under [root]: is it 16 KB aligned.
+
+    The population this exists for is the packaged asset tree, and it was
+    covered by nothing. Every download script checks the file it just placed,
+    and the Gradle sweep covers `jniLibs/` as a directory, but the ~150 aarch64
+    binaries under `assets/` are examined only at the moment they are fetched
+    and never again. A cache restore, a re-run of `package-assets.sh`, or a
+    server tree fetched whole from a release all reach packaging with nothing
+    having asked, and a misaligned addon is a `dlopen` failure on an Android 16
+    device with no sign of it at build time.
+
+    Alignment only, and the two questions it drops are dropped for one reason:
+    a tree we package is not a tree we built. It legitimately carries payloads
+    for platforms this app never runs (upstream ships x86_64 copies of ripgrep
+    beside the arm64 ones) and dependencies nothing here ever loads (both copies
+    of `kerberos.node` name `libstdc++.so.6`, measured, and no code path opens
+    them). Asking the full question of that tree would fail a build that is
+    correct. Alignment is different: it is a property of every file that could
+    be mapped, whoever built it, and a wrong answer is only ever a defect.
+    DT_NEEDED for these same trees is asked separately, by
+    `gen-glibc-forwarders.py --scan`, which knows about the shim.
+
+    A tree with no aarch64 ELF in it fails rather than passes, for the reason
+    `--dir` refuses an empty directory: "nothing was checked" must not read like
+    "everything passed".
+    """
+    checked = skipped = failed = 0
+    # os.walk rather than rglob: it does not follow directory symlinks, and the
+    # trees this runs over are node_modules, where a symlink pointing at an
+    # ancestor is ordinary rather than exotic.
+    for parent, _dirs, names in os.walk(root):
+        for name in sorted(names):
+            path = pathlib.Path(parent) / name
+            try:
+                if path.is_symlink() or not path.is_file():
+                    continue
+                # Four bytes rather than read_elf's whole file. Most of a tree
+                # this size is JavaScript, and reading all of it to find out
+                # would cost more than the check.
+                with path.open("rb") as handle:
+                    if handle.read(4) != ELF_MAGIC:
+                        continue
+            except OSError as e:
+                print(f"  FAIL   {path}: {e}")
+                failed += 1
+                continue
+            try:
+                machine, e_type, _needed, aligns = read_elf(path)
+            except (NotAnElf, IndexError, struct.error, OSError, ValueError) as e:
+                # It claimed to be an ELF in its first four bytes and then could
+                # not be read as one, which is a broken file rather than a file
+                # this mode has no opinion about.
+                print(f"  FAIL   {path}: {e}")
+                failed += 1
+                continue
+            if machine != EM_AARCH64 or e_type == ET_REL:
+                skipped += 1
+                continue
+            checked += 1
+            worst = min(aligns, default=0)
+            if worst < MIN_ALIGN:
+                print(f"  FAIL   {path}")
+                print(f"         LOAD segments aligned to {worst:#x}; "
+                      f"Android 16 needs {MIN_ALIGN:#x}")
+                failed += 1
+
+    if not checked:
+        print(f"  FAIL   no aarch64 ELF under {root}; nothing was examined")
+        return 1
+    print(f"  {'FAIL  ' if failed else 'ok    '} {checked} aarch64 binaries under {root}, "
+          f"{failed} misaligned, {skipped} skipped as another ABI or not loadable")
+    return 1 if failed else 0
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     # Optional so --dir can stand in for it. The nine existing callers each pass
@@ -196,9 +285,17 @@ def main() -> int:
     #     grep -c 'verify-android-elf.py' .github/workflows/*.yml
     ap.add_argument("--dir", type=pathlib.Path,
                     help="check every *.so in this directory instead of one file")
+    # --tree is the same idea one level out: --dir asks about a directory, this
+    # asks about a tree, and it asks less of it. See alignment_sweep for which
+    # question it keeps and why the other two cannot be asked there.
+    ap.add_argument("--tree", type=pathlib.Path,
+                    help="check LOAD alignment on every aarch64 ELF under this tree")
     ap.add_argument("--lib-dir", type=pathlib.Path, action="append", default=[],
                     help="directory whose libraries ship with the app")
     args = ap.parse_args()
+
+    if args.tree is not None:
+        return alignment_sweep(args.tree)
 
     if args.dir is not None:
         targets = sorted(args.dir.glob("*.so"))
@@ -211,7 +308,7 @@ def main() -> int:
     elif args.file is not None:
         targets = [args.file]
     else:
-        ap.error("give a file, or --dir to check a whole directory")
+        ap.error("give a file, --dir for a directory, or --tree for a whole tree")
 
     bundled = resolvable_names(args.lib_dir)
     if bundled is None:


### PR DESCRIPTION
The remaining work from the pre-release pass, plus two defects that only a
running app could show. Verified on cold first runs on API 33 and API 37, not
on relaunches: both emulators had their data cleared, both were driven through
setup and the picker, and every screen below was looked at.

## Two defects the source could not have told us

**The editor opened with the chat panel across roughly 40 percent of a phone's
width.** The walkthrough was squeezed into what remained, its heading wrapping
one word per line and the panel's own prompt box clipped. A setting to close it
shipped last cycle and did not work.

Why it did not work, measured rather than argued: the web client does not wait
for the machine settings. It starts from a copy cached in browser storage, and
that cache is only written after the remote environment resolves, which is after
the first paint has already chosen a layout. The first load in a profile
therefore falls back to upstream's default of visible, opens the bar, and
persists the open state, which every later load then reads.

Two controls settle it. A probe inside the bundled extension reported the
configuration service holding `hidden` at activation and ten seconds later while
the bar was open on screen, with an application-scoped key coming back undefined
in the same output to show the probe could tell the two apart. And with the
cache already warm, opening a different folder on the same device with the same
settings file came up with the bar closed.

The setting was inert for upgraders for a second, independent reason: it was
written only when the settings file did not yet exist, and 1.1.0 shipped a file
without it. It is now inserted on every launch when the document does not mention
it, and the bundled extension corrects a stored layout once per workspace.

**The process counter was amber on an untouched install.** The count was
checked from inside the app's own uid and is correct: five processes on both API
levels, none of them a thread, a zombie or something already gone. The threshold
was the defect. The soft budget was five, the idle baseline had grown to five,
so the warning was lit from the first paint on every device.

It was also written twice in two languages with nothing making the copies agree:
the monitor published a soft budget while the status bar coloured on literals of
its own under a comment naming the monitor's number. All four figures now come
from one place, named for what they mean, and the self-check pins the relation
rather than the numbers.

## The deferred work

Twenty-one items a previous pass had identified precisely and left alone because
the files belonged to another area at the time. The largest was a download that
survived only a renderer crash: the coordinator was told its page had gone from
two places, and no other main-frame replacement reached either, so a reload, a
folder switch or the server-gave-up screen left it holding a transfer that could
never finish, the stream open on the user's document and the queue wedged for
the session.

Following that one properly turned up something wider than reported. Four bridge
commands walk directory trees before they can answer, and the bundled extension
applied one five second deadline to every command. The extracted tree measures
873 MB, so on a real install the walk outruns the deadline, the call is reported
as a timeout and the answer is discarded when it arrives. One of the four is the
storage screen itself, which is the entry point to both screens that reclaim
disk, and no report had named it.

Also: the bug report clip is flagged sensitive, so the platform stops drawing a
preview of server output and crash logs over the editor; eight decline reasons
that crossed the bridge as literals are resources now; the setup screen holds the
display awake through an 800 MB unpack; the toolchain picker is offered until it
is answered rather than skipped for good by an interruption; a running download
is shown with its progress on a rebuilt card; and the app speaks one byte unit
instead of two that disagreed by five percent.

## What was refuted rather than changed

Several reported items did not survive being read. The claim that a WebView
version check runs too late was refuted from the code: the layout inflates a
WebView before either function, so ordering them differently changes nothing,
and the behaviour is documented as deliberate. A suggested unit formatter was
refuted because it is base 1000 on modern Android and would have reopened the
inconsistency this branch closes. A pure refactor of a symlink predicate was
declined: no test could pin it, and a regression in it silently reopens a
data-loss class.

## Verification

- Full unit suite with every task forced to re-run: **260 classes, 1647 tests, 0
  failures**, from 255 / 1631 at the branch point.
- Android Lint, `assembleRelease` and `lintVitalRelease` pass. All sixteen
  argument-free repository checks pass, and both JavaScript self-checks.
- Every guard added or changed was proved to bite by mutation, each with the
  opposite control so an over-tight guard would have been caught.
- One test in the previous branch collected log lines from two threads into an
  unsynchronised list, which loses a line only under the load of the whole
  suite. It is fixed rather than re-run until green.
