### PR TITLE
fix: correct defects found by a sweep of every production file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -275,8 +275,6 @@ jobs:
           fi
           echo "server-main.js present; libnode.so $libnode_size bytes"
 
-      # Needs the extensions tree, so it runs here rather than beside the other
-      # cheap checks in lint. A pattern that matches nothing is invisible twice:
       # Reads the packaged jniLibs, so it belongs here rather than with the
       # source-only checks: the directory is empty until the download scripts
       # above have run, and the gate refuses an empty one rather than passing
@@ -284,6 +282,9 @@ jobs:
       # four-byte libnode.so so Gradle will run.
       - name: Check the documented binary lists match what is packaged
         run: python3 scripts/check-binary-lists.py
+
+      # Needs the extensions tree, so it runs here rather than beside the other
+      # cheap checks in lint. A pattern that matches nothing is invisible twice:
       # the server keeps running, keeps counting against the phantom-process
       # budget, and the feature meant to reclaim it never sees it.
       - name: Check the monitor recognises the language servers that ship

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The release plan carries a checklist for an ordinary release, and tagging refuses a version this file has no section for.
 - Packaging checks that the documented list of bundled binaries matches what ships, so a binary added without its documentation fails the build.
 - The testing document gives the command that measures the suite instead of a figure that goes stale the next time a test is added.
+- Packaging refuses a release whose bundled extension tree failed to build, which previously deleted the extension and reported success.
 
 ### Fixed
 - The setup screen now keeps the display awake while it unpacks the app, so a screen timeout can no longer strand a first run part-way through an 800 MB extraction.
@@ -230,6 +231,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A modifier latched on the key row is cleared when the editor page is rebuilt after a crash, instead of staying held for a page that never heard of it.
 - Running out of space during setup says how much to free rather than how much the whole unpack needs.
 - The storage check no longer counts an installed toolchain's files as space the unpack can reuse, which let a full device through a gate meant to refuse it.
+- Files created in the editor inside a device folder no longer arrive on the device with .txt appended to their name.
+- A screen reader can reach Cancel during a toolchain download. Every progress report replaced the card, taking accessibility focus with it.
+- Cancelling a toolchain download now stops it during extraction and the copy, not only before the checksum, and no longer stalls the packs queued behind it.
+- A first run interrupted by the system no longer leaves a bundled extension permanently half-installed, listed but broken on every activation.
+- The loading screen is shown while the editor server starts, instead of a blank white page.
+- Renaming a folder inside a device folder keeps the record of edits that never reached the device, so a part-written copy can no longer overwrite the complete one.
+- Saving a download no longer freezes the app between chunks, and a storage provider that has gone away no longer ends the app when the destination is opened.
+- Ctrl+Shift+P and other two-modifier shortcuts no longer lose the modifier just pressed to a stale reading from the page.
+- Opening a device folder no longer does two cross-process lookups and a preferences read on the interface thread.
+- Workspace images, fonts and other assets edited on disk are served fresh instead of from a one-year cache.
+- Kill Idle Servers and the memory-pressure sweep no longer treat a program running from your own device folder as a language server.
+- The repair for a truncated .bashrc or settings.json no longer deletes the file before rewriting it, so a failed repair leaves it for the next launch instead of losing it.
+- Running out of space during setup says how much to free rather than the size of the whole unpack.
+- The process list no longer freezes for the rest of a session when the system reclaims the app's cache directory.
+- The toolchain removal dialog is dismissed on rotation instead of leaking its window.
 
 ### Security
 - Symbolic links inside a device folder's local copy are no longer written out to the device, where they arrived as ordinary files carrying whatever their target held.
@@ -240,6 +256,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Content rendered in the editor can no longer read workspace files across origins. Served files are readable by anyone, and a page in the built-in browser could fetch one.
 - A webview can no longer name an arbitrary file and have the app read it with the editor's own credential. The route that did was reachable but unused.
 - The editor can no longer make the app fetch an arbitrary web address on its behalf. The route reached any host, including addresses only this device can see.
+- Bug reports redact credentials named the way a server names them. A rule required the name to start at a word boundary, so NPM_TOKEN, DB_PASSWORD and their family were written out in full.
+- A device folder's path no longer reaches the system log when the folder is opened from the recent list.
+- Content rendered in the editor can no longer steer the address the app fetches when it proxies an editor asset.
 
 ## [1.1.0] - 2026-08-19
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1045,10 +1045,17 @@ val checkPackOverlap = tasks.register<Exec>("checkPackOverlap") {
     workingDir = rootProject.projectDir.parentFile
     commandLine("python3", "scripts/check-pack-overlap.py")
 
-    // Armed by the payload, the same predicate and the same reason as the Ruby
-    // sweep below: comparing an empty pack against the base module reports no
-    // overlap for the wrong reason.
-    onlyIf { rubyPackHoldsPayload() }
+    // Armed by ANY pack holding payload, because the script sweeps every pack
+    // rather than one. This asked whether the RUBY pack had been downloaded,
+    // borrowing the predicate from the Ruby-only sweep below without its
+    // subject, so a checkout that had run download-java.sh and not
+    // download-ruby.sh skipped the gate entirely and bundled the Java pack
+    // without ever comparing it against the base module. Both payload trees are
+    // gitignored, so that is an ordinary state to be in while working on one
+    // pack. The reason for arming on payload at all is unchanged: a pack holding
+    // only its tracked manifest overlaps nothing, and reporting that as no
+    // overlap answers a question nobody asked.
+    onlyIf { anyPackHoldsPayload() }
 
     isIgnoreExitValue = true
     val overlapResult = executionResult
@@ -1149,6 +1156,13 @@ val verifyPythonPlatform = tasks.register<Exec>("verifyPythonPlatform") {
 
 fun rubyPackHoldsPayload(): Boolean =
     File(rootProject.projectDir, "toolchain_ruby/src/main/assets/usr").isDirectory
+
+// The same question of every pack, found the way check-pack-overlap.py finds
+// them, so a pack added later is covered here without this line being edited.
+fun anyPackHoldsPayload(): Boolean =
+    rootProject.projectDir.listFiles()
+        ?.any { it.isDirectory && it.name.startsWith("toolchain_") &&
+            File(it, "src/main/assets/usr").isDirectory } == true
 
 // The same question asked of the Ruby asset pack, which is in neither jniLibs
 // nor the app module's assets.

--- a/android/app/src/main/assets/extensions/vscodroid.vscodroid-process-monitor-1.1.0/extension.js
+++ b/android/app/src/main/assets/extensions/vscodroid.vscodroid-process-monitor-1.1.0/extension.js
@@ -138,7 +138,17 @@ function updateStatusBar(snapshot) {
     // than a reading of this tree, so it stays in the sentence and now comes from
     // the same place as everything else.
     if (total >= error && !criticalShownAtThreshold) {
+        // Both latches, because this count already meets the softer tier as
+        // well: error is above soft, and the three arms are one else-if chain
+        // over two independent flags. Setting only the critical one left the
+        // warning latch false, so the NEXT poll at an unchanged high count fell
+        // through to the soft arm and put 'above the target of 5' on top of the
+        // error already on screen -- two notifications about one reading, the
+        // second the less severe of the two, and both then permanent, since
+        // only a count below the idle baseline clears either. Measured on polls
+        // of 3, 20, 20, 20: nothing, the error, the warning, nothing.
         criticalShownAtThreshold = true;
+        warningShownAtThreshold = true;
         vscode.window.showErrorMessage(
             'Too many phantom processes; Android may start killing them. ' +
                 'The live count is in the status bar.',
@@ -159,9 +169,35 @@ function updateStatusBar(snapshot) {
             if (choice === 'Kill Idle Servers') killIdleLanguageServers();
             else if (choice === 'Show Details') showProcessTree();
         });
-    } else if (total < idle) {
-        warningShownAtThreshold = false;
+    } else if (total < soft) {
+        // Re-arming, and each latch comes back at the tier below the one that
+        // set it. This asked for `total < idle`, one BELOW the idle baseline,
+        // which is the count process-monitor.js measures for a cold session
+        // left untouched: five, the bootstrap, the server, the file watcher,
+        // the agent host and the chat backend, on API 33 and API 37 alike. A
+        // session with the workbench open never has fewer than the workbench
+        // costs, so nothing on a device cleared either flag and both tiers were
+        // one-shot for the life of the extension host. Only the prompt was
+        // lost, not the remedy: the status item recolours on every poll and
+        // 'Kill Idle Servers' stays a palette command that showProcessTree()
+        // names, which is why this is a quiet failure rather than a loud one.
+        //
+        // The gap between firing and re-arming is the point, so the count
+        // crossing one threshold cannot raise the same notification twice: the
+        // critical tier fires at the error budget and comes back only once the
+        // count is under the soft one, and the warning tier fires at the soft
+        // budget and comes back only once the count is at the idle baseline,
+        // which is the app doing nothing. `<=` and not `<` for that one: the
+        // baseline is the floor, not a count to get below.
+        //
+        // The two are separate on purpose. A recovery to 6 or 7 has left the
+        // busy range and deserves the error again if the count climbs back past
+        // 14, but it is still above the target the warning names, so repeating
+        // the warning there says nothing new. An escalation is not affected
+        // either way: a latched warning does not block the critical arm, which
+        // tests its own flag.
         criticalShownAtThreshold = false;
+        if (total <= idle) warningShownAtThreshold = false;
     }
 }
 
@@ -226,11 +262,15 @@ function killIdleLanguageServers() {
 // The other direction was 'ptyHost', an entry for a type classify() cannot
 // return: the pty host became a worker_thread and stopped being a process in
 // /proc at all, and the stale entry read as evidence that it still was.
+// 'safSync' left for the same reason and did more damage on the way: the SAF
+// sync engine is a thread inside the Android app process, so the type only ever
+// landed on processes that happened to run inside a folder opened from device
+// storage, and a language server among them was labelled 'storage' here while
+// being outside every reclaim path.
 const TYPE_LABELS = {
     bootstrap: 'system',
     server: 'system',
     fileWatcher: 'system',
-    safSync: 'storage',
     system: 'system',
     tmux: 'terminal',
     terminal: 'terminal',

--- a/android/app/src/main/assets/extensions/vscodroid.vscodroid-saf-bridge-1.4.0/extension.js
+++ b/android/app/src/main/assets/extensions/vscodroid.vscodroid-saf-bridge-1.4.0/extension.js
@@ -322,6 +322,35 @@ function activate(context) {
                         `${STORAGE_LABELS[picked.key] || picked.key} is not cached data ` +
                             'and cannot be cleared from here.'
                     );
+                } else {
+                    // The Total row, the only item built without a key. Every
+                    // other unactionable row explains itself above, and this one
+                    // is the first and largest thing on a screen a person opens
+                    // because they are out of space: with no arm of its own it
+                    // closed the picker in silence, which reads as a screen that
+                    // does not work rather than as a row with nothing to do.
+                    //
+                    // It is NOT the sum of the rows, which is what this sentence
+                    // said first: Total is every byte under the app's data and
+                    // cache directories, while the rows name the subtrees that
+                    // can be identified and acted on. The same change widened
+                    // that gap, narrowing the cache row to the four directories
+                    // the clear action reaches while leaving the whole cache
+                    // directory in Total. A person out of disk adds the rows up,
+                    // and is owed the two figures rather than an equality the
+                    // breakdown does not maintain.
+                    //
+                    // Both numbers, rather than a sentence about the difference.
+                    // A sentence would be one more claim to keep true as rows are
+                    // added and narrowed, which is exactly what went wrong here;
+                    // these are read off the same breakdown the rows are drawn
+                    // from and cannot disagree with them.
+                    const named = parts.reduce((sum, p) => sum + p.bytes, 0);
+                    vscode.window.showInformationMessage(
+                        `That is every byte this app is using: ${formatBytes(Number(b.total) || 0)}. ` +
+                            `The rows below account for ${formatBytes(named)} of it. ` +
+                            'Pick one of those to see what can be freed.'
+                    );
                 }
             } catch (/** @type {*} */ err) {
                 vscode.window.showErrorMessage(

--- a/android/app/src/main/assets/process-monitor.js
+++ b/android/app/src/main/assets/process-monitor.js
@@ -58,6 +58,31 @@ const KILL_ON_PRESSURE = new Set(['critical']);
 // literals and refuses a disagreement in either direction.
 const PRESSURE_FILENAME = 'vscodroid-memory-pressure';
 
+// Where this app unpacks the editor, and the anchor the chat-backend rule in
+// classify() is written against.
+//
+// Derived rather than spelled out. server.js requires this module out of its own
+// directory and builds the server tree beside it the same way, from __dirname,
+// so this is the same path by construction instead of by agreement. It was a
+// hand-written copy of a location the Kotlin side owns in five places, and the
+// half of that which nothing would have caught is a move of the PARENT
+// directory: renaming the leaf drops the app into server.js's minimal
+// health-check server and is loud, while moving `server/` elsewhere leaves every
+// __dirname-relative path in server.js working and only stops this rule
+// matching -- and the chat agent's model backend, 226 MB and one of five
+// processes counted against the phantom budget, goes back to 'unknown', outside
+// the idle kill and outside the command that sheds language servers by hand.
+//
+// Exported for scripts/test-process-monitor.js, which loads a copy of this file
+// from a directory of its own and asks the same question there.
+const REH_ROOT = path.join(__dirname, 'vscode-reh');
+
+// classify() lower-cases the command line before comparing, so the needle is
+// lower-cased once here to meet it. The device's path has no capitals; a
+// checkout on a CI runner or a workstation does, and that is where this file's
+// own tests run.
+const REH_PREFIX = REH_ROOT.toLowerCase() + '/';
+
 // How an entry matches depends on its shape, which namesProgram() below reads:
 // a bare word has to name the program exactly (optionally with a .js, .mjs or
 // .cjs extension), while an entry carrying a separator is distinctive enough to
@@ -328,16 +353,25 @@ function classify(cmdline) {
     // names what it runs in one argument, and the directories above that name
     // are the user's to choose.
     //
-    // The paths below stay on the whole line deliberately: saf-mirrors and
-    // saf-writeback ARE directories rather than program names, so a basename
-    // would never see them.
+    // A 'safSync' rule used to stay on the whole line here, kept for being
+    // directories rather than program names, and it was 'vscode-eslint' again in
+    // another shape. Its subject is not a process: saf-writeback is a thread
+    // inside the Android app process (SafSyncEngine) and nothing under assets/
+    // is named safsync, so the only string it could ever reach was saf-mirrors,
+    // which is the root of the local copy of a folder opened through the SAF
+    // picker and therefore a directory the user chose. The cost was not a label.
+    // A language server whose own program path lies inside a device folder, a
+    // venv interpreter selected there or a workspace tsserver under its
+    // node_modules, returned here before the patterns below were read, so it
+    // never entered lsCpuTracker, never carried an idle verdict, and sat outside
+    // the pressure kill and outside 'Kill Idle Servers' alike while holding one
+    // of the 32 phantom slots. Where a process runs says nothing about what it
+    // is, mirrors included.
     const parts = cmd.split(' ').filter(Boolean);
     const names = parts.map((arg) => path.basename(arg));
 
     if (cmd.includes('server-main.js')) return 'server';
     if (cmd.includes('bootstrap-fork') && cmd.includes('filewatcher')) return 'fileWatcher';
-    // SAF sync engine: mirrors content:// URIs to local filesystem for VS Code access
-    if (cmd.includes('saf-mirrors') || cmd.includes('saf-writeback') || cmd.includes('safsync')) return 'safSync';
     // ptyHost is now a worker_thread: no longer visible in /proc
     if (names.includes('libtmux.so') || names.includes('tmux')) return 'tmux';
     if (names.includes('libbash.so') || names.includes('bash')) return 'terminal';
@@ -351,9 +385,9 @@ function classify(cmdline) {
     // above compares is `index.js`: that names the package's entry point and not
     // the program, so a bare word would miss it and a substring would claim every
     // index.js on the device, the user's own included. Matched on the package path
-    // instead, the exception the saf paths above already take, and the
-    // node_modules segment is what keeps the needle off a directory someone chose
-    // themselves.
+    // instead, the one rule here that reads a directory rather than a program
+    // name, and the node_modules segment is what keeps the needle off a directory
+    // someone chose themselves.
     //
     // Being unclassified was not cosmetic here. Measured idle on an API 33 and an
     // API 37 emulator, signed out, nothing but the Welcome tab open: 226 MB
@@ -375,11 +409,12 @@ function classify(cmdline) {
     // process eligible for the SIGTERM below.
     //
     // So the rule asks for the tree this app unpacks, in the one argument that
-    // names the program. filesDir/server/vscode-reh holds both alias sites
-    // FirstRunSetup.setupCopilotAndroidAliases builds, the agent host's and the
-    // session provider's, and a project directory cannot be inside it.
+    // names the program. REH_ROOT is that tree, derived above from where this
+    // file sits rather than written out here a second time. It holds both alias
+    // sites FirstRunSetup.setupCopilotAndroidAliases builds, the agent host's
+    // and the session provider's, and a project directory cannot be inside it.
     const script = scriptArgument(parts);
-    if (script.includes('/server/vscode-reh/') &&
+    if (script.startsWith(REH_PREFIX) &&
         script.includes('/node_modules/@github/copilot-')) return 'langserver';
 
     for (const pattern of LANG_SERVER_PATTERNS) {
@@ -479,6 +514,16 @@ function scan() {
             warnings
         };
 
+        // TMPDIR is cacheDir/tmp, and Android deletes an app's cache directory
+        // under storage pressure while the app keeps running, so the directory
+        // this writes into can go mid-session. Both Kotlin writers into that
+        // same path recreate it on the way past (ProcessManager.startServer,
+        // MainActivity.writeMemoryPressure); this one did not, and the write
+        // then threw ENOENT into a catch that only logs. Nothing else here
+        // recreates it, so the status bar counter, its tooltip and the process
+        // tree all froze on their last snapshot for the life of the server, and
+        // 'Kill Idle Servers' went on SIGTERMing pids read out of it.
+        fs.mkdirSync(path.dirname(outputPath), { recursive: true });
         fs.writeFileSync(outputPath, JSON.stringify(snapshot), 'utf8');
     } catch (e) {
         log('error', `Scan failed: ${e.message}`);
@@ -499,7 +544,15 @@ function scan() {
  */
 function isIdle(pid, now) {
     const tracked = lsCpuTracker.get(pid);
-    return !!tracked && now - tracked.lastActive >= IDLE_KILL_THRESHOLD_MS;
+    if (!tracked) return false;
+    // A SIGTERM this process has not answered keeps it eligible whatever its CPU
+    // reading says. Answering a signal is itself work: a server that runs a
+    // handler and then does not exit spends CPU doing it, which moves lastActive
+    // on the next scan and would otherwise report a process that is refusing to
+    // go as busy for another five minutes. The record is dropped when the
+    // process really goes, by the cleanup loop in scan().
+    if (tracked.termSentAt) return true;
+    return now - tracked.lastActive >= IDLE_KILL_THRESHOLD_MS;
 }
 
 function trackLangServer(pid, now) {
@@ -507,14 +560,20 @@ function trackLangServer(pid, now) {
     if (cpuTime < 0) return;
 
     const prev = lsCpuTracker.get(pid);
-    if (!prev) {
+    // CPU time only ever goes up within one process, so a reading that went
+    // backwards is a different process wearing a recycled pid. It starts over
+    // rather than inheriting its predecessor's record: that record can carry a
+    // SIGTERM this process never received, and the escalation below would then
+    // SIGKILL a server that had just started.
+    if (!prev || cpuTime < prev.cpuTime) {
         lsCpuTracker.set(pid, { cpuTime, lastActive: now });
         return;
     }
 
     if (cpuTime !== prev.cpuTime) {
-        // CPU time changed: process is active
-        lsCpuTracker.set(pid, { cpuTime, lastActive: now });
+        // CPU time changed: process is active. Spread rather than rebuilt, so
+        // that an unanswered SIGTERM survives the update; see isIdle above.
+        lsCpuTracker.set(pid, { ...prev, cpuTime, lastActive: now });
     }
     // else: cpuTime unchanged, lastActive stays the same (idle)
 }
@@ -526,11 +585,28 @@ function killIdleLangServers(now) {
     // this does not need to have an answer to.
     for (const pid of [...lsCpuTracker.keys()]) {
         if (isIdle(pid, now)) {
+            const tracked = lsCpuTracker.get(pid);
+            // A pid still carrying the last SIGTERM is one that outlived it: the
+            // mark is only ever set by an earlier scan, so at least one scan
+            // interval has passed and the server has had its chance to exit.
+            // Escalate rather than repeat. A second SIGTERM to a process that
+            // ignored the first reclaims nothing, and this path runs only when
+            // Android has reported critical memory pressure over a server that
+            // has not moved in five minutes.
+            const escalate = !!tracked.termSentAt;
             try {
                 const cmdline = readCmdline(pid);
-                process.kill(pid, 'SIGTERM');
+                process.kill(pid, escalate ? 'SIGKILL' : 'SIGTERM');
                 killed.push({ pid, cmd: cmdline });
-                lsCpuTracker.delete(pid);
+                // The attempt is recorded rather than forgotten. Deleting here
+                // erased the only evidence that a signal was ever sent, so a
+                // process that survived it was re-tracked by the next scan as a
+                // first sighting and bought itself another five idle minutes,
+                // every time, while the warning above had already told the user
+                // it was killed. Removal belongs to the cleanup loop in scan(),
+                // which drops the pids that really went and runs before this in
+                // the same scan.
+                lsCpuTracker.set(pid, { ...tracked, termSentAt: now });
             } catch {
                 // Process already gone
                 lsCpuTracker.delete(pid);
@@ -548,4 +624,6 @@ function readMemoryPressure() {
     return content.trim();
 }
 
-module.exports = { start, stop, readMemoryPressure, KILL_ON_PRESSURE, PRESSURE_FILENAME };
+module.exports = {
+    start, stop, readMemoryPressure, KILL_ON_PRESSURE, PRESSURE_FILENAME, REH_ROOT,
+};

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -15,7 +15,9 @@ import android.content.pm.PackageManager
 import android.graphics.Typeface
 import android.os.Bundle
 import android.net.Uri
+import android.os.Handler
 import android.os.IBinder
+import android.os.Looper
 import android.os.SystemClock
 import android.provider.DocumentsContract
 import android.text.util.Linkify
@@ -78,6 +80,7 @@ import org.json.JSONObject
 import kotlin.concurrent.thread
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -425,6 +428,21 @@ class MainActivity : AppCompatActivity() {
             } ?: downloads.onComplete(requestId, "there is no page to read this download")
         }
 
+        /**
+         * Hopped and unanswered, unlike [requestBytes]. A download can end on
+         * the WebView's bridge thread and `evaluateJavascript` is the main
+         * thread's alone; and there is nothing to learn from the answer, since
+         * a page that has no hold for this URL is the ordinary case rather than
+         * a failure.
+         */
+        override fun releaseBytes(url: String) {
+            val script = "(function() {" +
+                "  var d = window.__vscodroidDownload;" +
+                "  if (d) d.release(${JSONObject.quote(url)});" +
+                "})()"
+            runOnUiThread { webView?.evaluateJavascript(script, null) }
+        }
+
         override fun report(outcome: DownloadOutcome, fileName: String, detail: String?) {
             // Both halves are page supplied and this line is not gated on a
             // debuggable build, so it ships. `fileName` arrives through
@@ -478,15 +496,29 @@ class MainActivity : AppCompatActivity() {
         if (handOffToSetup()) return
         setContentView(R.layout.activity_main)
 
-        safManager = SafStorageManager(this)
+        // The application context, and that is the whole of what this outlives an
+        // Activity by. The manager's engine owns the `saf-writeback` daemon, which
+        // onDestroy waits two seconds for and then leaves running rather than
+        // discarding writes the user expects on the device; every reference the
+        // engine holds is held for as long as that drain takes. Built with `this`,
+        // that was a destroyed Activity and its whole inflated view tree, on a
+        // device this app is trying to leave memory on.
+        safManager = SafStorageManager(applicationContext)
+        // Read into locals for the same reason, and used by all three notices below:
+        // a lambda that says `this@MainActivity`, `getString` or `runOnUiThread`
+        // captures the Activity and hands it straight back to the engine. The
+        // notices themselves have to survive, because the drain they report on is
+        // exactly the part that outlives the screen.
+        val appContext = applicationContext
+        val toMainThread = Handler(Looper.getMainLooper())
         // A save that never reached the device folder looks exactly like one that did.
         // The engine has no screen, so the notice is wired here; it is throttled inside
         // the manager, because a provider that starts refusing refuses everything.
         safManager.onWriteBackFailed { file ->
-            runOnUiThread {
+            toMainThread.post {
                 Toast.makeText(
-                    this@MainActivity,
-                    getString(R.string.saf_write_back_failed, file.name),
+                    appContext,
+                    appContext.getString(R.string.saf_write_back_failed, file.name),
                     Toast.LENGTH_LONG,
                 ).show()
             }
@@ -498,12 +530,14 @@ class MainActivity : AppCompatActivity() {
         // device refusing.
         safManager.onUploadIncomplete { dir, lost, capped ->
             val message = if (capped) {
-                getString(R.string.saf_upload_capped, dir.name)
+                appContext.getString(R.string.saf_upload_capped, dir.name)
             } else {
-                resources.getQuantityString(R.plurals.saf_upload_incomplete, lost, lost, dir.name)
+                appContext.resources.getQuantityString(
+                    R.plurals.saf_upload_incomplete, lost, lost, dir.name
+                )
             }
-            runOnUiThread {
-                Toast.makeText(this@MainActivity, message, Toast.LENGTH_LONG).show()
+            toMainThread.post {
+                Toast.makeText(appContext, message, Toast.LENGTH_LONG).show()
             }
         }
 
@@ -511,10 +545,10 @@ class MainActivity : AppCompatActivity() {
         // Its own wording, because "the only copy is inside VSCodroid" is the opposite of
         // true for these, and would send the user looking for a file that is safe.
         safManager.onDocumentsNotCopied { count, outOfRoom ->
-            runOnUiThread {
+            toMainThread.post {
                 Toast.makeText(
-                    this@MainActivity,
-                    resources.getQuantityString(
+                    appContext,
+                    appContext.resources.getQuantityString(
                         if (outOfRoom) R.plurals.saf_documents_not_copied_no_room
                         else R.plurals.saf_documents_not_copied,
                         count,
@@ -751,9 +785,17 @@ class MainActivity : AppCompatActivity() {
         // throws, and a throw here is a crash on a path whose whole purpose is
         // to recover quietly.
         //
-        // Both captured into locals so nothing about this activity outlives it.
-        // Reading `safManager` or `tag` from inside the lambda would capture the
-        // Activity, and with it the view tree, for as long as the drain runs.
+        // Both captured into locals, which keeps this thread from holding the
+        // Activity: reading `safManager` or `tag` from inside the lambda would
+        // capture `this`, and with it the view tree, until the thread returns.
+        //
+        // Only half of what that costs was ever here, and the half that was is the
+        // smaller one: this thread ends when stopWatching does, about two seconds.
+        // The manager it names is what outlives the Activity, because the engine
+        // leaves the write-back worker running when the drain outruns that wait,
+        // which is why the manager is built on the application context and why the
+        // three notices in onCreate close over that and a main-thread Handler
+        // rather than over this Activity.
         val stopping = if (::safManager.isInitialized) safManager else null
         val logTag = tag
         if (stopping != null) {
@@ -793,6 +835,12 @@ class MainActivity : AppCompatActivity() {
             }
             serviceBindingInitiated = false
         }
+        // Dropped before the view it wraps, exactly as recreateWebView does it
+        // and for the same reason. The key row polls the page while a modifier
+        // is latched, and a tick already in the looper's queue still runs after
+        // this method returns; with the injector left in place it asks a
+        // destroyed WebView, which answers by logging and never calling back.
+        extraKeyRow?.keyInjector = null
         webView?.destroy()
         webView = null
         super.onDestroy()
@@ -859,11 +907,23 @@ class MainActivity : AppCompatActivity() {
      * activity is itself mid-sync on will start its own watcher when it finishes.
      */
     private fun adoptWorkbenchFolder(folderPath: String) {
-        val folder = safManager.folderForOpenedPath(folderPath) ?: return
-        if (watchedSafFolder?.first?.path == folder.mirrorPath) return
-        if (syncingFolder == folder.uri) return
-        Logger.i(tag, "Adopting a device folder the workbench opened on its own")
-        openSafFolder(folder.uri, navigate = false)
+        lifecycleScope.launch {
+            // Off the main thread, because this arrives from onPageFinished: the
+            // lookup asks the system server for every persisted grant and prunes
+            // the recent list against the answer, and a cold start whose remembered
+            // workspace is a mirror reaches it with the workbench already drawn.
+            val folder = withContext(Dispatchers.IO) {
+                safManager.folderForOpenedPath(folderPath)
+            } ?: return@launch
+            // Back on the main thread, which is where both of these are written:
+            // the coroutine resumes on Dispatchers.Main.immediate, and a second
+            // page load cannot interleave between the resume and openSafFolder's
+            // own assignment because that assignment is made before it suspends.
+            if (watchedSafFolder?.first?.path == folder.mirrorPath) return@launch
+            if (syncingFolder == folder.uri) return@launch
+            Logger.i(tag, "Adopting a device folder the workbench opened on its own")
+            openSafFolder(folder.uri, navigate = false)
+        }
     }
 
     /**
@@ -887,22 +947,25 @@ class MainActivity : AppCompatActivity() {
         // user's own directory (`.../tree/primary%3ADocuments%2F<folder>`),
         // `Logger.i` is not gated on a debuggable build, and logcat is readable
         // by anything holding READ_LOGS as well as by whoever a device bug report
-        // is sent to. `persistPermission` one line below already names this same
+        // is sent to. `persistPermission` in the hop below already names this same
         // folder by the six-byte digest of that URI, which is stable and is not
         // reversible; saying it in full here put the value back in logcat by
         // another route. The digest is a hash of the URI string and nothing else,
         // so it is answerable before any permission has been taken.
         Logger.i(tag, "Opening the device folder ${safManager.getMirrorDir(uri).name}")
 
-        // Persist permission so we can access this folder after app restart
-        safManager.persistPermission(uri)
-
-        val displayName = safManager.getDisplayName(uri)
-
-        // Show progress dialog during sync
+        // Up before the provider is asked anything, and named from the tree URI
+        // until it answers. Everything that used to run ahead of this dialog was a
+        // cross-process round trip: persistPermission resolves the display name and
+        // reads the persisted grants to prune the recent list, and getDisplayName
+        // queries the tree a second time. All three callers are on the thread that
+        // draws the screen (the picker result, the bridge through runOnUiThread, and
+        // onPageFinished through adoptWorkbenchFolder), so against a network- or
+        // MTP-backed provider that was seconds of frozen editor with nothing on it
+        // to say why. The real name replaces the placeholder below.
         val dialog = AlertDialog.Builder(this)
             .setTitle(getString(R.string.saf_sync_title))
-            .setMessage(getString(R.string.saf_sync_message, displayName))
+            .setMessage(getString(R.string.saf_sync_message, treeUriLabel(uri.lastPathSegment)))
             .setCancelable(false)
             .create()
         dialog.show()
@@ -912,6 +975,19 @@ class MainActivity : AppCompatActivity() {
 
         lifecycleScope.launch {
             try {
+                // NonCancellable, and for the permission alone. The grant used to be
+                // taken on the way in, so it was taken whatever happened next; a
+                // plain hop here would drop it if this activity were destroyed in
+                // the moment after the picker returned, and the folder would be
+                // missing from the recent list with nothing to explain it. The sync
+                // below must still be skipped in that case, which the ordinary hop
+                // after this one does by throwing.
+                val displayName = withContext(NonCancellable + Dispatchers.IO) {
+                    safManager.persistPermission(uri)
+                    safManager.getDisplayName(uri)
+                }
+                dialog.setMessage(getString(R.string.saf_sync_message, displayName))
+
                 // Before the sync, and this call was moved rather than added:
                 // there used to be one after it, which `startWatching` has since
                 // made redundant by stopping the previous watcher itself. Reading
@@ -1000,14 +1076,26 @@ class MainActivity : AppCompatActivity() {
                 if (!isFinishing && !isDestroyed) dialog.dismiss()
                 throw e
             } catch (e: SecurityException) {
-                dialog.dismiss()
+                // Guarded like the cancellation branch above, and for the reason
+                // that one gives. A real failure can land here while this screen
+                // is going away (a grant revoked mid-sync, a provider giving up
+                // on a network share, in the moment the user swipes the app
+                // away): dismissing a dialog whose window has already been torn
+                // down throws, and a throw raised inside a catch leaves the
+                // coroutine by the scope's uncaught handler rather than being
+                // handled here at all, which is a crash on the way out of a
+                // screen the user has already left. Skipping it leaves nothing on
+                // screen, because the window that carried the dialog is what has
+                // gone; the notice below is a toast and outlives it.
+                if (!isFinishing && !isDestroyed) dialog.dismiss()
                 Logger.e(tag, "SAF permission revoked during sync", e)
                 reportSyncFailure(
                     getString(R.string.saf_sync_denied),
                     restoreWatcherAfterFailure(previouslyWatched, uri)
                 )
             } catch (e: Exception) {
-                dialog.dismiss()
+                // Guarded for the reason the handler above it is.
+                if (!isFinishing && !isDestroyed) dialog.dismiss()
                 Logger.e(tag, "SAF sync failed", e)
                 reportSyncFailure(
                     getString(R.string.saf_sync_failed, e.message),
@@ -1428,7 +1516,9 @@ class MainActivity : AppCompatActivity() {
             wv.webViewClient = bootstrapClient()
             // Show a loading placeholder while Node.js starts
             // viewport-fit=cover enables rendering into display cutout area
-            wv.loadData(LOADING_PAGE, "text/html", "utf-8")
+            // Through dataUrlSafe, which is not cosmetic here: see its comment for
+            // what the unescaped page rendered as.
+            wv.loadData(dataUrlSafe(LOADING_PAGE), "text/html", "utf-8")
         }
     }
 
@@ -1725,7 +1815,7 @@ class MainActivity : AppCompatActivity() {
      * again anyway. Only the start is missing, and only the start is sent.
      */
     private fun retryServerStart() {
-        webView?.loadData(LOADING_PAGE, "text/html", "utf-8")
+        webView?.loadData(dataUrlSafe(LOADING_PAGE), "text/html", "utf-8")
         startForegroundService(Intent(this, NodeService::class.java))
     }
 
@@ -1746,13 +1836,32 @@ class MainActivity : AppCompatActivity() {
         // remembered one answers only where there is no URL to ask, which is a
         // WebView still holding the data: placeholder after this activity was
         // rebuilt over a server that never stopped.
-        navigateToFolder(
-            port,
-            folderPath
-                ?: folderFromUrl(webView?.url)
-                ?: rememberedWorkspaceFolder()
-                ?: FirstRunSetup(this).ensureProjectsDir()
-        )
+        //
+        // The first two answers cost nothing and are given here, on the thread
+        // that asked, so the ordinary navigation is as immediate as it ever was.
+        val known = folderPath ?: folderFromUrl(webView?.url)
+        if (known != null) {
+            navigateToFolder(port, known)
+            return
+        }
+        lifecycleScope.launch {
+            // Off the main thread for the reason adoptWorkbenchFolder hops, and
+            // this is the same lookup: deciding whether a remembered mirror is
+            // still granted asks the system server for every persisted grant and
+            // prunes the recent list against the answer, and the default is a
+            // directory this may have to create. Both are here on the cold-start
+            // path, on the thread drawing the screen, in the moment before the
+            // workbench is put up.
+            val folder = withContext(Dispatchers.IO) {
+                rememberedWorkspaceFolder() ?: FirstRunSetup(this@MainActivity).ensureProjectsDir()
+            }
+            // Asked again rather than carried across the hop. The URL outranks
+            // the remembered folder before the suspension and has to go on
+            // outranking it after: a renderer crash recovering into the folder it
+            // was showing arrives through this same method, and a remembered
+            // folder resolved before it would otherwise land last and win.
+            navigateToFolder(port, folderFromUrl(webView?.url) ?: folder)
+        }
     }
 
     /**
@@ -2330,8 +2439,11 @@ class MainActivity : AppCompatActivity() {
                 // minutes the later files were revoked while their own picker was
                 // still on screen, so the user chose a folder and a name and was
                 // handed a failure. The hold is released as soon as the bytes are
-                // being read (see readerFor), so this ceiling is only ever paid by
-                // a download nobody ever completes.
+                // being read (see readerFor), and again the moment Android gives
+                // up on a download it never read (see release), so this ceiling
+                // is the backstop for the one case neither covers: a download
+                // whose end nobody can report, because the page it belonged to
+                // is the thing that went away.
                 var HOLD_MS = 600000;
                 var MAX_TRACKED = 8;
 
@@ -2429,6 +2541,18 @@ class MainActivity : AppCompatActivity() {
                 }
 
                 window.__vscodroidDownload = {
+                    // Lets go of a download Android has finished with without
+                    // ever reading it: refused for being one of too many at
+                    // once, cancelled at the picker, or failed before the
+                    // bytes were asked for. Without this the blob stays
+                    // pinned here for the whole of HOLD_MS after the user has
+                    // been told the file is not coming, and a multi-select
+                    // pins every file the queue turned away at once.
+                    release: function(url) {
+                        if (!held.has(url)) return;
+                        held.delete(url);
+                        revoke(url);
+                    },
                     // Reads url and pushes it back in pieces under id. Answers
                     // whether it started, which is the one failure Android
                     // cannot be told about any other way.
@@ -2903,6 +3027,13 @@ class MainActivity : AppCompatActivity() {
                 Toast.makeText(this, getString(R.string.crash_report_copied), Toast.LENGTH_SHORT).show()
                 CrashReporter.clearCrashLogs()
             }
+            // The third exit, and the one most people take. Back and a tap outside
+            // cancel the dialog without running either button, and the guard above
+            // is false only once the files are gone, so the same modal came back
+            // over the loading editor on every later launch and there was nothing
+            // on screen offering a way to stop it. Clearing here is what the user
+            // believes the gesture already did.
+            .setOnCancelListener { CrashReporter.clearCrashLogs() }
             .setCancelable(true)
             .show()
     }
@@ -3553,3 +3684,46 @@ internal fun escapeHtml(s: String): String = s
     .replace(">", "&gt;")
     .replace("\"", "&quot;")
     .replace("'", "&#39;")
+
+/**
+ * Markup made safe for the `data:` URL that `WebView.loadData` splices it into.
+ *
+ * `loadData` does not load a document, it builds a URL out of one, and for an app
+ * targeting Q or later the platform stops escaping the content: the first `#`
+ * ends the URL and every byte after it becomes the fragment. The loading page
+ * opens with `background:#1e1e1e`, so what the WebView actually parsed was an
+ * unterminated `<body` start tag, which is dropped at end of input. The document
+ * was empty and the view painted its own default white for the whole of the
+ * server start, which is the first screen of every cold start and the screen the
+ * Retry link puts back.
+ *
+ * `%` is escaped before `#`, or the `%23` written here would be escaped a second
+ * time into `%2523` and reach the page as literal text.
+ *
+ * Not needed by [MainActivity.showServerGaveUp]: `loadDataWithBaseURL` with a
+ * base URL that is not a data URL loads the content as a plain string, which is
+ * why that page renders today while this one does not.
+ */
+internal fun dataUrlSafe(html: String): String = html
+    .replace("%", "%25")
+    .replace("#", "%23")
+
+/**
+ * A folder name read straight off a SAF tree URI, for the moment before the
+ * provider has been asked for the real one.
+ *
+ * Never the final name: [SafStorageManager.getDisplayName] replaces it as soon as
+ * the query answers. It exists because that query is a cross-process round trip
+ * and a network- or MTP-backed provider can make it a long one, and the sync
+ * dialog has to be on screen before it, not after.
+ *
+ * The last path segment of a tree URI arrives decoded, as `primary:Documents/Work`,
+ * so the tail after the last separator is the folder the user picked. A root
+ * (`primary:`) has no tail, and there the whole segment is closer to a name than
+ * an empty pair of quotes is.
+ */
+internal fun treeUriLabel(lastPathSegment: String?): String {
+    val segment = lastPathSegment.orEmpty()
+    val tail = segment.substringAfterLast('/').substringAfterLast(':')
+    return tail.ifBlank { segment }
+}

--- a/android/app/src/main/kotlin/com/vscodroid/SplashActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/SplashActivity.kt
@@ -41,6 +41,16 @@ class SplashActivity : AppCompatActivity() {
     private var currentDownloadIndex = -1
     private var cancelled = false
 
+    /**
+     * The picker's cards while the picker is the screen on show, and null in
+     * every other phase of this activity.
+     *
+     * Held so that coming back to the picker can correct what it says is already
+     * on disk. Nothing else may use it: after Continue the layout is replaced and
+     * these cards are detached, which is why [startDownloads] drops it.
+     */
+    private var pickerAdapter: ToolchainPickerAdapter? = null
+
     // Progress UI refs (only valid after setContentView to progress layout)
     private val progressRows = mutableMapOf<String, ProgressRow>()
 
@@ -128,7 +138,7 @@ class SplashActivity : AppCompatActivity() {
             // lifecycleScope is cancelled the moment we finish for MainActivity.
             if (setup.pythonRuntimeNeedsWork()) {
                 Logger.i(tag, "Bundled Python changed since the last extraction; reconciling")
-                setContentView(R.layout.activity_splash)
+                showSplashLayout()
                 findViewById<TextView>(R.id.statusText).text = getString(R.string.status_updating_python)
                 lifecycleScope.launch {
                     withContext(Dispatchers.IO) { setup.reconcilePythonRuntime() }
@@ -141,7 +151,7 @@ class SplashActivity : AppCompatActivity() {
             return
         }
 
-        setContentView(R.layout.activity_splash)
+        showSplashLayout()
         val statusText = findViewById<TextView>(R.id.statusText)
         val progressBar = findViewById<ProgressBar>(R.id.progressBar)
 
@@ -179,6 +189,24 @@ class SplashActivity : AppCompatActivity() {
         } catch (e: Exception) {
             Logger.e(tag, "Launch-time refresh of $what failed", e)
         }
+    }
+
+    /**
+     * The splash layout, padded for the system bars the window draws behind.
+     *
+     * Every other full-screen root in the app is padded at its own
+     * `setContentView` ([showToolchainPicker], [startDownloads],
+     * [ToolchainActivity]); this one was the exception, because its root carried
+     * no id to look up. Nothing else keeps a child off the navigation bar once
+     * `drawBehindSystemBars()` has run, and the one child that can reach it is
+     * the Retry button [showSetupError] anchors to the bottom.
+     *
+     * A method rather than two padded call sites, so a third cannot arrive
+     * unpadded.
+     */
+    private fun showSplashLayout() {
+        setContentView(R.layout.activity_splash)
+        findViewById<View>(R.id.splashRoot).padForSystemBars()
     }
 
     private fun runSetupWithRetry(
@@ -224,6 +252,16 @@ class SplashActivity : AppCompatActivity() {
         runOnUiThread {
             statusText.text = message
             progressBar.visibility = View.GONE
+            // Nothing is in flight from here, and this screen changes only when a
+            // person taps, so the reason activity_splash.xml holds the display
+            // awake has just expired. Left held, a phone put down or pocketed on
+            // this screen lights until the battery is flat. The layout's own
+            // comment makes this argument for the picker one screen later; the
+            // failure state is the wait it did not cover, because the same layout
+            // hosts it. Retry below turns it back on, and a Retry that succeeds
+            // leaves this layout for one that never had the flag.
+            val root = findViewById<View>(R.id.splashRoot)
+            root.keepScreenOn = false
             // Spoken, because the screen alone cannot say it. Setup writes into one
             // label for minutes; a user not touching the screen hears nothing between
             // the window opening and MainActivity arriving, so "still extracting" and
@@ -245,22 +283,41 @@ class SplashActivity : AppCompatActivity() {
                     statusText.text = getString(R.string.extracting_message)
                     progressBar.visibility = View.VISIBLE
                     progressBar.progress = 0
+                    // Extraction is about to run again, so the reason the flag
+                    // exists is back. Through the captured root rather than
+                    // findViewById here, where the receiver is the button.
+                    root.keepScreenOn = true
                     parent.removeView(this)
                     runSetupWithRetry(setup, statusText, progressBar)
                 }
             }
-            // Constrained below the (hidden) progress bar, centered. Added
-            // without LayoutParams, a ConstraintLayout child lays out at
-            // (0,0), the top-left corner, under the transparent status bar.
+            // Centered, below the (hidden) progress bar and against the bottom of
+            // the root. Added without LayoutParams, a ConstraintLayout child lays
+            // out at (0,0), the top-left corner, under the transparent status bar.
+            //
+            // Both vertical constraints, with the bias against the bottom, and
+            // that pair is what keeps the only control on this screen reachable.
+            // The message above it is the failed step plus up to
+            // FirstRunSetup.DETAIL_LIMIT characters of the cause, in a packed
+            // chain that grows downward as it wraps: anchored to the message
+            // alone, a long one in landscape or at a raised font scale pushes the
+            // button past the bottom of the window, and there is no scroll
+            // container to reach it with. Against the bottom it cannot be pushed
+            // anywhere, and it lands inside the padding showSplashLayout applies,
+            // which is what keeps it clear of the navigation bar. The top
+            // constraint stays so it is never drawn above the message it answers.
             if (parent is ConstraintLayout) {
                 val lp = ConstraintLayout.LayoutParams(
                     ConstraintLayout.LayoutParams.WRAP_CONTENT,
                     ConstraintLayout.LayoutParams.WRAP_CONTENT,
                 ).apply {
                     topToBottom = R.id.progressBar
+                    bottomToBottom = ConstraintLayout.LayoutParams.PARENT_ID
+                    verticalBias = 1f
                     startToStart = ConstraintLayout.LayoutParams.PARENT_ID
                     endToEnd = ConstraintLayout.LayoutParams.PARENT_ID
                     topMargin = (16 * resources.displayMetrics.density).toInt()
+                    bottomMargin = (24 * resources.displayMetrics.density).toInt()
                 }
                 parent.addView(retryButton, lp)
             } else {
@@ -275,6 +332,27 @@ class SplashActivity : AppCompatActivity() {
             // "Tap Retry", so the announcement above carries the instruction and
             // ordinary swiping reaches the control.
         }
+    }
+
+    /**
+     * Re-reads what is on disk for a picker that is still on show.
+     *
+     * The set behind the refusal in `ToolchainCardState.toggleSelection` was read
+     * once, when the cards were built, and this screen can be left and come back:
+     * the launcher shortcut to [ToolchainActivity] is already published on every
+     * launch that reaches the picker with the offer unanswered, so a toolchain can
+     * be installed from there while these cards sit waiting for a person. A card
+     * drawn from the older reading carries no badge and still takes a tick, and
+     * ticking one spends a download that has already been paid for.
+     *
+     * The only lifecycle callback this activity has beyond `onCreate` and
+     * `onDestroy`, and it exists for that one screen; [ToolchainActivity] re-reads
+     * in its own `onStart` for the same reason. Reading here costs one small JSON
+     * file and only while the picker is up.
+     */
+    override fun onStart() {
+        super.onStart()
+        pickerAdapter?.setInstalled(ToolchainManager(this).getInstalledToolchains())
     }
 
     override fun onDestroy() {
@@ -379,14 +457,29 @@ class SplashActivity : AppCompatActivity() {
         adapter.setInstalled(ToolchainManager(this).getInstalledToolchains())
         grid.layoutManager = GridLayoutManager(this, 2)
         grid.adapter = adapter
+        // So [onStart] can correct these cards when the screen comes back. One
+        // reading is a reading of the moment it was taken, and this screen waits
+        // for a person.
+        pickerAdapter = adapter
 
         continueBtn.setOnClickListener {
-            val selected = adapter.getSelectedPackNames()
+            // Asked of the record again rather than of the cards, because the two
+            // can disagree by the time this is tapped. `setInstalled` replaces what
+            // is installed and does not untick anything, so a pack ticked here and
+            // then installed from the Toolchains screen keeps its tick behind its
+            // own badge; and the record can change with no lifecycle callback to
+            // hang a refresh on, since `reconcileDeliveredPacks` runs on the
+            // toolchain I/O thread from the line that leads to this screen. This is
+            // the last point before the download is spent.
+            val selected = notYetInstalled(
+                adapter.getSelectedPackNames(),
+                ToolchainManager(this).getInstalledToolchains(),
+            )
             markPickerShown()
             if (selected.isEmpty()) {
                 launchMain()
             } else {
-                startDownloads(selected.toList())
+                startDownloads(selected)
             }
         }
 
@@ -399,6 +492,9 @@ class SplashActivity : AppCompatActivity() {
     // -- Download progress phase --
 
     private fun startDownloads(packNames: List<String>) {
+        // The picker's cards go with the layout that held them, so nothing may
+        // push into them after this line.
+        pickerAdapter = null
         setContentView(R.layout.layout_toolchain_progress)
         findViewById<View>(R.id.progressRoot)
             .padForSystemBars(basePx = (24 * resources.displayMetrics.density).toInt())
@@ -740,6 +836,11 @@ class SplashActivity : AppCompatActivity() {
  * until the user finds the Cancel button. Losing one is better than losing the
  * remainder, which is the only reason this defaults to advancing.
  *
+ * A second caller reads it for a different decision: [shouldReleaseSubscription]
+ * asks the same question of one pack to decide whether the Toolchains screen's
+ * Play Core subscription still has anything to hear. The two agree on what the
+ * word means, which is why they share this rather than each spelling out a list.
+ *
  * File scope so it can be tested without an Activity; this project's unit tests
  * have no Robolectric.
  */
@@ -750,6 +851,36 @@ internal fun isTerminalPackStatus(status: Int): Boolean = when (status) {
     AssetPackStatus.WAITING_FOR_WIFI,
     AssetPackStatus.REQUIRES_USER_CONFIRMATION -> false
     else -> true
+}
+
+/**
+ * The ticked packs still worth downloading, given what the install record says.
+ *
+ * The picker refuses to tick a toolchain it knows is installed, and that refusal
+ * reads a set the screen was handed earlier. Two things get past it. A pack
+ * ticked while it was genuinely absent stays ticked when a later reading finds it
+ * installed, because replacing that set unticks nothing; and the record can be
+ * written with no lifecycle callback to hang a re-read on, by the delivered-pack
+ * reconcile that runs on its own thread from the launch this screen is part of.
+ * Neither is caught downstream: `downloadNext` installs what it is given, and
+ * `ToolchainManager.install` has no already-installed branch, so what gets past
+ * here spends the whole download and the whole copy a second time.
+ *
+ * Both sides go through the registry rather than through string surgery, because
+ * the two halves spell a toolchain differently: the install record names it the
+ * short way ("java") and the cards name it the pack way ("toolchain_java"). A
+ * name neither half knows, a toolchain withdrawn from the registry, matches
+ * nothing and is left alone.
+ *
+ * File scope so it can be tested without an Activity; this project's unit tests
+ * have no Robolectric.
+ */
+internal fun notYetInstalled(
+    selected: Collection<String>,
+    installed: Collection<String>,
+): List<String> {
+    val onDisk = installed.mapNotNull { ToolchainRegistry.find(it)?.packName }.toSet()
+    return selected.filterNot { ToolchainRegistry.find(it)?.packName in onDisk }
 }
 
 /**

--- a/android/app/src/main/kotlin/com/vscodroid/ToolchainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/ToolchainActivity.kt
@@ -3,6 +3,7 @@ package com.vscodroid
 import android.os.Bundle
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.Lifecycle
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.appbar.MaterialToolbar
@@ -12,10 +13,14 @@ import com.vscodroid.util.drawBehindSystemBars
 import com.vscodroid.util.padForSystemBars
 import com.vscodroid.setup.ToolchainAction
 import com.vscodroid.setup.ToolchainCardMode
+import com.vscodroid.setup.ToolchainFailure
 import com.vscodroid.setup.ToolchainPickerAdapter
 import com.vscodroid.setup.ToolchainRegistry
 import com.vscodroid.util.Logger
 import android.widget.Toast
+import java.lang.ref.WeakReference
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Settings screen for managing on-demand toolchains.
@@ -48,6 +53,80 @@ class ToolchainActivity : AppCompatActivity() {
     private var lastSeenDownloads: Map<String, Int> = emptyMap()
 
     /**
+     * The "Remove Ruby?" confirmation, while one is on screen.
+     *
+     * Held because this Activity declares no `configChanges` (the manifest entry,
+     * and two comments in [ToolchainManager] rest on it), so a rotation destroys
+     * it with the dialog still attached to the old window token: the framework
+     * logs `WindowLeaked` and the question disappears with the user's answer
+     * unmade. Cleared by the dialog's own dismiss listener, so this never names a
+     * window that has already gone.
+     */
+    private var removeDialog: AlertDialog? = null
+
+    /**
+     * The packs this screen asked for that have not reported a settled state.
+     *
+     * A set rather than a flag, because the screen offers a card per toolchain
+     * and two of them can be in flight at once. Concurrent because a report does
+     * not always arrive on this screen's thread. Play Core delivers a state
+     * update on the main thread, so CANCELED, FAILED and NOT_INSTALLED reach
+     * here from there, but `ToolchainManager` holds the one that matters most
+     * back: COMPLETED is emitted only once the copy into `usr/` has run on its
+     * `ioExecutor`, and an HTTP transfer reports from that executor throughout.
+     * Those are the ones [shouldReleaseSubscription] has to order its read of
+     * [destroyed] against.
+     *
+     * What it decides is in [shouldReleaseSubscription]: the Play Core
+     * subscription now follows the download rather than the screen.
+     *
+     * It has a second reader, and the same fact answers both: a report for a pack
+     * in here is an answer to something this screen asked for, and a report for
+     * one that is not may be about a download begun by a screen that no longer
+     * exists. [shouldSayAlreadyInstalling] is where that matters, and the reason
+     * it matters is the retention above. Read before [shouldReleaseSubscription],
+     * never after, because that function empties the set of anything settled.
+     */
+    private val outstanding: MutableSet<String> = ConcurrentHashMap.newKeySet()
+
+    /**
+     * Whether this screen is past `onDestroy`.
+     *
+     * Ours rather than `isDestroyed`, because [shouldReleaseSubscription] reads
+     * it from whichever thread reported, and that flag is written by the
+     * framework with nothing to order the read against. This one is written on
+     * the line before the check it races with, and read after the set mutation it
+     * races with, which is the pairing that makes the handoff safe.
+     *
+     * It answers one question only: who is left to hand the Play Core
+     * subscription back. Whether a message may be put in front of the user is a
+     * different question with a different answer, asked of `lifecycle` on the
+     * main thread in [showPackState]. A screen the user pressed Home on is
+     * stopped and very much alive, and this flag says nothing about it.
+     */
+    private val destroyed = AtomicBoolean(false)
+
+    /**
+     * That Play asked for a cellular-data confirmation while this screen was not
+     * in front, so the question can be put when it comes back.
+     *
+     * `showCellularDataConfirmation` puts a window up and needs a started
+     * Activity behind it. Dropping the request instead would leave the pack
+     * waiting on an answer nobody is ever asked for: REQUIRES_USER_CONFIRMATION
+     * is not a settled status, so [shouldReleaseSubscription] keeps listening,
+     * and nothing here builds on Play re-emitting a state to a listener that was
+     * already subscribed. A flag rather than a pack name because the Play call is
+     * per-app and takes none.
+     *
+     * Main thread only: written in [showPackState], which the state callback
+     * reaches through `runOnUiThread`, and read in `onStart`. Cleared when the
+     * question is put, and by any settled status that arrives first, so a
+     * download cancelled while the screen was away does not leave it asking about
+     * nothing. It dies with the screen.
+     */
+    private var confirmationDeferred = false
+
+    /**
      * Re-asks the process what is downloading, because nothing tells this screen.
      *
      * Progress reaches the manager that began the transfer and nothing else, so a
@@ -72,7 +151,19 @@ class ToolchainActivity : AppCompatActivity() {
         setContentView(R.layout.activity_toolchain)
         findViewById<android.view.View>(R.id.toolchainRoot).padForSystemBars()
 
-        toolchainManager = ToolchainManager(this)
+        // The APPLICATION context, and the state callback below holds this screen
+        // weakly, which are the two halves of one fix rather than two changes.
+        // Both the things that outlive this Activity keep whatever the manager
+        // holds: an HTTP transfer runs on the manager's own executor, and the Play
+        // Core subscription is now kept until the download settles. AndroidBridge
+        // records what changing only one half costs, an Activity and its whole
+        // view tree still reachable through a lambda that merely called one of its
+        // members. Nothing the manager reads needs a screen: filesDir, cacheDir,
+        // assets, packageManager and packageName all answer the same on the
+        // application context, and showConfirmationDialog takes the Activity as a
+        // parameter.
+        val manager = ToolchainManager(applicationContext)
+        toolchainManager = manager
 
         // Toolbar back button
         val toolbar = findViewById<MaterialToolbar>(R.id.toolbar)
@@ -86,6 +177,12 @@ class ToolchainActivity : AppCompatActivity() {
             when (action) {
                 ToolchainAction.INSTALL,
                 ToolchainAction.RETRY -> {
+                    // Recorded before the call, not after: install() can report a
+                    // failure on this very thread, for an unknown pack or a
+                    // missing download URL, and the removal that follows would
+                    // then run against a set this pack was not in yet, leaving the
+                    // subscription held for a download that never began.
+                    outstanding.add(packName)
                     toolchainManager.install(packName)
                 }
                 ToolchainAction.REMOVE -> {
@@ -93,6 +190,19 @@ class ToolchainActivity : AppCompatActivity() {
                 }
                 ToolchainAction.CANCEL -> {
                     toolchainManager.cancel(packName)
+                    // Dropped here as well as on the report the download now
+                    // makes, because the two answer different moments. This one
+                    // is immediate: an `onStop` between the tap and the download
+                    // loop's next look at the flag would otherwise find the set
+                    // non-empty and keep the subscription for a transfer that is
+                    // already stopping. The report is the one that reaches the
+                    // set this line cannot -- the cancel token is process-wide,
+                    // so this button stops a transfer a destroyed screen began,
+                    // and only that screen's own manager can take the pack out of
+                    // that screen's set. Left to this line alone, the destroyed
+                    // screen kept the pack and the Play Core registration with it
+                    // for the life of the process, once per repetition.
+                    outstanding.remove(packName)
                     // CANCELED, and specifically not the neighbouring
                     // NOT_INSTALLED, which is the same trap ToolchainManager
                     // documents where it had to pick a status for something that
@@ -115,36 +225,126 @@ class ToolchainActivity : AppCompatActivity() {
         grid.layoutManager = GridLayoutManager(this, 2)
         grid.adapter = adapter
 
-        // Listen for download state changes
-        toolchainManager.onStateChange = { packName, status, percent, why ->
-            runOnUiThread {
-                adapter.updateState(packName, status, percent)
-                // Same reasoning as the first-run screen: the card carries a
-                // status, not an explanation, and the explanation is the part
-                // that tells the user whether to free space or move to wifi.
-                if (why != null) {
-                    Toast.makeText(this, getString(why.message), Toast.LENGTH_LONG).show()
-                }
-                // A decline reports UNKNOWN, and without this the screen answers a
-                // tap with nothing at all. The card cannot say it either: the pack
-                // is not installed yet and no progress belongs to this manager, so
-                // it draws the same Install it drew before, and the user taps again
-                // and gets the same silence. The install is genuinely happening,
-                // just not by this caller, so the sentence says so rather than
-                // reporting a failure.
-                if (status == AssetPackStatus.UNKNOWN && why == null) {
-                    Toast.makeText(
-                        this, getString(R.string.toolchain_already_installing), Toast.LENGTH_SHORT
-                    ).show()
-                }
-                if (status == AssetPackStatus.REQUIRES_USER_CONFIRMATION) {
-                    try {
-                        toolchainManager.showConfirmationDialog(this)
-                    } catch (e: Exception) {
-                        Logger.e(tag, "Failed to show confirmation dialog", e)
-                    }
-                }
+        // Listen for download state changes.
+        //
+        // Every name in here is a local, deliberately. Reading a field, or calling
+        // a member without qualifying it, captures this Activity as completely as
+        // naming it would, and this lambda is reachable from a Play Core registry
+        // and from an executor thread that both outlive the screen. That is the
+        // shape AndroidBridge had to correct twice, the second time in bytecode.
+        val screen = WeakReference(this)
+        val pending = outstanding
+        val screenGone = destroyed
+        manager.onStateChange = { packName, status, percent, why ->
+            // Read here and not in showPackState, because the call below takes a
+            // settled pack out of the set. Asked afterwards this is false for
+            // every terminal status, and a decline is terminal, so the one
+            // question [shouldSayAlreadyInstalling] exists to answer would always
+            // answer no. Read on this thread rather than the main one for the
+            // same reason: the post below is delivered later still.
+            val asked = packName in pending
+            // The flag itself, not a reading of it: [shouldReleaseSubscription]
+            // has to take the pack out of the set before it looks, or the two
+            // threads read in the same order and the handoff falls between them.
+            if (shouldReleaseSubscription(packName, status, pending, screenGone)) {
+                manager.unregisterListener()
             }
+            // Posted whatever this screen's state is, and gated on the far side.
+            // Whether anything may be shown is a main-thread question twice over:
+            // the screen can stop between a check made on this thread and the
+            // message being delivered, and a LifecycleRegistry may only be read
+            // from the thread that moves it. So there is one predicate and it
+            // lives in showPackState, which runs there. Asked here instead, a
+            // download ending after the user closed this screen put a toolchain
+            // message over the editor.
+            screen.get()?.let { live ->
+                live.runOnUiThread { live.showPackState(packName, status, percent, why, asked) }
+            }
+        }
+    }
+
+    /**
+     * The half of a state report that needs a screen, reached only through the
+     * weak reference the callback holds, and only on the main thread.
+     *
+     * [asked] is whether this screen was waiting on [packName] when the report
+     * arrived, taken by the caller because the set it comes from has been emptied
+     * of settled packs by the time this runs. Only [shouldSayAlreadyInstalling]
+     * needs it, and only because one status can now reach a screen that requested
+     * nothing.
+     */
+    private fun showPackState(
+        packName: String,
+        status: Int,
+        percent: Int,
+        why: ToolchainFailure?,
+        asked: Boolean,
+    ) {
+        // Outside the gate below, deliberately. This is this screen's own card,
+        // it costs one row rebind, and it is what has to be right the moment the
+        // user comes back. Only the half that interrupts them is gated.
+        adapter.updateState(packName, status, percent)
+
+        // Everything past here puts something in front of whoever is looking at
+        // the device, and that is no longer necessarily this screen. `onStop`
+        // hands the Play Core subscription back only when nothing is outstanding,
+        // which is what keeps the COMPLETED that installs a delivered pack
+        // reachable, and the price of that is state reports arriving at a screen
+        // the user has left. Destroyed is not the test for it: a screen the user
+        // pressed Home on is stopped and alive, and its Toast lands over the
+        // editor just the same. Play's own confirmation window is worse, since it
+        // takes the foreground.
+        //
+        // Asked of `lifecycle` rather than a flag of our own because there is
+        // then nothing to keep in step, and this runs on the main thread, which
+        // is both where the answer is authoritative and the only thread that may
+        // ask it.
+        if (!lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
+            if (status == AssetPackStatus.REQUIRES_USER_CONFIRMATION) {
+                confirmationDeferred = true
+            } else if (isTerminalPackStatus(status)) {
+                confirmationDeferred = false
+            }
+            return
+        }
+        // Same reasoning as the first-run screen: the card carries a
+        // status, not an explanation, and the explanation is the part
+        // that tells the user whether to free space or move to wifi.
+        if (why != null) {
+            Toast.makeText(this, getString(why.message), Toast.LENGTH_LONG).show()
+        }
+        // A decline reports UNKNOWN, and without this the screen answers a
+        // tap with nothing at all. The card cannot say it either: the pack
+        // is not installed yet and no progress belongs to this manager, so
+        // it draws the same Install it drew before, and the user taps again
+        // and gets the same silence. The install is genuinely happening,
+        // just not by this caller, so the sentence says so rather than
+        // reporting a failure. Which is why it is said only to the caller:
+        // [shouldSayAlreadyInstalling] carries how a decline reaches a screen
+        // that asked for nothing, and what is left wrong when it does.
+        if (shouldSayAlreadyInstalling(status, why, asked)) {
+            Toast.makeText(
+                this, getString(R.string.toolchain_already_installing), Toast.LENGTH_SHORT
+            ).show()
+        }
+        if (status == AssetPackStatus.REQUIRES_USER_CONFIRMATION) {
+            askForCellularConfirmation()
+        }
+    }
+
+    /**
+     * Puts Play's cellular-data question, from a screen that is in front.
+     *
+     * One method because two sites ask it: the report that arrives while the
+     * screen is up, and the one [confirmationDeferred] held back until `onStart`.
+     * The catch came with the first of those and is kept rather than argued for
+     * again; the manager has one of its own around the same call.
+     */
+    private fun askForCellularConfirmation() {
+        try {
+            toolchainManager.showConfirmationDialog(this)
+        } catch (e: Exception) {
+            Logger.e(tag, "Failed to show confirmation dialog", e)
         }
     }
 
@@ -158,10 +358,25 @@ class ToolchainActivity : AppCompatActivity() {
         // Install for a pack already downloading, with no progress and no Cancel.
         // Asked again on a timer from here on, because one reading goes stale while
         // the screen is still looking at it. Play's own downloads are not in this
-        // map and do not need to be: registerListener above makes Play re-deliver
-        // their state.
+        // map, and a Play transfer this screen did not begin therefore draws no
+        // progress until Play reports one. What must not depend on a report is the
+        // COMPLETED that installs a delivered pack, and that no longer does: the
+        // subscription is held until the download settles rather than resting on a
+        // re-emission Play Core promises nowhere. This comment used to assert that
+        // re-delivery as a fact, which is the claim AndroidBridge refuses to build
+        // on and nothing here has measured.
         refreshDownloads()
         grid.postDelayed(pollDownloads, DOWNLOAD_POLL_MS)
+        // Put now, because Play asked while there was no started screen to put it
+        // and nothing else will ask again. REQUIRES_USER_CONFIRMATION does not
+        // settle, so no report follows it and the pack simply waits; suppressing
+        // the question without this line would be the difference between a
+        // download the user was rudely interrupted for and one that never
+        // finishes.
+        if (confirmationDeferred) {
+            confirmationDeferred = false
+            askForCellularConfirmation()
+        }
     }
 
     override fun onStop() {
@@ -169,8 +384,34 @@ class ToolchainActivity : AppCompatActivity() {
         // away. The callback is the only thing keeping this activity referenced
         // from the view's message queue.
         grid.removeCallbacks(pollDownloads)
-        toolchainManager.unregisterListener()
+        // Only when this screen has nothing running. [shouldReleaseSubscription]
+        // carries why an install in flight keeps it, and hands it back itself once
+        // the last one settles with no screen left to hear it.
+        if (outstanding.isEmpty()) toolchainManager.unregisterListener()
         super.onStop()
+    }
+
+    override fun onDestroy() {
+        // Set before the check, and read in [shouldReleaseSubscription] after the
+        // removal, which together are the whole of it. This thread writes the
+        // flag then tests the set; a download settling on another thread mutates
+        // the set then reads the flag. Opposite orders, so the second of the two
+        // to run always sees what the first produced: whichever that is releases
+        // the subscription, and the call is idempotent, so both seeing it costs
+        // nothing. Taking the reading at the call site instead, which is what
+        // this used to do, put both threads in the same order and left one
+        // interleaving where the screen found the set non-empty and the report
+        // found a screen that was not gone yet, with nobody left to hand it back.
+        destroyed.set(true)
+        if (outstanding.isEmpty()) toolchainManager.unregisterListener()
+        // The window this dialog is attached to goes with the Activity, and a
+        // rotation destroys this one: nothing here declares configChanges. Left
+        // showing, it is torn down as a leaked window and the removal it was
+        // asking about is answered by nobody. Taken down here instead, which is
+        // also what a recreated screen needs, since it puts the question again
+        // only when the user taps Remove again.
+        removeDialog?.dismiss()
+        super.onDestroy()
     }
 
     /**
@@ -193,7 +434,7 @@ class ToolchainActivity : AppCompatActivity() {
 
     private fun showRemoveConfirmation(packName: String) {
         val info = ToolchainRegistry.find(packName) ?: return
-        AlertDialog.Builder(this)
+        removeDialog = AlertDialog.Builder(this)
             .setTitle(getString(R.string.toolchain_remove_confirm_title, info.displayName))
             .setMessage(getString(R.string.toolchain_remove_confirm_message, info.displayName))
             .setPositiveButton(getString(R.string.toolchain_remove)) { _, _ ->
@@ -202,6 +443,10 @@ class ToolchainActivity : AppCompatActivity() {
                 Logger.i(tag, "User confirmed removal of $shortName")
             }
             .setNegativeButton(android.R.string.cancel, null)
+            // Answered, dismissed or cancelled with the back button, all three end
+            // here, so the field never outlives the window it names and onDestroy
+            // has nothing to dismiss for a question the user already closed.
+            .setOnDismissListener { removeDialog = null }
             .show()
     }
 }
@@ -214,6 +459,107 @@ class ToolchainActivity : AppCompatActivity() {
  * transfer in flight, usually none. It runs only while this screen is in front.
  */
 private const val DOWNLOAD_POLL_MS = 1_000L
+
+/**
+ * Whether the Play Core subscription can be handed back now that [packName] has
+ * reported [status], dropping that pack from [outstanding] once it has settled.
+ *
+ * The decision `onStop` used to make on its own, and it made it wrong. Dropping
+ * the subscription mid-download is what `AndroidBridge` refuses to do with the
+ * same manager, for a reason that applies here word for word: the COMPLETED
+ * branch of the manager's state handler is the only thing that copies a
+ * delivered pack into `usr/`, and Play Core promises nothing about re-emitting a
+ * state to a listener that subscribes afterwards. `reconcileDeliveredPacks`
+ * repairs such a pack at the next launch that runs `SplashActivity`, and
+ * resuming a live task runs none, so a toolchain the user has already paid for
+ * stays unusable for the rest of that task's life.
+ *
+ * So the subscription follows the download rather than the screen, and the two
+ * conditions here are what stops it outliving both: nothing left to hear, and no
+ * screen left to hear it. A pack that never settles, a confirmation prompt the
+ * user walked away from, keeps it for the life of the process. That is the same
+ * bound `AndroidBridge` accepts, and it costs nothing but the manager now that
+ * the manager holds the application context.
+ *
+ * [isTerminalPackStatus] decides what settles, so UNKNOWN counts: that is how
+ * `ToolchainManager` declines a request for a pack another install already
+ * holds, and a declined caller hears nothing further about it. That predicate
+ * also counts a status this build has never heard of as settled, where
+ * `AndroidBridge` names its three outright. The difference is deliberate and
+ * cheap here: releasing early on such a status is the behaviour this whole
+ * function replaces, repaired at the next launch by the reconcile, while a set
+ * that never drains holds the subscription for the life of the process.
+ *
+ * [screenGone] is the flag itself and not a reading of it, and the read below
+ * happens after the removal. That ordering is load-bearing: `onDestroy` writes
+ * the flag and then tests the set, so this has to mutate the set and then test
+ * the flag for one of the two to see the final state. Taken as a `Boolean`
+ * argument the read happened at the call site, before the removal, which put
+ * both threads in the same order and left the interleaving where a report is
+ * preempted between the two: the screen tests a set the last pack has not left
+ * yet and skips, then the report empties it and reads a flag it took before the
+ * screen was gone and skips too, and Play Core keeps a listener nothing will
+ * ever hand back.
+ *
+ * File scope so it can be tested without an Activity; this project's unit tests
+ * have no Robolectric, the same reason [downloadRefreshFor] below lives here.
+ */
+internal fun shouldReleaseSubscription(
+    packName: String,
+    status: Int,
+    outstanding: MutableSet<String>,
+    screenGone: AtomicBoolean,
+): Boolean {
+    if (!isTerminalPackStatus(status)) return false
+    outstanding.remove(packName)
+    return screenGone.get() && outstanding.isEmpty()
+}
+
+/**
+ * Whether the "already installing" line answers a tap this screen made.
+ *
+ * A decline is a manager's answer to an install request: [status] UNKNOWN with no
+ * [why], reported at the three places `ToolchainManager` refuses a pack that some
+ * other install or download already holds. Two of the three are reached
+ * synchronously from `install()` on the calling thread, so they can only ever
+ * answer the caller. The third cannot: it is reported from the COMPLETED handler
+ * on the manager's own executor, and every registered listener hears Play's
+ * COMPLETED, not only the one whose screen asked for the pack.
+ *
+ * That third case became reachable when [shouldReleaseSubscription] made the
+ * subscription follow the download rather than the screen. A rotation
+ * mid-download destroys this screen with its listener still registered and keeps
+ * it that way until the pack settles, and the rebuilt screen registers a second
+ * one. Play then delivers COMPLETED to both managers, exactly one of them wins
+ * the process-wide claim, and the loser declines. When the loser is the rebuilt
+ * screen's manager, this line appeared on a screen where the user had tapped
+ * nothing at all. [asked] is the whole difference between an answer and an
+ * overheard remark, and it is why the caller reads the set before that function
+ * empties it.
+ *
+ * What this deliberately does not repair is the card behind the line. The decline
+ * is still recorded as this screen's last word on the pack, and
+ * `ToolchainCardState.managerCard` reads UNKNOWN as neither in flight nor
+ * installed, so the card offers Install for a toolchain another manager is
+ * installing right now. Nothing truer is available at that instant: the claim is
+ * taken before the copy, so the install record still says the pack is absent.
+ * Dropping the decline instead would be worse, not better, because it would leave
+ * the card on the TRANSFERRING that preceded it, offering Cancel for a transfer
+ * that has finished, with nothing that ever corrects it. Recorded, `onStart`
+ * corrects it: it re-reads the install record, so leaving this screen and coming
+ * back draws Remove. Correcting it in place would mean re-reading that record on
+ * the poll until some other manager's install ends, which is a file read a second
+ * against the one comment in `refreshDownloads` that refuses exactly that.
+ *
+ * File scope so it can be tested without an Activity; this project's unit tests
+ * have no Robolectric, the same reason [shouldReleaseSubscription] above and
+ * [downloadRefreshFor] below live here.
+ */
+internal fun shouldSayAlreadyInstalling(
+    status: Int,
+    why: ToolchainFailure?,
+    asked: Boolean,
+): Boolean = asked && status == AssetPackStatus.UNKNOWN && why == null
 
 /** What one reading of the download snapshot asks the screen to do. */
 internal data class DownloadRefresh(val push: Boolean, val rereadInstalled: Boolean)

--- a/android/app/src/main/kotlin/com/vscodroid/VSCodroidApp.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/VSCodroidApp.kt
@@ -1,8 +1,10 @@
 package com.vscodroid
 
+import android.app.Activity
 import android.app.Application
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.os.Bundle
 import android.webkit.WebView
 import com.vscodroid.util.CrashReporter
 import com.vscodroid.util.Logger
@@ -20,7 +22,20 @@ class VSCodroidApp : Application() {
         // WebView creation (~200-400ms). Creating and immediately destroying
         // a throwaway WebView triggers the library load so the real WebView
         // in MainActivity starts faster.
-        preWarmWebView { WebView(this).destroy() }
+        //
+        // Hung on the first Activity rather than run here, because this method
+        // runs for every process instantiation and not every one of them is a
+        // launch. NodeService declares no `android:process`, so a process the
+        // system creates purely to deliver a service intent runs all of this
+        // first: the notification's Stop action after the process was reclaimed,
+        // which routes straight to `shutdown()`, and the START_STICKY
+        // re-delivery whose foreground promotion is refused, which calls
+        // `stopSelf()` without starting anything. Neither ever hosts a WebView,
+        // and both were paying the whole Chromium load before they could act.
+        // Nothing is lost on the path this exists for: `Activity.onCreate`
+        // dispatches the callback below from `super.onCreate()`, so the library
+        // is still loading before the Activity has inflated anything.
+        registerActivityLifecycleCallbacks(FirstActivityPreWarm { WebView(this).destroy() })
 
         createNotificationChannel()
         Logger.i("VSCodroidApp", "Application created")
@@ -67,6 +82,45 @@ class VSCodroidApp : Application() {
         const val NOTIFICATION_CHANNEL_ID = "vscodroid_server"
         const val NOTIFICATION_ID = 1
     }
+}
+
+/**
+ * Runs [warm] when this process gets its first Activity, and never in one that
+ * only ever hosts a service.
+ *
+ * The distinction cannot be made in `Application.onCreate`, which is handed no
+ * account of what the process was created for; an Activity being created is the
+ * fact itself rather than a guess at it. It arrives from `super.onCreate()`,
+ * ahead of anything the Activity inflates, which is what keeps the saving this
+ * whole statement exists for.
+ *
+ * The flag is a plain `Boolean` and not an `AtomicBoolean`: activity lifecycle
+ * callbacks are dispatched on the main thread, so there is one writer. It is
+ * needed at all because the callback stays registered for the life of the
+ * process and every later Activity would otherwise build another WebView for
+ * nothing.
+ *
+ * Failure is still swallowed, by [preWarmWebView], and for the same reason: a
+ * missing WebView provider must not take down the process, only now it also
+ * cannot take down an Activity that would have thrown for itself a moment later.
+ */
+internal class FirstActivityPreWarm(private val warm: () -> Unit) :
+    Application.ActivityLifecycleCallbacks {
+
+    private var warmed = false
+
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+        if (warmed) return
+        warmed = true
+        preWarmWebView(warm)
+    }
+
+    override fun onActivityStarted(activity: Activity) = Unit
+    override fun onActivityResumed(activity: Activity) = Unit
+    override fun onActivityPaused(activity: Activity) = Unit
+    override fun onActivityStopped(activity: Activity) = Unit
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
+    override fun onActivityDestroyed(activity: Activity) = Unit
 }
 
 /**

--- a/android/app/src/main/kotlin/com/vscodroid/bridge/AndroidBridge.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/bridge/AndroidBridge.kt
@@ -663,12 +663,26 @@ class AndroidBridge(
 
     /**
      * Opens a previously selected SAF folder by its URI string.
+     *
+     * Named by its mirror, and [redactToken] is not an alternative here: it takes
+     * out the `tkn=` parameter and nothing else, so a tree URI passed through it
+     * arrives whole. A tree URI spells out the user's own directory
+     * (`.../tree/primary%3ADocuments%2F<folder>`), `Logger.i` is not gated on a
+     * debuggable build, and this is the ordinary success path, so every reopen from
+     * Open Recent put a client, an employer or a project name into release logcat
+     * and into any bug report the device produces. The mirror name is the six-byte
+     * digest of that same URI: stable, not reversible, and what every other line
+     * about this folder already uses. See `SafStorageManager.persistPermission`.
      */
     @JavascriptInterface
     fun openRecentFolder(authToken: String, uriString: String) {
         if (!security.validateToken(authToken)) return
         val uri = Uri.parse(uriString)
-        Logger.i(tag, "Opening recent SAF folder: ${redactToken(uri.toString())}")
+        // Null, and printed as such, only for a bridge built with no SAF manager,
+        // which is also a bridge whose open callback defaults to doing nothing.
+        // Production has no such caller: `MainActivity` passes both together.
+        val mirror = safManager?.getMirrorDir(uri)?.name
+        Logger.i(tag, "Opening recent device folder $mirror")
         onOpenRecentFolder(uri)
     }
 

--- a/android/app/src/main/kotlin/com/vscodroid/keyboard/ExtraKeyRow.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/keyboard/ExtraKeyRow.kt
@@ -50,6 +50,23 @@ class ExtraKeyRow @JvmOverloads constructor(
     private var longPressPopup: LongPressPopup? = null
 
     /**
+     * How many modifier triples have been pushed at the page.
+     *
+     * Not a modifier's state and not a copy of one: the row keeps none of that,
+     * and `ExtraKeyToggleStateTest` holds it to that. This counts pushes, which
+     * is the one thing about the page the poll cannot read back off it.
+     *
+     * The answer to [KeyInjector.queryModifierState] is a snapshot the renderer
+     * took when the query script ran, and scripts run in the order they were
+     * submitted, so a push made after the query was submitted cannot be in that
+     * answer: the modifier the user has just latched comes back clear. Read
+     * before the question and again in the answer, this is what separates "the
+     * page has spent this modifier", which is what the poll exists to notice,
+     * from "the page has not been told about it yet", which looks identical.
+     */
+    private var modifierPushCount = 0
+
+    /**
      * Polls JS modifier flags to detect when the soft keyboard consumed a modifier.
      * When the JS interceptor handles Ctrl+key from the soft keyboard, it resets the
      * JS flags. This runnable detects that and syncs the Kotlin visual state.
@@ -61,6 +78,25 @@ class ExtraKeyRow @JvmOverloads constructor(
      * keyboard was open.
      */
     private val modifierSyncRunnable: Runnable = object : Runnable {
+        /**
+         * The one [KeyInjector.queryModifierState] allowed to be waiting for its
+         * answer, held as the injector that was asked. See [OutstandingModifierQuery].
+         *
+         * The re-post below is unconditional, which is what keeps the chain alive
+         * when no answer ever comes. On its own that also gave up the bound the old
+         * callback-anchored re-post got for free: a renderer slow to reply was sent
+         * a fresh query every 200 ms with nothing waiting on the last one, for as
+         * long as a modifier stayed latched. Asking again only once the previous
+         * answer is in restores exactly one outstanding query, without making the
+         * poll depend on an answer arriving.
+         *
+         * On the runnable rather than on the row, because it is the poll's own
+         * bookkeeping and no other member reads it. It is deliberately not a
+         * modifier's state, which this class keeps nowhere and reads from the
+         * adapter instead; `ExtraKeyToggleStateTest` holds the row to that.
+         */
+        private val outstanding = OutstandingModifierQuery()
+
         override fun run() {
             val injector = keyInjector
             if (injector == null) {
@@ -70,6 +106,16 @@ class ExtraKeyRow @JvmOverloads constructor(
                 // about this latch went with it, so a row still painted as
                 // latched is promising a modifier to a page that never heard of
                 // it. Clearing also ends the chain, at a place that decided to.
+                //
+                // Reached only where no replacement injector has arrived: the
+                // Activity being destroyed, and the crash during a cold start,
+                // where recreateWebView rebuilds the injector through loadVSCode
+                // and therefore only once a port is bound. A crash with the
+                // editor up hands this row a new injector on the same main
+                // thread turn, before this tick runs at all. Either way the
+                // answer still owed is owed by an injector that is gone, so it
+                // is given up here rather than left standing over the next one.
+                outstanding.abandon()
                 resetModifiersIfNeeded()
                 return
             }
@@ -84,7 +130,38 @@ class ExtraKeyRow @JvmOverloads constructor(
             // below and in startModifierSync and resetModifiersIfNeeded, which are
             // the three places that know it should stop.
             postDelayed(modifierSyncRunnable, 200)
+            // The tick is what survives an answer that never comes; the answer is
+            // what says whether asking again is worth anything. See [outstanding]
+            // for why the two are separated, and [OutstandingModifierQuery] for why
+            // the question is "does this injector owe an answer" rather than "is an
+            // answer owed": the second is unanswerable once the injector that owed
+            // it is gone, and stays true for the life of the row.
+            if (!outstanding.claim(injector)) return
+            // Taken before the question, because [modifierPushCount] is only
+            // meaningful against the moment the query was submitted.
+            val pushedWhenAsked = modifierPushCount
             injector.queryModifierState { jsCtrl, jsAlt, jsShift ->
+                if (!outstanding.release(injector)) {
+                    // An answer about a page this row no longer has: it was asked
+                    // of an injector that has since been replaced or dropped. Its
+                    // flags describe a page that is gone, and releasing here would
+                    // free the claim the current injector's query is holding.
+                    return@queryModifierState
+                }
+                if (modifierPushCount != pushedWhenAsked) {
+                    // A modifier was latched while this answer was in the air, so
+                    // the answer predates it and reports it as clear. Applying it
+                    // would darken the key the user has just pressed while the
+                    // page goes on holding the modifier, and this is the one
+                    // place a modifier is cleared without pushing the new value
+                    // out, so nothing would correct that: the next ordinary
+                    // character typed on the soft keyboard is cancelled and
+                    // delivered as a chord instead. Ending the chain is skipped
+                    // with the rest; the push that moved the count came from
+                    // handleKeyAction, which calls startModifierSync after it and
+                    // is the site that decides whether the poll goes on at all.
+                    return@queryModifierState
+                }
                 if (ctrlActive && !jsCtrl) {
                     ctrlActive = false
                     Logger.d(tag, "Ctrl consumed by soft keyboard")
@@ -286,7 +363,12 @@ class ExtraKeyRow @JvmOverloads constructor(
 
     /** Push current Kotlin modifier state to the JS interceptor. */
     private fun syncModifierState() {
-        keyInjector?.setModifierState(ctrlActive, altActive, shiftActive)
+        val injector = keyInjector ?: return
+        // Counted only where a push actually happens. With no injector there is
+        // no page to have been told anything, so nothing an outstanding answer
+        // could be describing has moved. See [modifierPushCount].
+        modifierPushCount += 1
+        injector.setModifierState(ctrlActive, altActive, shiftActive)
     }
 
     /** Start polling JS state to detect when soft keyboard consumed a modifier. */
@@ -310,4 +392,77 @@ class ExtraKeyRow @JvmOverloads constructor(
 
     private fun dpToPx(dp: Int): Int =
         (dp * resources.displayMetrics.density + 0.5f).toInt()
+}
+
+/**
+ * The one modifier query allowed to be in the air, and whose answer it is.
+ *
+ * The poll re-posts itself before it asks anything, so the tick survives an
+ * answer that never comes. This is the other half: it keeps exactly one query
+ * outstanding, so a renderer slow to reply is not sent a fresh one five times a
+ * second for as long as a modifier stays latched.
+ *
+ * What it records is the injector that was asked, not merely that something was.
+ * The injector owns the answer's lifetime and therefore this record's: an answer
+ * travels back through `WebView.evaluateJavascript`, so a WebView destroyed
+ * before it replies never delivers one. A plain "a query is out" flag would then
+ * stay set for the rest of the Activity, because the row outlives the page.
+ * `MainActivity.recreateWebView` replaces only the WebView: it drops the
+ * injector, then reaches `initBridge` through `loadVSCode` on the same main
+ * thread turn and hands this same row a new `KeyInjector`, so the poll's
+ * no-injector branch is not even reached on that path. Every later tick would
+ * have returned at the guard without asking, and the row would never again learn
+ * that the page had spent a latched modifier: the next row key goes out as a
+ * chord, and a whole trackpad drag does, since the arrow path deliberately keeps
+ * the modifier.
+ *
+ * Asked against the injector, that cannot happen: a claim by an injector other
+ * than the one owing an answer displaces it, because an answer nobody can
+ * deliver is an answer nobody is waiting for. The record is therefore released
+ * on three occasions and can be stuck on none of them: [claim] by a new
+ * injector, [release] by the answer arriving, [abandon] when the row is left
+ * with no injector at all. Bounded at one reference, and that reference is
+ * replaced or dropped rather than accumulated.
+ *
+ * Main thread only, which is where both writers run: the tick is a
+ * `View.postDelayed` and the answer is an `evaluateJavascript` callback.
+ */
+internal class OutstandingModifierQuery {
+
+    /**
+     * The injector owing an answer, or null when none is.
+     *
+     * Identity only. It is never called through and never dereferenced; it says
+     * whose answer is still owed, which is the one thing a boolean could not.
+     */
+    private var askedOf: KeyInjector? = null
+
+    /**
+     * Takes the single outstanding slot for [injector], reporting whether the
+     * caller may now ask. False only while that same injector already owes an
+     * answer, which is the back-pressure; a different injector always takes it,
+     * displacing a claim whose answer can no longer arrive.
+     */
+    fun claim(injector: KeyInjector): Boolean {
+        if (askedOf === injector) return false
+        askedOf = injector
+        return true
+    }
+
+    /**
+     * Frees the slot for an answer from [injector], reporting whether that
+     * answer is the one being waited for. False for an answer from an injector
+     * that has since been replaced or dropped: it describes a page that is gone,
+     * and it must not free a slot a later query is holding.
+     */
+    fun release(injector: KeyInjector): Boolean {
+        if (askedOf !== injector) return false
+        askedOf = null
+        return true
+    }
+
+    /** Gives up on the answer entirely, for a row left with no injector. */
+    fun abandon() {
+        askedOf = null
+    }
 }

--- a/android/app/src/main/kotlin/com/vscodroid/keyboard/KeyInjector.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/keyboard/KeyInjector.kt
@@ -151,7 +151,9 @@ class KeyInjector(
      *
      * A Shift held on its own is not intercepted but is spent: the page keeps the
      * character it was about to insert, and the flag is cleared, so a latch cannot
-     * carry over into a key the user taps minutes later.
+     * carry over into a key the user taps minutes later. A Ctrl or Alt that meets
+     * input this listener has no chord for, a paste or an IME composition, is spent
+     * the same way and for the same reason.
      *
      * Call once after the page finishes loading.
      */
@@ -185,8 +187,10 @@ class KeyInjector(
                     // resolves it into a DIFFERENT character, so a Shift the
                     // user has forgotten turns a later tap on `/` into `?`,
                     // `;` into `:` and `[` into `{`. Ctrl and Alt are cleared
-                    // below on the same principle, one branch further on
-                    // because they are the two this listener acts on.
+                    // on every branch below, on the same principle: the two
+                    // this listener acts on spend them by acting, and the rest
+                    // spend them by reaching the end of the character they were
+                    // meant for.
                     if (!mod.ctrl && !mod.alt) {
                         mod.shift = false;
                         return;
@@ -221,7 +225,24 @@ class KeyInjector(
                         return;
                     }
 
-                    if (e.inputType !== 'insertText' || !e.data) return;
+                    // Everything else the page can insert: a paste, an IME
+                    // composition update, an autocorrect replacement, a word
+                    // delete. There is no chord to send for one, and cancelling
+                    // it would leave the tap producing nothing, so it is left to
+                    // the page exactly as a lone Shift is.
+                    //
+                    // The latch is still spent. A Ctrl that survives here does
+                    // not stay harmless: it attaches to whichever character is
+                    // typed next, and that character is then CANCELLED in favour
+                    // of a chord the user never asked for, so typing `a` after a
+                    // paste selects the document instead of inserting a letter,
+                    // and the keystroke after that replaces the selection.
+                    if (e.inputType !== 'insertText' || !e.data) {
+                        mod.ctrl = false;
+                        mod.alt = false;
+                        mod.shift = false;
+                        return;
+                    }
 
                     e.preventDefault();
                     e.stopImmediatePropagation();

--- a/android/app/src/main/kotlin/com/vscodroid/service/ProcessManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/service/ProcessManager.kt
@@ -101,6 +101,18 @@ class ProcessManager(private val context: Context) {
     private var spawnedOntoHeldPort = false
 
     /**
+     * Whether [probeReadiness] has already said that the holder of a port this
+     * start could not claim does not answer as this build.
+     *
+     * The poll asks five times a second for thirty seconds and then goes on
+     * asking, so an unthrottled line would be the whole of the log by the end of
+     * it while saying nothing the first one did not. Cleared beside
+     * [spawnedOntoHeldPort], which is the value it describes.
+     */
+    @Volatile
+    private var heldPortRefusalLogged = false
+
+    /**
      * Whether the process the last [startServer] spawned was given a ceiling the
      * user chose that is above the one the device would otherwise have had.
      *
@@ -211,6 +223,27 @@ class ProcessManager(private val context: Context) {
      * test calling through to it could only ever assert that nothing happened.
      */
     internal var killRecordedProcess: (Int) -> Unit = { android.os.Process.killProcess(it) }
+
+    /**
+     * The clock [waitForReady] measures its budget on, in nanoseconds.
+     *
+     * Monotonic, which is the whole requirement: the wall clock is corrected out
+     * from under a running app and the poll's bound must not move with it. See
+     * [waitForReady] for what a correction did to it.
+     *
+     * [System.nanoTime] rather than `SystemClock.elapsedRealtime`, which is what
+     * `NodeService.awaitLateReadiness` uses for the same event. Both are immune to
+     * a time correction, which is all this needs; they differ only over deep
+     * sleep, and this poll runs for thirty seconds with the launch in front of the
+     * user. What decides it is that this loop is reachable from the JVM suite,
+     * where every `android.os` member is a stub that throws, and the bound is the
+     * thing the suite has to be able to pin.
+     *
+     * A `var` for the same reason [procDir] is one, and not for a production
+     * caller: a time correction cannot be staged from a test, so a fake clock is
+     * the only way to show the loop is bounded by this and not by the wall.
+     */
+    internal var nanoClock: () -> Long = { System.nanoTime() }
 
     // Cached on the first successful read and never invalidated, which is correct
     // rather than merely convenient: the server generates the token only when the
@@ -462,12 +495,15 @@ class ProcessManager(private val context: Context) {
         // the life of this instance.
         //
         // What IS wrong is that nothing distinguishes the survivor from a server
-        // this class started. The health probe reads a response code and nothing
-        // else, so the survivor satisfies readiness, `NodeService.announceReady`
+        // this class started. The health probe reads a response code and, on this
+        // path, the build the holder claims to be -- see [probeReadiness] -- so a
+        // survivor of this build satisfies readiness, `NodeService.announceReady`
         // fires, and the WebView is pointed at it. That much works -- the token
         // matches, because `server.js` reuses the token file -- which is why
-        // nothing downstream notices. The cost is everywhere the app assumes the
-        // server it is serving is the one it spawned:
+        // nothing downstream notices. What no longer passes is a holder that is
+        // not this build, which is the party the token must never reach. The cost
+        // is everywhere the app assumes the server it is serving is the one it
+        // spawned:
         //
         //  - `serverProcess` refers to the process spawned here, not the survivor.
         //    So [stopServer] destroys the wrong one. Stop takes the notification
@@ -569,6 +605,7 @@ class ProcessManager(private val context: Context) {
         // reads held, is the one the free-at-first-ask path has always accepted.
         spawnedOntoHeldPort = !portIsFree &&
             !(reapedThisStart && PortFinder.isPortAvailable(_port))
+        heldPortRefusalLogged = false
         Logger.i(tag, "Starting server on port $_port")
 
         // Ensure TMPDIR is a usable directory: Android may clear cache between
@@ -684,10 +721,21 @@ class ProcessManager(private val context: Context) {
     /**
      * Suspends until the server responds to a health check or the timeout elapses.
      *
-     * Polls [isServerHealthy] at [pollIntervalMs] intervals and answers with the
+     * Polls [probeReadiness] at [pollIntervalMs] intervals and answers with the
      * outcome. The answer is the whole contract: there is no readiness callback
      * here, because a suspending function that returns the result already told
      * the caller, and the one that used to sit here was assigned by nobody.
+     *
+     * The budget is measured on [nanoClock] and not on the wall clock, which is
+     * the difference between a thirty-second poll and a poll that lasts thirty
+     * seconds of whatever the clock happens to say. The wall clock is corrected
+     * out from under a running app: NTP or NITZ lands as the network attaches,
+     * which is precisely when a first launch after a boot is inside this loop, and
+     * on a device whose RTC was materially wrong the step is large. Correcting
+     * forward ended the poll without another probe, correcting backward kept the
+     * launch coroutine in it long past the timeout, and the line below reported a
+     * figure that was neither. The counterpart loop for the same event,
+     * `NodeService.awaitLateReadiness`, has always used a monotonic source.
      *
      * @param timeoutMs  Maximum time to wait for the server to become ready.
      * @param pollIntervalMs  Interval between health check attempts.
@@ -697,10 +745,10 @@ class ProcessManager(private val context: Context) {
         timeoutMs: Long = READY_POLL_TIMEOUT_MS,
         pollIntervalMs: Long = 200,
     ): Boolean {
-        val startTime = System.currentTimeMillis()
-        while (System.currentTimeMillis() - startTime < timeoutMs) {
+        val startedAt = nanoClock()
+        while (elapsedMsSince(startedAt) < timeoutMs) {
             if (probeReadiness()) {
-                Logger.i(tag, "Server ready after ${System.currentTimeMillis() - startTime}ms")
+                Logger.i(tag, "Server ready after ${elapsedMsSince(startedAt)}ms")
                 return true
             }
             delay(pollIntervalMs)
@@ -708,6 +756,10 @@ class ProcessManager(private val context: Context) {
         Logger.e(tag, "Server failed to become ready within ${timeoutMs}ms")
         return false
     }
+
+    /** Milliseconds since a [nanoClock] reading. */
+    private fun elapsedMsSince(startNanos: Long): Long =
+        TimeUnit.NANOSECONDS.toMillis(nanoClock() - startNanos)
 
     /**
      * Whether the process holding our port is an editor server this app started.
@@ -992,9 +1044,12 @@ class ProcessManager(private val context: Context) {
      * readiness check that counts 403 as healthy reports a successful startup for
      * a server that will serve the user nothing but Forbidden.
      *
-     * Liveness only, deliberately. Which build answered is [probeVersion]'s
-     * business and only adoption asks it, because a readiness poll runs every
-     * 200 ms for thirty seconds and has no use for the answer.
+     * Liveness only, deliberately, which is what [startAdoptionWatch] wants of a
+     * heartbeat over a server whose identity was settled when it was adopted.
+     * Which build answered is [probeVersion]'s business, and it is asked by
+     * adoption and by [probeReadiness] on the one path where the holder cannot be
+     * the process this class spawned. An ordinary readiness poll runs every 200 ms
+     * for thirty seconds and has no use for the answer.
      */
     fun isServerHealthy(): Boolean = probeVersion() != null
 
@@ -1324,12 +1379,13 @@ class ProcessManager(private val context: Context) {
     /**
      * Asks the server once, and records the answer if it is yes.
      *
-     * Blocking: it is [isServerHealthy] underneath, so it belongs off the main
-     * thread like every other caller of that. Blocking also means cancellation
-     * does not reach it: a coroutine cancelled while this is in flight cannot act
-     * on the result, because it resumes by throwing, but the request itself runs
-     * to completion. The ceiling on that is the connect and read timeouts, a
-     * little over two seconds, and it is worth knowing rather than rediscovering.
+     * Blocking: it is [probeVersion] underneath, the same request [isServerHealthy]
+     * makes, so it belongs off the main thread like every other caller of that.
+     * Blocking also means cancellation does not reach it: a coroutine cancelled
+     * while this is in flight cannot act on the result, because it resumes by
+     * throwing, but the request itself runs to completion. The ceiling on that is
+     * the connect and read timeouts, a little over two seconds, and it is worth
+     * knowing rather than rediscovering.
      *
      * The single place `_isReady` is ever set true, which is the point of it
      * existing rather than being written inline in [waitForReady]. [waitForReady]
@@ -1339,8 +1395,53 @@ class ProcessManager(private val context: Context) {
      * bounded loop, that second later was unreachable: the flag stayed false for
      * as long as the process lived, and every caller reading it refused a server
      * that was serving perfectly well.
+     *
+     * Being that single writer is why the identity question below is asked here
+     * and not in [isServerHealthy]: this answer is what points the WebView at the
+     * port, and `MainActivity` builds that URL with the connection token in it.
+     * [isServerHealthy] stays the plain liveness probe its own documentation
+     * describes, which is what [startAdoptionWatch] wants of it.
      */
-    fun probeReadiness(): Boolean = isServerHealthy().also { if (it) _isReady = true }
+    fun probeReadiness(): Boolean {
+        val served = probeVersion() ?: return false
+        // A start that recorded [spawnedOntoHeldPort] already knows the process it
+        // spawned is not what is answering: the editor server it forked printed
+        // EADDRINUSE and, measured, did not exit, so whoever holds the port took
+        // it first. A status code cannot tell that party from ours -- the same gap
+        // [recordedServerIsServing] closes before adoption, and for the same
+        // reason, since binding a loopback port on Android needs no permission.
+        // The cost of being wrong is larger here than there: readiness is what
+        // navigates, and the URL carries the credential that authenticates every
+        // route of the editor server. So on this path the holder names the build
+        // it is before it is believed.
+        //
+        // Only on this path, deliberately. A start whose port was free at the
+        // spawn has no second party to be confused with, and asking every start
+        // for an identity would refuse to serve a tree that records no commit.
+        // That direction is one adoption can afford, because declining it costs a
+        // spawn; readiness cannot, because it costs the editor.
+        //
+        // The port answering as this build is not proof it is the process we
+        // spawned -- the commit is public, [recordedServerIsServing] says so at
+        // length -- and it does not need to be. What it rules out is the case this
+        // guard exists for, and it deliberately keeps the two starts that reach
+        // here with a server of ours on the port: a reap whose signal freed the
+        // socket a moment after it was asked, and an orphan of this same build
+        // that no note identifies. Both serve the user, and both keep working.
+        if (spawnedOntoHeldPort && served != bundledServerCommit()) {
+            if (!heldPortRefusalLogged) {
+                heldPortRefusalLogged = true
+                Logger.w(
+                    tag,
+                    "Port $_port is answering as \"$served\", which is not this build, and " +
+                        "this start could not have bound it; not treating that as ready",
+                )
+            }
+            return false
+        }
+        _isReady = true
+        return true
+    }
 
     // -- Internal --
 

--- a/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
@@ -1433,12 +1433,53 @@ class FirstRunSetup(
      * Both writers live in `runSetupLocked`, which an already-complete install
      * never re-enters, and the every-launch repairs all open with
      * `if (bashrc.exists())`. Deleting the file would have turned a truncated
-     * one into no file at all, with nothing to write it again. So each clear is
-     * followed immediately by the writer that owns the file, whose own
-     * `!exists()` guard the clear has just satisfied.
+     * one into no file at all, with nothing to write it again.
      *
-     * Runs on every launch, and before the appenders, so they extend the file
-     * this has just restored rather than the one it removed.
+     * Which is why nothing here deletes. The second draft cleared the file and
+     * then called the writer, whose `!exists()` guard the clear had just
+     * satisfied, and that leaves the same hole one failure further along: the
+     * rewrite can fail, on exactly the full disk this repair exists for, and
+     * the file is then gone with every guard that could have tried again
+     * keyed on its presence. [writeBashrc] and [writeDefaultSettings] are the
+     * guardless halves of those two writers, so this replaces through
+     * [writeAtomically]'s rename instead: on failure the bad file is still
+     * there, this runs again on the next launch, and freeing space is enough
+     * to heal the install.
+     *
+     * Runs on every launch, and before the appenders, so a file this has just
+     * restored is what they extend.
+     *
+     * WHICH IS ALSO WHAT BOUNDS THE RETRY, and the bound arrived with the
+     * delete going away. A rewrite that fails leaves the file for the next
+     * launch to find, and leaves it for the rest of THIS launch too: the
+     * appenders behind this one are gated on `exists()`, which a file this
+     * could not rewrite still answers. What they append then decides whether
+     * this recognises the file again.
+     *
+     *  - the header shape retries until it heals. An append lands after the
+     *    header and brings no `PROJECTS_DIR`, so the test below classifies the
+     *    file the same way however many launches it takes.
+     *  - the empty shape retries only until an append lands on it.
+     *    `createNpmWrappers` and `ensureToolchainEnvSourcing` extend a
+     *    zero-byte `.bashrc` quite happily, and what they leave is neither
+     *    blank nor header-first, so this stops seeing it: the install keeps the
+     *    npm/claude functions and the toolchain sourcing, and loses the prompt,
+     *    the exports, the aliases and the startup `cd` until Clear Data.
+     *
+     * That second case needs a rewrite that fails and an append moments later
+     * that succeeds, and no state of the device produces the pair: both go
+     * through the same `.bashrc.tmp~`, and neither payload reaches 4 KiB (the
+     * rewrite roughly 2.3 KB, most of it PROMPT_BLOCK; the append 1.8 KB),
+     * so each wants one inode and one block and a full disk, a quota, an
+     * occupied temporary path or a failing rename stops both alike. It takes
+     * something else freeing a block in between, which is why this is written
+     * down rather than closed.
+     *
+     * Closing it would mean testing the empty shape for what an append cannot
+     * remove: a `.bashrc` with no `PROJECTS_DIR` export, whatever its first
+     * bytes. That is refused, because the description fits a `.bashrc` the user
+     * wrote themselves just as well, and nothing here is replaced on evidence
+     * that can be their own choice. A lost prompt is worth less than their file.
      */
     fun repairTruncatedSetupFiles() {
         val bashrc = File(context.filesDir, "home/.bashrc")
@@ -1448,23 +1489,57 @@ class FirstRunSetup(
             val headerWithoutBody = text != null &&
                 text.startsWith(BASHRC_HEADER) &&
                 !text.contains("export PROJECTS_DIR")
-            if ((emptied || headerWithoutBody) && bashrc.delete()) {
-                // Its writer throws on failure, which is right inside setup and
-                // wrong here: this runs beside other per-launch repairs and must
-                // not take them down. A failure leaves no .bashrc, which is what
-                // the previous line already produced, and the next launch tries
-                // again.
-                runCatching { createBashrc() }
-                    .onSuccess { Logger.i(tag, "Rewrote a half-written .bashrc") }
-                    .onFailure { Logger.e(tag, "Could not rewrite the half-written .bashrc", it as? Exception) }
+            if (emptied || headerWithoutBody) {
+                // Written OVER, never deleted first. Deleting is what satisfied
+                // createBashrc's `!exists()` guard, and it is also what let this
+                // repair finish the job the full disk started: the rewrite can
+                // fail, and the file was then absent -- outside the `isFile`
+                // test this branch re-enters through, outside every per-launch
+                // appender's own `exists()` guard, and outside createBashrc,
+                // which runSetupLocked reaches only when versionName or
+                // versionCode moves. So one launch that could not write turned a
+                // repairable install into one nothing repairs until the next app
+                // update. [writeBashrc] renames over the path instead: a failed
+                // write leaves the bad file exactly where it was, and this
+                // branch finds it again on the next launch. For the one shape
+                // where an appender behind this one can take that retry away
+                // before the next launch gets here, see the KDoc.
+                //
+                // The rewrite is not expected to throw (a failed write is
+                // reported as false), but a throw must not skip the settings
+                // repair below either.
+                val rewritten = runCatching { writeBashrc() }
+                    .onFailure { Logger.e(tag, "The .bashrc rewrite threw", it as? Exception) }
+                    .getOrDefault(false)
+                if (rewritten) {
+                    Logger.i(tag, "Rewrote a half-written .bashrc")
+                } else {
+                    Logger.e(
+                        tag,
+                        "Could not rewrite the half-written .bashrc. It is unchanged rather " +
+                            "than gone, so there is still something for the next launch to repair.",
+                    )
+                }
             }
         }
 
         val settings = File(Environment.getMachineSettingsPath(context))
-        if (settings.isFile && settings.length() == 0L && settings.delete()) {
-            runCatching { createDefaultSettings() }
-                .onSuccess { Logger.i(tag, "Rewrote an empty settings.json") }
-                .onFailure { Logger.e(tag, "Could not rewrite the empty settings.json", it as? Exception) }
+        if (settings.isFile && settings.length() == 0L) {
+            // Replaced rather than deleted and rewritten, for the reason above.
+            // Deleting a zero-byte file frees nothing, so the disk that emptied
+            // it is still full when the rewrite runs.
+            val rewritten = runCatching { writeDefaultSettings() }
+                .onFailure { Logger.e(tag, "The settings.json rewrite threw", it as? Exception) }
+                .getOrDefault(false)
+            if (rewritten) {
+                Logger.i(tag, "Rewrote an empty settings.json")
+            } else {
+                Logger.e(
+                    tag,
+                    "Could not rewrite the empty settings.json. It is still there rather than " +
+                        "gone, so the next launch tries again.",
+                )
+            }
         }
     }
 
@@ -1869,25 +1944,8 @@ claude() {
     }
 
     private fun createBashrc() {
-        val projectsDir = Environment.getProjectsDir(context)
-        val safMirrorsDir = Environment.getSafMirrorsDir(context)
         val bashrc = File(context.filesDir, "home/.bashrc")
         if (!bashrc.exists()) {
-            // Atomic for the reason the rewrite in ensurePromptFix() is: this
-            // writer's guard is the file's own existence, so a first-run write
-            // that stopped partway left a .bashrc that answered `exists()` and
-            // was never written again -- the prompt half-defined and the
-            // PROJECTS_DIR export missing, on a device that had never had a
-            // working shell to compare against.
-            val initial = BASHRC_HEADER + "\n" + PROMPT_BLOCK + "\n\n" + """
-                export PROJECTS_DIR='$projectsDir'
-                export SAF_MIRRORS_DIR='$safMirrorsDir'
-                alias ls='ls --color=auto'
-                alias ll='ls -la'
-
-                # On-demand toolchain env vars (Go, Ruby, Java, etc.)
-                [ -f "${'$'}HOME/.vscodroid/toolchain-env.sh" ] && . "${'$'}HOME/.vscodroid/toolchain-env.sh"
-            """.trimIndent() + "\n\n" + STARTUP_DIR_BLOCK + "\n"
             // Thrown, not logged. This runs only from runSetupLocked, whose
             // markSetupComplete() is the last statement of the same try block --
             // so swallowing the failure certifies an install that has no
@@ -1902,162 +1960,108 @@ claude() {
             // that satisfied the guard above. Atomicity alone leaves the file
             // absent but tells no one, so no retry is offered. Together the
             // retry starts from a clean slate and produces a working shell.
-            if (!writeAtomically(bashrc) { it.write(initial.toByteArray()) }) {
+            if (!writeBashrc()) {
                 throw IOException("could not write $bashrc")
             }
         }
     }
 
+    /**
+     * Writes the `.bashrc` this app owns, over whatever is at the path.
+     *
+     * Split from [createBashrc]'s `!exists()` guard so that
+     * [repairTruncatedSetupFiles] can replace a file it has judged unusable
+     * without first deleting it to satisfy that guard. Deleting is what made
+     * the repair able to destroy the install it exists to rescue: the writer
+     * can fail, and the file was then absent, which is outside the repair's own
+     * re-entry test and outside every per-launch appender, so nothing tried
+     * again until the next app update. Going through the rename leaves the bad
+     * file in place on failure, so the repair fires again on the next launch
+     * and heals as soon as the disk has room.
+     *
+     * @return true if `.bashrc` now holds what this writes. On false it is
+     *   untouched, which is [writeAtomically]'s contract and the whole of what
+     *   makes a retry worth offering.
+     */
+    private fun writeBashrc(): Boolean {
+        val projectsDir = Environment.getProjectsDir(context)
+        val safMirrorsDir = Environment.getSafMirrorsDir(context)
+        val bashrc = File(context.filesDir, "home/.bashrc")
+        // Atomic for the reason the rewrite in ensurePromptFix() is: the
+        // caller's guard is the file's own existence, so a first-run write
+        // that stopped partway left a .bashrc that answered `exists()` and
+        // was never written again -- the prompt half-defined and the
+        // PROJECTS_DIR export missing, on a device that had never had a
+        // working shell to compare against.
+        val initial = BASHRC_HEADER + "\n" + PROMPT_BLOCK + "\n\n" + """
+            export PROJECTS_DIR='$projectsDir'
+            export SAF_MIRRORS_DIR='$safMirrorsDir'
+            alias ls='ls --color=auto'
+            alias ll='ls -la'
+
+            # On-demand toolchain env vars (Go, Ruby, Java, etc.)
+            [ -f "${'$'}HOME/.vscodroid/toolchain-env.sh" ] && . "${'$'}HOME/.vscodroid/toolchain-env.sh"
+        """.trimIndent() + "\n\n" + STARTUP_DIR_BLOCK + "\n"
+        return writeAtomically(bashrc) { it.write(initial.toByteArray()) }
+    }
+
     private fun createBashProfile() {
         val bashProfile = File(context.filesDir, "home/.bash_profile")
         if (!bashProfile.exists()) {
-            bashProfile.writeText("""
+            val content = """
                 # Source .bashrc for login shells (e.g. tmux sessions)
                 if [ -f "${'$'}HOME/.bashrc" ]; then
                     . "${'$'}HOME/.bashrc"
                 fi
-            """.trimIndent() + "\n")
+            """.trimIndent() + "\n"
+            // Atomic and loud, the same pair createBashrc is, and for the same
+            // pair of reasons. `writeText` creates and truncates before writing
+            // a byte, so a write that failed left a file the guard above
+            // accepts for ever, and this writer is reached only from
+            // runSetupLocked, which isFirstRun() gates on versionName or
+            // versionCode: no per-launch repair reads this path at all. What
+            // that costs is confined to INTERACTIVE LOGIN shells, which is what
+            // a tmux window is. Those read .bash_profile and never .bashrc or
+            // BASH_ENV, so they come up with no prompt, no aliases and no
+            // npm/npx/claude while the editor's own terminals (non-login) and
+            // `bash -c` (BASH_ENV) are unaffected. Throwing reaches
+            // runSetupLocked's catch, and the Retry it offers then starts from
+            // an absent file rather than a truncated one.
+            if (!writeAtomically(bashProfile) { it.write(content.toByteArray()) }) {
+                throw IOException("could not write $bashProfile")
+            }
         }
     }
 
     private fun createTmuxConf() {
         val tmuxConf = File(context.filesDir, "home/.tmux.conf")
         if (!tmuxConf.exists()) {
-            tmuxConf.writeText("""
+            val content = """
                 # VSCodroid tmux configuration
                 set -g mouse on
                 set -g default-terminal "xterm-256color"
                 set -g history-limit 10000
                 set -g escape-time 10
                 set -g status off
-            """.trimIndent() + "\n")
+            """.trimIndent() + "\n"
+            // Atomic like its neighbours, so a failed write leaves nothing
+            // rather than a truncated file that answers the guard above for
+            // ever. Logged rather than thrown, which is where it parts from
+            // .bash_profile beside it: what is lost is the mouse, the colours
+            // and the scrollback, and tmux starts perfectly well without them,
+            // so failing the whole unpack over five options would cost the user
+            // more than the options are worth.
+            if (!writeAtomically(tmuxConf) { it.write(content.toByteArray()) }) {
+                Logger.w(tag, "Could not write $tmuxConf; tmux will run with its own defaults")
+            }
         }
     }
 
     private fun createDefaultSettings() {
-        val nativeLibDir = context.applicationInfo.nativeLibraryDir
         // Environment.getMachineSettingsPath explains why it is this path and not
         // the `User/` one that looks like the obvious home for user settings.
         val settingsFile = File(Environment.getMachineSettingsPath(context))
-        settingsFile.parentFile?.mkdirs()
         if (!settingsFile.exists()) {
-            // The terminal profile is read, and the `linux` suffix is not a guess.
-            // The workbench builds the key from the OS *integer* the remote sends:
-            // `getPlatformKey()` maps 1 to "windows", 2 to "osx" and everything
-            // else to "linux", and the server computes that integer as
-            // `isMacintosh || isIOS ? 2 : isWindows ? 1 : 3`. Linux is the branch
-            // nothing tests for, so Android (neither darwin nor win32) has always
-            // landed on it. isLinux is not consulted anywhere on this path, so
-            // patches/0001 neither made this work nor is needed for it.
-            //
-            // Both fields below carry weight: the path names the symlink so the
-            // basename is `bash`, which is the key the ptyHost looks up to decide
-            // the injection arguments, and the args stay empty because it only
-            // injects shell integration for empty or login args.
-            //
-            // This block was once documented as inert, on the grounds that the
-            // remote "reports its platform as android". No such mechanism exists:
-            // it reports an integer, never a platform string. The device
-            // measurement offered as proof predates the settings-path fix, when
-            // everything written here went to a file the workbench never read, so
-            // no default profile was selected and terminals took the $SHELL
-            // fallback for an unrelated reason.
-            // Atomic like the migration and the refresh, and for the same
-            // reason: the guard is the file's own existence, so a first-run
-            // write that stopped partway would leave a truncated settings.json
-            // that `exists()` accepts forever. The workbench reads a short file
-            // as the settings rather than as an error, so the user would come
-            // up with an arbitrary subset of the defaults and no way to tell.
-            //
-            // The two Python discovery keys are pinned here as well as in
-            // [refreshManagedPaths], and the duplication is load-bearing:
-            // SplashActivity runs that refresh BEFORE runSetup(), so on a clean
-            // install it returns at its own `!exists()` guard and a first
-            // session would otherwise run unpinned. See PYTHON_LOCATOR for why
-            // neither value is a preference.
-            //
-            // The secondary side bar starts hidden, and on a phone that is not a
-            // preference either: it takes roughly 45 percent of the width for a
-            // chat view whose provider this build prunes, and what is beside it
-            // then wraps mid-word.
-            //
-            // Writing the key here does not by itself close the bar, however
-            // plainly its name reads. It decides a workspace with no recorded
-            // layout, and by the time this file reaches the web client that
-            // record exists: the workbench starts from a copy of these settings
-            // in browser storage that the first load in a profile has not
-            // written yet, falls back to
-            // upstream's "visibleInWorkspace", opens the bar and stores
-            // `workbench.auxiliaryBar.hidden: false` against the workspace. Every
-            // later load reads the record and never consults the default again.
-            // The bundled welcome extension is what corrects the record, once per
-            // workspace; this is the value it reads to decide whether to.
-            //
-            // Still only a default, and the view's own title menu reverses it, so
-            // a user who opens the bar keeps it open.
-            val defaults = """
-                {
-                    "workbench.secondarySideBar.defaultVisibility": "hidden",
-                    "workbench.startupEditor": "none",
-                    "workbench.colorTheme": "Default Dark Modern",
-                    "editor.fontSize": 14,
-                    "editor.wordWrap": "on",
-                    "editor.minimap.enabled": false,
-                    "diffEditor.wordWrap": "on",
-                    "terminal.integrated.fontSize": 13,
-                    "terminal.integrated.defaultProfile.linux": "bash",
-                    "terminal.integrated.profiles.linux": {
-                        "bash": {
-                            "path": "${Environment.getTerminalShellPath(context)}",
-                            "args": [],
-                            "icon": "terminal-bash"
-                        }
-                    },
-                    "git.path": "$nativeLibDir/libgit.so",
-                    "terminal.integrated.shellIntegration.enabled": true,
-                    "extensions.verifySignature": false,
-                    "telemetry.telemetryLevel": "off",
-                    "telemetry.enableTelemetry": false,
-                    "update.mode": "none",
-                    "update.showReleaseNotes": false,
-                    "security.workspace.trust.enabled": false,
-                    "python.languageServer": "Jedi",
-                    "python.defaultInterpreterPath": "${context.filesDir.absolutePath}/usr/bin/python3",
-                    "python.locator": "js",
-                    "python.useEnvironmentsExtension": false,
-                    "claudeCode.claudeProcessWrapper": "${Environment.getMuslLoaderPath(context)}",
-                    "launch": {
-                        "version": "0.2.0",
-                        "configurations": [
-                            {
-                                "name": "Attach to Node.js",
-                                "type": "node",
-                                "request": "attach",
-                                "port": 9229,
-                                "restart": true,
-                                "skipFiles": ["<node_internals>/**"]
-                            },
-                            {
-                                "name": "NestJS: Debug",
-                                "type": "node",
-                                "request": "launch",
-                                "runtimeArgs": ["--inspect", "-r", "ts-node/register", "-r", "tsconfig-paths/register"],
-                                "args": ["${'$'}{workspaceFolder}/src/main.ts"],
-                                "skipFiles": ["<node_internals>/**"],
-                                "console": "integratedTerminal"
-                            },
-                            {
-                                "name": "Node.js: Run Current File",
-                                "type": "node",
-                                "request": "launch",
-                                "program": "${'$'}{file}",
-                                "skipFiles": ["<node_internals>/**"],
-                                "console": "integratedTerminal"
-                            }
-                        ]
-                    }
-                }
-            """.trimIndent()
             // Thrown for the reason createBashrc() throws: this runs only from
             // runSetupLocked, markSetupComplete() is downstream in the same try
             // block, and the every-launch repair that would otherwise catch up
@@ -2065,10 +2069,149 @@ claude() {
             // failure here means no terminal profile, no git.path, no
             // claudeProcessWrapper and no verifySignature until the app
             // updates -- reported to the user as a successful first run.
-            if (!writeAtomically(settingsFile) { it.write(defaults.toByteArray()) }) {
+            if (!writeDefaultSettings()) {
                 throw IOException("could not write $settingsFile")
             }
         }
+    }
+
+    /**
+     * Writes the managed settings this app owns, over whatever is at the path.
+     *
+     * Split from [createDefaultSettings]'s `!exists()` guard for the reason
+     * [writeBashrc] is: [repairTruncatedSetupFiles] has to be able to replace an
+     * empty settings.json without deleting it first to satisfy that guard, and
+     * the delete is what turned a file this app could still heal on any later
+     * launch into one nothing writes again. The rename leaves the empty file in
+     * place if the write fails, so the repair keeps its next attempt.
+     *
+     * @return true if settings.json now holds these defaults; on false it is
+     *   untouched, per [writeAtomically].
+     */
+    private fun writeDefaultSettings(): Boolean {
+        val nativeLibDir = context.applicationInfo.nativeLibraryDir
+        // Environment.getMachineSettingsPath explains why it is this path and not
+        // the `User/` one that looks like the obvious home for user settings.
+        val settingsFile = File(Environment.getMachineSettingsPath(context))
+        settingsFile.parentFile?.mkdirs()
+        // The terminal profile is read, and the `linux` suffix is not a guess.
+        // The workbench builds the key from the OS *integer* the remote sends:
+        // `getPlatformKey()` maps 1 to "windows", 2 to "osx" and everything
+        // else to "linux", and the server computes that integer as
+        // `isMacintosh || isIOS ? 2 : isWindows ? 1 : 3`. Linux is the branch
+        // nothing tests for, so Android (neither darwin nor win32) has always
+        // landed on it. isLinux is not consulted anywhere on this path, so
+        // patches/0001 neither made this work nor is needed for it.
+        //
+        // Both fields below carry weight: the path names the symlink so the
+        // basename is `bash`, which is the key the ptyHost looks up to decide
+        // the injection arguments, and the args stay empty because it only
+        // injects shell integration for empty or login args.
+        //
+        // This block was once documented as inert, on the grounds that the
+        // remote "reports its platform as android". No such mechanism exists:
+        // it reports an integer, never a platform string. The device
+        // measurement offered as proof predates the settings-path fix, when
+        // everything written here went to a file the workbench never read, so
+        // no default profile was selected and terminals took the $SHELL
+        // fallback for an unrelated reason.
+        // Atomic like the migration and the refresh, and for the same
+        // reason: the guard is the file's own existence, so a first-run
+        // write that stopped partway would leave a truncated settings.json
+        // that `exists()` accepts forever. The workbench reads a short file
+        // as the settings rather than as an error, so the user would come
+        // up with an arbitrary subset of the defaults and no way to tell.
+        //
+        // The two Python discovery keys are pinned here as well as in
+        // [refreshManagedPaths], and the duplication is load-bearing:
+        // SplashActivity runs that refresh BEFORE runSetup(), so on a clean
+        // install it returns at its own `!exists()` guard and a first
+        // session would otherwise run unpinned. See PYTHON_LOCATOR for why
+        // neither value is a preference.
+        //
+        // The secondary side bar starts hidden, and on a phone that is not a
+        // preference either: it takes roughly 45 percent of the width for a
+        // chat view whose provider this build prunes, and what is beside it
+        // then wraps mid-word.
+        //
+        // Writing the key here does not by itself close the bar, however
+        // plainly its name reads. It decides a workspace with no recorded
+        // layout, and by the time this file reaches the web client that
+        // record exists: the workbench starts from a copy of these settings
+        // in browser storage that the first load in a profile has not
+        // written yet, falls back to
+        // upstream's "visibleInWorkspace", opens the bar and stores
+        // `workbench.auxiliaryBar.hidden: false` against the workspace. Every
+        // later load reads the record and never consults the default again.
+        // The bundled welcome extension is what corrects the record, once per
+        // workspace; this is the value it reads to decide whether to.
+        //
+        // Still only a default, and the view's own title menu reverses it, so
+        // a user who opens the bar keeps it open.
+        val defaults = """
+            {
+                "workbench.secondarySideBar.defaultVisibility": "hidden",
+                "workbench.startupEditor": "none",
+                "workbench.colorTheme": "Default Dark Modern",
+                "editor.fontSize": 14,
+                "editor.wordWrap": "on",
+                "editor.minimap.enabled": false,
+                "diffEditor.wordWrap": "on",
+                "terminal.integrated.fontSize": 13,
+                "terminal.integrated.defaultProfile.linux": "bash",
+                "terminal.integrated.profiles.linux": {
+                    "bash": {
+                        "path": "${Environment.getTerminalShellPath(context)}",
+                        "args": [],
+                        "icon": "terminal-bash"
+                    }
+                },
+                "git.path": "$nativeLibDir/libgit.so",
+                "terminal.integrated.shellIntegration.enabled": true,
+                "extensions.verifySignature": false,
+                "telemetry.telemetryLevel": "off",
+                "telemetry.enableTelemetry": false,
+                "update.mode": "none",
+                "update.showReleaseNotes": false,
+                "security.workspace.trust.enabled": false,
+                "python.languageServer": "Jedi",
+                "python.defaultInterpreterPath": "${context.filesDir.absolutePath}/usr/bin/python3",
+                "python.locator": "js",
+                "python.useEnvironmentsExtension": false,
+                "claudeCode.claudeProcessWrapper": "${Environment.getMuslLoaderPath(context)}",
+                "launch": {
+                    "version": "0.2.0",
+                    "configurations": [
+                        {
+                            "name": "Attach to Node.js",
+                            "type": "node",
+                            "request": "attach",
+                            "port": 9229,
+                            "restart": true,
+                            "skipFiles": ["<node_internals>/**"]
+                        },
+                        {
+                            "name": "NestJS: Debug",
+                            "type": "node",
+                            "request": "launch",
+                            "runtimeArgs": ["--inspect", "-r", "ts-node/register", "-r", "tsconfig-paths/register"],
+                            "args": ["${'$'}{workspaceFolder}/src/main.ts"],
+                            "skipFiles": ["<node_internals>/**"],
+                            "console": "integratedTerminal"
+                        },
+                        {
+                            "name": "Node.js: Run Current File",
+                            "type": "node",
+                            "request": "launch",
+                            "program": "${'$'}{file}",
+                            "skipFiles": ["<node_internals>/**"],
+                            "console": "integratedTerminal"
+                        }
+                    ]
+                }
+            }
+        """.trimIndent()
+        return writeAtomically(settingsFile) { it.write(defaults.toByteArray()) }
     }
 
     private fun extractBundledExtensions() {
@@ -2109,7 +2252,15 @@ claude() {
             ?.filter { it.isDirectory }
             ?.map { it.name }
             ?: emptyList()
-        val toExtract = bundledDirsToExtract(installed, bundled.toList())
+        // And which of those are not installs at all, but what a killed unpack
+        // left behind. Only names this build bundles are asked the question:
+        // the same listing feeds the newer-version decision inside
+        // [bundledDirsToExtract], and a directory belonging to a user's own
+        // gallery install is not ours to call unfinished.
+        val abandoned = installed
+            .filter { it in bundled && unpackWasAbandoned(File(extensionsDir, it)) }
+            .toSet()
+        val toExtract = bundledDirsToExtract(installed, bundled.toList(), abandoned)
         for (name in toExtract) {
             // Merges rather than emptying the directory first. That leaves a
             // file this build no longer ships behind, which is inert because
@@ -2138,12 +2289,20 @@ claude() {
             // package.json that did land: installed to look at, dead on every
             // activation, permanently.
             //
-            // Only what this attempt created. A directory that was already
-            // there belongs to the previous release and its files were each
-            // replaced atomically, so what survives is whole even if mixed, and
-            // ours are re-unpacked unconditionally so a mixed one heals next
-            // run. A fetched one is in this list only because it was absent,
-            // which is why this branch is the whole of its retry.
+            // Only what nothing else would name again, which is not the same
+            // question as "what this attempt created". A directory that was
+            // already there belongs to the previous release and its files were
+            // each replaced atomically, so what survives is whole even if mixed,
+            // and ours are re-unpacked unconditionally so a mixed one heals next
+            // run. A fetched one used to be in this list only because it was
+            // absent, which is what made "did this attempt create it" the whole
+            // test -- and [abandoned] above is exactly what stopped that being
+            // true: a present directory a kill left half full is now selected
+            // too, and for that one the delete is suppressed while the mark that
+            // replaces it is written best-effort a few lines below. So the test
+            // is [failedUnpackMustBeRemoved], which asks whether the next run
+            // would select this name again and leaves the delete as the fallback
+            // for when nothing would.
             //
             // That makes the retry rest on the delete succeeding, in the
             // condition that caused the failure. Two things could defeat it:
@@ -2164,13 +2323,15 @@ claude() {
             //   yields it and removes it.
             //
             // So the error line below reports a state nobody expects rather
-            // than guarding one we do. If it fires the next attempt skips the
-            // extension exactly as it did before this branch existed -- the fix
-            // not applying, not a new defect. There is deliberately no second
-            // mechanism: producing the state for a test needs an unreadable
-            // directory, and a permission test passes vacuously wherever the
-            // suite runs as root, so a fallback here would be unmeasured state
-            // guarding an unmeasured failure.
+            // than guarding one we do. Usually the extension is still retried
+            // even then: the directory it could not remove carries the in-flight
+            // mark written below, which puts the name back on this list, and
+            // before that mark existed the next attempt skipped it for good. The
+            // exception is the one case where the mark could not be written
+            // either, which is the only reason the delete was attempted for a
+            // directory that was already there. Two failures at once leave
+            // nothing to retry from, so the line says which of the two happened
+            // rather than promising a retry it cannot know about.
             val dest = File(extensionsDir, name)
             // isDirectory, not exists, and for the same reason createDirectories
             // asks it: the question is whether a previous release left something
@@ -2180,16 +2341,62 @@ claude() {
             // fetched extension, since the retry drops it from the list. Reading
             // it as "nothing usable here" clears it and lets the retry work.
             val existedBefore = dest.isDirectory
+            // The other half of the retry, and the half that survives a kill.
+            // Everything above answers an unpack that FAILED; nothing answers
+            // one that was never allowed to finish. Setup runs in
+            // SplashActivity's scope with no foreground service holding the
+            // process, so a Recents swipe or a low-memory kill during this copy
+            // ends it outright, and the directory extractAssetDir created is
+            // then the whole of what a later run has to go on: presence, which
+            // is the only staleness test a fetched extension gets, reads a few
+            // hundred of 3787 files as installed and never touches it again.
+            //
+            // A file this app writes inside the directory before the copy and
+            // removes after it is what tells the two apart. It costs one create
+            // and one unlink per extension that actually needs unpacking, it is
+            // read by [unpackWasAbandoned] and by nothing else, and the answer
+            // it gives on a device that predates it is "finished", which is the
+            // reading every install already had.
+            //
+            // Resuming over the partial tree rather than clearing it first is
+            // deliberate, and it is the same choice the top of this loop makes:
+            // extractAssetFile writes every file through a rename, so no file
+            // on disk is half of anything, and merging the missing ones in
+            // yields a whole tree. Clearing would spend the copy again and open
+            // a window where the extension is not there at all.
+            dest.mkdirs()
+            val marker = File(dest, UNPACK_MARKER_NAME)
+            if (!marker.isFile && !runCatching { marker.createNewFile() }.getOrDefault(false)) {
+                // Not fatal: the copy below is worth attempting either way, and
+                // the failure path below compensates by deleting a directory it
+                // could not mark. Nothing compensates for a process kill, which
+                // is what the mark is for, so this is said out loud: an unpack
+                // nobody marked is exactly as recoverable as it was before any
+                // of this existed.
+                Logger.w(
+                    tag,
+                    "Could not mark $name as being unpacked; a process kill during its copy " +
+                        "would leave it looking installed",
+                )
+            }
             if (!extractAssetDir("extensions/$name", "home/.vscodroid/extensions/$name")) {
-                if (!existedBefore && !dest.deleteRecursively()) {
+                if (failedUnpackMustBeRemoved(name, existedBefore, marker.isFile) &&
+                    !dest.deleteRecursively()
+                ) {
                     Logger.e(
                         tag,
-                        "Could not remove the partially unpacked $name. The next attempt will " +
-                            "read it as installed and skip it, so this extension needs the " +
-                            "directory removed by hand or an app update to recover.",
+                        "Could not remove the partially unpacked $name. The next attempt " +
+                            "unpacks it again only while the unpacking mark is on it, and " +
+                            "that mark is ${if (marker.isFile) "there" else "not"}.",
                     )
                 }
                 throw IOException("could not unpack bundled extension $name")
+            }
+            // Only now is the directory an install. A clear that fails costs
+            // one wasted re-copy on the next run, never a broken extension,
+            // which is why it is a warning and not a throw.
+            if (marker.exists() && !marker.delete()) {
+                Logger.w(tag, "Could not clear the unpacking mark on $name; it will be unpacked again")
             }
         }
 
@@ -3295,6 +3502,69 @@ internal fun retiredIdsToSweep(
 internal const val OWN_EXTENSION_PREFIX = "vscodroid."
 
 /**
+ * The file that says an extension directory is being unpacked right now.
+ *
+ * Written inside the directory before the copy starts and removed after it
+ * lands, so that the directory means "unpacked" rather than "created". A dot
+ * name because the directory is also an extension root: the scanner reads
+ * `package.json` and nothing else, and a dot file is out of the way of anyone
+ * listing it by hand.
+ */
+internal const val UNPACK_MARKER_NAME = ".vscodroid-unpacking"
+
+/**
+ * Whether the copy that created this extension directory never finished.
+ *
+ * Two things are asked, and the second is not redundant. The mark is the
+ * reliable answer, but only for a directory created since it existed; an
+ * install unpacked by an earlier release carries no mark whatever state it is
+ * in. A fetched extension with no `package.json` is not loadable by anything --
+ * `manifestEntryFor` declines it, the workbench's scanner cannot see it -- so
+ * reading that as unfinished costs a copy the extension needed anyway, and
+ * recovers the devices this app already broke rather than only the ones it has
+ * yet to.
+ *
+ * Both directions matter. Answering yes for a healthy directory would re-copy
+ * 57 MB on every upgrade and take with it whatever an extension has written
+ * inside its own tree since install, which is the cost [bundledDirsToExtract]
+ * exists to avoid; answering no for a wrecked one is the defect this closes.
+ */
+internal fun unpackWasAbandoned(dir: File): Boolean =
+    File(dir, UNPACK_MARKER_NAME).isFile || !File(dir, "package.json").isFile
+
+/**
+ * Whether an unpack that failed has to remove the directory it was writing
+ * into, for the next run to try again.
+ *
+ * The question is "would anything name this again", not "did this attempt
+ * create it", and the two stopped being the same answer when [abandoned] began
+ * selecting a fetched directory that is present. Three cases:
+ *
+ *  - a directory this attempt created goes. A fetched extension whose directory
+ *    is merely present is dropped by [bundledDirsToExtract], and the half of it
+ *    that landed is enough for `manifestEntryFor` to list it as an install.
+ *  - one that was already there and carries the mark stays. [unpackWasAbandoned]
+ *    reads that mark, so the name comes back on the list, and what is on disk is
+ *    the previous release's install with part of this one merged over it: whole
+ *    even if mixed, since every file is written through a rename.
+ *  - one that was already there and carries NO mark stays only if it is ours.
+ *    Ours are re-unpacked unconditionally, so the previous release's copy is
+ *    worth more kept than deleted. A fetched one is not: it reached this loop
+ *    because it read as abandoned, and if the mark could not be written while
+ *    the manifest did land, nothing on the device would select it again --
+ *    wreckage that lists itself as installed and is dead on every activation.
+ *    Removing it puts it back in the ABSENT case the retry has always handled.
+ *
+ * Pure, and takes the three facts rather than a `File`, so every combination is
+ * decidable without a tree.
+ */
+internal fun failedUnpackMustBeRemoved(
+    name: String,
+    existedBefore: Boolean,
+    marked: Boolean,
+): Boolean = !existedBefore || !(marked || name.startsWith(OWN_EXTENSION_PREFIX))
+
+/**
  * Which bundled extension directories have to be unpacked over what is already
  * on disk.
  *
@@ -3308,7 +3578,14 @@ internal const val OWN_EXTENSION_PREFIX = "vscodroid."
  * directory carrying this version string been unpacked before" and nothing
  * about its contents. For an extension `download-extensions.sh` fetches at a
  * pinned version that is an exact staleness test -- the same version is the
- * same bytes. For one this repository edits in place it is no test at all,
+ * same bytes -- **once the unpack that created it has finished**. It is created
+ * before the first file is copied into it, so on its own it also answers yes
+ * for a directory a process kill left half full, which is a state no sweep here
+ * can reach and no later run would retry: that is what [abandoned] carries, and
+ * a name in it is treated as though the directory were not there. A newer
+ * install of the same id still wins over it, deliberately, since the copy the
+ * user chose is the one that runs and unpacking beside it writes 29 MiB that
+ * nothing loads. For one this repository edits in place presence is no test at all,
  * which is the defect that removed the check: the process-monitor extension's
  * code was rewritten while its `package.json` stayed at 1.0.0, so the fix
  * reached clean installs and no one who upgraded.
@@ -3339,17 +3616,24 @@ internal const val OWN_EXTENSION_PREFIX = "vscodroid."
  * Python extension alone, re-created on every upgrade. Not unpacking it is the
  * whole remedy: the copy the user chose is the one that runs either way.
  *
- * Pure, and takes the two listings rather than a directory, so the decision is
+ * Pure, and takes listings rather than a directory, so the decision is
  * testable without a Context or a tree. `(present, bundled)` in that order, the
  * same as [supersededExtensionDirs] and [retiredOwnExtensionDirs]: all three
  * take two `List<String>` and a swap between them compiles in silence, so the
- * only protection is that there is nothing to remember.
+ * only protection is that there is nothing to remember. [abandoned] is a `Set`
+ * rather than a third list of the same type, so it cannot join that swap, and
+ * it is defaulted because a caller with nothing to say about wreckage gets the
+ * behaviour that was here before it existed.
  */
-internal fun bundledDirsToExtract(present: List<String>, bundled: List<String>): List<String> {
+internal fun bundledDirsToExtract(
+    present: List<String>,
+    bundled: List<String>,
+    abandoned: Set<String> = emptySet(),
+): List<String> {
     val installed = present.mapNotNull(::splitExtensionDir)
     return bundled.filter { dir ->
         if (dir.startsWith(OWN_EXTENSION_PREFIX)) return@filter true
-        if (dir in present) return@filter false
+        if (dir in present && dir !in abandoned) return@filter false
         val (id, version) = splitExtensionDir(dir) ?: return@filter true
         installed.none { (otherId, otherVersion) ->
             otherId == id && isOlderVersion(version, otherVersion)

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainCardState.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainCardState.kt
@@ -224,12 +224,22 @@ class ToolchainCardState(private val mode: ToolchainCardMode) {
         /**
          * Reports that mean the download is still going somewhere, so the card
          * keeps offering Cancel rather than a second Install.
+         *
+         * REQUIRES_USER_CONFIRMATION belongs here for the same reason the other
+         * four do, and it is the one that was missing. Play emits it and then
+         * waits, indefinitely, for a dialog the user may have dismissed: the pack
+         * is queued and not moving, and this card's Cancel is the only route in
+         * the app to `assetPackManager.cancel`. Without it the card fell through
+         * to a plain Install, which says a download is neither running nor
+         * pending. `isTerminalPackStatus`, the other predicate in this project
+         * asking the same question, has always counted it as unsettled.
          */
         val IN_FLIGHT = listOf(
             AssetPackStatus.DOWNLOADING,
             AssetPackStatus.PENDING,
             AssetPackStatus.WAITING_FOR_WIFI,
             AssetPackStatus.TRANSFERRING,
+            AssetPackStatus.REQUIRES_USER_CONFIRMATION,
         )
     }
 }

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
@@ -619,7 +619,26 @@ class ToolchainManager(private val context: Context) {
 
         // Remove from state
         state.remove(idx)
-        writeState(state)
+        // Asked, exactly as [installFromDirectoryHoldingPack] asks it, and for the
+        // sibling reason: the record is what everything else reads, so a removal
+        // whose record write failed is not a removal that happened. The files are
+        // gone either way -- they were deleted above -- but reporting
+        // NOT_INSTALLED on top of a record that still names the toolchain tells
+        // the user it is gone while the next launch draws it as installed and
+        // `getAllToolchainEnv` goes on exporting JAVA_HOME for a directory that no
+        // longer exists. Nothing reconciles that later: the repair pass only
+        // checks execute bits.
+        //
+        // FAILED rather than silence, because it is the only channel that reaches
+        // the user with a reason, and the Retry it puts on the card reinstalls the
+        // toolchain, which is the repair for a record that outlived its files.
+        // STORAGE for the reason the install sibling picks it: [writeAtomically]
+        // writes a temporary file and renames it, and what stops that is space or
+        // an I/O fault, both of which "free some space and try again" survives.
+        if (!writeState(state)) {
+            fail("toolchain_$name", ToolchainFailure.STORAGE)
+            return
+        }
         regenerateDerivedFilesLocked()
 
         Logger.i(tag, "Uninstalled toolchain: $name")
@@ -1312,6 +1331,15 @@ class ToolchainManager(private val context: Context) {
                 }
                 Logger.i(tag, "$packName matches the digest the release publishes")
 
+                // Asked again, because the digest above hashes the whole archive
+                // and the card offers Cancel throughout it. Everything past this
+                // line writes: the extraction fills a staging tree the size of the
+                // unpacked toolchain, and the copy after it is ~155 MB into `usr/`.
+                if (download.cancelled) {
+                    Logger.i(tag, "HTTP download cancelled for $packName")
+                    return@execute
+                }
+
                 // Extract: report as TRANSFERRING (file copy phase)
                 download.percent = 90
                 report(packName, AssetPackStatus.TRANSFERRING, 90)
@@ -1323,6 +1351,21 @@ class ToolchainManager(private val context: Context) {
                 // so holding it through installFromDirectory buys nothing and
                 // costs a device its whole download size in headroom.
                 zipFile.delete()
+
+                // The last point at which stopping leaves nothing behind, and the
+                // reason the check is here rather than inside the copy. Extraction
+                // has just spent seconds on a tree the size of the toolchain, and
+                // the card has been offering Cancel for all of it; but
+                // [installFromDirectoryHoldingPack] copies into the shared `usr/`
+                // tree and only then writes the manifest naming what it put there,
+                // so a copy abandoned partway leaves files no uninstall can name,
+                // which is worse than the unwanted install this check refuses. The
+                // staging tree above is this download's own and the finally below
+                // deletes it whole.
+                if (download.cancelled) {
+                    Logger.i(tag, "HTTP download cancelled for $packName")
+                    return@execute
+                }
 
                 // Install from extracted directory (same path as Play Asset Delivery)
                 //
@@ -1356,9 +1399,40 @@ class ToolchainManager(private val context: Context) {
                 // Two-argument remove: a later request for the same pack has
                 // already replaced this entry, and dropping its token would
                 // leave that download uncancellable.
-                httpDownloads.remove(packName, download)
+                val heldThePack = httpDownloads.remove(packName, download)
                 // Clean up temp files
                 tempDir.deleteRecursively()
+                // The cancellation, said out loud. Every `return@execute` on the
+                // flag above leaves without reporting, and a report goes to the
+                // manager that began this download and to no other, so what the
+                // silence withheld was withheld from the only party that could
+                // act on it. The toolchain screen takes the pack out of its own
+                // outstanding set when Cancel is tapped, but that set belongs to
+                // the screen the tap happened on, while the token is process-wide
+                // precisely so a rebuilt screen can stop a transfer the destroyed
+                // one began. Cancelled that way, the destroyed screen's set kept
+                // the pack, and with it the Play Core registration
+                // `ToolchainActivity.shouldReleaseSubscription` hands back only
+                // when that set empties. The first-run queue is the other reader
+                // that needs an ending: it advances on a terminal status, so the
+                // row sat where it was with every pack behind it waiting.
+                //
+                // Here rather than at each of those exits, so a check added later
+                // at a new expensive boundary cannot forget it, and after the
+                // bookkeeping above so a listener asking [packsDownloading] on
+                // its way through does not read this transfer as still running.
+                // Only while this token still held the pack: once a later request
+                // has replaced it, that download owns what is said about the pack.
+                //
+                // CANCELED, because nothing failed and every listener already has
+                // a branch for it -- Play emits it on the other delivery path. A
+                // cancel landing during the final copy is reported after that
+                // copy's COMPLETED, which costs nothing: the card reads CANCELED
+                // against the install record and draws Remove, and the first-run
+                // queue has already moved past the pack.
+                if (heldThePack && download.cancelled) {
+                    report(packName, AssetPackStatus.CANCELED, 0)
+                }
             }
         }
     }
@@ -1731,6 +1805,10 @@ class ToolchainManager(private val context: Context) {
         report(packName, AssetPackStatus.DOWNLOADING, 0)
 
         var bytesRead = 0L
+        // What the last report said, so the loop below reports a figure rather
+        // than an iteration. Starts at the 0 just reported, which is also the
+        // whole of what a transfer with no length to divide by can ever say.
+        var lastReported = 0
         BufferedInputStream(conn.inputStream).use { input ->
             FileOutputStream(destFile).use { output ->
                 val buffer = ByteArray(DOWNLOAD_BUFFER_SIZE)
@@ -1747,9 +1825,22 @@ class ToolchainManager(private val context: Context) {
                     } else 0
                     // On the token as well as in the report: the report reaches
                     // only the manager that began this download, and a screen
-                    // rebuilt mid-transfer holds a different one.
+                    // rebuilt mid-transfer holds a different one. Written every
+                    // iteration, unlike the report, because it costs a field
+                    // store and it is what [packsDownloading] hands the screens
+                    // that were never subscribed.
                     download.percent = percent
-                    report(packName, AssetPackStatus.DOWNLOADING, percent)
+                    // Only when the figure has moved. The buffer is 8 KB and
+                    // `percent` takes 86 values, so a 55 MB toolchain reported
+                    // 6,763 times to say 86 different things, and both consumers
+                    // post every one of them onto the main thread: the card
+                    // rebinds and the first-run row re-formats its text. The poll
+                    // channel on the toolchain screen already refuses to push an
+                    // unchanged snapshot for exactly this reason.
+                    if (percent != lastReported) {
+                        lastReported = percent
+                        report(packName, AssetPackStatus.DOWNLOADING, percent)
+                    }
                 }
             }
         }

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainPickerAdapter.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainPickerAdapter.kt
@@ -47,17 +47,30 @@ class ToolchainPickerAdapter(
      * MANAGER mode: replaces the downloads this screen was never told about.
      *
      * See [ToolchainCardState.setDownloading]. Called when the screen starts,
-     * because that is the moment a rebuilt one holds no reports at all.
+     * because that is the moment a rebuilt one holds no reports at all, and then
+     * once a second for as long as the screen is in front of a running transfer.
+     *
+     * A range with a payload rather than [notifyDataSetChanged], for the reason
+     * [PAYLOAD_REBIND] gives: at one push a second, the change animation the
+     * plain call runs was taking accessibility focus off the Cancel button as
+     * fast as the user could find it. The range covers every card because the
+     * item list is fixed ([ToolchainCardState.items] is the registry), so nothing
+     * here can add or remove a row.
      */
-    @SuppressLint("NotifyDataSetChanged")
     fun setDownloading(percentByPack: Map<String, Int>) {
         cards.setDownloading(percentByPack)
-        notifyDataSetChanged()
+        notifyItemRangeChanged(0, itemCount, PAYLOAD_REBIND)
     }
 
     fun updateState(packName: String, status: Int, percent: Int) {
         val pos = cards.updateState(packName, status, percent)
-        if (pos >= 0) notifyItemChanged(pos)
+        // With a payload, exactly as the selection tap below rebinds: this is the
+        // channel that fires hardest. A download reports once per 8 KB read, so a
+        // 55 MB toolchain rebinds this card thousands of times, and without a
+        // payload every one of them runs the default change animation, swaps the
+        // item view and takes accessibility focus with it. The button that focus
+        // is taken from is Cancel, which is the only way to stop the transfer.
+        if (pos >= 0) notifyItemChanged(pos, PAYLOAD_REBIND)
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
@@ -158,7 +171,7 @@ class ToolchainPickerAdapter(
             // accessibility focus with it, so the user who just double-tapped a card
             // is returned to the top of the list. RecyclerView skips that animation
             // when a payload is supplied, and the rebind below is the same work.
-            notifyItemChanged(holder.bindingAdapterPosition, PAYLOAD_SELECTION)
+            notifyItemChanged(holder.bindingAdapterPosition, PAYLOAD_REBIND)
             onSelectionChanged?.invoke(cards.selectedPackNames())
         }
     }
@@ -225,13 +238,18 @@ class ToolchainPickerAdapter(
 
     companion object {
         /**
-         * Marks a rebind that only changes selection.
+         * Marks a rebind that redraws a card where it stands.
          *
          * Its value is never read; supplying any payload is what makes RecyclerView
          * skip the change animation, and skipping it is what keeps accessibility
-         * focus on the card the user just tapped.
+         * focus on the card the user is standing on. One constant rather than one
+         * per caller because there is nothing to tell apart: no
+         * `onBindViewHolder(holder, position, payloads)` override exists, so every
+         * rebind here is the full one and the payload's only job is to suppress the
+         * animation. It was named for the selection tap when that was the only
+         * rebind that had been fixed; the download reports need it more.
          */
-        private const val PAYLOAD_SELECTION = "selection"
+        private const val PAYLOAD_REBIND = "rebind"
         private fun labelFor(action: ToolchainAction): Int = when (action) {
             ToolchainAction.INSTALL -> R.string.toolchain_install
             ToolchainAction.REMOVE -> R.string.toolchain_remove

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafStorageManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafStorageManager.kt
@@ -3,6 +3,7 @@ package com.vscodroid.storage
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.os.SystemClock
 import android.provider.DocumentsContract
 import androidx.annotation.StringRes
 import com.vscodroid.R
@@ -27,11 +28,37 @@ import kotlin.concurrent.thread
  * VS Code Server (Node.js) requires real filesystem paths, we maintain a
  * local "mirror" directory that is kept in sync with the SAF source.
  */
-class SafStorageManager(private val context: Context) {
+class SafStorageManager(context: Context) {
+
+    /**
+     * The application context, whatever the caller handed over.
+     *
+     * Both production callers construct this with an Activity, and one of them
+     * ([com.vscodroid.SplashActivity]) then starts [reclaimRevokedMirrors], whose
+     * detached thread captures this object and through it whatever Context it
+     * holds. That thread outlives the Activity by construction (the file says so
+     * where the thread is started), and its duration is the recursive delete of a
+     * project-sized mirror, so an Activity kept here stays reachable, with its
+     * Window and its ContextImpl, through exactly the minutes when `MainActivity`,
+     * the WebView renderer and the Node server are all starting.
+     *
+     * Nothing here needs an Activity: what is read is `contentResolver`, `filesDir`
+     * (through [com.vscodroid.util.Environment]) and the preferences file, all
+     * identical on the application context. This is the same reasoning
+     * `AndroidBridge` gives for building its `ToolchainManager` on
+     * `applicationContext`.
+     *
+     * ⚠️ The two initialisers below say `this.context` deliberately. A constructor
+     * parameter shadows the property of the same name inside an initialiser, so a
+     * bare `context` there is the Activity again, and handing that to
+     * [SafSyncEngine] would keep the whole retention with the unwrapping still in
+     * place and reading as though it worked.
+     */
+    private val context: Context = context.applicationContext ?: context
 
     private val tag = "SafStorageManager"
-    private val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-    private val syncEngine = SafSyncEngine(context)
+    private val prefs = this.context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    private val syncEngine = SafSyncEngine(this.context)
 
     /**
      * Told when a write-back has given up on a file, once per burst.
@@ -44,10 +71,18 @@ class SafStorageManager(private val context: Context) {
      * refuses everything, and the editor saves on a timer, so the unthrottled version is
      * a wall of the same notice. Globally rather than per file, for the same reason. The
      * user's problem is the folder.
+     *
+     * The reading is the monotonic clock, never wall time, and that is the same reason
+     * `AuthTabWindow` gives one file over. The throttle is a subtraction against a stamp
+     * held for the life of this object, so a wall clock corrected backwards by more than
+     * the interval (NTP after a drifted RTC, or the user setting the date) leaves every
+     * later difference below it, and a folder that is still refusing every save
+     * says nothing at all until the clock catches up. Silence is the failure this notice
+     * exists to prevent.
      */
     fun onWriteBackFailed(announce: (File) -> Unit) {
         syncEngine.onWriteBackFailed = { file ->
-            if (claimAnnouncement(System.currentTimeMillis(), lastFailureAnnouncedAt.get())) {
+            if (claimAnnouncement(SystemClock.elapsedRealtime(), lastFailureAnnouncedAt.get())) {
                 announce(file)
             }
         }
@@ -102,7 +137,7 @@ class SafStorageManager(private val context: Context) {
         syncEngine.onUploadIncomplete = announce
     }
 
-    private val lastFailureAnnouncedAt = AtomicLong(0)
+    private val lastFailureAnnouncedAt = AtomicLong(NEVER_ANNOUNCED)
 
     // -- Permission Management --
 
@@ -118,6 +153,10 @@ class SafStorageManager(private val context: Context) {
             val flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or
                     Intent.FLAG_GRANT_WRITE_URI_PERMISSION
             context.contentResolver.takePersistableUriPermission(uri, flags)
+            // Between the grant and the row, and that order is what [grantsTaken] is
+            // read against: a reader whose snapshot of the grants was taken before this
+            // line must not judge the row the next one writes.
+            grantsTaken.incrementAndGet()
             addToRecentFolders(uri)
             Logger.i(tag, "Persisted permission for ${getMirrorDir(uri).name}")
         } catch (e: SecurityException) {
@@ -173,14 +212,61 @@ class SafStorageManager(private val context: Context) {
      * in the editor out from under it. That reclamation lives in [reclaimRevokedMirrors]
      * alone now.
      */
-    fun getPersistedFolders(): List<SafFolderInfo> =
-        synchronized(recentFoldersLock) { readAndPruneRecentFolders() }
+    fun getPersistedFolders(): List<SafFolderInfo> {
+        // Read before the lock, and as one call rather than one per entry. The prune
+        // below used to ask the system server for each folder in turn, so a listing held
+        // the monitor across up to [MAX_RECENT] binder round trips while the bridge's
+        // disk-work thread, a sync on Dispatchers.IO and the reclaim thread waited on
+        // it. One reading also judges every entry against one answer, which is what the
+        // per-entry version could not promise.
+        //
+        // What this does not buy is a monitor free of binder calls, which is how the
+        // hoist has already been read once. Three of the four read-modify-writes the
+        // lock exists for call this from inside it ([releaseGrantFor],
+        // [addToRecentFolders], [updateLastOpened]; the fourth is the prune below), and
+        // each of those nested calls makes its own [persistedReadUris] round trip with
+        // the monitor already held. What the hoist bounds is the cost of that: one round
+        // trip rather than one per entry.
+        // Who pays it is a background thread in every case, so it is a wait and not a
+        // freeze: MainActivity hops folderForOpenedPath, persistPermission and
+        // syncToLocal onto Dispatchers.IO (DeviceFolderOpenThreadTest pins that), the
+        // bridge answers listings on its disk-work executor and on the JavaBridge
+        // thread, and [reclaimRevokedMirrors] runs on a thread of its own.
+        val stamp = grantsTaken.get()
+        val granted = persistedReadUris()
+        return synchronized(recentFoldersLock) {
+            // What holding the reading inside the lock used to buy, without holding it
+            // there. The prune below is a read-modify-write that DELETES rows, and a
+            // reading taken before the lock can be older than the list read inside it: a
+            // grant taken in between belongs to a row the picker saves before this thread
+            // gets the monitor, and judging that row against the older reading prunes the
+            // folder the user just picked and persists the list without it, with the
+            // grant still held. Nothing here can tell which row that would be, so against
+            // such a reading no row is judged at all: the list is returned as it stands
+            // and left alone, and the next read, whose reading names the new grant,
+            // prunes then. Keeping a row too long is the harmless direction, because the
+            // pass that deletes mirrors is [reclaimRevokedMirrors] and it never consults
+            // this list.
+            readAndPruneRecentFolders(granted.takeIf { grantsTaken.get() == stamp })
+        }
+    }
+
+    /** Every tree this app still holds a persisted read grant for, in one binder call. */
+    private fun persistedReadUris(): Set<Uri> =
+        context.contentResolver.persistedUriPermissions
+            .filter { it.isReadPermission }
+            .map { it.uri }
+            .toSet()
 
     /**
      * The body of [getPersistedFolders]. Caller must hold [recentFoldersLock]: the
      * prune below is itself a read-modify-write of the list.
+     *
+     * [granted] is every tree still granted, as of a reading the caller took. Null means
+     * the caller cannot vouch that its reading is not older than this list, and then
+     * nothing is pruned and nothing is written: see [getPersistedFolders].
      */
-    private fun readAndPruneRecentFolders(): List<SafFolderInfo> {
+    private fun readAndPruneRecentFolders(granted: Set<Uri>?): List<SafFolderInfo> {
         val json = prefs.getString(KEY_RECENT_FOLDERS, "[]") ?: "[]"
         val array = JSONArray(json)
         val result = mutableListOf<SafFolderInfo>()
@@ -191,7 +277,7 @@ class SafStorageManager(private val context: Context) {
             val uri = Uri.parse(obj.getString("uri"))
 
             // Prune folders whose permissions have been revoked externally
-            if (!hasPersistedPermission(uri)) {
+            if (granted != null && uri !in granted) {
                 toRemove.add(i)
                 continue
             }
@@ -886,6 +972,36 @@ class SafStorageManager(private val context: Context) {
         private val recentFoldersLock = Any()
 
         /**
+         * How many persisted grants this process has taken, counted only so that two
+         * readings of them can be told apart.
+         *
+         * The prune inside [getPersistedFolders] judges the saved list against a reading
+         * of the system server's grants, and that reading is deliberately taken outside
+         * [recentFoldersLock], so an ordinary listing does not hold the monitor across a
+         * binder round trip. A call nested inside one of the read-modify-writes still
+         * does, and [getPersistedFolders] says which ones and what it costs.
+         * Taking the reading first leaves one ordering the lock used to forbid: a
+         * reading older than the list
+         * it is judging, which is what a grant taken between the two produces, and which
+         * would prune away the row the picker has just written. This is bumped between
+         * the grant and the row (see [persistPermission]), so a reader that took its
+         * reading before the grant sees a different value once it holds the monitor, and
+         * declines to judge.
+         *
+         * Only a grant TAKEN is counted. A grant released moves the other way: the
+         * reading still names it, so the row survives one more listing and the next one
+         * prunes it, which is the same one-listing delay a revocation in system settings
+         * already has.
+         *
+         * Never reset, so no path can leave it stale: it counts up, comparisons are for
+         * equality between two reads on one thread, and the whole of it dies with the
+         * process. In the companion for the reason [recentFoldersLock] gives, and because
+         * the grants it counts belong to the process rather than to one activity's
+         * manager.
+         */
+        private val grantsTaken = AtomicLong(0)
+
+        /**
          * Whether a mirror with no live permission may be deleted, given the writes
          * this app records as never having reached the device.
          *
@@ -1084,15 +1200,29 @@ class SafStorageManager(private val context: Context) {
         internal const val FAILURE_NOTICE_INTERVAL_MS = 10_000L
 
         /**
+         * The stamp of a session in which nothing has been announced yet.
+         *
+         * Tested for rather than subtracted from, and that became necessary with the
+         * clock. Under wall time zero was further back than any interval on its own;
+         * under the monotonic clock the reading is milliseconds since boot, so a device
+         * that has been up for less than the interval would have found the FIRST failure
+         * of a session too close to zero to be worth saying, which is the one notice
+         * that always has to be given.
+         */
+        internal const val NEVER_ANNOUNCED = 0L
+
+        /**
          * Whether a failure at [now] is far enough from [lastAnnouncedAt] to be said.
          *
          * A function rather than an inline comparison so the rule can be asserted: the
-         * wiring around it reaches a Toast, which no JVM test here can see. The first
-         * failure of a session announces, because a zero last-announced time is further
-         * back than any interval.
+         * wiring around it reaches a Toast, which no JVM test here can see.
+         *
+         * [now] comes from the monotonic clock; see [onWriteBackFailed] for why it is
+         * not the wall clock.
          */
         internal fun shouldAnnounce(now: Long, lastAnnouncedAt: Long): Boolean =
-            now - lastAnnouncedAt >= FAILURE_NOTICE_INTERVAL_MS
+            lastAnnouncedAt == NEVER_ANNOUNCED ||
+                now - lastAnnouncedAt >= FAILURE_NOTICE_INTERVAL_MS
     }
 }
 

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
@@ -755,6 +755,10 @@ class SafSyncEngine(private val context: Context) {
             processWriteBack(session, remaining)
             remaining = session.queue.poll()
         }
+        // Said after the last poll rather than before it, so the flag is never set while
+        // this thread could still deliver: an event that reads it answers "nothing will
+        // take this now" only when that is already true.
+        session.abandoned = true
         if (interrupted) Thread.currentThread().interrupt()
     }
 
@@ -799,6 +803,7 @@ class SafSyncEngine(private val context: Context) {
             // asking why needs this line to exist in a bug report.
             val dropped = closing.queue.size
             closing.queue.clear()
+            closing.abandoned = true
             if (dropped > 0) {
                 Logger.w(tag, "$dropped write-back(s) arrived after the drain ended")
             }
@@ -812,7 +817,12 @@ class SafSyncEngine(private val context: Context) {
         // after this point: a MOVED_TO of the next folder must not be able to claim a
         // directory that left the previous one, which would rename a document in a folder
         // the user has closed.
-        synchronized(vanishedLock) { vanishedDirectories.clear() }
+        //
+        // Which is the same instant their upload records stop being able to move: a claim
+        // is the only thing that carries a line to the directory's new path. Retired here
+        // rather than left standing, because after this nothing can; see
+        // [consumeStaleUploadsUnder].
+        dropVanished { true }
         Logger.i(tag, "File watcher stopped")
     }
 
@@ -1057,7 +1067,11 @@ class SafSyncEngine(private val context: Context) {
                 }
             } ?: false
         } catch (e: Exception) {
-            Logger.w(tag, "Could not compare ${localFile.name} with its device copy: ${e.message}")
+            Logger.w(
+                tag,
+                "Could not compare ${localFile.name} with its device copy: " +
+                    e.javaClass.simpleName,
+            )
             false
         }
     }
@@ -1126,7 +1140,7 @@ class SafSyncEngine(private val context: Context) {
 
     /** The copy itself, with the document already claimed by the caller. */
     private fun writeLocalToSafHoldingDocument(localFile: File, safDocUri: Uri) {
-        markUploadInFlight(localFile.absolutePath)
+        val claim = markUploadInFlight(localFile.absolutePath)
         // Released in a finally rather than at each exit, and this is not style.
         // The claim taken above was originally dropped at the one exit its author
         // had in mind, and the failure exits added later each returned without it,
@@ -1140,7 +1154,10 @@ class SafSyncEngine(private val context: Context) {
         // The distinction the two paths draw is what the journal means, and it is
         // the reason there are two calls rather than one. The line records an edit
         // that has not reached the device, so a landed write retires it and a
-        // failed one must leave it standing for the next sync to retry.
+        // failed one leaves it standing for the next sync to retry. The one thing
+        // that leaves nothing to retry is the mirror file going away while this
+        // write ran, and the failing path retires the line for that alone; see
+        // [releaseUploadClaim].
         var landed = false
         try {
             var attempts = 0
@@ -1176,8 +1193,10 @@ class SafSyncEngine(private val context: Context) {
                 }
             }
         } finally {
-            if (landed) clearUploadInFlight(localFile.absolutePath)
-            else releaseUploadClaim(localFile.absolutePath)
+            // By the claim rather than by the path this opened with: a rename of the
+            // directory above it moves both records while the stream runs.
+            if (landed) clearUploadInFlight(claim)
+            else releaseUploadClaim(claim)
         }
     }
 
@@ -1287,53 +1306,91 @@ class SafSyncEngine(private val context: Context) {
 
     private fun uploadJournal(): File = File(context.filesDir, UPLOADS_IN_FLIGHT_FILE)
 
-    /** Takes this writer's claim on [absolutePath] and records that a write began. */
-    private fun markUploadInFlight(absolutePath: String) = synchronized(uploadJournalLock) {
-        uploadWriters[absolutePath] = (uploadWriters[absolutePath] ?: 0) + 1
-        try {
-            val journal = uploadJournal()
-            val lines = if (journal.isFile) journal.readLines() else emptyList()
-            if (absolutePath !in lines) {
-                rewriteJournal(lines + absolutePath)
+    /**
+     * Takes this writer's claim on [absolutePath] and records that a write began.
+     *
+     * The claim is handed back rather than looked up again at the end, because the path
+     * it names can move while the stream runs; see [UploadClaim].
+     */
+    private fun markUploadInFlight(absolutePath: String): UploadClaim =
+        synchronized(uploadJournalLock) {
+            val claim = UploadClaim(absolutePath)
+            uploadClaims.add(claim)
+            try {
+                val journal = uploadJournal()
+                val lines = if (journal.isFile) journal.readLines() else emptyList()
+                if (absolutePath !in lines) {
+                    rewriteJournal(lines + absolutePath)
+                }
+            } catch (e: Exception) {
+                Logger.w(tag, "Could not record the upload in flight: ${e.message}")
             }
-        } catch (e: Exception) {
-            Logger.w(tag, "Could not record the upload in flight: ${e.message}")
+            claim
         }
-    }
 
     /**
-     * Drops this writer's claim while leaving standing whatever its failure recorded.
+     * Drops this writer's claim, and with it the line only when the mirror file it names
+     * went away while the write ran.
      *
      * The counterpart to [clearUploadInFlight], and deliberately not the same
      * function. Both say "this writer is finished"; only one of them says "and the
      * device copy is current now". A failed write-back has to say the first without
      * the second, or the mirror edit it could not deliver is forgotten and the next
      * sync has no reason to retry it.
+     *
+     * The one line it does take is the one with nothing left to retry. Two retirements
+     * defer to a live claim rather than take it, [consumeStaleUploadRecord] for a delete
+     * or rename of the file itself and [consumeStaleUploadsUnder] for a directory that
+     * left the mirror, and each of them was the last pass that could reach that line
+     * while the file was gone. Deferring to a writer that then fails here left it
+     * standing, and a standing line is not inert: `SafStorageManager.mayReclaim` reads it
+     * as the mirror holding a write the device never received, so the launch pass keeps
+     * that mirror and the device-folder screen reports it as holding work the device
+     * folder does not have. So the test here is the one [consumeStaleUploadsUnder]
+     * applies, the file being there, asked at the moment this writer is the only party
+     * that knows the line is now unowned.
+     *
+     * How long that used to last is worth stating exactly, because the two deferrals
+     * differ and only one of them ever healed. A directory departure nobody claimed is
+     * never propagated to the device ([handleMirrorEvent] holds it back), so the device
+     * still holds the document: the next open of the folder copies it back into the
+     * mirror, and the open after that reaches [initialSync]'s repair and consumes the
+     * line. That is two whole reopens with the mirror mislabelled in between, and no
+     * repair at all where the copy cannot come back, which is a folder never opened
+     * again, a document past [MAX_FILE_SIZE], one outside the enumeration cap, or one
+     * whose stale old-named copy the user removed on the device first. A delete or rename
+     * of the file itself has no such second chance: that one IS propagated, so the device
+     * document goes with it and nothing can ever copy it back down.
+     *
+     * The other two branches are unchanged and both matter: a line whose file is still in
+     * the mirror stands, because that is the edit the next sync retries, and a line
+     * another writer holds a claim on is left to that writer's own release, for the
+     * reason [clearUploadInFlight] gives.
      */
-    private fun releaseUploadClaim(absolutePath: String) = synchronized(uploadJournalLock) {
-        val stillWriting = (uploadWriters[absolutePath] ?: 0) - 1
-        if (stillWriting > 0) uploadWriters[absolutePath] = stillWriting
-        else uploadWriters.remove(absolutePath)
+    private fun releaseUploadClaim(claim: UploadClaim) = synchronized(uploadJournalLock) {
+        uploadClaims.remove(claim)
+        if (!File(claim.path).exists() && uploadClaims.none { it.path == claim.path }) {
+            removeJournalLine(claim.path)
+        }
     }
 
     /**
-     * Releases this writer's claim on [absolutePath], and removes the journal line only
-     * when it was the last claim.
+     * Releases [claim] and removes the journal line only when no other writer holds the
+     * path it names now.
      *
      * Paired with [markUploadInFlight] and called by writers alone. A second writer of
      * the same path is reachable whenever a folder is reopened while a drain of the
      * previous session is still streaming: the mirror is named by a hash of the folder,
-     * so both writers address one file, and before the count the first to finish removed
+     * so both writers address one file, and before the claims the first to finish removed
      * the line the other was still inside.
+     *
+     * The line is named by the claim rather than by the path the writer opened, which is
+     * what makes a write that lands during a rename of the directory above it retire its
+     * own line: [renameUploadsUnder] moved both records while this one streamed.
      */
-    private fun clearUploadInFlight(absolutePath: String) = synchronized(uploadJournalLock) {
-        val stillWriting = (uploadWriters[absolutePath] ?: 0) - 1
-        if (stillWriting > 0) {
-            uploadWriters[absolutePath] = stillWriting
-            return@synchronized
-        }
-        uploadWriters.remove(absolutePath)
-        removeJournalLine(absolutePath)
+    private fun clearUploadInFlight(claim: UploadClaim) = synchronized(uploadJournalLock) {
+        uploadClaims.remove(claim)
+        if (uploadClaims.none { it.path == claim.path }) removeJournalLine(claim.path)
     }
 
     /**
@@ -1347,13 +1404,17 @@ class SafSyncEngine(private val context: Context) {
      *
      * Not the same operation as [clearUploadInFlight] and deliberately not spelled as
      * one. Treating either of those as releasing a claim would
-     * decrement a live writer to zero and remove the line while that writer was still
-     * streaming, which is the defect the count exists to prevent, arriving through a
+     * drop a live writer's claim and remove the line while that writer was still
+     * streaming, which is the defect the claims exist to prevent, arriving through a
      * different door. A path somebody is writing right now is left alone, and that
-     * writer's own clear removes the line when it lands.
+     * writer's own release retires the line: [clearUploadInFlight] when the write lands,
+     * and [releaseUploadClaim] when it fails onto a path the file has left, which is the
+     * state the [processWriteBack] caller defers in. The [initialSync] caller defers in
+     * the other one, where the file is there and about to be written out again, so the
+     * line it leaves is retired by that write landing.
      */
     private fun consumeStaleUploadRecord(absolutePath: String) = synchronized(uploadJournalLock) {
-        if (uploadWriters.containsKey(absolutePath)) return@synchronized
+        if (uploadClaims.any { it.path == absolutePath }) return@synchronized
         removeJournalLine(absolutePath)
     }
 
@@ -1393,21 +1454,119 @@ class SafSyncEngine(private val context: Context) {
      * because that is the last moment anything can still tell them apart. It survives a
      * process death for the same reason the rename does: both are on disk before
      * anything else happens.
+     *
+     * The live writers' claims move with the lines, in the same critical section, because
+     * they are two records of one write and this runs on a thread of its own: a directory
+     * can be renamed in the editor while a write below it is still streaming. Moving only
+     * the line would leave that write releasing a name nothing is filed under, so a write
+     * that landed would be recorded for ever as one that never reached the device.
+     *
+     * Which is why the claims move *after* the lines, and not at all when moving the
+     * lines threw. The journal half is best effort by design, and it fails in exactly the
+     * state that fills the journal in the first place: [rewriteJournal] writes a temporary
+     * file in `filesDir`, so internal storage that has run out refuses it. A claim that
+     * moved on its own is the same defect from the other side, and permanent rather than
+     * retried: the writer would retire a line nobody ever wrote and leave the real one
+     * standing under a path that has gone, which nothing can consume afterwards
+     * ([consumeStaleUploadsUnder] never sees a claimed departure, and [initialSync]'s
+     * repair needs the file the line names to be there), so `SafStorageManager.mayReclaim`
+     * would refuse that mirror for a save that did reach the device. Both records staying
+     * at the old name is the recoverable half of the pair: the writer's release still
+     * names the line it is filed under.
      */
     internal fun renameUploadsUnder(from: File, to: File) {
+        synchronized(uploadJournalLock) {
+            val old = from.absolutePath + File.separator
+            val new = to.absolutePath + File.separator
+            try {
+                val journal = uploadJournal()
+                // A journal that is not there, and a rewrite with nothing to move, are
+                // both moves that succeeded: there is no line to disagree with the claim.
+                // A writer whose own record could not be written is exactly that case,
+                // and its claim still has to follow the file.
+                if (journal.isFile) {
+                    val all = journal.readLines()
+                    val moved =
+                        all.map { if (it.startsWith(old)) new + it.removePrefix(old) else it }
+                    if (moved != all) rewriteJournal(moved)
+                }
+            } catch (e: Exception) {
+                Logger.w(tag, "Could not move the upload records of ${from.name}: ${e.message}")
+                return
+            }
+            uploadClaims.forEach {
+                if (it.path.startsWith(old)) it.path = new + it.path.removePrefix(old)
+            }
+        }
+    }
+
+    /**
+     * Retires the journal lines under [directory] whose mirror file is no longer there.
+     *
+     * The directory-shaped counterpart to [consumeStaleUploadRecord], and it exists
+     * because the delete that retires a line never arrives for the files under a
+     * directory that leaves the mirror. [handleMirrorEvent] holds that departure back for
+     * a rename to claim rather than queueing anything, inotify raises no event at all for
+     * the entries beneath a directory that moved, and [consumeStaleUploadRecord] matches
+     * one exact path, so it would not reach them even if it ran. Nothing else could:
+     * [initialSync]'s call is guarded by the file still existing, and [clearUploadsUnder]
+     * runs only once the whole mirror is going away. One write-back that gave up followed
+     * by a directory move no rename claimed therefore left a line standing for the life of
+     * the install, and a stranded line is not inert: `SafStorageManager.mayReclaim` reads
+     * any line under a mirror as that mirror holding a write the device never received, so
+     * the launch pass kept it and the device-folder screen described it as holding work
+     * the device folder does not have.
+     *
+     * A line whose file is still there is left alone, and that is the whole distinction:
+     * something is at that path again, a directory recreated under the same name or a
+     * checkout that restored it, and the line still records that the mirror holds an edit
+     * the device never received. So is a line some writer holds a claim on, for the reason
+     * [consumeStaleUploadRecord] gives, and taking it here is the defect [UploadClaim]
+     * exists to prevent. That deferral is not a hand-off into nothing: the writer applies
+     * this same test when it releases, so a write that fails onto the path this pass
+     * skipped retires the line itself ([releaseUploadClaim]), and one that lands retires
+     * it through [clearUploadInFlight].
+     */
+    private fun consumeStaleUploadsUnder(directory: File) {
         synchronized(uploadJournalLock) {
             try {
                 val journal = uploadJournal()
                 if (!journal.isFile) return
-                val old = from.absolutePath + File.separator
-                val new = to.absolutePath + File.separator
+                val prefix = directory.absolutePath + File.separator
                 val all = journal.readLines()
-                val moved = all.map { if (it.startsWith(old)) new + it.removePrefix(old) else it }
-                if (moved != all) rewriteJournal(moved)
+                val kept = all.filter { line ->
+                    !line.startsWith(prefix) || File(line).exists() ||
+                        uploadClaims.any { it.path == line }
+                }
+                if (kept.size != all.size) rewriteJournal(kept)
             } catch (e: Exception) {
-                Logger.w(tag, "Could not move the upload records of ${from.name}: ${e.message}")
+                Logger.w(
+                    tag,
+                    "Could not retire the upload records under ${directory.name}: ${e.message}"
+                )
             }
         }
+    }
+
+    /**
+     * Drops every vanished directory [predicate] answers for, and retires the upload
+     * records the files beneath them left behind.
+     *
+     * One function for all three removals of an *unclaimed* departure, so that the
+     * retirement cannot be forgotten at one of them. The fourth removal is deliberately
+     * not here: [claimVanishedDirectory] takes an entry precisely because a rename is
+     * about to move its records to the new path, which [renameUploadsUnder] does.
+     *
+     * The journal is touched outside [vanishedLock], because it has a lock of its own
+     * and this is the only path that would otherwise hold both.
+     */
+    private fun dropVanished(predicate: (VanishedDirectory) -> Boolean) {
+        val gone = synchronized(vanishedLock) {
+            val taken = vanishedDirectories.filter(predicate)
+            vanishedDirectories.removeAll(predicate)
+            taken
+        }
+        gone.forEach { consumeStaleUploadsUnder(File(it.localPath)) }
     }
 
     /**
@@ -1527,11 +1686,11 @@ class SafSyncEngine(private val context: Context) {
                 val mimeType = if (localFile.isDirectory) {
                     DocumentsContract.Document.MIME_TYPE_DIR
                 } else {
-                    guessMimeType(localFile.name)
+                    CREATED_FILE_MIME_TYPE
                 }
                 DocumentsContract.createDocument(
                     context.contentResolver, parentSafUri, mimeType, localFile.name
-                )
+                )?.also { warnIfNameNotHonoured(it, localFile.name) }
             } ?: return null
 
             if (localFile.isFile) {
@@ -1570,8 +1729,60 @@ class SafSyncEngine(private val context: Context) {
             }
             docUri
         } catch (e: Exception) {
-            Logger.w(tag, "Failed to create ${localFile.name} in SAF: ${e.message}")
+            // The class rather than the message, for the reason [copyDocumentToLocal]
+            // spells out: a provider quotes the document URI in its own exception, and
+            // the platform provider builds that URI out of the user's own directory path.
+            Logger.w(tag, "Failed to create ${localFile.name} in SAF: ${e.javaClass.simpleName}")
             null
+        }
+    }
+
+    /**
+     * Says so when the provider stored a document under a name other than the one it was
+     * asked for.
+     *
+     * The name is the only thing tying a mirror file to its device document: every lookup
+     * here is [findChildDocId] by display name, and the cache below is keyed by the
+     * mirror's own path. A provider that renames on create therefore leaves the device
+     * holding the bytes under a name the next [initialSync] reads as a second file, so the
+     * editor shows both and the next edit of the original creates a third.
+     *
+     * Said and not repaired, and both halves are deliberate. What made this happen was the
+     * type this app asked for, which [CREATED_FILE_MIME_TYPE] settles for every extension.
+     * What is left is a provider normalising the name itself, as the platform one does for
+     * characters FAT cannot hold, and a rename back would be handed to the same
+     * normaliser; deleting the document it did make would take the user's bytes off the
+     * device to tidy up a name, which is the wrong way round. So the bytes stay where the
+     * provider put them and this is the line that explains the duplicate in a bug report.
+     *
+     * A provider that will not answer for the document it just made proves nothing either
+     * way, and this stays quiet: the create itself succeeded.
+     */
+    private fun warnIfNameNotHonoured(docUri: Uri, requestedName: String) {
+        val stored = try {
+            context.contentResolver.query(
+                docUri,
+                arrayOf(DocumentsContract.Document.COLUMN_DISPLAY_NAME),
+                null, null, null,
+            )?.use { cursor ->
+                val nameIndex = cursor.getColumnIndex(
+                    DocumentsContract.Document.COLUMN_DISPLAY_NAME
+                )
+                if (nameIndex >= 0 && cursor.moveToFirst()) cursor.getString(nameIndex) else null
+            }
+        } catch (e: Exception) {
+            Logger.d(
+                tag,
+                "Could not read back the name of $requestedName: ${e.javaClass.simpleName}",
+            )
+            null
+        }
+        if (stored != null && stored != requestedName) {
+            Logger.w(
+                tag,
+                "The device folder stored $requestedName as $stored; the editor will show " +
+                    "both the next time the folder is opened",
+            )
         }
     }
 
@@ -1679,7 +1890,7 @@ class SafSyncEngine(private val context: Context) {
     private fun renameInSaf(safDocUri: Uri, newName: String): Boolean = try {
         DocumentsContract.renameDocument(context.contentResolver, safDocUri, newName) != null
     } catch (e: Exception) {
-        Logger.w(tag, "Could not rename a document to $newName: ${e.message}")
+        Logger.w(tag, "Could not rename a document to $newName: ${e.javaClass.simpleName}")
         false
     }
 
@@ -1705,7 +1916,7 @@ class SafSyncEngine(private val context: Context) {
             context.contentResolver, safDocUri, sourceParentUri, targetParentUri
         )
     } catch (e: Exception) {
-        Logger.w(tag, "Could not move a document between directories: ${e.message}")
+        Logger.w(tag, "Could not move a document between directories: ${e.javaClass.simpleName}")
         null
     }
 
@@ -1716,7 +1927,7 @@ class SafSyncEngine(private val context: Context) {
         try {
             DocumentsContract.deleteDocument(context.contentResolver, safDocUri)
         } catch (e: Exception) {
-            Logger.w(tag, "Failed to delete from SAF: ${e.message}")
+            Logger.w(tag, "Failed to delete from SAF: ${e.javaClass.simpleName}")
         }
     }
 
@@ -1773,10 +1984,13 @@ class SafSyncEngine(private val context: Context) {
                 // editor was enough to strand a line for ever, and a stranded line is
                 // not inert: `SafStorageManager.mayReclaim` reads any line under a
                 // mirror as "this mirror holds a write that never reached the device",
-                // so the launch pass kept the mirror, the storage screen described it
-                // as holding work the device does not, and the removal the user asked
-                // for was refused, all on the strength of a file that is not there.
-                // The claim count is what keeps this off a path somebody is streaming
+                // so the launch pass kept the mirror and the storage screen described
+                // it as holding work the device does not, all on the strength of a file
+                // that is not there. Not that the removal is refused: the bridge
+                // extension sends `force` for exactly the rows this mislabels, so what
+                // the user gets is a modal saying the copy holds files that exist
+                // nowhere else and then the deletion they asked for.
+                // The claims are what keep this off a path somebody is streaming
                 // into right now; see [consumeStaleUploadRecord].
                 consumeStaleUploadRecord(job.localPath)
             }
@@ -1893,8 +2107,10 @@ class SafSyncEngine(private val context: Context) {
         // starts a worker and it opens with a stop that clears that queue again. A save
         // offered there went nowhere and said nothing. Read at entry, a late offer lands
         // in the queue the closing folder's drain is still emptying, which is what the
-        // grace period exists for; if that drain has already finished, the stop's own
-        // clear says so.
+        // grace period exists for; if that drain has already finished, the offer below
+        // says so, because the stop's own count cannot. That count is read and the queue
+        // cleared in microseconds on an idle folder, while this event is still inside the
+        // provider, so the one job it can see is one that was already queued.
         //
         // A capture rather than a liveness re-check, because the answer has to be the
         // same object for the whole event: two threads polling one queue is what the
@@ -2000,9 +2216,11 @@ class SafSyncEngine(private val context: Context) {
         // in the editor propagates, because an outright delete arrives as DELETE and is
         // still acted on; nothing removes it on the user's behalf.
         if (isDirectory && (event and FileObserver.ALL_EVENTS) == FileObserver.MOVED_FROM) {
+            dropVanished { now - it.atMillis > RENAME_PAIR_WINDOW_MS }
             synchronized(vanishedLock) {
-                vanishedDirectories.removeAll { now - it.atMillis > RENAME_PAIR_WINDOW_MS }
-                vanishedDirectories.add(VanishedDirectory(relativePath, now))
+                vanishedDirectories.add(
+                    VanishedDirectory(relativePath, now, localFile.absolutePath)
+                )
             }
             Logger.i(
                 tag,
@@ -2059,9 +2277,11 @@ class SafSyncEngine(private val context: Context) {
         // unclaimed one falls back to createInSaf, which writes every child out again
         // and brackets each write with the journal itself.
         //
-        // The in-memory writer claims are deliberately not moved with it. Each writer
-        // releases the key it took, in its own finally, so renaming those keys would
-        // strand a claim for ever, which is the defect the count exists to prevent.
+        // This runs on the observer thread while write-backs run on their own, so a save
+        // can be streaming out of the directory that is moving. Its claim travels with
+        // the lines, which is why [UploadClaim] carries a path rather than being found by
+        // one: a writer that released the name it opened with would leave the moved line
+        // standing for a write that landed.
         if (renamedFrom != null) renameUploadsUnder(File(rootDir, renamedFrom), localFile)
         // Resolved after the claim rather than when the directory vanished, so that the
         // provider is only asked on the events that turn out to be renames. Null means
@@ -2097,6 +2317,20 @@ class SafSyncEngine(private val context: Context) {
         // which is what an unclaimed move has always fallen back to, and leaves the old
         // copy standing on the device where the user can see it.
         val pairedRename = renamedFromUri != null && !(crossesDirectories && sourceParentUri == null)
+
+        // Asked before the offer, never after. A session that has stopped being polled
+        // never starts again, so an answer taken here cannot go stale in the two
+        // instructions that follow, while the other order would report a job the drain
+        // had already taken as lost. Still offered: the queue is the honest record of
+        // what was asked for, and the mirror keeps the file either way. What is missing
+        // is the user knowing, and that is what this line is.
+        if (target.abandoned) {
+            Logger.w(
+                tag,
+                "Write-back of $relativePath arrived after the drain ended; the save is " +
+                    "in the mirror only until the folder is opened again",
+            )
+        }
 
         target.queue.offer(
             SyncJob(
@@ -2151,10 +2385,16 @@ class SafSyncEngine(private val context: Context) {
      * inotify event for the whole mirror. Pruning here as well as on the add is what
      * stops it: the verdict is unchanged, since [renameSourceFor] applies the same
      * window, and the walk it saves is the point.
+     *
+     * Pruning through [dropVanished] rather than off the list here, so that a departure
+     * expiring at this reader retires the upload records left under it exactly as one
+     * expiring at any other does. That reads the journal, one small file in `filesDir`,
+     * and only when something did expire, which is a fraction of the binder walk this
+     * check exists to keep off the observer thread.
      */
-    internal fun hasVanishedCandidate(now: Long): Boolean = synchronized(vanishedLock) {
-        vanishedDirectories.removeAll { now - it.atMillis > RENAME_PAIR_WINDOW_MS }
-        vanishedDirectories.isNotEmpty()
+    internal fun hasVanishedCandidate(now: Long): Boolean {
+        dropVanished { now - it.atMillis > RENAME_PAIR_WINDOW_MS }
+        return synchronized(vanishedLock) { vanishedDirectories.isNotEmpty() }
     }
 
     /**
@@ -2213,12 +2453,41 @@ class SafSyncEngine(private val context: Context) {
         return DocumentsContract.buildDocumentUriUsingTree(treeUri, currentDocId)
     }
 
-    private fun guessMimeType(filename: String): String =
-        Companion.guessMimeType(filename)
-
     companion object {
         private const val COPY_BUFFER_SIZE = 8192
         private const val WRITEBACK_POLL_MS = 200L
+
+        /**
+         * The type every file is created on the device with, and the file's NAME is the
+         * reason it is this one.
+         *
+         * `createDocument` takes a name and a type, and the platform provider settles a
+         * disagreement between them by rewriting the name. Measured on an API 33
+         * emulator's own `framework.jar` rather than read from a source tree:
+         * `FileSystemProvider.createDocument` (classes4.dex) calls
+         * `FileUtils.buildValidFatFilename` and then `FileUtils.buildUniqueFile(parent,
+         * mimeType, displayName)`, whose `splitFileName` (classes2.dex, source lines
+         * 1216-1217) keeps the requested extension only while the type is the one the
+         * platform's own table gives that extension, or the extension is the one it gives
+         * that type, and otherwise sets `name = displayName; ext = extFromMimeType`.
+         *
+         * A table of guesses therefore decided what the user's file was called. `.kt`,
+         * `.java` and `.md` were all claimed to be `text/plain`, whose extension is `txt`
+         * (`res/android.mime.types:85`), while those tables give `md` to `text/markdown`,
+         * `java` to `text/x-java` and have no `kt` entry at all, so both tests failed and
+         * `Main.kt` was stored on the device as `Main.kt.txt`. Nothing noticed: the name
+         * was never read back, and every reopen enumerated the mangled name into the
+         * mirror beside the original and made one more.
+         *
+         * This is the one value that cannot do that, whatever the extension. The same
+         * method maps `ContentResolver.MIME_TYPE_DEFAULT` to a null `extFromMimeType`
+         * (0x0033-0x003b in the same disassembly), so a mismatch takes `name =
+         * displayName` with nothing to append, and `buildFile` appends no dot for an empty
+         * extension. It costs nothing where the type is read back either: the same
+         * provider reports `COLUMN_MIME_TYPE` from the file's own extension
+         * (`getDocumentType`, classes4.dex), not from what a create asked for.
+         */
+        internal const val CREATED_FILE_MIME_TYPE = "application/octet-stream"
 
         /** How long [stopWatching] waits for queued writes to reach the device. */
         private const val DRAIN_GRACE_MS = 2000L
@@ -2241,8 +2510,8 @@ class SafSyncEngine(private val context: Context) {
         private val uploadJournalLock = Any()
 
         /**
-         * How many write-backs are streaming into each mirror path right now, across
-         * engine instances and guarded by [uploadJournalLock].
+         * The write-backs streaming into a mirror path right now, one entry per writer,
+         * across engine instances and guarded by [uploadJournalLock].
          *
          * The journal line means "an upload of this path did not finish", and one line
          * cannot carry two writers: [initialSync] writes a newer mirror copy back on the
@@ -2253,11 +2522,17 @@ class SafSyncEngine(private val context: Context) {
          * what makes the two paths identical, because the mirror is named by a hash of
          * the folder rather than by the session.
          *
+         * A claim per writer rather than a count per path, because the two records of one
+         * write have to move together. [renameUploadsUnder] moves the journal line when
+         * the directory above it is renamed mid-stream, and a count keyed by the name the
+         * writer opened with could no longer name the line that writer has to retire.
+         * Each writer releases its own [UploadClaim], whatever its path is called by then.
+         *
          * In memory rather than in the file, because the writers are threads of one
          * process. A process that dies mid-write leaves the line behind, which is exactly
          * what the journal is for.
          */
-        private val uploadWriters = mutableMapOf<String, Int>()
+        private val uploadClaims = mutableListOf<UploadClaim>()
 
         /**
          * Documents a write is streaming into right now, keyed by document URI.
@@ -2270,7 +2545,7 @@ class SafSyncEngine(private val context: Context) {
          * drain on the same document.
          *
          * In this object rather than on the engine, next to [uploadJournalLock] and
-         * [uploadWriters] and for the reason those give: the engine is one per
+         * [uploadClaims] and for the reason those give: the engine is one per
          * [SafStorageManager] and the manager one per activity, while
          * [SafSyncEngine.stopWatching] waits [DRAIN_GRACE_MS] and then deliberately
          * leaves a drain it could not join to finish on its own. The two writers above
@@ -2787,22 +3062,6 @@ class SafSyncEngine(private val context: Context) {
             if (segments.dropLast(1).any { shouldSkip(it, isDir = true) }) return false
             return !shouldSkip(name, isDirectory)
         }
-
-        /** Testable: heuristic MIME type detection from filename extension. */
-        internal fun guessMimeType(filename: String): String {
-            return when {
-                filename.endsWith(".txt") || filename.endsWith(".md") -> "text/plain"
-                filename.endsWith(".html") -> "text/html"
-                filename.endsWith(".js") || filename.endsWith(".ts") -> "text/javascript"
-                filename.endsWith(".json") -> "application/json"
-                filename.endsWith(".py") -> "text/x-python"
-                filename.endsWith(".kt") || filename.endsWith(".java") -> "text/plain"
-                filename.endsWith(".xml") -> "text/xml"
-                filename.endsWith(".css") -> "text/css"
-                filename.endsWith(".sh") -> "text/x-shellscript"
-                else -> "application/octet-stream"
-            }
-        }
     }
 }
 
@@ -2872,8 +3131,31 @@ internal data class UploadPlan(val entries: List<File>, val truncated: Boolean)
  */
 internal data class VanishedDirectory(
     val relativePath: String,
-    val atMillis: Long
+    val atMillis: Long,
+    /**
+     * Where it was in the mirror, absolutely, which is the only spelling the upload
+     * journal answers to: its lines are absolute paths because one engine serves every
+     * folder in turn, while [relativePath] is what the device side needs. Carried on the
+     * record rather than rebuilt from a mirror root, because the readers that retire
+     * those lines ([SafSyncEngine.dropVanished]'s callers) run where no root is in hand.
+     */
+    val localPath: String
 )
+
+/**
+ * One write-back's claim on the mirror path it is streaming into, held from the moment
+ * its journal line is written until that write ends.
+ *
+ * [path] is a var because the directory above it can be renamed in the editor while the
+ * stream runs, and the claim and the line are two records of one write:
+ * [SafSyncEngine.renameUploadsUnder] moves both together, so the writer's release names
+ * the line as it is spelled then rather than as it was spelled when the stream opened.
+ * Identity is what a writer releases, so this is deliberately not a data class: two
+ * writers of one path hold two claims and each must retire only its own.
+ *
+ * Read and written only under the journal lock, which is what makes a plain var safe here.
+ */
+private class UploadClaim(var path: String)
 
 /**
  * One folder's write-back: the jobs its observers produced, and the thread sending them.
@@ -2889,6 +3171,20 @@ internal class WatchSession {
 
     /** Cleared by [SafSyncEngine.stopWatching]; the loop's own termination condition. */
     @Volatile var running = true
+
+    /**
+     * Whether [queue] has stopped being polled, which no session ever comes back from:
+     * a worker is started once, by the [SafSyncEngine.startWatching] that installed the
+     * session, and never again.
+     *
+     * What it buys is a sentence in a bug report. An event observed while the folder was
+     * open can finish its provider round trips after the drain has taken its last look,
+     * and the save it carries then reaches no device and nothing retries it. The stop's
+     * own count cannot see that one: on an ordinary folder switch the idle drain exits in
+     * microseconds, so the queue is counted and cleared while the event is still inside
+     * the provider, and the offer that follows is what has to say so.
+     */
+    @Volatile var abandoned = false
 
     /** The thread draining [queue], or null before one is started and once it is joined. */
     @Volatile var worker: Thread? = null

--- a/android/app/src/main/kotlin/com/vscodroid/util/CrashReporter.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/util/CrashReporter.kt
@@ -41,19 +41,24 @@ object CrashReporter {
     /**
      * Returns the most recent crash log, or null if no crashes have been recorded.
      *
-     * The text goes through [redactToken] on the way out. This is the boundary
-     * the log crosses: it reaches the dialog `MainActivity.checkPreviousCrash`
-     * puts on screen and the `AndroidBridge.getLastCrash` method the page can
-     * call, and redacting here covers both without either caller having to
-     * remember. `MainActivity` cuts its preview at 500 characters after this
-     * returns, so the substitution shifts where that cut lands.
+     * The text goes through [redactToken] and [redactSecrets] on the way out.
+     * This is the boundary the log crosses: it reaches the dialog
+     * `MainActivity.checkPreviousCrash` puts on screen and the
+     * `AndroidBridge.getLastCrash` method the page can call, and redacting here
+     * covers both without either caller having to remember. Both scrubbers and
+     * not only the token, for the reason [generateBugReport] gives: what a text
+     * has to be scrubbed for follows from the boundary it crosses, and this one
+     * ends up in the same places the report does. `MainActivity` cuts its preview
+     * at 500 characters after this returns, so the substitution shifts where that
+     * cut lands.
      */
     fun getLastCrash(): String? {
         if (!::crashDir.isInitialized) return null
         return crashDir.listFiles()
             ?.sortedByDescending { it.lastModified() }
             ?.firstOrNull()
-            ?.let { redactToken(it.readText()) }
+            ?.let { readOrNull(it) }
+            ?.let { redactSecrets(redactToken(it)) }
     }
 
     /**
@@ -84,14 +89,25 @@ object CrashReporter {
      * function's does, at the literal `tkn=` parameter, so a bare token in no
      * parameter at all still passes through.
      *
-     * The server section carries a second class of secret, and [redactSecrets]
-     * is what answers it. That section is not this app's own output: the editor
+     * [redactSecrets] answers a second class of secret, and it runs over both
+     * sections rather than only over the server one. The server section is where
+     * a leak is demonstrable: it is not this app's own output, because the editor
      * server echoes the extension host's stdout and stderr into its console, so
      * an extension that dumps a failing request writes whatever authenticated it
-     * onto the stream this section quotes. [ServerLog] takes the same two
-     * functions on the way in, so a file written by this build holds neither
-     * shape; both run again here, because this is the boundary the text crosses
-     * and a file written by an older build is still on the device.
+     * onto the stream that section quotes. A crash log holds the stack trace of
+     * an uncaught throwable in this process and nothing is known to put a
+     * credential of that shape into one. It is scrubbed all the same, because
+     * what a text needs taking out of it follows from where it is going, not from
+     * who wrote it, and both sections leave here on the same clipboard. Splitting
+     * that rule per section is how one half of a boundary ends up unguarded. A
+     * crash log is a whole file rather than the single line the server section is
+     * read in, and [redactSecrets] takes it a line at a time for that reason: its
+     * patterns are written against one line and would otherwise swallow the stack
+     * trace under a match.
+     * [ServerLog] takes the same two functions on the way in, so a file written
+     * by this build holds neither shape; both run again here, because this is the
+     * boundary the text crosses and a file written by an older build is still on
+     * the device.
      */
     fun generateBugReport(context: Context): String {
         val sb = StringBuilder()
@@ -126,8 +142,15 @@ object CrashReporter {
             if (logs.isNotEmpty()) {
                 sb.appendLine("--- Crash Logs (${logs.size}) ---")
                 for (log in logs.take(3)) {
+                    val text = readOrNull(log)
                     sb.appendLine()
-                    sb.appendLine(redactToken(log.readText()))
+                    // Named rather than dropped: the count above already promised
+                    // this log, so leaving a silent hole in the report says the
+                    // crash never happened.
+                    sb.appendLine(
+                        text?.let { redactSecrets(redactToken(it)) }
+                            ?: "(${log.name} could not be read)"
+                    )
                     sb.appendLine("---")
                 }
             } else {
@@ -179,9 +202,6 @@ object CrashReporter {
             if (!::crashDir.isInitialized) return
             crashDir.mkdirs()
 
-            val timestamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
-            val file = File(crashDir, "crash_$timestamp.txt")
-
             val sw = StringWriter()
             sw.appendLine("Crash at ${SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z", Locale.US).format(Date())}")
             sw.appendLine(threadIdentity(thread))
@@ -189,12 +209,59 @@ object CrashReporter {
             sw.appendLine()
             throwable.printStackTrace(PrintWriter(sw))
 
+            // The name is only as fine-grained as a second, and this handler is
+            // the process-wide default, entered by whichever thread faulted. It
+            // also runs before the chain to the handler that kills the process,
+            // so nothing about the process dying serializes two threads that
+            // fault together: the second one arrives on the same name and
+            // writeText truncates, which used to lose the first crash, the one
+            // that started the cascade.
+            // createNewFile is the atomic half of "take this name if nobody has
+            // it": the loser of a race gets false rather than a shared file.
+            // Giving up after a handful of names costs nothing, since [MAX_LOGS]
+            // is all pruneOldLogs would keep anyway. Chosen after the trace is
+            // rendered, so a render that fails leaves no empty file behind, which
+            // would read as a crash that had nothing to say.
+            val timestamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
+            var file = File(crashDir, "crash_$timestamp.txt")
+            var taken = 1
+            while (taken < MAX_LOGS && !file.createNewFile()) {
+                file = File(crashDir, "crash_${timestamp}_$taken.txt")
+                taken++
+            }
+
             file.writeText(sw.toString())
             Logger.e(TAG, "Crash log written: ${file.name}")
         } catch (_: Throwable) {
             // Last-resort: can't even write the crash log (including OOM)
         }
     }
+
+    /**
+     * The text of [log], or null if it cannot be read.
+     *
+     * Both readers list the directory and then read what the listing gave them,
+     * and the two steps are not one operation. The directory is under `cacheDir`,
+     * which the OS may evict under storage pressure at any moment, and two of the
+     * app's own entry points empty it from other threads with no lock shared with
+     * these readers: `AndroidBridge.clearCrashLogs`, and `clearCaches`, whose
+     * disk thread deletes this directory outright. An entry that has gone by the
+     * time it is read raises FileNotFoundException.
+     *
+     * That mattered because of who calls. `MainActivity.checkPreviousCrash` reads
+     * a crash log on the main thread during `onCreate` and again from the dialog
+     * button, and nothing on that path catches anything, so the throw reached the
+     * looper and killed the process: a crash raised by the crash reporter, which
+     * also loses the report the user was trying to send. Every other disk touch
+     * in this object was already guarded, [writeCrashLog] and [pruneOldLogs]
+     * both, and these two were the exception.
+     */
+    private fun readOrNull(log: File): String? =
+        try {
+            log.readText()
+        } catch (_: Exception) {
+            null
+        }
 
     private fun pruneOldLogs() {
         try {

--- a/android/app/src/main/kotlin/com/vscodroid/util/ServerLog.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/util/ServerLog.kt
@@ -178,7 +178,7 @@ internal class ServerLog(private val file: File) {
 }
 
 /**
- * [line] with the credential shapes that are not the connection token taken out.
+ * [text] with the credential shapes that are not the connection token taken out.
  *
  * `redactToken` covers exactly one secret, the server's own connection token, and
  * says so. That was the whole exposure while this file held only the bootstrap's
@@ -194,15 +194,38 @@ internal class ServerLog(private val file: File) {
  * still see which header or which key was involved, which is most of what the
  * line was worth diagnostically.
  *
+ * One line at a time, whatever the caller hands over. Every pattern below is
+ * written against a single line and several of them cross a newline when they
+ * are given one: the header rule's value class excludes quotes, commas and
+ * braces but not newlines, and the `\s+` in the scheme rule and the `\s*` in the
+ * header and named-key rules match a newline like any other space, so either can
+ * reach past the end of a line and take the first word of the next one. That was
+ * invisible while every caller held one line, and [CrashReporter] hands whole
+ * crash files here, where
+ * one `authorization:` in a throwable's message takes the stack trace under it
+ * as far as the next quote, comma or brace, none of which a Java stack trace
+ * contains. A report whose crash section is one truncated line is worse than one
+ * carrying the credential, because it still reads as a complete crash log under
+ * a header that counts it. Settled here rather than inside each pattern, so the
+ * next pattern added cannot forget it.
+ *
  * The containment is worth stating as plainly as `redactToken`'s is. This catches
  * a credential that travels next to a name that suggests it, or that carries a
  * vendor prefix. A secret printed bare, with no name and no prefix, is
- * indistinguishable from any other word and passes through. Widening it further
- * would start eating the diagnostics the file exists for; narrowing what is
- * mirrored in the first place is the other direction, and it would throw away the
- * extension-host output that is often the only account of what went wrong.
+ * indistinguishable from any other word and passes through. So is a name with a
+ * letter welded onto the front of the keyword, because the absence of a boundary
+ * there is the same thing that keeps `mytoken=` out; `PGPASSWORD` is the one name
+ * of that shape common enough to be listed by hand, and another vendor's spelling
+ * of it would need listing too. Widening it further would start eating the
+ * diagnostics the file exists for; narrowing what is mirrored in the first place
+ * is the other direction, and it would throw away the extension-host output that
+ * is often the only account of what went wrong.
  */
-internal fun redactSecrets(line: String): String {
+internal fun redactSecrets(text: String): String =
+    if ('\n' !in text) redactOneLine(text)
+    else text.split('\n').joinToString("\n") { redactOneLine(it) }
+
+private fun redactOneLine(line: String): String {
     var out = line
     for ((pattern, replacement) in SECRET_PATTERNS) {
         out = out.replace(pattern, replacement)
@@ -213,23 +236,73 @@ internal fun redactSecrets(line: String): String {
 /**
  * The patterns [redactSecrets] applies, each with what it leaves behind.
  *
- * Order matters in one place: the header rule runs before the bare-scheme rule so
- * that `Authorization: Bearer x` is consumed whole. Reversed, the scheme rule
- * would take `Bearer x` and leave the header rule matching nothing, which is
- * harmless here but stops being harmless for any scheme that is not recognised.
+ * Order matters in one place: the header rule runs before the bare-scheme rule.
+ * Not because `Authorization: Bearer x` needs consuming whole, which either order
+ * does: the scheme rule leaves `Authorization: Bearer <redacted>`, and the header
+ * value class still matches `Bearer <redacted>` and still collapses it. The reason
+ * is that the scheme rule's token class accepts letters, so it can eat the word
+ * the header rule anchors on where the two abut. Run first, it turns
+ * `Bearer authorization:Bearer` into `Bearer <redacted>:Bearer` and leaves the
+ * trailing credential standing; run second, that line ends `<redacted>:<redacted>`.
  *
  * The header value runs to the end of the line or to the next quote, comma or
  * brace, rather than to the next space: an authorization value has a space in it
  * by construction (`Bearer `, `Basic `), and stopping at the space leaves the
- * secret itself in the file.
+ * secret itself in the file. The end of the line is where it stops because
+ * [redactSecrets] never hands a pattern more than one line, not because this
+ * class excludes a newline. It does not.
+ *
+ * The named-key rule reads its keyword as one segment of a name, not as a whole
+ * word. `\b` is defined over `[A-Za-z0-9_]`, so an underscore is a word character
+ * and no boundary exists inside `DB_PASSWORD` or `AWS_SECRET_ACCESS_KEY`: anchored
+ * that way the rule fired on `password=` and on almost nothing an environment
+ * variable is ever called, which is the shape a Node server prints and the shape
+ * an extension leaks. The lookbehind is over letters and digits only, so a `_` or
+ * `-` before the keyword is a boundary while a letter is not, and `mytoken=` or
+ * `InvalidTokenError:` is still left alone. `pgpassword` is spelled out for that
+ * same reason: libpq's variable welds its prefix on with no separator, so the
+ * lookbehind refuses it exactly as it refuses `mytoken`, and it is the one name
+ * of that shape common enough on this stream to be worth naming.
+ *
+ * The rest of the name is one optional class, `(?:[_-][A-Za-z0-9_-]*)?`, and not
+ * a repeated group. java.util.regex compiles a quantified group into a `Loop`
+ * that recurses once per repetition, so `(?:[_-][A-Za-z0-9]+)*` raises
+ * StackOverflowError on a long enough run of segments: measured here at 2000 of
+ * them on a 1 MiB stack. That is an `Error`, so it passes through the
+ * `IOException` catch in [ServerLog.append] and the `Exception` catch in
+ * `ProcessManager.startOutputReader`, reaching the default handler, which kills
+ * the process the editor runs in. A character class repeats iteratively and has
+ * no such limit to find: 500000 segments on the same stack return normally.
+ * Nothing guards the right-hand end of the name, because nothing has to: whatever
+ * follows it has to be the `[:=]` this rule is built around, and no separator is
+ * a letter, so a keyword with letters welded onto its right (`Tokenizer: 12
+ * tokens`) cannot reach one.
+ *
+ * A quoted value is taken whole, closing quote included, and is tried before the
+ * unquoted alternative. Unquoted, the value has to stop at the first space or it
+ * would eat the rest of the line, and that leaves a passphrase written down from
+ * its second word on, beside a `<redacted>` telling the reader it was handled. A
+ * closing quote says where the value ends without guessing, so
+ * `DB_PASSWORD="correct horse battery staple"` goes as far as that quote. An
+ * unterminated quote matches no alternative of that kind and falls through to the
+ * unquoted one, which is what it did before.
+ *
+ * The cost of accepting the name's remaining segments is that an ordinary
+ * segmented word in front of a `:` or an `=` loses what follows it, on both
+ * separators and after a flag: `secret-storage: initialised`,
+ * `password_hash_algorithm: bcrypt` and `--secret-file=/etc/k.pem` each lose the
+ * word after the separator. The value class excludes whitespace but not `:`, so
+ * what goes is the whole space-delimited run and any punctuation inside it, which
+ * is one word rather than one line, but is more than the name alone suggests.
  */
 private val SECRET_PATTERNS: List<Pair<Regex, String>> = listOf(
     Regex("""(?i)(\bauthorization\b\s*["']?\s*[:=]\s*)["']?[^"',}]+""") to "\$1<redacted>",
     Regex("""(?i)(\b(?:bearer|basic)\s+)[A-Za-z0-9._~+/=-]{8,}""") to "\$1<redacted>",
     Regex(
-        """(?i)(\b(?:api[_-]?key|apikey|access[_-]?token|refresh[_-]?token|auth[_-]?token""" +
-            """|client[_-]?secret|password|passwd|secret|token)\b\s*["']?\s*[:=]\s*)""" +
-            """["']?[^\s"',}&]+"""
+        """(?i)((?<![A-Za-z0-9])(?:api[_-]?key|apikey|access[_-]?token|refresh[_-]?token""" +
+            """|auth[_-]?token|client[_-]?secret|pgpassword|password|passwd|secret|token)""" +
+            """(?:[_-][A-Za-z0-9_-]*)?\s*["']?\s*[:=]\s*)""" +
+            """(?:"[^"]*"|'[^']*'|["']?[^\s"',}&]+)"""
     ) to "\$1<redacted>",
     // Vendor-prefixed keys, which are the ones that travel with no name beside
     // them at all: an npm or GitHub token pasted into a URL, or a key echoed by a

--- a/android/app/src/main/kotlin/com/vscodroid/util/StorageManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/util/StorageManager.kt
@@ -39,7 +39,9 @@ object StorageManager {
             put("logs", dirSize(File(filesDir, "home/.vscodroid/data/logs")))
             put("tools", dirSize(File(filesDir, "usr")))
             put("saf_mirrors", dirSize(File(filesDir, "saf-mirrors")))
-            put("cache", dirSize(cacheDir))
+            put("cache", CLEARABLE_CACHE_DIRS.sumOf { dirSize(File(cacheDir, it)) })
+            // The whole cache directory, unlike the row above it: this is the disk
+            // the app occupies rather than a figure anyone is offered a button for.
             put("total", dirSize(filesDir) + dirSize(cacheDir))
             // Which of the keys above the clear action can reach. Sent rather
             // than duplicated on the JavaScript side: the two live in different
@@ -62,9 +64,39 @@ object StorageManager {
     internal val CLEARABLE_KEYS = setOf("logs", "cache")
 
     /**
+     * The subtrees of `cacheDir` this app writes, which is what the `cache` row
+     * measures and what [clearCaches] empties.
+     *
+     * The row used to be the whole cache directory, and that directory is not this
+     * app's alone. The platform WebView keeps its own store in it, under the name
+     * `WebView.setDataDirectorySuffix("vscodroid")` gives it, and Chromium holds
+     * that store open in a live renderer, so it is neither ours to delete nor
+     * something the clear action has ever touched. Measured on a debug install
+     * after one short editor session: 9428 KiB in the cache directory, of which
+     * 9356 KiB was `webview_vscodroid` and 40 KiB was reachable by the action.
+     * [CLEARABLE_KEYS] offers this row to that action, so a user out of disk tapped
+     * Clear, was told a small number had been freed, and watched the figure they
+     * had picked stay where it was: the same "the report is not about the row you
+     * picked" failure that set survives inside the one row still offered.
+     *
+     * Those bytes are not hidden: `total` still counts the whole directory, because
+     * that question is how much disk the app occupies rather than what a button can
+     * give back.
+     */
+    internal val CLEARABLE_CACHE_DIRS =
+        listOf("npm-cache", "tmp", "crash-logs", "toolchain-download")
+
+    /**
      * Clears caches: npm-cache, tmp dir, crash logs, VS Code logs, and the
      * toolchain staging directories no download is using.
      * Returns the number of bytes freed.
+     *
+     * The cache directories below are spelled out rather than looped over
+     * [CLEARABLE_CACHE_DIRS], because each is emptied differently: `tmp` is
+     * recreated because the runtime needs it, and the toolchain staging tree keeps
+     * whatever a running download owns. They are still the same four, and
+     * `ClearableStorageTest` fails if the row starts counting one this does not
+     * reach.
      */
     fun clearCaches(context: Context): Long {
         var freed = 0L

--- a/android/app/src/main/kotlin/com/vscodroid/webview/DownloadCoordinator.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/webview/DownloadCoordinator.kt
@@ -1,10 +1,15 @@
 package com.vscodroid.webview
 
 import android.net.Uri
+import android.os.Handler
+import android.os.Looper
 import com.vscodroid.util.Logger
-import java.io.IOException
 import java.io.OutputStream
 import java.util.Base64
+import java.util.concurrent.Executor
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
 
 /** How a download ended, which is the one thing the user has to be told. */
 enum class DownloadOutcome { SAVED, CANCELLED, FAILED }
@@ -33,10 +38,53 @@ private const val MAX_NAMES = 8
 internal const val MAX_QUEUED = 8
 
 /**
+ * How long the provider thread outlives the last call made on it.
+ *
+ * Long enough that a burst of downloads, or a picker the user takes a while to
+ * answer, is served by one thread rather than a new one each time; short enough
+ * that a screen the user has left behind is not still holding one.
+ */
+internal const val PROVIDER_IDLE_MS = 30_000L
+
+/**
+ * The thread provider calls nobody is waiting for are made on, and the way it
+ * ends.
+ *
+ * It ends by running out of work, which is the only ending this class can be
+ * given. Being told to stop is the obvious alternative and it is wrong here:
+ * every teardown path defers to a thread already inside the provider
+ * ([DownloadCoordinator.closeAndDiscard]), and that thread comes back through
+ * the same hand-off on its way out, after `onDestroy` has returned. An executor
+ * shut down by `onDestroy` answers that late hand-off with
+ * `RejectedExecutionException`, thrown on the bridge or main thread, and the
+ * user's part-written document is left in their folder, which is the one thing
+ * the hand-off exists to remove. So the core thread is allowed to time out
+ * instead: no submission is ever refused, and nothing is parked once the
+ * downloads stop.
+ *
+ * That timeout is also standing in for something `Executors` used to do here.
+ * `newSingleThreadExecutor` returns a wrapper that shuts its pool down when it
+ * becomes unreachable (a finalizer up to API 35, a `Cleaner` from 36), which is
+ * what kept an abandoned coordinator's thread from lasting for ever, at the cost
+ * of waiting for a collection that may not come. A raw [ThreadPoolExecutor] has
+ * no such wrapper, and needs none: once the queue is empty for [idleMs] the pool
+ * holds no thread at all, so there is nothing left to reclaim.
+ *
+ * One thread and a FIFO queue, so the ordering the callers rely on survives the
+ * thread itself: a close still precedes the discard queued behind it, and a task
+ * handed over after the thread has gone starts a new one and still runs behind
+ * whatever is already waiting.
+ */
+internal fun providerWorkExecutor(idleMs: Long = PROVIDER_IDLE_MS): Executor =
+    ThreadPoolExecutor(1, 1, idleMs, TimeUnit.MILLISECONDS, LinkedBlockingQueue()) { r ->
+        Thread(r, "download-provider").apply { isDaemon = true }
+    }.apply { allowCoreThreadTimeOut(true) }
+
+/**
  * Everything [DownloadCoordinator] needs from the Activity it runs inside.
  *
  * An interface rather than the pile of lambdas the chrome client uses, because
- * these five are one collaborator seen from five sides and a test wants to
+ * these six are one collaborator seen from six sides and a test wants to
  * watch them together: the ordering between opening a document, writing to it
  * and discarding it is most of what can go wrong here.
  */
@@ -61,6 +109,24 @@ interface DownloadHost {
 
     /** Asks the page to read [url] and push its bytes back under [requestId]. */
     fun requestBytes(requestId: String, url: String)
+
+    /**
+     * Tells the page it may let go of the bytes it is holding for [url].
+     *
+     * The page pins a download's blob from the click that started it, because
+     * the user has a picker to answer before anyone asks for the bytes, and the
+     * hold is sized for a whole queue of pickers. A download that reaches its
+     * end without ever being read leaves that hold to expire on its own, so the
+     * file stays resident in the page for minutes after the user was told it
+     * was not saved, and a multi-select of files the queue refused holds all of
+     * them at once. Reading the bytes releases the hold by itself, so this is
+     * only ever the downloads that were never read.
+     *
+     * Not called from [DownloadCoordinator.onPageGone]: the document that took
+     * the hold is the one that has gone, so there is nobody left to tell and
+     * nothing left holding anything.
+     */
+    fun releaseBytes(url: String)
 
     /** Tells the user how a download ended. [detail] is for the log, not the screen. */
     fun report(outcome: DownloadOutcome, fileName: String, detail: String?)
@@ -100,7 +166,55 @@ interface DownloadHost {
  * [onComplete] arrive on the WebView's bridge thread, so the state is guarded
  * outright rather than by a convention that has no way to hold.
  */
-class DownloadCoordinator(private val host: DownloadHost) {
+class DownloadCoordinator(
+    private val host: DownloadHost,
+    /**
+     * The one thread the provider is spoken to from when nobody is waiting for
+     * the answer.
+     *
+     * Closing a `content://` stream commits its bytes and deleting the document
+     * behind it is a second trip into the same provider, and neither has a
+     * timeout: a cloud or MTP provider takes as long as it takes. Every teardown
+     * arrives on the UI thread ([onPageGone] from `onDestroy`, from
+     * `onPageFinished` and from `recreateWebView`) and the picker's answer does
+     * too, so those two calls cannot be made where they are decided, and the
+     * monitor cannot be held across them either or the next UI-thread caller
+     * queues behind the provider as well.
+     *
+     * Single, so the close of a document still precedes the delete of it.
+     * Daemon, so it never holds the process up, and one per coordinator, which
+     * is one per Activity. What an Activity leaves behind is therefore a thread
+     * with no work and no queue, and [providerWorkExecutor] is where that thread
+     * ends: it is not parked for the life of the process, nor until the
+     * coordinator is collected, but until the work stops for [PROVIDER_IDLE_MS].
+     * Nothing here shuts it down, and that function says why not.
+     *
+     * A constructor argument rather than a private field so that a test can
+     * drive it: with the work handed to a thread this class owned privately,
+     * "the caller did not wait" and "the work never happened" look the same
+     * from outside.
+     */
+    private val providerWork: Executor = providerWorkExecutor(),
+    /**
+     * Where the answer to an off-thread open is brought back to.
+     *
+     * The picker's answer arrives on the main thread and everything it decides
+     * used to be decided there, the open included. Only one of the host calls
+     * that decision makes still needs that thread: [DownloadHost.requestBytes]
+     * reaches the page through `WebView.evaluateJavascript`, which refuses every
+     * thread but the one the WebView was made on, while `askDestination`,
+     * `releaseBytes` and `report` hop for themselves. So the open goes to
+     * [providerWork] and the decision comes back here, rather than following the
+     * open onto a thread the page cannot be spoken to from.
+     *
+     * A constructor argument for the reason [providerWork] is: run inline, "the
+     * caller did not wait" and "the work never happened" look the same from
+     * outside. The default builds its handler when it is first used rather than
+     * when this class is, so constructing a coordinator still costs nothing and
+     * needs no looper.
+     */
+    private val mainThread: Executor = Executor { work -> Handler(Looper.getMainLooper()).post(work) },
+) {
 
     private val tag = "DownloadCoordinator"
 
@@ -169,18 +283,24 @@ class DownloadCoordinator(private val host: DownloadHost) {
         var destination: Uri? = null,
         var stream: OutputStream? = null,
         /**
-         * Whether a thread is inside `write` or `close` on [stream] right now,
-         * outside the monitor.
+         * Whether a thread is inside the open, a `write` or the `close` of this
+         * download's document right now, outside the monitor.
          *
          * The claim, and the whole of the exclusion. The stream comes from
-         * `contentResolver.openOutputStream`, and a stream to a cloud or MTP
-         * provider has no timeout, so the call cannot be made while holding the
-         * monitor: every teardown here arrives on the UI thread (`onDestroy`,
-         * `onPageFinished`, `recreateWebView`) and would queue behind a provider
-         * free to take as long as it likes. What the monitor still guarantees is
-         * that this is set before the call and cleared after it, so no second
-         * writer starts and no teardown closes the stream underneath one: the
-         * download is claimed, not unguarded.
+         * `contentResolver.openOutputStream`, and neither that call nor a stream
+         * to a cloud or MTP provider has any timeout, so none of the three can be
+         * made while holding the monitor: every teardown here arrives on the UI
+         * thread (`onDestroy`, `onPageFinished`, `recreateWebView`) and would
+         * queue behind a provider free to take as long as it likes. What the
+         * monitor still guarantees is that this is set before the call and
+         * cleared after it, so no second writer starts and no teardown closes or
+         * deletes the document underneath one: the download is claimed, not
+         * unguarded.
+         *
+         * The open is claimed for the same reason the write is, and for one of
+         * its own: a teardown that finds the download unclaimed deletes the
+         * document, and a delete that overtakes the open it raced leaves the
+         * provider holding a document created after it.
          */
         var busy: Boolean = false,
     )
@@ -231,6 +351,7 @@ class DownloadCoordinator(private val host: DownloadHost) {
                         "${waiting.size} downloads already waiting"
                 )
                 host.report(DownloadOutcome.FAILED, fileName, "too many downloads at once")
+                host.releaseBytes(request.url)
                 return
             }
             waiting.addLast(request)
@@ -298,13 +419,14 @@ class DownloadCoordinator(private val host: DownloadHost) {
         val request = pending?.takeIf { it.id == requestId }
         if (request == null) {
             Logger.w(tag, "Destination for $requestId belongs to no download in flight")
-            destination?.let { host.discardDestination(it) }
+            destination?.let { offThread("discard") { host.discardDestination(it) } }
             startNextIfIdle()
             return
         }
         if (destination == null) {
             pending = null
             host.report(DownloadOutcome.CANCELLED, request.fileName, null)
+            host.releaseBytes(request.url)
             startNextIfIdle()
             return
         }
@@ -313,17 +435,65 @@ class DownloadCoordinator(private val host: DownloadHost) {
         // the time it answers, so an unopenable one is an empty file sitting in
         // the user's chosen folder wearing the name of the file they wanted.
         request.destination = destination
-        val stream = try {
-            host.openDestination(destination)
-        } catch (e: IOException) {
-            Logger.w(tag, "Could not open the chosen document", e)
-            null
+        // Claimed here rather than on the provider thread, so that no teardown
+        // can slip between deciding to open the document and the claim that
+        // makes it wait. See [Pending.busy].
+        request.busy = true
+        // Handed over rather than made here. This is the first trip into the
+        // provider and the last one that was still made from the UI thread under
+        // the monitor: `openOutputStream` cold-starts the provider's process and
+        // can go to a network, with no timeout on either, and this runs in the
+        // activity-result callback, so a slow provider froze the editor from the
+        // moment the picker closed and past five seconds it was an ANR. The
+        // close and the discard were moved off for exactly this reason; see
+        // [providerWork], which is single, so an open still queues behind the
+        // close of the document before it.
+        providerWork.execute {
+            val stream = try {
+                host.openDestination(destination)
+            } catch (e: Exception) {
+                // Everything the provider can throw, not only IOException.
+                // Opening the document is a binder call into another app, and
+                // one that was force-stopped, updated or had its grant revoked
+                // between the picker answering and this line answers with
+                // SecurityException or IllegalArgumentException instead. Nothing
+                // above this catches: it would reach the uncaught handler on the
+                // provider thread and take the process with it, and the download
+                // would keep its claim for ever on the way out.
+                Logger.w(tag, "Could not open the chosen document", e)
+                null
+            }
+            mainThread.execute { onDestinationOpened(request, stream) }
+        }
+    }
+
+    /**
+     * The provider answered the open for [request], with null when the document
+     * would not open.
+     *
+     * Back on the thread the picker's answer arrived on, because [mainThread]
+     * says why, and back under the monitor, because the state this settles is
+     * the same state every other answer settles.
+     */
+    @Synchronized
+    private fun onDestinationOpened(request: Pending, stream: OutputStream?) {
+        request.busy = false
+        // Recorded before the test below, so that a download ended while its
+        // document was opening hands [closeAndDiscard] a stream to close rather
+        // than leaving one open on a document nobody will ever read back.
+        request.stream = stream
+        if (pending !== request) {
+            // Ended while the provider was still thinking, by a teardown that
+            // found this claimed and left the document to the thread inside it.
+            // This is that thread's way out; `pending` no longer names the
+            // request, exactly as it does not for a write that outlived one.
+            closeAndDiscard(request)
+            return
         }
         if (stream == null) {
             fail(request, "the chosen document could not be opened")
             return
         }
-        request.stream = stream
         host.requestBytes(request.id, request.url)
     }
 
@@ -349,7 +519,13 @@ class DownloadCoordinator(private val host: DownloadHost) {
         val failure = try {
             chunk.stream.write(chunk.bytes)
             null
-        } catch (e: IOException) {
+        } catch (e: Exception) {
+            // Everything, because the claim taken above has to be given back
+            // whatever the provider throws. A RuntimeException on its way out of
+            // here leaves [Pending.busy] set for good: every teardown then defers
+            // to a writer that is already gone, so the stream is never closed,
+            // the user's document is never removed and the queue behind it never
+            // drains again.
             e
         }
         return synchronized(this) {
@@ -442,7 +618,9 @@ class DownloadCoordinator(private val host: DownloadHost) {
         val failure = try {
             request.stream?.close()
             null
-        } catch (e: IOException) {
+        } catch (e: Exception) {
+            // Everything, for the reason the write above gives: the claim below
+            // is only given back if this returns.
             e
         }
         synchronized(this) {
@@ -516,37 +694,68 @@ class DownloadCoordinator(private val host: DownloadHost) {
         pending = null
         closeAndDiscard(request)
         host.report(DownloadOutcome.FAILED, request.fileName, detail)
+        // Whether or not the page ever got as far as reading this one. A hold
+        // already given up is told again here and answers nothing; a download
+        // that failed before anyone asked for its bytes, which is every failure
+        // up to and including the document not opening, is holding them still.
+        host.releaseBytes(request.url)
         startNextIfIdle()
     }
 
     /**
-     * Closes the stream and removes the document behind it.
+     * Closes the stream and removes the document behind it, off this thread.
      *
-     * The close comes first and its failure is swallowed on purpose: this runs
-     * only on paths that have already decided the download failed, so there is
-     * no verdict left for it to change, and a throw here would skip the discard
-     * and leave behind exactly the half-written file the discard exists to
-     * prevent.
+     * The two calls are separate hand-offs and the close goes first, which is
+     * the whole of the ordering they need. Its failure is swallowed on purpose:
+     * this runs only on paths that have already decided the download failed, so
+     * there is no verdict left for it to change, and letting a throw carry the
+     * discard away with it would leave behind exactly the half-written file the
+     * discard exists to prevent.
+     *
+     * What stays here is the state transition. The stream and the document are
+     * taken off the request under the monitor, so the request is over the moment
+     * this returns and nothing can close or delete either of them twice; the two
+     * calls that reach the provider are what goes to [providerWork], because
+     * this is called from the UI thread on every teardown path and from the
+     * bridge thread under the monitor on the rest.
      */
     private fun closeAndDiscard(request: Pending) {
         if (request.busy) {
             // Left to the thread inside the provider, which is the only one that
-            // can free the stream without closing it under a write in progress.
+            // can free the document without closing it under a write in progress
+            // or deleting it out from under the open that is creating the stream.
             // It re-enters here on its way out, by which time `pending` no longer
             // names this request. Waiting for that thread instead is the stall
             // this whole split exists to avoid: the caller here is routinely the
             // UI thread.
-            Logger.d(tag, "Deferring the discard of a download still inside a write")
+            Logger.d(tag, "Deferring the discard of a download still inside the provider")
             return
         }
-        try {
-            request.stream?.close()
-        } catch (e: IOException) {
-            Logger.d(tag, "Ignoring a close failure on a download already lost: ${e.message}")
-        }
+        val stream = request.stream
         request.stream = null
-        request.destination?.let { host.discardDestination(it) }
+        val destination = request.destination
         request.destination = null
+        stream?.let { offThread("close") { it.close() } }
+        destination?.let { offThread("discard") { host.discardDestination(it) } }
+    }
+
+    /**
+     * Hands the provider one call nobody is waiting for, and swallows what it
+     * throws.
+     *
+     * Swallowed twice over. The caller has already decided this download failed,
+     * and there is no thread left to tell: this runs on [providerWork], where an
+     * exception on the way out reaches the process's uncaught handler rather
+     * than a caller who could do something about it.
+     */
+    private fun offThread(what: String, work: () -> Unit) {
+        providerWork.execute {
+            try {
+                work()
+            } catch (e: Exception) {
+                Logger.d(tag, "Ignoring a failed $what on a download already lost: ${e.message}")
+            }
+        }
     }
 
     /** The pending download when [requestId] names it, or null when it names a stale one. */

--- a/android/app/src/main/kotlin/com/vscodroid/webview/VSCodroidWebViewClient.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/webview/VSCodroidWebViewClient.kt
@@ -161,6 +161,26 @@ internal fun workspaceRootOrNull(candidatePath: String?, sensitive: List<String>
 }
 
 /**
+ * The last workspace [resourceRootsInForce] refused, so the refusal is explained
+ * once rather than on every request that follows it.
+ *
+ * The condition is sticky, which is what made the report a stream rather than an
+ * event: the supplier answers the same folder for as long as it stays open and
+ * the caller invokes it per webview resource request, so one markdown preview or
+ * notebook render turned a single refused folder into hundreds of identical
+ * lines, each repeating the absolute path, at a level that is not gated on a
+ * debuggable build. Cleared whenever a candidate is accepted or absent, so a user
+ * who closes the folder and opens it again is told again rather than met with
+ * silence.
+ *
+ * A benign race, deliberately: two threads seeing the same stale value cost one
+ * duplicate line, which is the failure this exists to bound rather than one it
+ * reintroduces.
+ */
+@Volatile
+private var lastRefusedWorkspace: String? = null
+
+/**
  * The roots in force for one request: the published set, plus the open folder
  * when it is safe to publish.
  *
@@ -169,17 +189,23 @@ internal fun workspaceRootOrNull(candidatePath: String?, sensitive: List<String>
  * the user's own workspace) otherwise looks like a bug rather than a refusal.
  * Nothing is logged in the ordinary case: an accepted folder and an absent one
  * are both silent, so this only speaks when the workspace holds a location that
- * must stay unreadable.
+ * must stay unreadable, and then once per folder rather than once per request.
+ * See [lastRefusedWorkspace].
  */
 internal fun resourceRootsInForce(
     published: List<String>, sensitive: List<String>, candidate: String?
 ): List<String> {
     val workspace = workspaceRootOrNull(candidate, sensitive)
     if (candidate != null && workspace == null) {
-        Logger.w(
-            "WebViewClient",
-            "Workspace not published as a resource root, it holds a sensitive location: $candidate"
-        )
+        if (candidate != lastRefusedWorkspace) {
+            lastRefusedWorkspace = candidate
+            Logger.w(
+                "WebViewClient",
+                "Workspace not published as a resource root, it holds a sensitive location: $candidate"
+            )
+        }
+    } else {
+        lastRefusedWorkspace = null
     }
     return published + listOfNotNull(workspace)
 }
@@ -1058,21 +1084,52 @@ class VSCodroidWebViewClient(
                     is ResourceOutcome.Serve -> outcome.file
                 }
 
+                // Opened before the response is built, and inside a try, because
+                // the check above and the open are two syscalls with a gap between
+                // them and nothing upstream catches. `resourceOutcome` answers
+                // Serve for a file that exists and is a regular file, which is not
+                // the same question as whether it opens: a watch build or a
+                // `git checkout` can unlink it in that gap, and a file with no read
+                // permission fails every time without any race at all. The throw
+                // travelled out of `shouldInterceptRequest` into the WebView's own
+                // callback, where `CrashReporter` recorded the death rather than
+                // preventing it, so a workspace being rewritten under a preview
+                // took the editor down with it. IOException and not Exception:
+                // FileNotFoundException is the whole of what an open reports, and
+                // widening it here would swallow failures that are not this one.
+                val stream = try {
+                    FileInputStream(file)
+                } catch (e: IOException) {
+                    Logger.w(
+                        TAG,
+                        "Resource could not be opened ($scheme): $path (${e.javaClass.simpleName})"
+                    )
+                    return notFound("Unreadable: $path")
+                }
+
                 val mimeType = guessMimeType(path)
                 Logger.d(TAG, "Resource served ($scheme): $path ($mimeType)")
 
+                // No Cache-Control on this arm, deliberately. The commit hash that
+                // makes an asset safe to keep forever belongs to the URL the *other*
+                // arm proxies, `/{quality}-{commit}/static/...`; what this one serves
+                // is a plain filesystem path resolved against roots that include the
+                // open workspace, the projects tree and the SAF mirrors, all of which
+                // the user rewrites in place. `immutable` forbids revalidation, so an
+                // image regenerated from the terminal or pulled with `git pull` went
+                // on rendering from the old bytes in the markdown preview for the life
+                // of the renderer, and nothing in the app could force a refetch: that
+                // extension emits query-less resource URLs, unlike `media-preview`,
+                // which appends its own `version=`. The server tree and the extensions
+                // directory do not change within an install, so all they lose is a
+                // warm-start saving on a local file read.
                 return WebResourceResponse(
                     mimeType, null, 200, "OK",
-                    buildMap {
-                        put("Access-Control-Allow-Origin", "*")
-                        put("Content-Length", file.length().toString())
-                        // Static resources are versioned by commit hash in the URL,
-                        // so they never change; cache aggressively for warm starts.
-                        if (isStaticAsset(path)) {
-                            put("Cache-Control", CACHE_IMMUTABLE)
-                        }
-                    },
-                    FileInputStream(file)
+                    mapOf(
+                        "Access-Control-Allow-Origin" to "*",
+                        "Content-Length" to file.length().toString(),
+                    ),
+                    stream
                 )
             }
 
@@ -1154,8 +1211,12 @@ class VSCodroidWebViewClient(
                     ?.toMutableMap()
                     ?: mutableMapOf()
 
-                // Ensure static assets from the local server get cached.
-                // VS Code Server may not set Cache-Control on all responses.
+                // A fallback for a static asset the local server answers without
+                // a Cache-Control of its own. The route this arm proxies,
+                // `/{quality}-{commit}/static/...`, does send one, so the branch
+                // is expected to stay quiet; it stopped being able to fire at all
+                // once the token joined the URL, which is what [assetPathOf]
+                // exists to undo.
                 if (responseCode in 200..299 && isStaticAsset(url) &&
                     !headers.containsKey("Cache-Control")
                 ) {
@@ -1204,6 +1265,42 @@ class VSCodroidWebViewClient(
          *
          * Input:  /stable/cd4ee3b1.../out/vs/workbench/contrib/webview/browser/pre/index.html
          * Output: http://127.0.0.1:{port}/stable-cd4ee3b1.../static/out/vs/workbench/contrib/webview/browser/pre/index.html
+         *
+         * [path] is `Uri.getPath()`, which is DECODED, and every part of it is the
+         * page's: any rendered document may name a `*.vscode-cdn.net` host, which is
+         * the only test the caller applies. Built by concatenation, `%3F` arrived
+         * here as a real `?` and `%2E%2E%2F` as a real `../`, so both became URL
+         * syntax rather than text, and [withToken] then signed the result with the
+         * server's credential. That is the hazard the two removed arms in
+         * [interceptResourceRequest] were deleted for, and it reached the same
+         * place: `/vscode-remote-resource?path=<absolute>` sits behind the token
+         * gate and then reads any file the server can read, the passphrase-less SSH
+         * key included.
+         *
+         * So the URL is assembled through `java.net.URI`, whose multi-argument
+         * constructor quotes everything in a path component that would otherwise be
+         * a delimiter: `?`, `#`, a bare `%`, CR and LF, and anything non-ASCII.
+         * `java.net.URI` rather than `android.net.Uri` for the reason [tlsHostLabel]
+         * gives: the second is a stub under the unit-test `android.jar`, so a case
+         * written against it would measure the mock and not the encoding. It also
+         * fixes a smaller thing the concatenation got wrong, an ordinary space in a
+         * resource name arriving unencoded in a URL string.
+         *
+         * Dot segments are refused rather than quoted, because they are legal path
+         * syntax and `URI` keeps them: `..` inside [path] walks out of
+         * `/{quality}-{commit}/static/` onto any route of our own server. What
+         * resolves them is the HTTP client, and on Android that is OkHttp behind
+         * `HttpURLConnection`, which canonicalises the path as it writes the request
+         * line: standard behaviour, not measured on a device here, and neither the
+         * desktop JVM the unit suite runs on nor the server's own `url.parse` does
+         * it. Refusing is what keeps the app from issuing a request whose route
+         * depends on which end resolves it. `quality` and `commit` need no such
+         * test: they are joined by a hyphen, so the segment they produce can never
+         * be `.` or `..`.
+         *
+         * Nothing the workbench asks for carries one, so refusing costs nothing, and
+         * the caller answers a null here with a 404 of its own rather than handing
+         * the address back to the WebView to fetch from the real CDN.
          */
         private fun rewriteCdnUrl(path: String, query: String?, port: Int, token: String?): String? {
             val segments = path.removePrefix("/").split("/", limit = 3)
@@ -1213,9 +1310,20 @@ class VSCodroidWebViewClient(
             val commit = segments[1]    // commit hash
             val rest = if (segments.size > 2) segments[2] else ""
 
+            if (rest.split("/").any { it == "." || it == ".." }) return null
+
             val localPath = "/$quality-$commit/static/$rest"
-            val queryPart = if (!query.isNullOrEmpty()) "?$query" else ""
-            return withToken("http://127.0.0.1:$port$localPath$queryPart", token)
+            // Empty and absent are one case here, as they were for the `?` this
+            // replaces: `URI` writes a bare `?` for an empty query, which [withToken]
+            // would then read as a query to extend.
+            val localUrl = try {
+                URI(
+                    "http", null, "127.0.0.1", port, localPath, query?.ifEmpty { null }, null
+                ).toASCIIString()
+            } catch (e: URISyntaxException) {
+                return null
+            }
+            return withToken(localUrl, token)
         }
 
         /**
@@ -1249,14 +1357,29 @@ class VSCodroidWebViewClient(
             return "$url$separator" + "tkn=" + Uri.encode(token)
         }
 
-        private fun isStaticAsset(path: String): Boolean {
+        /**
+         * The part of [pathOrUrl] the two suffix tests below can answer for.
+         *
+         * They are asked both ways: the resource arm has a bare `uri.path`,
+         * while the proxy has the whole rewritten URL. Since the editor server
+         * began requiring a connection token, every one of those URLs ends in
+         * `tkn=<hex>`, so a suffix test on the raw string matched no asset at
+         * all and both fallbacks reading it, the immutable cache header and the
+         * MIME type for a response that carries none of its own, had quietly
+         * stopped being reachable.
+         */
+        private fun assetPathOf(pathOrUrl: String): String = pathOrUrl.substringBefore('?')
+
+        internal fun isStaticAsset(pathOrUrl: String): Boolean {
+            val path = assetPathOf(pathOrUrl)
             return path.endsWith(".js") || path.endsWith(".css") ||
                     path.endsWith(".woff2") || path.endsWith(".woff") ||
                     path.endsWith(".ttf") || path.endsWith(".svg") ||
                     path.endsWith(".png") || path.endsWith(".jpg")
         }
 
-        private fun guessMimeType(path: String): String {
+        internal fun guessMimeType(pathOrUrl: String): String {
+            val path = assetPathOf(pathOrUrl)
             return when {
                 path.endsWith(".html") -> "text/html"
                 path.endsWith(".js") -> "application/javascript"

--- a/android/app/src/main/res/layout/activity_splash.xml
+++ b/android/app/src/main/res/layout/activity_splash.xml
@@ -11,9 +11,21 @@
      this screen does. setContentView swaps in the picker next, which waits on a
      person and could hold the display awake until the battery is flat; a window
      flag would keep burning through that wait, and this drops the moment the
-     view is detached. -->
+     view is detached.
+
+     What that argument does not cover is the wait this same layout hosts. When
+     setup fails, showSetupError rewrites the status line and adds a Retry button
+     into this view, so nothing is in flight and the screen changes only when a
+     person taps, with the flag still held. showSetupError clears it there and
+     Retry sets it back, which is the picker's argument one screen earlier.
+
+     The id is what both of those need: it is looked up to clear the flag and to
+     pad the root for the system bars, which every other full-screen root in the
+     app gets at its own setContentView. Without one this was the only screen
+     drawing under the navigation bar. -->
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/splashRoot"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:keepScreenOn="true"

--- a/android/app/src/test/kotlin/com/vscodroid/ActivityRetentionTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/ActivityRetentionTest.kt
@@ -1,0 +1,125 @@
+package com.vscodroid
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * What the device-folder machinery is allowed to hold once the Activity is gone.
+ *
+ * `SafSyncEngine` starts the `saf-writeback` daemon and `stopWatching` waits two
+ * seconds for it before leaving it running, rather than discarding writes the user
+ * expects on their device. That worker's runnable holds the engine, the engine
+ * holds its `Context`, and the manager's three notice callbacks hold whatever they
+ * closed over. Built on the Activity, all of that kept a destroyed MainActivity and
+ * its whole inflated view tree alive for the length of an unbounded drain, on a
+ * device where the Node server and the extension host are competing for the same
+ * heap. `onDestroy` clears the service callbacks and nothing else, and the started
+ * foreground service keeps the process alive so nothing reclaims it wholesale.
+ *
+ * Read off the source: a leak that takes a live SAF drain to observe cannot be
+ * built in a plain JVM test, and the property being pinned is a property of the
+ * text (what the constructor and the lambdas name), not of a value at runtime.
+ *
+ * NEGATIVE CONTROL, measured rather than assumed:
+ *  - changing `SafStorageManager(applicationContext)` back to
+ *    `SafStorageManager(this)` reddens `the manager is built on the application
+ *    context`.
+ *  - putting `this@MainActivity` back as the Toast context in any one of the three
+ *    notices reddens `no device-folder notice closes over the Activity`.
+ *  - changing one notice's `appContext.getString(` back to `getString(` reddens the
+ *    same case, since an unqualified resource lookup is a call on the Activity.
+ */
+class ActivityRetentionTest {
+
+    private val source = File("src/main/kotlin/com/vscodroid/MainActivity.kt").readText()
+
+    /** The braced block that follows [marker], to its closing brace. */
+    private fun blockAt(marker: String): String {
+        val start = source.indexOf(marker)
+        assertTrue(start >= 0) { "'$marker' is gone from MainActivity.kt, so this test is measuring nothing" }
+        val open = source.indexOf('{', start)
+        var depth = 0
+        var i = open
+        while (i < source.length) {
+            if (source[i] == '{') depth += 1
+            if (source[i] == '}') {
+                depth -= 1
+                if (depth == 0) return source.substring(open, i + 1)
+            }
+            i += 1
+        }
+        throw AssertionError("Could not find the end of the block after '$marker'")
+    }
+
+    /** Comment text removed, so an explanation cannot satisfy a search for the rule. */
+    private fun code(text: String): String =
+        text.lines().joinToString("\n") { line ->
+            val marker = line.indexOf("//")
+            if (marker >= 0) line.substring(0, marker) else line
+        }
+
+    private val notices = listOf(
+        "safManager.onWriteBackFailed {",
+        "safManager.onUploadIncomplete {",
+        "safManager.onDocumentsNotCopied {",
+    )
+
+    @Test
+    fun `the manager is built on the application context`() {
+        val built = code(source).lines().filter { it.contains("SafStorageManager(") }
+
+        assertEquals(
+            listOf("safManager = SafStorageManager(applicationContext)"),
+            built.map { it.trim() },
+            "the manager outlives this Activity by design: its engine leaves the " +
+                "write-back worker running when a drain outruns the two-second wait in " +
+                "onDestroy, so an Activity handed to it here is retained, with its view " +
+                "tree, for as long as that drain takes",
+        )
+    }
+
+    @Test
+    fun `no device-folder notice closes over the Activity`() {
+        notices.forEach { marker ->
+            val block = code(blockAt(marker))
+
+            assertTrue(block.isNotBlank()) { "the block after '$marker' is empty; this case is measuring nothing" }
+            assertTrue(!block.contains("this@MainActivity")) {
+                "$marker hands the engine a strong reference to this Activity, which the " +
+                    "write-back worker then holds for the length of an unbounded drain"
+            }
+            assertTrue(!block.contains("runOnUiThread")) {
+                "$marker posts through the Activity, which captures it for the same reason. " +
+                    "A Handler on the main looper does the same job holding nothing."
+            }
+            // Every resource lookup qualified, because an unqualified one is a call
+            // on the Activity and captures it exactly as naming it would. Judged a
+            // line at a time rather than by a lookbehind, since the qualifier is one
+            // hop further away in `appContext.resources.getQuantityString`.
+            val unqualified = block.lines().filter { line ->
+                (line.contains("getString(") || line.contains("getQuantityString(")) &&
+                    !line.contains("appContext.")
+            }
+            assertEquals(
+                emptyList<String>(), unqualified.map { it.trim() },
+                "$marker looks up a resource on the Activity, so the lambda captures it",
+            )
+        }
+    }
+
+    @Test
+    fun `the notices still say what they are for`() {
+        // Without this the case above is satisfied by deleting the notices, which
+        // would trade a bounded leak for the silence they exist to end: a save that
+        // never reached the device folder looks exactly like one that did.
+        // WriteBackNoticeWiringTest pins the wiring itself; this only refuses a
+        // fix that removes the subject.
+        notices.forEach { marker ->
+            assertTrue(code(blockAt(marker)).contains("Toast.makeText(")) {
+                "$marker no longer puts anything on screen"
+            }
+        }
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/CrashDialogExitTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/CrashDialogExitTest.kt
@@ -1,0 +1,114 @@
+package com.vscodroid
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * Every way out of the crash dialog has to clear the crash log.
+ *
+ * `checkPreviousCrash` runs unconditionally from `onCreate`, and its only guard is
+ * `CrashReporter.hasPendingCrash()`, which is false only once the files under
+ * `cacheDir/crash-logs` are deleted. The dialog has three exits and two of them
+ * deleted: the "Dismiss" button and "Copy Report". The third is the gesture most
+ * dialogs are closed with, Back or a tap outside, and it ran no handler at all, so
+ * the same modal came back over the loading editor on every later cold start.
+ *
+ * Read off the source, because the dialog needs a device: an `AlertDialog.Builder`
+ * on an Activity is not something a plain JVM test can build, and `CrashReporterTest`
+ * already drives the object underneath it.
+ *
+ * NEGATIVE CONTROL, measured rather than assumed: deleting the
+ * `.setOnCancelListener { CrashReporter.clearCrashLogs() }` line reddens
+ * `cancelling the dialog clears the crash log` and nothing else; adding a
+ * `setNegativeButton` whose body clears nothing reddens `an exit added without a
+ * clear is refused` and nothing else.
+ */
+class CrashDialogExitTest {
+
+    private val source = File("src/main/kotlin/com/vscodroid/MainActivity.kt").readText()
+
+    /** The body of a `private fun name(` declaration, to its closing brace. */
+    private fun body(name: String): String {
+        val start = source.indexOf("private fun $name(")
+        assertTrue(start >= 0) {
+            "$name is gone from MainActivity.kt, so this test is measuring nothing. " +
+                "If it moved or was renamed, point this at the new site."
+        }
+        val open = source.indexOf('{', start)
+        var depth = 0
+        var i = open
+        while (i < source.length) {
+            if (source[i] == '{') depth += 1
+            if (source[i] == '}') {
+                depth -= 1
+                if (depth == 0) return source.substring(open, i + 1)
+            }
+            i += 1
+        }
+        throw AssertionError("Could not find the end of $name in MainActivity.kt")
+    }
+
+    /** Comment text removed, so the prose beside a rule cannot satisfy a search for it. */
+    private fun code(text: String): List<String> =
+        text.lines().map { line ->
+            val marker = line.indexOf("//")
+            if (marker >= 0) line.substring(0, marker) else line
+        }
+
+    private val dialog by lazy { code(body("checkPreviousCrash")) }
+
+    @Test
+    fun `the body being checked was actually found`() {
+        assertTrue(dialog.any { it.contains("setPositiveButton") }) {
+            "checkPreviousCrash no longer builds a dialog, so these cases are searching " +
+                "the wrong text and would pass over anything"
+        }
+    }
+
+    @Test
+    fun `cancelling the dialog clears the crash log`() {
+        val cancel = dialog.filter { it.contains("setOnCancelListener") }
+
+        assertEquals(
+            1, cancel.size,
+            "Back and a tap outside cancel this dialog without running either button, " +
+                "and nothing else on a normal path deletes a crash log, so the modal " +
+                "returns over the editor on every launch from then on. Found: " +
+                cancel.map { it.trim() },
+        )
+        assertTrue(cancel.single().contains("clearCrashLogs()")) {
+            "the cancel handler does not clear the log, which is the one thing that " +
+                "stops the dialog coming back. Found: ${cancel.single().trim()}"
+        }
+    }
+
+    /**
+     * ⚠️ Its ceiling, measured rather than assumed: deleting the cancel listener
+     * leaves this green, because it counts the exits that are present and a missing
+     * exit is not one of them. That is the case above's job, and it does redden.
+     * What this one catches is the other direction, measured too: adding a
+     * `setNegativeButton` with an empty body reddens it.
+     */
+    @Test
+    fun `an exit added without a clear is refused`() {
+        // Whichever exit forgets, the user is back to a modal that returns on every
+        // launch, so the count is the assertion rather than a list of the three
+        // that exist today.
+        val exits = dialog.count {
+            it.contains("setPositiveButton") ||
+                it.contains("setNeutralButton") ||
+                it.contains("setNegativeButton") ||
+                it.contains("setOnCancelListener")
+        }
+        val clears = dialog.count { it.contains("clearCrashLogs()") }
+
+        assertEquals(
+            exits, clears,
+            "an exit from the crash dialog leaves the crash log in place. Exits found: " +
+                dialog.filter { it.contains("set") && it.contains("Button") || it.contains("setOnCancel") }
+                    .map { it.trim() },
+        )
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/DeviceFolderOpenThreadTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/DeviceFolderOpenThreadTest.kt
@@ -1,0 +1,253 @@
+package com.vscodroid
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * Opening a device folder must not ask a DocumentsProvider anything on the thread
+ * that draws the screen.
+ *
+ * `persistPermission` is two cross-process round trips of its own (it resolves the
+ * display name and reads every persisted grant to prune the recent list) and
+ * `getDisplayName` is a third; `folderForOpenedPath` is a fourth. All four used to
+ * run before the progress dialog existed, from the picker result, from the bridge
+ * and from `onPageFinished`, which are all the main thread. Against a local
+ * provider that is milliseconds; against one backed by a network share or a phone
+ * on MTP it is an unresponsive editor and, past five seconds, an ANR.
+ *
+ * Read off the source, for the reason `SafFolderLogCallSiteTest` gives: there is
+ * no seam. These functions show an `AlertDialog` and launch on `lifecycleScope`,
+ * neither of which a plain JVM test can build. Comments are stripped first,
+ * because the rule is discussed at length beside the lines it governs and a search
+ * over the raw text would be satisfied by the explanation.
+ *
+ * NEGATIVE CONTROL, measured rather than assumed:
+ *  - restoring the shape this replaced (both provider calls above `dialog.show()`,
+ *    with no hop) reddens all three of `nothing is asked of the provider before the
+ *    dialog is on screen`, `the provider round trips in openSafFolder are hopped
+ *    off the main thread` and `the permission is taken even if the activity goes
+ *    away`, and nothing else.
+ *  - deleting the `withContext(Dispatchers.IO)` around `folderForOpenedPath` in
+ *    `adoptWorkbenchFolder` reddens `the page-load lookup is hopped off the main
+ *    thread`.
+ *  - resolving the remembered folder inline in `loadVSCode` again, with no hop,
+ *    reddens `the remembered workspace is resolved off the main thread` and, since
+ *    it leaves no hop for that case to sit before, `a folder already known is
+ *    navigated to without waiting for a hop`; nothing else.
+ *  - returning `segment` instead of `tail` from [treeUriLabel] reddens `the
+ *    placeholder name is the folder, not the whole tree path`.
+ */
+class DeviceFolderOpenThreadTest {
+
+    private val source = File("src/main/kotlin/com/vscodroid/MainActivity.kt").readText()
+
+    /** The body of a `private fun name(` declaration, to its closing brace. */
+    private fun body(name: String): String {
+        val start = source.indexOf("private fun $name(")
+        assertTrue(start >= 0) {
+            "$name is gone from MainActivity.kt, so this test is measuring nothing. " +
+                "If it moved or was renamed, point this at the new site rather than " +
+                "deleting it."
+        }
+        val open = source.indexOf('{', start)
+        var depth = 0
+        var i = open
+        while (i < source.length) {
+            if (source[i] == '{') depth += 1
+            if (source[i] == '}') {
+                depth -= 1
+                if (depth == 0) return source.substring(open, i + 1)
+            }
+            i += 1
+        }
+        throw AssertionError("Could not find the end of $name in MainActivity.kt")
+    }
+
+    /**
+     * Lines with comments removed, so prose about a hop cannot stand in for one.
+     * Both forms, because both disable code, and a block counts as a comment only
+     * where it opens a line.
+     */
+    private fun code(text: String): List<String> {
+        var inBlock = false
+        return text.lines().map { raw ->
+            var line = raw
+            if (inBlock) {
+                val close = line.indexOf("*/")
+                if (close < 0) return@map ""
+                inBlock = false
+                line = line.substring(close + 2)
+            }
+            while (line.trimStart().startsWith("/*")) {
+                val open = line.indexOf("/*")
+                val close = line.indexOf("*/", open + 2)
+                if (close < 0) {
+                    inBlock = true
+                    return@map line.substring(0, open)
+                }
+                line = line.substring(0, open) + line.substring(close + 2)
+            }
+            val marker = line.indexOf("//")
+            if (marker >= 0) line.substring(0, marker) else line
+        }
+    }
+
+    private val opened by lazy { code(body("openSafFolder")) }
+    private val adopted by lazy { code(body("adoptWorkbenchFolder")) }
+
+    @Test
+    fun `the bodies being checked were actually found`() {
+        assertTrue(opened.any { it.contains("persistPermission") }) {
+            "openSafFolder no longer looks like the function these cases were written " +
+                "against, so they are searching the wrong text and would pass over " +
+                "anything. Point them at wherever a device folder is opened now."
+        }
+        assertTrue(adopted.any { it.contains("folderForOpenedPath") }) {
+            "adoptWorkbenchFolder no longer looks up the folder the workbench opened, " +
+                "so this case is measuring nothing"
+        }
+    }
+
+    @Test
+    fun `nothing is asked of the provider before the dialog is on screen`() {
+        val shown = opened.indexOfFirst { it.contains("dialog.show()") }
+        val asked = opened.withIndex().filter { (_, line) ->
+            line.contains("persistPermission") || line.contains("getDisplayName")
+        }
+
+        assertTrue(shown >= 0) { "the sync dialog is no longer shown; this case is measuring nothing" }
+        assertTrue(asked.isNotEmpty()) { "the provider calls are gone; this case is measuring nothing" }
+        assertEquals(
+            emptyList<String>(), asked.filter { it.index < shown }.map { it.value.trim() },
+            "a DocumentsProvider is queried before the progress dialog exists, so the " +
+                "editor freezes with nothing on screen saying why",
+        )
+    }
+
+    @Test
+    fun `the provider round trips in openSafFolder are hopped off the main thread`() {
+        // The hop is looked for on the call's own line and the three above it,
+        // which covers both shapes in use here: a one-line withContext, and a
+        // block whose calls sit under its opening line. It cannot tell a hop that
+        // encloses a call from one that merely precedes it, which is the same
+        // ceiling ActivityTeardownTest states for the watcher calls.
+        val calls = opened.withIndex().filter { (_, line) ->
+            line.contains("safManager.persistPermission(") || line.contains("safManager.getDisplayName(")
+        }
+
+        assertEquals(
+            2, calls.size,
+            "expected persistPermission and getDisplayName. If a call site was added " +
+                "or removed, update this count and check the new one is off the main " +
+                "thread. Found: " + calls.map { it.value.trim() },
+        )
+
+        val onMainThread = calls.filter { (index, _) ->
+            opened.subList(maxOf(0, index - 3), index + 1).none {
+                it.contains("withContext(") && it.contains("Dispatchers.IO")
+            }
+        }
+
+        assertEquals(
+            emptyList<String>(), onMainThread.map { it.value.trim() },
+            "a DocumentsProvider query runs on the thread that draws the screen. A " +
+                "network- or MTP-backed provider answers in seconds, and this path is " +
+                "reached from a page load as well as from the picker.",
+        )
+    }
+
+    @Test
+    fun `the permission is taken even if the activity goes away`() {
+        // The grant used to be taken synchronously on the way in, so it was taken
+        // whatever happened next. Moving it into the coroutine without this makes
+        // it best-effort: a scope cancelled in the moment after the picker
+        // returned would leave the user's folder missing from the recent list with
+        // nothing to explain it.
+        val hop = opened.indexOfFirst { it.contains("safManager.persistPermission(") }
+        assertTrue(hop >= 0) { "persistPermission is gone; this case is measuring nothing" }
+        assertTrue(
+            opened.subList(maxOf(0, hop - 3), hop + 1).any { it.contains("NonCancellable") },
+            "the persisted grant is inside a cancellable hop, so destroying the " +
+                "activity in the moment after the picker returns silently drops it",
+        )
+    }
+
+    @Test
+    fun `the page-load lookup is hopped off the main thread`() {
+        val lookup = adopted.indexOfFirst { it.contains("safManager.folderForOpenedPath(") }
+        assertTrue(lookup >= 0) { "the lookup is gone; this case is measuring nothing" }
+        assertTrue(
+            adopted.subList(maxOf(0, lookup - 3), lookup + 1).any {
+                it.contains("withContext(") && it.contains("Dispatchers.IO")
+            },
+            "onPageFinished reads every persisted grant and prunes the recent list on " +
+                "the main thread, on every cold start whose remembered workspace is a " +
+                "device folder",
+        )
+    }
+
+    @Test
+    fun `the remembered workspace is resolved off the main thread`() {
+        // The fourth round trip, and the sibling the hop above skipped.
+        // `rememberedWorkspaceFolder` asks `folderForOpenedPath` whether a
+        // remembered mirror is still granted, which is the same read of every
+        // persisted grant, and `loadVSCode` reaches it from `onServerReady` and
+        // from the already-serving branch of the service binding, both of which
+        // are the main thread, in the moment before the workbench is navigated to.
+        val load = code(body("loadVSCode"))
+        val remembered = load.indexOfFirst { it.contains("rememberedWorkspaceFolder()") }
+
+        assertTrue(remembered >= 0) {
+            "loadVSCode no longer falls back to the remembered workspace, so this case " +
+                "is measuring nothing"
+        }
+        assertTrue(
+            load.subList(maxOf(0, remembered - 3), remembered + 1).any {
+                it.contains("withContext(") && it.contains("Dispatchers.IO")
+            },
+            "the remembered workspace is resolved on the thread that draws the screen: " +
+                "one read of every persisted grant, a prune of the recent list and, on " +
+                "the fallback, a directory that may have to be created, all on the cold " +
+                "start path immediately before the navigation",
+        )
+    }
+
+    @Test
+    fun `a folder already known is navigated to without waiting for a hop`() {
+        // Control for the case above, which deleting the fast path would also
+        // satisfy. A folder handed in by the caller, or read off the URL the
+        // WebView already holds, costs nothing to work out, and every ordinary
+        // folder switch is one of those: making them wait for a thread hop would
+        // buy nothing and delay the navigation the user asked for.
+        val load = code(body("loadVSCode"))
+        val known = load.indexOfFirst { it.contains("folderFromUrl(") }
+        val hop = load.indexOfFirst { it.contains("withContext(") && it.contains("Dispatchers.IO") }
+
+        assertTrue(known >= 0 && hop >= 0) {
+            "loadVSCode no longer both reads the URL and hops; this case is measuring nothing"
+        }
+        assertTrue(known < hop) {
+            "the URL is read after the hop rather than before it, so the navigation that " +
+                "already knows its folder is queued behind a lookup it never needed"
+        }
+    }
+
+    @Test
+    fun `the placeholder name is the folder, not the whole tree path`() {
+        // What a tree URI's last path segment actually looks like once decoded.
+        assertEquals("ClientProject", treeUriLabel("primary:Documents/ClientProject"))
+        assertEquals("Documents", treeUriLabel("primary:Documents"))
+    }
+
+    @Test
+    fun `a segment with no folder in it is shown as it stands`() {
+        // The storage root, and the empty and absent cases. Quoting an empty name
+        // in the dialog says less than the segment does, and this runs for at most
+        // the one provider query it stands in for.
+        assertEquals("primary:", treeUriLabel("primary:"))
+        assertEquals("", treeUriLabel(""))
+        assertEquals("", treeUriLabel(null))
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/LoadingPlaceholderTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/LoadingPlaceholderTest.kt
@@ -1,0 +1,94 @@
+package com.vscodroid
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * The first screen of every cold start, and the one that was blank.
+ *
+ * `WebView.loadData` does not load a document, it builds a `data:` URL out of one,
+ * and an app targeting Q or later gets no escaping from the platform: the first
+ * `#` ends the URL and the rest becomes a fragment. The placeholder opens with
+ * `background:#1e1e1e`, so the WebView parsed an unterminated `<body` start tag,
+ * dropped it at end of input and painted its own default white for the whole of
+ * the server start, and again behind the Retry link.
+ *
+ * Two halves, because either one alone passes over the defect. [dataUrlSafe] can
+ * be driven here; the call sites cannot, so they are read off the source the way
+ * `SafFolderLogCallSiteTest` reads the same file. A helper nothing calls escapes
+ * nothing.
+ *
+ * NEGATIVE CONTROL, measured rather than assumed:
+ *  - dropping `.replace("#", "%23")` from [dataUrlSafe] reddens
+ *    `the character that ends a data URL is encoded`.
+ *  - swapping the two replacements so `#` is escaped before `%` reddens
+ *    `a percent is encoded first, so an escape is not escaped twice`, and the case
+ *    above it as well, since a bare `#` then comes out as `%2523`.
+ *  - deleting `dataUrlSafe(` from either `loadData` call in MainActivity.kt
+ *    reddens `both loading-page loads go through the escape`.
+ */
+class LoadingPlaceholderTest {
+
+    private val source = File("src/main/kotlin/com/vscodroid/MainActivity.kt").readText()
+
+    @Test
+    fun `the character that ends a data URL is encoded`() {
+        assertEquals("%23", dataUrlSafe("#"))
+        assertEquals("background:%231e1e1e;color:%23888", dataUrlSafe("background:#1e1e1e;color:#888"))
+    }
+
+    @Test
+    fun `a percent is encoded first, so an escape is not escaped twice`() {
+        // The ordering bug this is most likely to acquire, and it takes a subject
+        // holding both characters to see: with "#" escaped first, the "%" of the
+        // "%23" it just wrote is escaped again into "%2523", and the page shows
+        // the three characters "%23" where a hash belonged. A subject with only
+        // one of the two comes out the same either way, which is why the case
+        // below cannot stand in for this one.
+        assertEquals("%23%25", dataUrlSafe("#%"))
+        assertEquals("width:50%25", dataUrlSafe("width:50%"))
+    }
+
+    @Test
+    fun `markup with nothing to encode is returned unchanged`() {
+        val plain = """<html><body><p>Starting server...</p></body></html>"""
+        assertEquals(plain, dataUrlSafe(plain))
+    }
+
+    @Test
+    fun `both loading-page loads go through the escape`() {
+        // The setup one is what a launch shows; the retry one is what the Retry
+        // link on the server-gave-up page shows, and that is the copy a user
+        // reaches only after something has already gone wrong.
+        val calls = source.lines().filter { line ->
+            val code = line.substringBefore("//")
+            code.contains(".loadData(")
+        }
+
+        assertEquals(
+            2, calls.size,
+            "expected the load in setupWebView and the one in retryServerStart. If a " +
+                "call site was added or removed, update this count and check the new " +
+                "one escapes its content. Found: " + calls.map { it.trim() },
+        )
+        calls.forEach { line ->
+            assertTrue(line.contains("dataUrlSafe(")) {
+                "a loading page is handed to loadData raw, so everything from its first " +
+                    "'#' is read as the URL fragment and the WebView shows a blank white " +
+                    "screen for the whole server start. Found: ${line.trim()}"
+            }
+        }
+    }
+
+    @Test
+    fun `the page still carries the colours that made it fail`() {
+        // Without this the pair above can be satisfied by a placeholder with no
+        // '#' left in it, which would be a different page rather than a fixed one:
+        // the dark background is the whole point of showing it at all.
+        assertTrue(source.contains("background:#1e1e1e")) {
+            "the loading page no longer sets the dark background it exists to show"
+        }
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/PackagingGateArmingTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/PackagingGateArmingTest.kt
@@ -1,0 +1,135 @@
+package com.vscodroid
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * A packaging gate is armed by a predicate, and the predicate has to cover the
+ * gate's whole subject.
+ *
+ * `checkPackOverlap` runs `scripts/check-pack-overlap.py`, which sweeps every
+ * pack's assets directory under `android/toolchain_<name>` against the base
+ * module's. It was armed by
+ * `rubyPackHoldsPayload()`, a predicate borrowed from the Ruby-only shell sweep
+ * beside it, which asks whether ONE pack has been downloaded. Both payload trees
+ * are gitignored, so a checkout that has run `download-java.sh` and not
+ * `download-ruby.sh` is an ordinary state to work in, and in it the predicate is
+ * false: a local `./gradlew bundleRelease` skipped the overlap gate with no
+ * output and packaged the Java pack without ever comparing it against the base
+ * module. The duplicate entry that gate exists to catch early then surfaces when
+ * bundletool assembles the whole thing, which is the late failure it was added
+ * to move forward.
+ *
+ * Kotlin cannot express "this predicate covers that script's subject", and a
+ * unit test cannot execute a build-script function, so the arming is read out of
+ * the build script as text. What is asserted is the relation that broke: a gate
+ * whose subject is the family of packs may not be armed by a predicate that
+ * names one member of it. Dropping the `onlyIf` altogether is the other correct
+ * answer and passes here, because an unconditional gate covers every pack by
+ * construction.
+ *
+ * These tests see the build script only because `tasks.withType<Test>` declares
+ * it an input; without that line an edit to it leaves the task UP-TO-DATE and
+ * every mutation below passes.
+ *
+ * NEGATIVE CONTROL: restore `onlyIf { rubyPackHoldsPayload() }` in the
+ * `checkPackOverlap` block and the first test goes red, naming toolchain_ruby.
+ * Point `verifyRubyPackShellPaths` at the family predicate instead and the
+ * second goes red, which is what stops this file being read as "no gate may name
+ * a pack".
+ */
+class PackagingGateArmingTest {
+
+    // Unit tests run with app/ as the working directory.
+    private val buildScript = File("build.gradle.kts")
+
+    /**
+     * The body of one `tasks.register<...>("name") { ... }` block.
+     *
+     * Ended on a closing brace in the first column, which is where a top-level
+     * registration's is and where nothing inside one can be.
+     */
+    private fun taskBody(name: String): String {
+        val script = buildScript.readText()
+        val body = script.substringAfter("(\"$name\") {", "").substringBefore("\n}")
+        assertTrue(body.isNotEmpty(), "the $name task is gone from build.gradle.kts")
+        return body
+    }
+
+    /**
+     * The predicate a task is armed by, or null when it is armed by nothing.
+     *
+     * Anchored at the start of a line: `build.gradle.kts` is Kotlin, so a
+     * commented-out `onlyIf` is not an arming and must not be read as one.
+     */
+    private fun armingPredicate(task: String): String? =
+        Regex("""(?m)^\s*onlyIf\s*\{\s*(\w+)\(\)\s*}""").find(taskBody(task))?.groupValues?.get(1)
+
+    /**
+     * The declaration of a top-level predicate function, comments stripped.
+     *
+     * The comments go because this reads the body for the names of packs, and a
+     * comment explaining which pack a predicate no longer singles out would
+     * otherwise be read as it singling that pack out.
+     */
+    private fun predicateBody(name: String): String {
+        val body = buildScript.readText()
+            .substringAfter("fun $name()", "").substringBefore("\n\n")
+        assertTrue(body.contains("Boolean"), "$name() is not declared in build.gradle.kts")
+        return body.lines().joinToString("\n") { it.substringBefore("//") }
+    }
+
+    /** Every pack this build packages, by module name. */
+    private fun packedModules(): List<String> {
+        val list = Regex("""(?m)^\s*assetPacks\s*\+=\s*listOf\(([^)]*)\)""")
+            .find(buildScript.readText())?.groupValues?.get(1)
+        assertTrue(list != null, "build.gradle.kts no longer names the asset packs it packages")
+        val modules = Regex(""""\s*:(toolchain_\w+)\s*"""").findAll(list!!)
+            .map { it.groupValues[1] }.toList()
+        assertTrue(
+            modules.size > 1,
+            "only ${modules.size} asset pack(s) are packaged, so a predicate naming one pack " +
+                "and a predicate naming the family cannot be told apart by anything below"
+        )
+        return modules
+    }
+
+    @Test
+    fun `the overlap gate is not armed by a predicate that one pack can answer for`() {
+        val predicate = armingPredicate("checkPackOverlap") ?: return
+        val body = predicateBody(predicate)
+        for (module in packedModules()) {
+            assertFalse(
+                body.contains(module),
+                "checkPackOverlap sweeps every asset pack, but it is armed by $predicate(), " +
+                    "which asks about $module alone. A checkout that has downloaded another " +
+                    "pack and not this one skips the gate entirely and bundles that pack " +
+                    "without comparing it against the base module."
+            )
+        }
+        assertTrue(
+            body.contains("toolchain_"),
+            "$predicate() no longer looks at the toolchain packs at all, so what arms " +
+                "checkPackOverlap is unrelated to whether there is a pack to compare"
+        )
+    }
+
+    @Test
+    fun `the Ruby shell sweep keeps the predicate its own subject needs`() {
+        val predicate = armingPredicate("verifyRubyPackShellPaths")
+        assertTrue(
+            predicate != null,
+            "verifyRubyPackShellPaths is armed by nothing, so a checkout that has never run " +
+                "download-ruby.sh sweeps a pack holding only its manifest and reports it clean"
+        )
+        assertTrue(
+            predicateBody(predicate!!).contains("toolchain_ruby"),
+            "verifyRubyPackShellPaths checks the Ruby pack and nothing else, deliberately: the " +
+                "Java pack carries the same path in files that are unreachable on Android. " +
+                "Arming it by $predicate(), which answers for the family, fails builds that " +
+                "are correct."
+        )
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/PickerSpendGuardTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/PickerSpendGuardTest.kt
@@ -1,0 +1,88 @@
+package com.vscodroid
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * What the first-run picker is allowed to spend when Continue is tapped.
+ *
+ * The cards refuse to tick a toolchain they have been told is installed, and
+ * that is not enough on its own. The set behind the refusal is a reading of a
+ * moment, and two things get past it: replacing the set unticks nothing, so a
+ * pack ticked while it was genuinely absent keeps its tick once it is installed
+ * from the Toolchains screen; and the delivered-pack reconcile writes the record
+ * from its own thread while this screen waits for a person, with no lifecycle
+ * callback to hang a re-read on.
+ *
+ * Nothing downstream catches it. `downloadNext` installs what it is handed and
+ * `ToolchainManager.install` has no already-installed branch, so a tick that
+ * gets through spends the download and the copy again, 55 MB and 155 MB for
+ * Java 17, or meets the in-flight claim and paints a red "Failed" row for an
+ * install that is going perfectly well.
+ *
+ * [notYetInstalled] is the last check before that spend, and these pin it.
+ */
+class PickerSpendGuardTest {
+
+    /**
+     * NEGATIVE CONTROL: make [notYetInstalled] return `selected.toList()` and
+     * this goes red. That is precisely the line the Continue handler carried.
+     */
+    @Test
+    fun `a toolchain already on disk is not downloaded again`() {
+        assertEquals(
+            listOf("toolchain_ruby"),
+            notYetInstalled(setOf("toolchain_java", "toolchain_ruby"), listOf("java")),
+            "the picker started a fresh install for a toolchain the record already " +
+                "calls installed",
+        )
+    }
+
+    /**
+     * NEGATIVE CONTROL: drop the `ToolchainRegistry.find` from the installed side
+     * of [notYetInstalled], so the record's names are compared as they are
+     * written, and this goes red.
+     */
+    @Test
+    fun `the two halves spell a toolchain differently and still match`() {
+        // The install record names a toolchain the short way, the cards name it
+        // the pack way, and both spellings reach here.
+        assertTrue(
+            notYetInstalled(setOf("toolchain_java"), listOf("java")).isEmpty(),
+            "the short name in the install record did not match the pack name on the " +
+                "card, so an installed toolchain reads as absent",
+        )
+        assertTrue(
+            notYetInstalled(setOf("toolchain_java"), listOf("toolchain_java")).isEmpty(),
+            "the pack spelling reaches here too, from a card that reported COMPLETED",
+        )
+    }
+
+    @Test
+    fun `nothing installed leaves the choice exactly as it was made`() {
+        assertEquals(
+            listOf("toolchain_java", "toolchain_ruby"),
+            notYetInstalled(listOf("toolchain_java", "toolchain_ruby"), emptyList()),
+            "the guard dropped a toolchain that is not installed, which costs the user " +
+                "the one thing this screen exists to offer",
+        )
+    }
+
+    /**
+     * NEGATIVE CONTROL: make the lookup on the installed side assert instead,
+     * `ToolchainRegistry.find(it)!!.packName`, and this goes red on the name the
+     * registry no longer knows.
+     */
+    @Test
+    fun `a name the registry does not know decides nothing`() {
+        // Go was withdrawn from the registry and its name is still in the install
+        // record on a device that had it. It has no card, so it can neither be
+        // ticked nor filter anything, and it must not remove a live pack either.
+        assertEquals(
+            listOf("toolchain_java"),
+            notYetInstalled(setOf("toolchain_java"), listOf("go", "")),
+            "a name outside the registry changed what gets downloaded",
+        )
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/SplashLifetimeTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/SplashLifetimeTest.kt
@@ -85,6 +85,109 @@ class SplashLifetimeTest {
         }
     }
 
+    /**
+     * The other half of the flag, and the half nothing asked for.
+     *
+     * `showSetupError` leaves the extraction layout in place: it rewrites the
+     * status line, hides the progress bar and adds a Retry button into the same
+     * root. Nothing is in flight after that and the screen changes only when a
+     * person taps, so the argument the layout makes for holding the display awake
+     * has expired, and the layout's own comment makes exactly that argument
+     * against the picker one screen later. Held anyway, a phone put down or
+     * pocketed on the failure screen lights until the battery is flat.
+     *
+     * NEGATIVE CONTROL: delete `root.keepScreenOn = false` from `showSetupError`
+     * and the first assertion goes red; delete `root.keepScreenOn = true` from
+     * the Retry listener and the second does. Both measured.
+     */
+    @Test
+    fun `the failure screen stops holding the display awake`() {
+        val onLayout = layoutRoot().getAttribute("android:keepScreenOn") == "true"
+        val onWindow = code().any { it.contains("FLAG_KEEP_SCREEN_ON") }
+        assertTrue(onLayout || onWindow) {
+            "nothing holds the display awake at all, so this test has no subject; " +
+                "see the test above"
+        }
+
+        val error = body("showSetupError")
+        assertTrue(error.isNotEmpty()) { "showSetupError is empty; this test is measuring nothing" }
+
+        assertTrue(error.any { Regex("""keepScreenOn\s*=\s*false""").containsMatchIn(it) }) {
+            "showSetupError leaves the display held awake on a screen that waits " +
+                "for a person and changes for nothing else. The reachable way in is " +
+                "a phone with under ~875 MB free, which fails the storage pre-flight " +
+                "on first launch."
+        }
+        assertTrue(error.any { Regex("""keepScreenOn\s*=\s*true""").containsMatchIn(it) }) {
+            "nothing gives the flag back, so tapping Retry restarts an 800 MB " +
+                "extraction that the display timeout may now stop part-way through, " +
+                "with no partial progress to resume from"
+        }
+    }
+
+    /**
+     * The splash root is padded for the system bars, like every other full-screen
+     * root in this app.
+     *
+     * `SplashActivity.onCreate` calls `drawBehindSystemBars()`, so this window
+     * draws under the status and navigation bars. `pickerRoot`, `progressRoot`
+     * and `toolchainRoot` are each padded at their own `setContentView`; this one
+     * was not, because its root carried no id to look it up by. The child that
+     * pays for it is the Retry button `showSetupError` adds, which is anchored to
+     * the bottom of the root.
+     *
+     * NEGATIVE CONTROL: drop the `padForSystemBars()` line from
+     * `showSplashLayout` and the second assertion goes red; inline the
+     * `setContentView` back into either caller and the first does. Both measured.
+     */
+    @Test
+    fun `the splash layout is shown from the one place that pads it`() {
+        val shows = code().filter { it.contains("setContentView(R.layout.activity_splash)") }
+        assertEquals(1, shows.size) {
+            "activity_splash is shown from ${shows.size} places:\n${shows.joinToString("\n")}\n" +
+                "One of them will be the one that forgets the insets. It belongs in " +
+                "showSplashLayout() alone."
+        }
+
+        val show = body("showSplashLayout")
+        assertTrue(show.any { it.contains("padForSystemBars") }) {
+            "the splash root is not padded, so this edge-to-edge window draws its " +
+                "one control under the navigation bar:\n${show.joinToString("\n")}"
+        }
+        assertTrue(show.any { it.contains("R.id.splashRoot") }) {
+            "showSplashLayout pads something other than the splash root"
+        }
+    }
+
+    /**
+     * The Retry button is held against the bottom of the root, not only under the
+     * message.
+     *
+     * It is the single control on that screen, there is no scroll container, and
+     * the message above it is the failed step plus up to `DETAIL_LIMIT`
+     * characters of the cause in a packed chain that grows downward as it wraps.
+     * Anchored to the message alone, a long cause in landscape or at a raised
+     * font scale puts the button past the bottom of the window with no way to
+     * reach it, and reinstalling is the only way out.
+     *
+     * NEGATIVE CONTROL: remove `bottomToBottom` from the button's LayoutParams
+     * and this goes red, naming the button. Measured.
+     */
+    @Test
+    fun `the retry button cannot be pushed off the bottom of the screen`() {
+        val error = body("showSetupError")
+        assertTrue(error.any { it.contains("bottomToBottom") }) {
+            "the Retry button is constrained downward from the message only, so a " +
+                "long failure detail can push the only control on the screen out of " +
+                "the window:\n${error.joinToString("\n")}"
+        }
+        assertTrue(error.any { it.contains("verticalBias") }) {
+            "a bottom constraint without the bias against it centres the button in " +
+                "the gap instead of pinning it, which is the same overflow one half " +
+                "as far down"
+        }
+    }
+
     @Test
     fun `every launch that is past setup asks whether the picker was answered`() {
         // The picker is offered once and answering it is what records the answer,

--- a/android/app/src/test/kotlin/com/vscodroid/SyncDialogTeardownTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/SyncDialogTeardownTest.kt
@@ -1,0 +1,124 @@
+package com.vscodroid
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * That a folder sync failing while the screen goes away does not take the process
+ * with it.
+ *
+ * The progress dialog belongs to a window, and dismissing one whose window has
+ * already been torn down throws. Inside a catch handler that throw is not caught
+ * by anything: it leaves the handler, leaves the coroutine, and reaches the
+ * process's uncaught handler, so the app dies while the user is swiping it away
+ * and the crash notice greets them on the next launch. The two ways in are
+ * ordinary: a grant revoked mid-sync raises `SecurityException`, and a provider
+ * on a network share or a phone on MTP raises an `IOException` into the
+ * catch-all, either of them able to land in the moment the activity is finishing.
+ *
+ * The cancellation branch beside them has carried this guard since it was
+ * written. These are its two siblings, which did not.
+ *
+ * Source reading, and the weaker layer, for the reason [SyncDialogTeardownTest]
+ * shares with the other cases over this method: the handler is inside an Activity
+ * method holding an `AlertDialog` and a `lifecycleScope`, and a plain JVM test
+ * can build neither.
+ *
+ * NEGATIVE CONTROL, measured rather than assumed: dropping the
+ * `if (!isFinishing && !isDestroyed)` from either failure handler reddens `every
+ * failure handler guards the dialog it dismisses` and nothing else.
+ */
+class SyncDialogTeardownTest {
+
+    private val file = File("src/main/kotlin/com/vscodroid/MainActivity.kt")
+
+    private val source by lazy {
+        check(file.isFile) {
+            "MainActivity.kt not found at ${file.absolutePath}; this test would " +
+                "otherwise pass by looking at nothing"
+        }
+        file.readText()
+    }
+
+    /** The body of a `private fun name(` declaration, to its closing brace. */
+    private fun body(name: String): String {
+        val start = source.indexOf("private fun $name(")
+        assertTrue(start >= 0) {
+            "$name is gone from MainActivity.kt, so this test is measuring nothing. " +
+                "If it moved or was renamed, point this at the new site rather than " +
+                "deleting it."
+        }
+        val open = source.indexOf('{', start)
+        var depth = 0
+        var i = open
+        while (i < source.length) {
+            if (source[i] == '{') depth += 1
+            if (source[i] == '}') {
+                depth -= 1
+                if (depth == 0) return source.substring(open, i + 1)
+            }
+            i += 1
+        }
+        throw AssertionError("Could not find the end of $name in MainActivity.kt")
+    }
+
+    /**
+     * Comment lines dropped, so prose about the guard cannot stand in for one and
+     * a dismiss that has been commented out cannot be read as a live one.
+     */
+    private fun code(text: String): List<String> =
+        text.lines().filterNot {
+            val t = it.trimStart()
+            t.startsWith("//") || t.startsWith("*") || t.startsWith("/*")
+        }
+
+    @Test
+    fun `every failure handler guards the dialog it dismisses`() {
+        val opened = code(body("openSafFolder"))
+
+        val firstCatch = opened.indexOfFirst { it.contains("} catch (") }
+        assertTrue(firstCatch >= 0) {
+            "openSafFolder no longer handles anything, so this case is measuring nothing"
+        }
+        val handlers = opened.count { it.contains("} catch (") }
+        assertEquals(3, handlers) {
+            "expected the cancellation, permission and catch-all handlers. If one was " +
+                "added or removed, check the new one dismisses the dialog only while " +
+                "there is still a window under it."
+        }
+
+        val dismissals = opened.drop(firstCatch).filter { it.contains("dialog.dismiss()") }
+        assertEquals(3, dismissals.size) {
+            "expected one dismissal in each handler; found " +
+                dismissals.joinToString("\n") { "  ${it.trim()}" }
+        }
+
+        val unguarded = dismissals.filterNot {
+            it.contains("if (!isFinishing && !isDestroyed)")
+        }
+        assertEquals(emptyList<String>(), unguarded.map { it.trim() }) {
+            "a failure handler dismisses the sync dialog without asking whether its " +
+                "window is still there. A sync that fails for a real reason while the " +
+                "activity is being torn down throws out of the handler, out of the " +
+                "coroutine and into the uncaught handler, which kills the app."
+        }
+    }
+
+    @Test
+    fun `the dialog is still dismissed when the sync succeeds`() {
+        // Control. Guarding every dismissal in the method, or deleting them, would
+        // satisfy the case above by removing its subject: a finished sync has to
+        // take its progress dialog off the screen, and there the activity is alive
+        // by construction, because a cancelled scope cannot reach that line.
+        val opened = code(body("openSafFolder"))
+        val firstCatch = opened.indexOfFirst { it.contains("} catch (") }
+
+        val success = opened.take(firstCatch).filter { it.contains("dialog.dismiss()") }
+        assertEquals(1, success.size) {
+            "the successful sync no longer dismisses its own progress dialog, so a modal " +
+                "with no way out is left over the editor. Found: $success"
+        }
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/ToolchainRemoveDialogTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/ToolchainRemoveDialogTest.kt
@@ -1,0 +1,113 @@
+package com.vscodroid
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * That the remove confirmation is let go of when the screen is.
+ *
+ * `ToolchainActivity` declares no `android:configChanges`, unlike the editor and
+ * the splash screen, so a rotation or a multi-window resize destroys it and
+ * builds it again. A dialog left showing is attached to the window that goes with
+ * it: the framework logs `android.view.WindowLeaked` and the question the user
+ * was asked disappears with their answer unmade.
+ *
+ * Read out of the source for the reason `ActivityTeardownTest` gives: no plain
+ * JVM test here can drive an Activity lifecycle, and this project's unit tests
+ * have no Robolectric. What is checkable is the shape -- the dialog is held, and
+ * `onDestroy` dismisses it -- and the manifest's silence about configChanges,
+ * which is what makes the shape necessary.
+ */
+class ToolchainRemoveDialogTest {
+
+    private val activity = File("src/main/kotlin/com/vscodroid/ToolchainActivity.kt")
+    private val manifest = File("src/main/AndroidManifest.xml")
+
+    /**
+     * The source with its comments dropped. Every rule below is discussed in
+     * prose beside the line it governs, and a search over raw text would be
+     * satisfied by the discussion.
+     */
+    private val code: String by lazy {
+        assertTrue(
+            activity.isFile,
+            "${activity.path} is not at ${activity.absolutePath}; this test would " +
+                "otherwise pass by reading nothing",
+        )
+        activity.readText()
+            .replace(Regex("""/\*.*?\*/""", RegexOption.DOT_MATCHES_ALL), " ")
+            .replace(Regex("""//[^\n]*"""), " ")
+    }
+
+    /** The body of a declaration, by brace matching from it. */
+    private fun body(declaration: String): String {
+        val start = code.indexOf(declaration)
+        assertTrue(start >= 0, "`$declaration` is gone from ToolchainActivity.kt")
+        val open = code.indexOf('{', start)
+        var depth = 0
+        var i = open
+        while (i < code.length) {
+            if (code[i] == '{') depth += 1
+            if (code[i] == '}') {
+                depth -= 1
+                if (depth == 0) return code.substring(open, i + 1)
+            }
+            i += 1
+        }
+        throw AssertionError("Could not find the end of `$declaration` in ToolchainActivity.kt")
+    }
+
+    /**
+     * The premise, and it is not decoration: if this screen ever declares
+     * configChanges the rotation stops destroying it, and the case below would go
+     * on asserting a shape for a reason that no longer applies. It would still be
+     * right for a `finish()` from the toolbar, which is why it stays either way,
+     * but the reader deserves to know which of the two they are looking at.
+     */
+    @Test
+    fun `the toolchains screen is still one a rotation destroys`() {
+        assertTrue(manifest.isFile, "${manifest.path} is missing")
+        val entry = manifest.readText()
+            .substringAfter(""".ToolchainActivity""")
+            .substringBefore("/>")
+
+        assertTrue(
+            entry.isNotEmpty() && entry.length < 2_000,
+            "the ToolchainActivity entry was not found in the manifest",
+        )
+        assertTrue(
+            "configChanges" !in entry,
+            "ToolchainActivity now declares configChanges, so a rotation no longer " +
+                "recreates it. The dismissal below is still right for finish(), but the " +
+                "leak it was written for is gone: $entry",
+        )
+    }
+
+    /**
+     * NEGATIVE CONTROL: drop the `removeDialog?.dismiss()` line from `onDestroy`,
+     * or stop assigning the built dialog to the field, and this goes red on the
+     * matching assertion. Measured for both.
+     */
+    @Test
+    fun `the remove confirmation is held and dismissed when the screen goes`() {
+        assertTrue(
+            Regex("""(?m)^\s*removeDialog = AlertDialog\.Builder\(""").containsMatchIn(code),
+            "showRemoveConfirmation drops the dialog it built, so nothing can take it " +
+                "down when the Activity is destroyed and the framework logs WindowLeaked",
+        )
+        assertTrue(
+            Regex("""(?m)^\s*removeDialog\?\.dismiss\(\)""").containsMatchIn(body("override fun onDestroy()")),
+            "onDestroy does not dismiss the remove confirmation, so rotating while it is " +
+                "up leaks the window and loses the user's answer",
+        )
+        // Cleared where the dialog itself ends, so the field cannot outlive the
+        // window it names: a stale reference is dismissed a second time, and the
+        // Activity is kept alive by it in the meantime.
+        assertTrue(
+            Regex("""setOnDismissListener \{ removeDialog = null \}""").containsMatchIn(code),
+            "nothing clears removeDialog when the user answers, so the field holds a " +
+                "dialog that has already gone",
+        )
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/ToolchainSubscriptionTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/ToolchainSubscriptionTest.kt
@@ -1,0 +1,521 @@
+package com.vscodroid
+
+import com.google.android.play.core.assetpacks.model.AssetPackStatus
+import com.vscodroid.setup.ToolchainFailure
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * When the Toolchains screen is allowed to stop listening to Play Core.
+ *
+ * The screen used to drop its subscription in `onStop`, which is what
+ * `AndroidBridge` refuses to do with the same manager: the COMPLETED branch of
+ * the manager's state handler is the only thing that copies a delivered pack
+ * into `usr/`, and Play Core promises nothing about re-emitting a state to a
+ * listener that subscribes afterwards. A user who started a 155 MB install and
+ * pressed Home therefore paid for a pack that was delivered and never installed,
+ * repaired only by the next launch that runs `SplashActivity`, which resuming a
+ * live task never does.
+ *
+ * [shouldReleaseSubscription] is the replacement rule, and these pin it. The
+ * wiring, that `onStop` and `onDestroy` consult it rather than unsubscribing
+ * outright, is read from the source below for the reason `PackStatusTest` gives:
+ * an Activity method cannot be reached from a JVM test here.
+ */
+class ToolchainSubscriptionTest {
+
+    private fun outstandingOf(vararg packs: String): MutableSet<String> =
+        ConcurrentHashMap.newKeySet<String>().apply { addAll(packs) }
+
+    private fun gone(value: Boolean) = AtomicBoolean(value)
+
+    /**
+     * NEGATIVE CONTROL: drop the `screenGone &&` from the return in
+     * [shouldReleaseSubscription] and `a screen still on show keeps listening`
+     * goes red; return `true` unconditionally and both of the others do.
+     */
+    @Test
+    fun `the last download settling with no screen left hands the subscription back`() {
+        val outstanding = outstandingOf("toolchain_java")
+
+        assertTrue(
+            shouldReleaseSubscription("toolchain_java", AssetPackStatus.COMPLETED, outstanding, gone(true)),
+            "a settled download with no screen behind it has nothing left to hear, so the " +
+                "subscription would be held for the life of the process",
+        )
+        assertTrue(outstanding.isEmpty(), "the settled pack was left in the set")
+    }
+
+    @Test
+    fun `a download still running keeps the subscription`() {
+        val outstanding = outstandingOf("toolchain_java", "toolchain_ruby")
+
+        assertFalse(
+            shouldReleaseSubscription("toolchain_ruby", AssetPackStatus.COMPLETED, outstanding, gone(true)),
+            "the subscription went while Java was still downloading, so the COMPLETED " +
+                "that installs it reaches nobody and the pack stays delivered and uncopied",
+        )
+    }
+
+    @Test
+    fun `a screen still on show keeps listening`() {
+        val outstanding = outstandingOf("toolchain_java")
+
+        assertFalse(
+            shouldReleaseSubscription("toolchain_java", AssetPackStatus.COMPLETED, outstanding, gone(false)),
+            "a screen still in front stopped hearing Play, so a second install started " +
+                "from those same cards would draw no progress",
+        )
+        assertTrue(
+            outstanding.isEmpty(),
+            "the pack has to leave the set even while the screen is up, or the onStop " +
+                "that follows finds it non-empty and never unsubscribes at all",
+        )
+    }
+
+    /**
+     * NEGATIVE CONTROL: move the `outstanding.remove(packName)` above the
+     * `isTerminalPackStatus` guard and this goes red.
+     */
+    @Test
+    fun `a download still going somewhere neither settles nor releases`() {
+        listOf(
+            AssetPackStatus.DOWNLOADING,
+            AssetPackStatus.TRANSFERRING,
+            AssetPackStatus.PENDING,
+            AssetPackStatus.WAITING_FOR_WIFI,
+            // The one that matters most: a confirmation prompt the user walked
+            // away from is the state AndroidBridge names as the reason a
+            // subscription cannot be dropped on teardown.
+            AssetPackStatus.REQUIRES_USER_CONFIRMATION,
+        ).forEach { status ->
+            val outstanding = outstandingOf("toolchain_java")
+
+            assertFalse(
+                shouldReleaseSubscription("toolchain_java", status, outstanding, gone(true)),
+                "status $status is still on its way, and unsubscribing on it drops the " +
+                    "install that finishes it",
+            )
+            assertTrue(
+                "toolchain_java" in outstanding,
+                "status $status took the pack out of the set, so the next status to " +
+                    "arrive would find nothing outstanding and release the subscription",
+            )
+        }
+    }
+
+    /**
+     * The one interleaving `onDestroy` and this function have to survive between
+     * them, placed rather than waited for.
+     *
+     * `onDestroy` writes the flag and then tests the set. If this asked in the
+     * same order, reading the flag before taking the pack out, a report preempted
+     * between its two steps would leave the screen finding the set non-empty and
+     * the report finding a screen that was not gone yet: neither unregisters, and
+     * Play Core keeps a listener with no screen and no download behind it.
+     *
+     * The set below stands in for that preemption exactly, by flipping the flag
+     * at the instant the last pack leaves. A reading taken before the call cannot
+     * see it; a read taken after the removal has to.
+     *
+     * NEGATIVE CONTROL: hoist the read in [shouldReleaseSubscription] above
+     * `outstanding.remove(packName)`, which is the shape the call site used to
+     * impose by passing a `Boolean`, and this goes red on its own.
+     */
+    @Test
+    fun `a screen destroyed as the last pack leaves the set is still seen`() {
+        val screenGone = AtomicBoolean(false)
+        val outstanding = FlippingSet(outstandingOf("toolchain_java")) { screenGone.set(true) }
+
+        assertTrue(
+            shouldReleaseSubscription(
+                "toolchain_java", AssetPackStatus.COMPLETED, outstanding, screenGone,
+            ),
+            "the flag was read before the pack left the set, so this report and the " +
+                "onDestroy it raced each decided the other would hand the subscription " +
+                "back, and Play Core holds a listener nothing will ever unregister",
+        )
+    }
+
+    /**
+     * NEGATIVE CONTROL: spell the settled states out as COMPLETED, FAILED and
+     * CANCELED, the way `AndroidBridge` does, and the UNKNOWN case goes red.
+     */
+    @Test
+    fun `a declined request settles, because nothing further is coming for it`() {
+        // UNKNOWN is how ToolchainManager declines a request for a pack another
+        // install already holds, and the declined caller hears nothing more about
+        // it. Left in the set it would hold the subscription open for good.
+        listOf(
+            AssetPackStatus.UNKNOWN,
+            AssetPackStatus.FAILED,
+            AssetPackStatus.CANCELED,
+            AssetPackStatus.NOT_INSTALLED,
+        ).forEach { status ->
+            val outstanding = outstandingOf("toolchain_java")
+
+            assertTrue(
+                shouldReleaseSubscription("toolchain_java", status, outstanding, gone(true)),
+                "status $status leaves nothing to wait for, so the subscription must go",
+            )
+        }
+    }
+}
+
+/**
+ * Who the "already installing" line is addressed to.
+ *
+ * The retention [shouldReleaseSubscription] introduced is what makes the question
+ * exist. A rotation mid-download leaves the destroyed screen's listener
+ * registered until the pack settles, the rebuilt screen registers a second one,
+ * Play delivers COMPLETED to both managers, and the one that loses the
+ * process-wide claim declines with UNKNOWN. Roughly half the time the loser is
+ * the rebuilt screen's manager, and the line then landed on a screen where the
+ * user had tapped nothing.
+ */
+class ToolchainDeclineToastTest {
+
+    /**
+     * NEGATIVE CONTROL: drop the `asked &&` from [shouldSayAlreadyInstalling] and
+     * this goes red; return `false` unconditionally and
+     * `a decline answering this screen's own tap is said` goes red.
+     */
+    @Test
+    fun `a decline for a pack this screen never asked for says nothing`() {
+        assertFalse(
+            shouldSayAlreadyInstalling(AssetPackStatus.UNKNOWN, null, asked = false),
+            "a decline this screen did not ask for is announced to it. That report is " +
+                "the losing half of a claim race between two managers after a rotation, " +
+                "so the user sees a toolchain popping up an explanation for a tap they " +
+                "never made",
+        )
+    }
+
+    @Test
+    fun `a decline answering this screen's own tap is said`() {
+        assertTrue(
+            shouldSayAlreadyInstalling(AssetPackStatus.UNKNOWN, null, asked = true),
+            "a tap on Install was answered with nothing at all: the card cannot say it " +
+                "either, so the user taps again and gets the same silence",
+        )
+    }
+
+    /**
+     * NEGATIVE CONTROL: drop the `why == null` from [shouldSayAlreadyInstalling]
+     * and the failure case goes red; drop `status == AssetPackStatus.UNKNOWN` and
+     * the rest do.
+     */
+    @Test
+    fun `nothing but a decline is read as one`() {
+        assertFalse(
+            shouldSayAlreadyInstalling(AssetPackStatus.UNKNOWN, ToolchainFailure.STORAGE, asked = true),
+            "a failure carrying a reason is also announced as an install someone else " +
+                "is doing, so the user is told two contradictory things about one pack",
+        )
+        listOf(
+            AssetPackStatus.COMPLETED,
+            AssetPackStatus.FAILED,
+            AssetPackStatus.CANCELED,
+            AssetPackStatus.NOT_INSTALLED,
+            AssetPackStatus.DOWNLOADING,
+        ).forEach { status ->
+            assertFalse(
+                shouldSayAlreadyInstalling(status, null, asked = true),
+                "status $status is announced as a decline, and a completed install is " +
+                    "the worst of them: the toolchain is on disk and the screen says " +
+                    "someone else is still fetching it",
+            )
+        }
+    }
+
+    /**
+     * That the reading [shouldSayAlreadyInstalling] rests on can ever be true.
+     *
+     * [shouldReleaseSubscription] removes any settled pack and a decline settles,
+     * so a membership taken after that call is false for every decline there is
+     * and the gate refuses the user's own tap as well as the overheard one. This
+     * pins the property the call site's ordering has to respect; the ordering
+     * itself is read from the source in [ToolchainScreenRetentionTest].
+     */
+    @Test
+    fun `a decline takes the pack out of the set it is recognised by`() {
+        val outstanding = ConcurrentHashMap.newKeySet<String>().apply { add("toolchain_java") }
+
+        shouldReleaseSubscription(
+            "toolchain_java", AssetPackStatus.UNKNOWN, outstanding, AtomicBoolean(false),
+        )
+
+        assertFalse(
+            "toolchain_java" in outstanding,
+            "the decline left the pack in the set, so the ordering rule the callback " +
+                "and ToolchainScreenRetentionTest both carry is measuring nothing",
+        )
+    }
+}
+
+/**
+ * A set that runs [onRemove] as a removal happens, so the other thread's step
+ * can be placed at the one instruction where a race would put it.
+ *
+ * Nothing here is concurrent, deliberately: a test that starts threads and hopes
+ * to hit a few-instruction window measures the scheduler, not the code.
+ */
+private class FlippingSet(
+    private val delegate: MutableSet<String>,
+    private val onRemove: () -> Unit,
+) : MutableSet<String> by delegate {
+    override fun remove(element: String): Boolean {
+        onRemove()
+        return delegate.remove(element)
+    }
+}
+
+/**
+ * That the Toolchains screen asks [shouldReleaseSubscription] rather than
+ * unsubscribing on its own, and that nothing the manager outlives is a screen.
+ *
+ * Source reading, because both live in Activity callbacks and this project has
+ * no Robolectric. It proves the calls are written where they have to be, not
+ * that Android delivers the callbacks.
+ */
+class ToolchainScreenRetentionTest {
+
+    private val file = File("src/main/kotlin/com/vscodroid/ToolchainActivity.kt")
+
+    private val source by lazy {
+        assertTrue(
+            file.isFile,
+            "${file.path} is not at ${file.absolutePath}; this test would otherwise " +
+                "pass by reading nothing",
+        )
+        file.readText()
+    }
+
+    /** Comments dropped: every rule here is argued in prose beside the line it governs. */
+    private val code by lazy {
+        source
+            .replace(Regex("""/\*.*?\*/""", RegexOption.DOT_MATCHES_ALL), " ")
+            .replace(Regex("""//[^\n]*"""), " ")
+    }
+
+    /**
+     * NEGATIVE CONTROL: write `ToolchainManager(this)` back into `onCreate` and
+     * both halves of this go red.
+     */
+    @Test
+    fun `the manager that outlives this screen is not built with it`() {
+        assertTrue(
+            "ToolchainManager(applicationContext)" in code,
+            "the Toolchains screen builds its manager with something other than the " +
+                "application context. An HTTP transfer runs on that manager's own " +
+                "executor and reads cacheDir and filesDir from the Context it was given, " +
+                "so a finished or rotated-away Activity, its adapter and its whole view " +
+                "tree stay reachable from a live thread until the download ends.",
+        )
+        assertFalse(
+            "ToolchainManager(this)" in code,
+            "the screen hands itself to a ToolchainManager again",
+        )
+    }
+
+    /**
+     * NEGATIVE CONTROL: change the callback to capture the Activity, for instance
+     * by replacing `screen.get()` with a direct `runOnUiThread`, and this goes
+     * red.
+     */
+    @Test
+    fun `the state callback reaches the screen weakly or not at all`() {
+        assertTrue(
+            "WeakReference(this)" in code,
+            "the state callback holds this Activity directly. It outlives the screen by " +
+                "design now, kept by Play Core while a download settles and by the " +
+                "manager's executor on the HTTP path, so anything it captures is a leak " +
+                "and a toast over the editor from a screen the user closed.",
+        )
+        assertTrue(
+            Regex("""(?m)^\s*manager\.onStateChange = \{""").containsMatchIn(code),
+            "the callback is assigned through something other than the local manager. " +
+                "Naming the field instead captures the Activity as completely as naming " +
+                "the Activity would, which is the correction AndroidBridge had to make " +
+                "in bytecode.",
+        )
+    }
+
+    /** The body of a declaration, by brace matching from it over comment-free source. */
+    private fun body(declaration: String): String {
+        val start = code.indexOf(declaration)
+        assertTrue(start >= 0, "`$declaration` is gone from ToolchainActivity.kt")
+        val open = code.indexOf('{', start)
+        var depth = 0
+        var i = open
+        while (i < code.length) {
+            if (code[i] == '{') depth += 1
+            if (code[i] == '}') {
+                depth -= 1
+                if (depth == 0) return code.substring(open, i + 1)
+            }
+            i += 1
+        }
+        throw AssertionError("Could not find the end of `$declaration` in ToolchainActivity.kt")
+    }
+
+    /**
+     * That a state report cannot put anything in front of a screen the user has
+     * left, which is not the same screen as one that has been destroyed.
+     *
+     * `onStop` keeps the Play Core subscription while a download is outstanding,
+     * because the COMPLETED branch is the only thing that copies a delivered pack
+     * into `usr/`. So reports now arrive at a stopped screen by design, and the
+     * only thing standing between them and a toolchain toast over the editor is
+     * this gate. `destroyed` does not answer it: pressing Home stops this screen
+     * and destroys nothing.
+     *
+     * NEGATIVE CONTROL: put `if (!screenGone.get())` back in place of the
+     * lifecycle test, or delete the test outright, and this goes red. Measured
+     * for both.
+     */
+    @Test
+    fun `a stopped screen shows nothing, not merely a destroyed one`() {
+        val shown = body("private fun showPackState(")
+        val gate = shown.indexOf("lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)")
+        val toast = shown.indexOf("Toast.makeText")
+        val confirm = shown.indexOf("askForCellularConfirmation()")
+
+        assertTrue(
+            gate >= 0,
+            "showPackState no longer asks the lifecycle whether this screen is in " +
+                "front. A Play report landing while the user is in the editor then " +
+                "toasts over it, and REQUIRES_USER_CONFIRMATION takes the foreground " +
+                "from them: $shown",
+        )
+        assertTrue(toast >= 0 && confirm >= 0, "the guarded calls are gone; this measures nothing")
+        assertTrue(
+            "return" in shown.substring(gate, toast),
+            "the lifecycle test does not stop anything: no return between it and the " +
+                "first Toast",
+        )
+        assertTrue(
+            gate < toast && gate < confirm,
+            "a Toast or Play's confirmation window is reached before the screen is " +
+                "asked whether it is in front (gate $gate, toast $toast, confirm $confirm)",
+        )
+    }
+
+    /**
+     * The other branch of that gate. Suppressing Play's cellular-data question is
+     * only right if it is put again, since REQUIRES_USER_CONFIRMATION never
+     * settles: no further report follows it, so a pack whose question was
+     * swallowed waits for an answer nobody is asked for.
+     *
+     * NEGATIVE CONTROL: delete the `confirmationDeferred` block from `onStart`
+     * and this goes red; delete the `confirmationDeferred = true` from the gate
+     * and it goes red on the other assertion. Measured for both.
+     */
+    @Test
+    fun `a confirmation asked for while the screen was away is put again on return`() {
+        val shown = body("private fun showPackState(")
+        val started = body("override fun onStart()")
+
+        assertTrue(
+            "confirmationDeferred = true" in shown,
+            "the gate drops Play's cellular-data question instead of holding it, and " +
+                "nothing else will ever ask: the download waits for good",
+        )
+        assertTrue(
+            "confirmationDeferred" in started && "askForCellularConfirmation()" in started,
+            "onStart does not put the question the gate held back, so suppressing it " +
+                "turned a rude interruption into a download that never finishes",
+        )
+        assertTrue(
+            "confirmationDeferred = false" in started,
+            "onStart asks but never clears the flag, so every later onStart asks Play " +
+                "again for a confirmation nothing is waiting on",
+        )
+    }
+
+    /**
+     * NEGATIVE CONTROL: drop either `if (outstanding.isEmpty())` guard and this
+     * goes red; that is exactly the code that shipped, and it left a Play pack
+     * delivered and never installed when the user pressed Home mid-download.
+     */
+    @Test
+    fun `the subscription is only dropped when nothing is outstanding`() {
+        val guarded = Regex(
+            """(?m)^\s*if \(outstanding\.isEmpty\(\)\) toolchainManager\.unregisterListener\(\)"""
+        ).findAll(code).count()
+        val total = Regex("""toolchainManager\.unregisterListener\(\)""").findAll(code).count()
+
+        assertTrue(
+            guarded == 2,
+            "expected the guarded call in onStop and in onDestroy, found $guarded. An " +
+                "unguarded one unsubscribes mid-download, and the COMPLETED that copies " +
+                "a delivered pack into usr/ then reaches nobody.",
+        )
+        assertTrue(
+            total == guarded,
+            "an unguarded unregisterListener() is back in the Toolchains screen: " +
+                "$total calls, $guarded of them guarded",
+        )
+    }
+
+    /**
+     * That the "did this screen ask for it" reading is taken before the set that
+     * answers it is emptied.
+     *
+     * `shouldReleaseSubscription` removes any settled pack, and a decline settles.
+     * Taken after that call, or taken on the main thread inside `showPackState`,
+     * the reading is false for every decline there is, so the gate refuses the
+     * user's own tap too and the screen answers Install with nothing again. That
+     * is a silent failure in the direction opposite to the one the gate exists
+     * for, which is why the ordering is pinned rather than left to the comment.
+     *
+     * NEGATIVE CONTROL: move the `val asked` line below the
+     * `shouldReleaseSubscription` call and this goes red; move the reading into
+     * `showPackState` and it goes red on the first assertion. Measured for both.
+     */
+    @Test
+    fun `what this screen asked for is read before the settled pack leaves the set`() {
+        val created = body("override fun onCreate(")
+        val asked = created.indexOf("val asked = packName in pending")
+        val release = created.indexOf("shouldReleaseSubscription(")
+
+        assertTrue(
+            asked >= 0,
+            "nothing records whether the report answers a tap this screen made, so a " +
+                "decline from a claim race after a rotation announces itself on a " +
+                "screen the user tapped nothing on: $created",
+        )
+        assertTrue(release >= 0, "the release decision is gone; this test measures nothing")
+        assertTrue(
+            asked < release,
+            "the reading is taken after shouldReleaseSubscription, which removes any " +
+                "settled pack. A decline is settled, so the reading is false for every " +
+                "one of them and a tap on Install is answered with silence again " +
+                "(asked $asked, release $release)",
+        )
+    }
+
+    /**
+     * NEGATIVE CONTROL: delete the `outstanding.add(packName)` line above
+     * `install(packName)` and this goes red, and the guard above becomes an
+     * `isEmpty()` that is always true.
+     */
+    @Test
+    fun `a download this screen starts is recorded before it starts`() {
+        val add = code.indexOf("outstanding.add(packName)")
+        val install = code.indexOf("toolchainManager.install(packName)")
+
+        assertTrue(add >= 0, "nothing records what this screen asked for, so the guard above is empty")
+        assertTrue(install >= 0, "the install call is gone; this test is measuring nothing")
+        assertTrue(
+            add < install,
+            "the pack is recorded after install(), which can report a failure on the " +
+                "calling thread: the removal then runs against a set the pack is not in " +
+                "yet, and the subscription is held for a download that never began",
+        )
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/WebViewPreWarmTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/WebViewPreWarmTest.kt
@@ -4,15 +4,17 @@ import com.vscodroid.util.Logger
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
+import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 /**
- * The WebView pre-warm in `Application.onCreate`, and what happens when the
+ * The WebView pre-warm the application registers, and what happens when the
  * device cannot give us one.
  *
  * The statement is an optimisation worth 200-400 ms of Chromium load, and it sat
@@ -72,5 +74,63 @@ class WebViewPreWarmTest {
         preWarmWebView { warmed = true }
 
         assertTrue(warmed, "the pre-warm did not run at all")
+    }
+
+    /**
+     * And which processes pay for it.
+     *
+     * `Application.onCreate` runs for every process instantiation, not for every
+     * launch, and `NodeService` declares no `android:process`, so it shares this
+     * one. Two service-only starts exist in the shipped build: the notification's
+     * Stop action after the process was reclaimed, which routes straight to
+     * `shutdown()`, and the START_STICKY re-delivery whose foreground promotion is
+     * refused, which calls `stopSelf()` without starting anything. Both used to
+     * load the whole Chromium library and build and destroy a WebView first, in a
+     * process that then died without ever showing a page.
+     *
+     * An Activity being created is the fact itself rather than a guess at it, and
+     * it costs the launch nothing: `Activity.onCreate` dispatches this callback
+     * from `super.onCreate()`, before the Activity has inflated anything.
+     *
+     * NEGATIVE CONTROL, both measured: move `preWarmWebView(warm)` into an `init`
+     * block of `FirstActivityPreWarm` and
+     * `a process that only hosts a service never loads Chromium` goes red; drop
+     * the `warmed` guard and `only the first Activity pays for the pre-warm` goes
+     * red at two calls.
+     */
+    @Test
+    fun `a process that only hosts a service never loads Chromium`() {
+        var warmed = 0
+
+        FirstActivityPreWarm { warmed += 1 }
+
+        assertEquals(
+            0, warmed,
+            "registering the pre-warm is enough to run it, so a process created purely to " +
+                "deliver a service intent still pays for a WebView it will never host",
+        )
+    }
+
+    @Test
+    fun `the first Activity still gets the pre-warm`() {
+        var warmed = 0
+        val callbacks = FirstActivityPreWarm { warmed += 1 }
+
+        callbacks.onActivityCreated(mockk(relaxed = true), null)
+
+        assertEquals(1, warmed, "the launch this optimisation exists for lost it")
+    }
+
+    @Test
+    fun `only the first Activity pays for the pre-warm`() {
+        // The callback stays registered for the life of the process, and the app
+        // has more than one Activity. Chromium is loaded once; building a
+        // throwaway WebView for every Activity after that buys nothing.
+        var warmed = 0
+        val callbacks = FirstActivityPreWarm { warmed += 1 }
+
+        repeat(3) { callbacks.onActivityCreated(mockk(relaxed = true), null) }
+
+        assertEquals(1, warmed, "a throwaway WebView was built for every Activity created")
     }
 }

--- a/android/app/src/test/kotlin/com/vscodroid/bridge/PageSuppliedLoggingTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/bridge/PageSuppliedLoggingTest.kt
@@ -20,6 +20,13 @@ import java.io.File
  * missed because a reader sweeping for `url` and `uri` does not match `name` or
  * `uriString`. A list would have been written from the same sweep and inherited
  * the same blind spot.
+ *
+ * What the scan asks has since been widened twice, both times because a live leak
+ * satisfied it. It asked whether the value opened an interpolation, so a value
+ * sitting INSIDE one read as not logged; and it accepted the presence of
+ * `redactToken` as a treatment, which for an address is a call that changes
+ * nothing. `openRecentFolder` was both at once, and this file was already reading
+ * that line. See [treated] for the distinction that replaced the second question.
  */
 class PageSuppliedLoggingTest {
 
@@ -139,6 +146,35 @@ class PageSuppliedLoggingTest {
     private data class Scan(val offenders: List<String>, val examined: Int)
 
     /**
+     * What may stand between a page-supplied value and the log, and for which values.
+     *
+     * [REDACTION] takes one thing out of a string it is otherwise happy to print:
+     * `redactToken` replaces the `tkn=` parameter and nothing else. That is the whole
+     * treatment a page's own free text needs, which is what `logToNative` carries.
+     *
+     * [REDUCERS] answer a different question. They do not clean a value up, they
+     * replace it with something that names the same thing without spelling it out:
+     * `urlLogLabel` reduces an address to a scheme and a host, `getMirrorDir(…).name`
+     * to the digest the mirror is named after.
+     *
+     * The distinction is load-bearing rather than tidy, and it is why this file no
+     * longer accepts `redactToken` everywhere. A SAF tree URI is the user's directory
+     * spelled out and carries no `tkn=` at all, so wrapping one satisfies a scan
+     * looking for the call while changing nothing about what ships. That is exactly
+     * how `openRecentFolder` printed the user's folder past a guard written about it.
+     */
+    private val REDACTION = listOf("redactToken")
+    private val REDUCERS = listOf("urlLogLabel", "getMirrorDir")
+
+    /**
+     * Whether [text] hands [value] to the log through something that makes it
+     * printable. An address can only be reduced; redacting it changes nothing.
+     */
+    private fun treated(value: String, text: String, isAddress: Boolean): Boolean =
+        (if (isAddress) REDUCERS else REDUCERS + REDACTION)
+            .any { Regex("""$it\(\s*$value\b""").containsMatchIn(text) }
+
+    /**
      * Every page-supplied value that reaches a log call in [source] unredacted,
      * and every redacted call that hands over the exception beside it.
      *
@@ -167,11 +203,26 @@ class PageSuppliedLoggingTest {
             // right-hand side is read to the end of the statement rather than the
             // end of the line, for the reason [statementFrom] gives.
             val tainted = params.toMutableSet()
+            // The values that ARE an address rather than text that might contain one.
+            // A local parsed out of one is an address, and so is the string it was
+            // parsed from: the two spell out the same place on the device, and
+            // neither has a `tkn=` for a redaction to take out.
+            val addresses = mutableSetOf<String>()
             for (m in Regex("""val\s+(\w+)\s*=""").findAll(chunk)) {
+                val local = m.groupValues[1]
                 val rhs = statementFrom(chunk, m.range.last + 1)
-                if (tainted.any { Regex("""\b$it\b""").containsMatchIn(rhs) }) {
-                    tainted += m.groupValues[1]
+                val carried = tainted.filter { Regex("""\b$it\b""").containsMatchIn(rhs) }
+                if (carried.isEmpty()) continue
+                if (rhs.contains("Uri.parse(")) {
+                    addresses += local
+                    addresses += carried
                 }
+                // A local assigned the value itself carries its taint; one assigned
+                // the result of treating it carries the treatment instead, which is
+                // what `logToNative`'s `safeTag` and `safeMessage` are. Without that
+                // the rule below would report the two lines in this file that do
+                // exactly what it asks for.
+                if (carried.any { !treated(it, rhs, it in addresses) }) tainted += local
             }
             // What a catch binds. A throwable is the second channel a log line has,
             // and redacting the first while handing over the second only looks like
@@ -186,13 +237,23 @@ class PageSuppliedLoggingTest {
                 val text = statementFrom(chunk, call.range.last)
                 examined++
                 for (value in tainted) {
-                    val interpolated = Regex("""\$\{?$value\b""").containsMatchIn(text)
-                    val redacted = Regex("""redactToken\(\s*$value\b""").containsMatchIn(text)
-                    if (interpolated && !redacted) {
-                        offenders += "$name logs $value unredacted: ${text.trim()}"
+                    // Any appearance in the statement, not only `$value` and
+                    // `${value`. The shape that got past this was
+                    // `${redactToken(uri.toString())}`, where the value is inside the
+                    // interpolation rather than at the start of it, so the narrower
+                    // pattern answered "not logged" for a line that logs it.
+                    if (!Regex("""\b$value\b""").containsMatchIn(text)) continue
+                    val isAddress = value in addresses
+                    if (treated(value, text, isAddress)) continue
+                    offenders += if (isAddress) {
+                        "$name logs $value in full, and it is an address: redactToken " +
+                            "only takes out tkn=, so the user's own path ships whether " +
+                            "or not it is wrapped in one: ${text.trim()}"
+                    } else {
+                        "$name logs $value unredacted: ${text.trim()}"
                     }
                 }
-                if (text.contains("redactToken(")) {
+                if ((REDUCERS + REDACTION).any { text.contains("$it(") }) {
                     for (binding in caught) {
                         if (Regex(""",\s*$binding\s*\)""").containsMatchIn(text)) {
                             offenders += "$name redacts its message and then hands over " +
@@ -289,6 +350,89 @@ class PageSuppliedLoggingTest {
             result.offenders.any { it.contains("logs uri ") },
             "the local built from a page-supplied parameter over two lines was not " +
                 "tainted, so the log below it looked clean: ${result.offenders}",
+        )
+    }
+
+    /**
+     * The scanner against a redaction that redacts nothing.
+     *
+     * `redactToken` replaces `tkn=…` and touches nothing else, so wrapping a SAF tree
+     * URI in it is a call, not a treatment: the string that reaches logcat is the
+     * user's own directory, spelled out, on a level that ships. This is the live
+     * defect that stood in `openRecentFolder` while this very file scanned the line,
+     * because the old questions were "is the value interpolated at the start of a
+     * `${'$'}{…}`" and "does the word redactToken appear beside it", and the line
+     * answered no and yes.
+     */
+    @Test
+    fun `an address wrapped in redactToken is not treated as redacted`() {
+        val fixture = """
+            @JavascriptInterface
+            fun openThing(uriString: String, authToken: String) {
+                val uri = Uri.parse(uriString)
+                Logger.i(tag, "Opening: ${'$'}{redactToken(uri.toString())}")
+            }
+        """.trimIndent()
+
+        val result = scan(fixture)
+
+        assertEquals(1, result.examined, "the call was not examined at all")
+        assertTrue(
+            result.offenders.any { it.contains("logs uri ") },
+            "a tree URI passed through redactToken counted as redacted, which is what " +
+                "let the user's device folder ship in release logcat: ${result.offenders}",
+        )
+    }
+
+    /**
+     * The control for the case above, and the reason it is not "never call
+     * redactToken". The same URI named by its mirror is what the app is asked to do,
+     * and a rule that reported it would push the next author back to printing the URI.
+     */
+    @Test
+    fun `an address named by its mirror is left alone`() {
+        val fixture = """
+            @JavascriptInterface
+            fun openThing(uriString: String, authToken: String) {
+                val uri = Uri.parse(uriString)
+                val mirror = safManager?.getMirrorDir(uri)?.name
+                Logger.i(tag, "Opening recent device folder ${'$'}mirror")
+            }
+        """.trimIndent()
+
+        val result = scan(fixture)
+
+        assertEquals(1, result.examined, "the call was not examined at all")
+        assertTrue(
+            result.offenders.isEmpty(),
+            "the shape this rule exists to ask for was reported as an offence: " +
+                "${result.offenders}",
+        )
+    }
+
+    /**
+     * And free text a page chose to log is still redactable, which is the other half
+     * of the same distinction. `logToNative` takes whatever the workbench decided to
+     * print, and the workbench holds the connection token, so `tkn=` is the likely
+     * case there rather than a theoretical one.
+     */
+    @Test
+    fun `a page-supplied message redacted into a local is left alone`() {
+        val fixture = """
+            @JavascriptInterface
+            fun logIt(authToken: String, tag: String, message: String) {
+                val safeTag = redactToken(tag)
+                val safeMessage = redactToken(message)
+                Logger.i(safeTag, safeMessage)
+            }
+        """.trimIndent()
+
+        val result = scan(fixture)
+
+        assertEquals(1, result.examined, "the call was not examined at all")
+        assertTrue(
+            result.offenders.isEmpty(),
+            "the redaction this file asks for was reported as an offence: ${result.offenders}",
         )
     }
 

--- a/android/app/src/test/kotlin/com/vscodroid/bridge/RecentFolderLoggingTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/bridge/RecentFolderLoggingTest.kt
@@ -1,0 +1,135 @@
+package com.vscodroid.bridge
+
+import android.content.Context
+import android.net.Uri
+import com.vscodroid.storage.SafStorageManager
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+/**
+ * That reopening a device folder from the workbench's recent list does not put the
+ * user's directory into logcat.
+ *
+ * The same subject as `SafFolderPathLoggingTest`, one layer up: that class watches the
+ * manager, and this one watches the bridge method the editor calls. A SAF tree URI
+ * spells the folder out (`.../tree/primary%3ADocuments%2F<folder>`), `Logger.i` is not
+ * gated on a debuggable build, and this is the ordinary success path, so the folder
+ * name shipped on every reopen and travelled in every device bug report.
+ *
+ * Asserted at `android.util.Log` rather than at `Logger`, for the reason that class
+ * gives: a line can leak through its message or through a throwable it hands over, and
+ * only the sink sees both.
+ *
+ * Negative controls, both measured. Restoring the line to
+ * `Logger.i(tag, "Opening recent SAF folder: ${'$'}{redactToken(uri.toString())}")` reddens
+ * BOTH cases, and that is the point of the pair rather than a redundancy: the first
+ * because `redactToken` replaces `tkn=` and nothing else, so a tree URI passes through
+ * it exactly as it arrived, and the second because a line naming the URI names no
+ * mirror. Dropping the interpolation instead, so the line reads "Opening recent device
+ * folder" and identifies nothing, reddens only the second, which is the half that
+ * refuses a fix that deletes the record along with the secret.
+ */
+class RecentFolderLoggingTest {
+
+    @TempDir
+    lateinit var filesDir: File
+
+    private val treeUri =
+        "content://com.android.externalstorage.documents/tree/primary%3ADocuments%2FClientProject"
+
+    /** The part of that URI a reader could turn back into a place on the device. */
+    private val folderName = "ClientProject"
+
+    /** Every string the app handed the log, message and throwable alike. */
+    private val emitted = mutableListOf<String>()
+
+    private val security = SecurityManager()
+    private lateinit var context: Context
+    private lateinit var safManager: SafStorageManager
+
+    @BeforeEach
+    fun setUp() {
+        emitted.clear()
+
+        mockkStatic(android.util.Log::class)
+        every { android.util.Log.i(any(), any()) } answers { note(args); 0 }
+        every { android.util.Log.d(any(), any()) } answers { note(args); 0 }
+        every { android.util.Log.w(any(), any<String>()) } answers { note(args); 0 }
+        every { android.util.Log.w(any(), any<String>(), any<Throwable>()) } answers { note(args); 0 }
+        every { android.util.Log.e(any(), any()) } answers { note(args); 0 }
+        every { android.util.Log.e(any(), any<String>(), any<Throwable>()) } answers { note(args); 0 }
+
+        val folderUri = mockk<Uri>(relaxed = true)
+        every { folderUri.toString() } returns treeUri
+        mockkStatic(Uri::class)
+        every { Uri.parse(treeUri) } returns folderUri
+
+        context = mockk(relaxed = true)
+        every { context.filesDir } returns filesDir
+        // The manager unwraps to the application context, so a mock that answers a
+        // different object for it would hand the manager a different filesDir.
+        every { context.applicationContext } returns context
+        safManager = SafStorageManager(context)
+    }
+
+    @AfterEach
+    fun tearDown() = unmockkAll()
+
+    private fun note(args: List<Any?>) {
+        args.forEach { arg ->
+            emitted += when (arg) {
+                is Throwable -> arg.toString() + (arg.message ?: "")
+                else -> arg.toString()
+            }
+        }
+    }
+
+    /** A bridge with the SAF wiring, which is what `MainActivity` builds. */
+    private fun bridge(): AndroidBridge = AndroidBridge(
+        context = context,
+        security = security,
+        clipboard = mockk(relaxed = true),
+        onBackPressed = mockk(relaxed = true),
+        onMinimize = mockk(relaxed = true),
+        safManager = safManager,
+    )
+
+    @Test
+    fun `opening a recent folder does not log the user's directory`() {
+        bridge().openRecentFolder(security.getSessionToken(), treeUri)
+
+        assertTrue(
+            emitted.isNotEmpty(),
+            "nothing reached the log at all, so this run proves nothing about what does",
+        )
+        val leaked = emitted.filter { it.contains(folderName) || it.contains("tree/primary") }
+        assertTrue(leaked.isEmpty(), "the user's device folder reached release logcat: $leaked")
+    }
+
+    /**
+     * The control. Redaction that leaves nothing behind is deletion, and a bug report
+     * still has to be able to line this line up with the folder it is about. The
+     * mirror's own name is what does that, and it is what every other line about the
+     * folder already uses.
+     */
+    @Test
+    fun `the line still identifies the folder by its mirror name`() {
+        val hash = safManager.getMirrorDir(Uri.parse(treeUri)).name
+
+        bridge().openRecentFolder(security.getSessionToken(), treeUri)
+
+        assertTrue(
+            emitted.any { it.contains(hash) },
+            "no line named the folder at all, so the redaction removed the record rather " +
+                "than the secret: $emitted",
+        )
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/keyboard/ExtraKeyModifierStalenessTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/keyboard/ExtraKeyModifierStalenessTest.kt
@@ -1,0 +1,186 @@
+package com.vscodroid.keyboard
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * That the modifier poll never applies an answer older than the latch it is
+ * about.
+ *
+ * `queryModifierState` is answered with a snapshot the renderer took when the
+ * query script ran, and `setModifierState` is a separate, later script. Scripts
+ * run in the order they were submitted, so a modifier latched after a query went
+ * out is guaranteed to be missing from that query's answer, which reports it as
+ * clear. The poll's answer only ever clears, so it read that as "the page spent
+ * the modifier" and unlatched what the user had just pressed: the Shift of a
+ * Ctrl+Shift+P goes dark on its own and the key that follows is delivered as
+ * Ctrl+P.
+ *
+ * The half that outlives the wrong shortcut is worse. This callback is the one
+ * place a modifier is cleared without pushing the new value out, so after it
+ * clears a flag the page has just been told is held, nothing corrects either
+ * side: the row goes dark, `window.__vscodroid.ctrl` stays true, and the next
+ * ordinary character typed on the soft keyboard is cancelled by the interceptor
+ * and dispatched as a chord instead, so `a` selects the whole document and the
+ * character after it replaces the selection.
+ *
+ * Source-reading, for the reason the rest of this package gives: [ExtraKeyRow]
+ * is a `View` whose initialiser reaches resources, colours and display metrics
+ * before its constructor finishes, so no JVM test can build one and no JVM test
+ * can run a `postDelayed` or answer an `evaluateJavascript`. Every case opens
+ * with a control, so a scan that has stopped matching cannot report a healthy
+ * poll by finding nothing at all.
+ */
+class ExtraKeyModifierStalenessTest {
+
+    /**
+     * The row's source with comment lines dropped, so prose naming a call is
+     * not a call. Both comment forms, because both switch code off, and the
+     * guard this file is about is discussed at length in the comments beside it.
+     */
+    private fun code(): List<String> {
+        val file = File("src/main/kotlin/com/vscodroid/keyboard/ExtraKeyRow.kt")
+        assertTrue(
+            file.isFile,
+            "ExtraKeyRow.kt is not at ${file.absolutePath}; this test would otherwise " +
+                "pass by reading nothing",
+        )
+        var inBlock = false
+        return file.readText().lines().filterNot { line ->
+            val start = line.trimStart()
+            when {
+                inBlock -> {
+                    if (line.indexOf("*/") >= 0) inBlock = false
+                    true
+                }
+                start.startsWith("/*") -> {
+                    if (line.indexOf("*/", line.indexOf("/*") + 2) < 0) inBlock = true
+                    true
+                }
+                else -> start.startsWith("//") || start.startsWith("*")
+            }
+        }
+    }
+
+    /** The runnable's body, from its declaration to the init block that follows it. */
+    private fun pollBody(): List<String> {
+        val lines = code()
+        val start = lines.indexOfFirst { it.contains("private val modifierSyncRunnable") }
+        assertTrue(start >= 0, "modifierSyncRunnable is no longer where this test looks")
+        val body = lines.drop(start).takeWhile { !it.startsWith("    init {") }
+        assertTrue(
+            body.any { it.contains("queryModifierState") },
+            "the window found does not poll the page, so its verdict is worth nothing. " +
+                "It reads:\n${body.joinToString("\n")}",
+        )
+        return body
+    }
+
+    /** What the answer is judged against, as the poll names it. */
+    private fun snapshotLocal(body: List<String>): String {
+        val named = body.firstNotNullOfOrNull {
+            Regex("""modifierPushCount\s*!=\s*(\w+)""").find(it)?.groupValues?.get(1)
+        }
+        assertTrue(
+            named != null,
+            "nothing in the poll compares the push count it recorded with the one now, " +
+                "so an answer that predates a latch is applied to it. It reads:" +
+                "\n${body.joinToString("\n")}",
+        )
+        return named!!
+    }
+
+    /**
+     * NEGATIVE CONTROL: delete the `if (modifierPushCount != pushedWhenAsked)`
+     * branch from the answer. `snapshotLocal` then finds no comparison and this
+     * goes red there.
+     */
+    @Test
+    fun `an answer older than the latch it describes is dropped before anything is cleared`() {
+        val body = pollBody()
+        val local = snapshotLocal(body)
+        val query = body.indexOfFirst { it.contains("queryModifierState") }
+        val guard = body.indexOfFirst { it.contains("modifierPushCount != $local") }
+        val cleared = body.indexOfFirst { it.contains("ctrlActive = false") }
+        assertTrue(
+            cleared > query,
+            "the answer no longer clears a modifier at all, so this case is reading a " +
+                "poll that cannot commit the mistake it guards. It reads:" +
+                "\n${body.joinToString("\n")}",
+        )
+        assertTrue(
+            guard > query && guard < cleared,
+            "the staleness test does not stand between the answer and the first thing " +
+                "it clears, so an answer that predates the user's latch unlatches it. " +
+                "It reads:\n${body.joinToString("\n")}",
+        )
+        assertTrue(
+            body.subList(guard, cleared).any { it.contains("return@queryModifierState") },
+            "the staleness test decides nothing: the answer is applied whatever it " +
+                "found. It reads:\n${body.joinToString("\n")}",
+        )
+    }
+
+    /**
+     * The count is meaningful only against the moment the query was submitted,
+     * which is the moment the renderer's answer describes.
+     *
+     * NEGATIVE CONTROL: move `val pushedWhenAsked = modifierPushCount` inside the
+     * `queryModifierState` callback. Read there it is the count as of the answer
+     * arriving, so it can never differ from the count it is compared with, the
+     * guard above is dead code, and this goes red.
+     */
+    @Test
+    fun `the count an answer is judged against is read before the query goes out`() {
+        val body = pollBody()
+        val local = snapshotLocal(body)
+        val read = body.indexOfFirst { it.contains("val $local = modifierPushCount") }
+        val query = body.indexOfFirst { it.contains("queryModifierState") }
+        assertTrue(
+            read >= 0 && read < query,
+            "the poll records the push count from inside the answer rather than before " +
+                "asking, so it compares a value with itself and every stale answer is " +
+                "applied. It reads:\n${body.joinToString("\n")}",
+        )
+    }
+
+    /**
+     * And the count moves where a push happens, nowhere else.
+     *
+     * Both directions matter. A count that does not move on a push makes the
+     * guard above answer "current" for every answer, which is the defect; a count
+     * moved anywhere else makes it answer "stale" for every answer, so no
+     * modifier the page has spent is ever cleared and the row keeps a Ctrl lit
+     * that no page is holding, which is the defect the poll itself exists for.
+     *
+     * NEGATIVE CONTROL: delete `modifierPushCount += 1` from `syncModifierState`
+     * and this goes red on the first assertion; add a second one to the poll's
+     * answer and it goes red on the second.
+     */
+    @Test
+    fun `the count moves only where the page is pushed a new modifier state`() {
+        val lines = code()
+        val start = lines.indexOfFirst { it.contains("private fun syncModifierState()") }
+        assertTrue(start >= 0, "syncModifierState is no longer where this test looks")
+        val body = lines.drop(start).takeWhile { it != "    }" }
+        assertTrue(
+            body.any { it.contains("setModifierState") },
+            "the window found does not push anything at the page, so its verdict is " +
+                "worth nothing. It reads:\n${body.joinToString("\n")}",
+        )
+        assertTrue(
+            body.any { it.contains("modifierPushCount +=") },
+            "the one site that pushes a modifier state at the page does not record that " +
+                "it did, so an answer that predates the push is indistinguishable from " +
+                "one that saw it. It reads:\n${body.joinToString("\n")}",
+        )
+        assertEquals(
+            1, lines.count { it.contains("modifierPushCount +=") },
+            "the push count moves somewhere other than the push. Every outstanding " +
+                "answer is then judged stale and thrown away, so nothing ever notices " +
+                "the page spending a modifier and the row keeps it lit",
+        )
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/keyboard/ExtraKeyModifierSyncTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/keyboard/ExtraKeyModifierSyncTest.kt
@@ -87,6 +87,65 @@ class ExtraKeyModifierSyncTest {
         )
     }
 
+    /**
+     * The bound the unconditional re-post gave up, put back where it costs the
+     * property above nothing.
+     *
+     * A tick that always re-posts is what survives an answer that never comes.
+     * On its own it also lets the ticks stack: a renderer slow to reply is sent
+     * a fresh query every 200 ms with nothing waiting on the last one, for as
+     * long as a modifier stays latched, where the old callback-anchored re-post
+     * had exactly one query outstanding at a time. Skipping the question while
+     * the previous answer is outstanding keeps the ticks and restores the bound.
+     *
+     * The claim is made against the injector the tick just read, which is what
+     * keeps the bound from outliving the page it bounds;
+     * [ExtraKeyQueryOwnershipTest] holds that half and runs it.
+     *
+     * NEGATIVE CONTROL: delete `if (!outstanding.claim(injector)) return` from
+     * the poll and this goes red.
+     */
+    @Test
+    fun `the poll asks again only once the last answer is in`() {
+        val body = pollBody()
+        val repost = body.indexOfFirst { it.contains("postDelayed(modifierSyncRunnable, 200)") }
+        val guard = body.indexOfFirst { it.contains("outstanding.claim(") }
+        val query = body.indexOfFirst { it.contains("queryModifierState") }
+        assertTrue(
+            repost >= 0 && guard > repost && guard < query,
+            "the tick re-posts with nothing between it and the next query, so a renderer " +
+                "that has not answered is sent another one five times a second for as " +
+                "long as the latch holds. It reads:\n${body.joinToString("\n")}",
+        )
+        assertTrue(
+            body[guard].contains("if (!outstanding.claim(injector)) return"),
+            "the claim decides nothing, so the query goes out whatever it found and every " +
+                "tick asks again. It reads:\n${body.joinToString("\n")}",
+        )
+    }
+
+    /**
+     * NEGATIVE CONTROL: delete `if (!outstanding.release(injector))` and its
+     * body from the answer and this goes red. That mutation is the worse half of
+     * the pair: the ticks would go on running and never ask anything again, so
+     * the row would keep a modifier lit that the page has already spent.
+     */
+    @Test
+    fun `an answer that arrives releases the guard it was waiting behind`() {
+        val body = pollBody()
+        val query = body.indexOfFirst { it.contains("queryModifierState") }
+        // After the query line, not merely present: a scan for the call alone
+        // could be satisfied from anywhere in the poll and would pass with
+        // nothing releasing the claim where the answer actually arrives.
+        val released = body.drop(query + 1).any { it.contains("outstanding.release(injector)") }
+        assertTrue(
+            released,
+            "the outstanding query is never released where the answer arrives, so the " +
+                "poll asks once and then ticks forever without asking again. It reads:" +
+                "\n${body.joinToString("\n")}",
+        )
+    }
+
     @Test
     fun `a poll with no injector clears the row instead of stopping quietly`() {
         val body = pollBody()

--- a/android/app/src/test/kotlin/com/vscodroid/keyboard/ExtraKeyQueryOwnershipTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/keyboard/ExtraKeyQueryOwnershipTest.kt
@@ -1,0 +1,232 @@
+package com.vscodroid.keyboard
+
+import android.webkit.WebView
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * Who owns the lifetime of the one modifier query allowed to be in the air.
+ *
+ * The poll keeps a single query outstanding so a renderer slow to reply is not
+ * sent a fresh one five times a second. Held as a plain "a query is out" flag,
+ * that bound outlived the page it was bounding: the answer comes back through
+ * `WebView.evaluateJavascript`, a WebView destroyed before it replies never
+ * delivers one, and the row is not destroyed with it.
+ * `MainActivity.recreateWebView` replaces only the WebView and hands this same
+ * row a new `KeyInjector` on the same main thread turn, so nothing would ever
+ * have cleared the flag and every later tick would return without asking. The
+ * row would then never again learn that the page had spent a latched modifier:
+ * the next row key goes out as a chord, and a whole trackpad drag does, since
+ * the arrow path deliberately keeps the modifier through a drag.
+ *
+ * So the record is kept against the injector that was asked. That is the piece
+ * this file runs: [OutstandingModifierQuery] is an ordinary object, so unlike
+ * the rest of the poll it can be exercised on the JVM rather than argued from
+ * the source text. The last case is the control that ties it to the row, so a
+ * class the poll no longer calls cannot pass here on its own behaviour.
+ *
+ * [ExtraKeyModifierSyncTest] holds the other half, that the tick survives an
+ * answer that never comes at all.
+ */
+class ExtraKeyQueryOwnershipTest {
+
+    /** Two injectors that differ only in identity, which is all this reads. */
+    private fun injector() = KeyInjector(mockk<WebView>(relaxed = true))
+
+    /** Uniform across this package; [KeyInjectorShiftTest] gives the reason. */
+    @AfterEach
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    /**
+     * The defect, as the row meets it: a renderer that died owing an answer.
+     *
+     * NEGATIVE CONTROL: make [OutstandingModifierQuery.claim] refuse whenever
+     * anything is outstanding (`if (askedOf != null) return false`), which is
+     * the plain flag this replaced, and this goes red on the second claim.
+     */
+    @Test
+    fun `a query the dead page never answered does not silence the query about the next one`() {
+        val query = OutstandingModifierQuery()
+        val crashed = injector()
+
+        assertTrue(query.claim(crashed), "the first tick must be allowed to ask")
+
+        // The renderer dies here. Nothing answers, and MainActivity hands the
+        // row a new injector without the poll ever seeing a null one.
+        val replacement = injector()
+        assertTrue(
+            query.claim(replacement),
+            "the query owed by the destroyed page still bars the new one, so the row " +
+                "never asks again for the rest of the Activity and goes on painting a " +
+                "modifier the fresh page is not holding",
+        )
+    }
+
+    /**
+     * The bound itself, which is what the record exists for.
+     *
+     * NEGATIVE CONTROL: make [OutstandingModifierQuery.claim] always return true
+     * and this goes red on the second claim, where a renderer that has not
+     * answered would be sent another query every 200 ms.
+     */
+    @Test
+    fun `one injector is asked once until it answers`() {
+        val query = OutstandingModifierQuery()
+        val injector = injector()
+
+        assertTrue(query.claim(injector))
+        assertFalse(
+            query.claim(injector),
+            "a second query goes out while the first is unanswered, so a slow renderer is " +
+                "asked five times a second for as long as a modifier stays latched",
+        )
+        assertTrue(query.release(injector), "the answer that arrived is the one being waited for")
+        assertTrue(query.claim(injector), "with the answer in, the next tick must ask again")
+    }
+
+    /**
+     * An answer that outlived the page it describes.
+     *
+     * It must not be applied, and it must not free the claim the current
+     * injector's query is holding, which would give back the bound above.
+     *
+     * NEGATIVE CONTROL: make [OutstandingModifierQuery.release] clear
+     * unconditionally (`askedOf = null; return true`) and this goes red on the
+     * first assertion.
+     */
+    @Test
+    fun `an answer from a replaced injector is refused and leaves the live claim standing`() {
+        val query = OutstandingModifierQuery()
+        val crashed = injector()
+        val replacement = injector()
+
+        query.claim(crashed)
+        query.claim(replacement)
+
+        assertFalse(
+            query.release(crashed),
+            "an answer about a page that is gone is taken as the answer to the live query, " +
+                "so its flags are applied to a page that never had them",
+        )
+        assertFalse(
+            query.claim(replacement),
+            "the stale answer freed the live claim, so the bound on outstanding queries is " +
+                "back to nothing",
+        )
+        assertTrue(query.release(replacement), "the live answer still releases its own claim")
+    }
+
+    /**
+     * The branch where the row is left with no injector at all: the Activity
+     * being destroyed, or a renderer crash during a cold start, where no
+     * replacement is built because no port is bound yet.
+     *
+     * NEGATIVE CONTROL: make [OutstandingModifierQuery.abandon] a no-op and this
+     * goes red; delete the `outstanding.abandon()` call from the poll's
+     * no-injector branch and the last case in this file goes red.
+     */
+    @Test
+    fun `a row left with no injector gives up the answer it can never get`() {
+        val query = OutstandingModifierQuery()
+        val gone = injector()
+
+        query.claim(gone)
+        query.abandon()
+
+        assertTrue(
+            query.claim(gone),
+            "the query owed by an injector the row no longer has is still outstanding, so " +
+                "it bars every later one",
+        )
+    }
+
+    /**
+     * The control: the poll actually keeps its one query here.
+     *
+     * Without it every case above is a class talking to itself, and a poll that
+     * had gone back to a bare flag would pass this file untouched.
+     *
+     * Source-reading, for the reason the rest of this package gives: [ExtraKeyRow]
+     * is a `View` whose initialiser reaches resources, colours and display
+     * metrics before its constructor finishes, so no JVM test can build one.
+     * Comment lines are dropped first, so prose naming a call is not a call.
+     *
+     * NEGATIVE CONTROL: comment out any one of the three calls in the poll and
+     * the matching assertion below goes red.
+     */
+    @Test
+    fun `the poll keeps its one outstanding query in this class`() {
+        val lines = code()
+        val start = lines.indexOfFirst { it.contains("private val modifierSyncRunnable") }
+        assertTrue(start >= 0, "modifierSyncRunnable is no longer where this test looks")
+        val body = lines.drop(start).takeWhile { !it.startsWith("    init {") }
+        assertTrue(
+            body.any { it.contains("queryModifierState") },
+            "the window found does not poll the page, so its verdict is worth nothing. " +
+                "It reads:\n${body.joinToString("\n")}",
+        )
+        assertTrue(
+            body.any { it.contains("OutstandingModifierQuery()") },
+            "the poll holds something else, so the behaviour proved above is not the " +
+                "behaviour the row gets. It reads:\n${body.joinToString("\n")}",
+        )
+
+        val query = body.indexOfFirst { it.contains("queryModifierState") }
+        assertTrue(
+            body.take(query).any { it.contains("outstanding.claim(injector)") },
+            "nothing claims the outstanding slot before the query goes out, so the bound " +
+                "is not applied at all. It reads:\n${body.joinToString("\n")}",
+        )
+        assertTrue(
+            body.drop(query + 1).any { it.contains("outstanding.release(injector)") },
+            "the answer does not release the claim it is answering, so the poll asks once " +
+                "and then ticks forever without asking again. It reads:" +
+                "\n${body.joinToString("\n")}",
+        )
+
+        val noInjector = body.indexOfFirst { it.contains("if (injector == null)") }
+        assertTrue(
+            noInjector in 0 until query,
+            "the poll no longer has a branch for a row with no injector, so this case is " +
+                "reading a poll that cannot reach the state it guards. It reads:" +
+                "\n${body.joinToString("\n")}",
+        )
+        assertTrue(
+            body.subList(noInjector, query).any { it.contains("outstanding.abandon()") },
+            "the branch that gives up on the page keeps waiting for its answer, which " +
+                "nothing can now send. It reads:\n${body.joinToString("\n")}",
+        )
+    }
+
+    /** The row's source with comment lines dropped. */
+    private fun code(): List<String> {
+        val file = File("src/main/kotlin/com/vscodroid/keyboard/ExtraKeyRow.kt")
+        assertTrue(
+            file.isFile,
+            "ExtraKeyRow.kt is not at ${file.absolutePath}; this test would otherwise " +
+                "pass by reading nothing",
+        )
+        var inBlock = false
+        return file.readText().lines().filterNot { line ->
+            val start = line.trimStart()
+            when {
+                inBlock -> {
+                    if (line.indexOf("*/") >= 0) inBlock = false
+                    true
+                }
+                start.startsWith("/*") -> {
+                    if (line.indexOf("*/", line.indexOf("/*") + 2) < 0) inBlock = true
+                    true
+                }
+                else -> start.startsWith("//") || start.startsWith("*")
+            }
+        }
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/keyboard/KeyInjectorLatchTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/keyboard/KeyInjectorLatchTest.kt
@@ -1,0 +1,121 @@
+package com.vscodroid.keyboard
+
+import android.webkit.WebView
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.unmockkAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * What a latched Ctrl or Alt does when the page reports input this listener has
+ * no chord for.
+ *
+ * The interceptor acts on two kinds of `beforeinput`: an `insertText`, which it
+ * turns into a chord, and the two deletes, which become Ctrl+Backspace and its
+ * neighbours. Both spend the latch on the way out. Everything else a soft
+ * keyboard produces, a paste, an IME composition update, an autocorrect
+ * replacement, a word delete, used to leave it standing, and a modifier left
+ * standing is not a modifier that did nothing: the next ordinary character is
+ * cancelled and dispatched as a chord in its place, so typing `a` after a paste
+ * selects the document instead of inserting a letter and the keystroke after
+ * that replaces the selection.
+ *
+ * [KeyInjectorShiftTest] holds the same rule for a lone Shift, which was already
+ * spent on every event. These hold the branch the other two modifiers reach.
+ * Reachable in the shipped build: `MainActivity.injectBridgeToken` installs this
+ * listener with no debug-only guard.
+ *
+ * Read off the injected script, the way `KeyInjectorShiftTest` reads the branch
+ * it is about, because there is no JS engine on the test classpath. The branch is
+ * delimited by its own braces rather than searched for across the whole listener:
+ * the delete branch above it clears the same three flags, so a whole-script
+ * search would be satisfied by that copy while this branch cleared nothing.
+ *
+ * NEGATIVE CONTROL, per case below. Dropping the three `mod.* = false;` lines
+ * from the branch, which is a return to the bare `if (...) return;` this was,
+ * turns the slice's own control assertion red, because the block it looks for is
+ * gone; keeping the block and dropping only `mod.ctrl = false;` turns `a
+ * modifier the listener cannot act on is spent` red. Adding an
+ * `e.preventDefault();` to the branch turns `the page keeps the input this
+ * listener has no chord for` red.
+ */
+class KeyInjectorLatchTest {
+
+    private val script = slot<String>()
+    private val webView = mockk<WebView>(relaxed = true).also {
+        every { it.evaluateJavascript(capture(script), any()) } returns Unit
+    }
+
+    /** Uniform across this package; [KeyInjectorShiftTest] gives the reason. */
+    @AfterEach
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    /**
+     * The branch a `beforeinput` takes when Ctrl or Alt is held and the input is
+     * neither an insertText nor one of the two deletes.
+     */
+    private fun unhandledInputBranch(): String {
+        KeyInjector(webView).setupModifierInterceptor()
+        val installed = script.captured
+        val guard = "if (e.inputType !== 'insertText' || !e.data) {"
+        val start = installed.indexOf(guard)
+        assertTrue(
+            start >= 0,
+            "the listener has no block for an inputType it cannot act on, so either this " +
+                "test is reading nothing or the branch is back to a bare `return` that " +
+                "leaves the latch standing. It reads:\n$installed"
+        )
+        val end = installed.indexOf("}", start + guard.length)
+        assertTrue(end > start, "the branch's block is never closed")
+        return installed.substring(start, end + 1)
+    }
+
+    @Test
+    fun `a modifier the listener cannot act on is spent, not carried`() {
+        val branch = unhandledInputBranch()
+
+        assertTrue(
+            branch.contains("mod.ctrl = false;"),
+            "a Ctrl held across a paste or a composition survives it, and attaches to " +
+                "whichever character is typed next: that character is cancelled and sent " +
+                "as Ctrl+<char> instead. It reads: $branch"
+        )
+        assertTrue(
+            branch.contains("mod.alt = false;"),
+            "an Alt held across the same input survives it, on the same terms. " +
+                "It reads: $branch"
+        )
+        assertTrue(
+            branch.contains("mod.shift = false;"),
+            "a Shift held together with Ctrl or Alt skips the lone-Shift branch above, " +
+                "so this is the only place that spends it, and a surviving one decides " +
+                "WHICH character the next row key types. It reads: $branch"
+        )
+    }
+
+    @Test
+    fun `the page keeps the input this listener has no chord for`() {
+        // There is nothing to send in its place: no chord exists for a paste or a
+        // composition update, so cancelling one would leave the user's tap
+        // producing nothing at all. That is the same trade the lone-Shift branch
+        // makes, and it is what makes spending the latch here safe.
+        val branch = unhandledInputBranch()
+
+        assertFalse(
+            branch.contains("preventDefault"),
+            "the page's own insertion is cancelled for input nothing replaces, so the " +
+                "paste or the composed word is lost. It reads: $branch"
+        )
+        assertFalse(
+            branch.contains("dispatchEvent"),
+            "a synthetic keystroke is sent for an inputType this listener has no key " +
+                "for. It reads: $branch"
+        )
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/service/ProcessManagerTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/service/ProcessManagerTest.kt
@@ -1539,6 +1539,289 @@ class ServerReadinessTest {
 }
 
 /**
+ * Readiness when the port was already taken at the spawn.
+ *
+ * The pair this covers is `spawnedOntoHeldPort` and the credential. A start that
+ * recorded the flag knows the process it spawned cannot be what is on the port:
+ * the editor server it forked prints EADDRINUSE and, measured, does not exit. Any
+ * answer from that port therefore comes from somebody else, and readiness is not
+ * an idle question about it: it is what points the WebView at the port, and
+ * `MainActivity` builds that URL with the connection token in it. A bare 200 was
+ * the whole test, which is the test `recordedServerIsServing` already refused to
+ * accept for adoption, on the reasoning that binding a loopback port on Android
+ * needs no permission at all.
+ *
+ * The two directions are both here on purpose. A guard that simply refused every
+ * start that saw a held port would satisfy the first case and break the two that
+ * matter to a working user: a reap whose signal freed the socket a moment after
+ * the port was asked, and an orphan of this same build that no note identifies.
+ * Both of those are serving, and both keep working.
+ */
+class HeldPortReadinessTest {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    private lateinit var manager: ProcessManager
+    private lateinit var contextMock: Context
+    private var stub: StubServer? = null
+
+    /** What the packaged tree records, and so what `/version` answers here. */
+    private val commit = "a5b500951314efd502d07465bd138dfbd714a960"
+
+    /** A build that is not this one, in the shape `/version` answers with. */
+    private val stranger = "1111111111111111111111111111111111111111"
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(Logger)
+        every { Logger.w(any(), any(), any()) } just Runs
+        every { Logger.w(any(), any()) } just Runs
+        every { Logger.i(any(), any()) } just Runs
+        every { Logger.d(any(), any()) } just Runs
+        every { Logger.e(any(), any(), any()) } just Runs
+        every { Logger.e(any(), any()) } just Runs
+
+        File(tempDir, "server/vscode-reh").mkdirs()
+        File(tempDir, "server/$REH_PRODUCT_FILE").writeText("""{"commit":"$commit"}""")
+
+        mockkObject(Environment)
+        every { Environment.getNodePath(any()) } returns "/bin/echo"
+        every { Environment.getServerScript(any()) } returns "server.js"
+        every { Environment.buildProcessEnvironment(any(), any()) } returns emptyMap()
+        every { Environment.getExtensionsDir(any()) } returns "extensions"
+        every { Environment.getUserDataDir(any()) } returns "data"
+        every { Environment.getLogsDir(any()) } returns "logs"
+
+        contextMock = mockk<Context>(relaxed = true)
+        every { contextMock.cacheDir } returns tempDir
+        every { contextMock.filesDir } returns tempDir
+
+        manager = ProcessManager(contextMock)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        stub?.stop()
+        manager.stopServer()
+        unmockkAll()
+    }
+
+    /** Points the manager at a loopback server answering [status] as [reports]. */
+    private fun serving(status: Int, reports: String): StubServer =
+        StubServer(status, reports).also { stub = it; manager.portField = it.port }
+
+    /**
+     * Spawns onto the port the stub is holding, and waits for the spawned process
+     * to be reaped before returning.
+     *
+     * The wait is not tidiness. `/bin/echo` exits at once and the watchdog clears
+     * readiness when it does, so an assertion made while that thread is still on
+     * its way would be racing it and would fail on a busy machine for a reason
+     * that has nothing to do with the probe.
+     */
+    private fun spawnOntoHeldPort() {
+        val exited = CountDownLatch(1)
+        manager.onServerCrashed = { exited.countDown() }
+        assertTrue(manager.startServer(), "the spawn must happen or nothing here is under test")
+        assertTrue(exited.await(5, TimeUnit.SECONDS), "the watchdog never reported the exit")
+        assertTrue(
+            manager.spawnedOntoHeldPort(),
+            "the fixture must be a spawn onto a held port, or the guard is not reached",
+        )
+    }
+
+    @Test
+    fun `a holder this start could not have bound is not ready for answering 200`() {
+        // Kills: restoring `probeReadiness` to `isServerHealthy().also { ... }`,
+        // which is any 200 from anybody. This is the disclosure: readiness is
+        // what `NodeService.announceReady` fires on and what sends MainActivity
+        // to `?folder=...&tkn=<connection token>`, so a stranger that answers
+        // here is handed the credential for every route of the editor server.
+        // The token file is generated once and reused across restarts, so the
+        // disclosure outlives the session it happened in.
+        serving(200, reports = stranger)
+        spawnOntoHeldPort()
+
+        assertFalse(
+            manager.probeReadiness(),
+            "a 200 from a party this start could not have bound the port for proves " +
+                "only that something is there",
+        )
+        assertFalse(manager.isReady(), "and nothing may record it as ready")
+        assertFalse(
+            runBlocking { manager.waitForReady(timeoutMs = 300, pollIntervalMs = 25) },
+            "the whole poll must reach the same answer, or CANNOT_BIND is never reached",
+        )
+    }
+
+    @Test
+    fun `a server of this build on that port is ready, held port or not`() {
+        // The complement, and the reason the guard asks for an identity rather
+        // than refusing outright. Kills: narrowing the guard to
+        // `if (spawnedOntoHeldPort)`. Two real starts land exactly here -- a reap
+        // whose signal released the socket just after the port was asked, and an
+        // orphan of this build that no note names -- and in both the user has a
+        // working editor on that port. Refusing them ends the launch in
+        // CANNOT_BIND and, when the holder outlives the retries, in the terminal
+        // state, with a healthy server sitting right there.
+        serving(200, reports = commit)
+        spawnOntoHeldPort()
+
+        assertTrue(
+            manager.probeReadiness(),
+            "a holder answering as this build is the server the user is already using",
+        )
+        assertTrue(manager.isReady(), "and that has to be recorded for the main thread")
+    }
+
+    @Test
+    fun `a start that had its port to itself is not asked for an identity`() {
+        // Kills: dropping `spawnedOntoHeldPort &&` from the guard, which would
+        // make every readiness poll an identity test. That direction is the one
+        // adoption can afford and readiness cannot: declining adoption costs a
+        // spawn, while refusing readiness costs the editor, and a tree that
+        // records no commit would then never start at all.
+        //
+        // The port is moved after the start rather than before it, because what
+        // is under test is the flag the start recorded and not what is listening:
+        // a free port at the spawn means there is no second party for the answer
+        // to have come from.
+        manager.portField = PortFinder.findAvailablePort()
+        spawnOnFreePort()
+        val elsewhere = StubServer(200, stranger).also { stub = it }
+        manager.portField = elsewhere.port
+
+        assertTrue(
+            manager.probeReadiness(),
+            "a start that owned its port answers to nobody about which build it is",
+        )
+    }
+
+    @Test
+    fun `a build that cannot say what it is trusts nobody on a port it could not bind`() {
+        // Kills: making the comparison fail open when the tree records no commit,
+        // for instance `bundledServerCommit()?.let { served != it } == true`. With
+        // no commit of our own there is nothing that tells the holder from us,
+        // which is the same fail-closed direction `recordedServerIsServing`
+        // already takes for adoption, and the cost is bounded: the run ends in
+        // CANNOT_BIND, which the service reports and retries.
+        File(tempDir, "server/$REH_PRODUCT_FILE").delete()
+        serving(200, reports = commit)
+        spawnOntoHeldPort()
+
+        assertFalse(
+            manager.probeReadiness(),
+            "a build with no commit cannot recognise itself, so it must not accept " +
+                "somebody else's word for it",
+        )
+    }
+
+    /** Starts on a port nothing holds, and waits for the spawn to be reaped. */
+    private fun spawnOnFreePort() {
+        val exited = CountDownLatch(1)
+        manager.onServerCrashed = { exited.countDown() }
+        assertTrue(manager.startServer(), "the spawn must happen or nothing here is under test")
+        assertTrue(exited.await(5, TimeUnit.SECONDS), "the watchdog never reported the exit")
+        assertFalse(
+            manager.spawnedOntoHeldPort(),
+            "the fixture must be a start onto a free port, or it tests the other branch",
+        )
+    }
+}
+
+/**
+ * The clock the start poll spends its budget on.
+ *
+ * `waitForReady` bounded thirty seconds with `System.currentTimeMillis()`, which
+ * is the wall clock and is corrected out from under a running app: NTP or NITZ
+ * arrives as the network attaches, which is exactly where a first launch after a
+ * boot sits, and on a device whose RTC was materially wrong the step is large.
+ * Forward, the poll ended without another probe and the launch fell through to
+ * the slower late-readiness path; backward, the coroutine stayed in the poll past
+ * the timeout; and either way the "Server ready after Nms" line in a bug report
+ * was a number that never happened.
+ *
+ * A time correction cannot be staged from a JVM test, which is why the clock is a
+ * seam. These pin the two halves that make the seam mean something: the loop is
+ * bounded by what it reads there, and what it reads there by default is not the
+ * wall clock.
+ */
+class ReadyPollClockTest {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    private lateinit var manager: ProcessManager
+    private var stub: StubServer? = null
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(Logger)
+        every { Logger.w(any(), any(), any()) } just Runs
+        every { Logger.w(any(), any()) } just Runs
+        every { Logger.i(any(), any()) } just Runs
+        every { Logger.d(any(), any()) } just Runs
+        every { Logger.e(any(), any(), any()) } just Runs
+        every { Logger.e(any(), any()) } just Runs
+
+        val contextMock = mockk<Context>(relaxed = true)
+        every { contextMock.cacheDir } returns tempDir
+        every { contextMock.filesDir } returns tempDir
+        manager = ProcessManager(contextMock)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        stub?.stop()
+        unmockkAll()
+    }
+
+    @Test
+    fun `the poll spends the budget on its own clock and not on the wall`() {
+        // Kills: restoring `System.currentTimeMillis()` to either end of the loop
+        // bound. The fake clock steps a second per reading while real time barely
+        // moves, so a loop bounded by it leaves after about ten readings, and a
+        // loop bounded by anything else sits here for the whole ten seconds --
+        // which is the backward-correction half of the defect, measured in the
+        // only direction a test can move a clock.
+        val server = StubServer(403).also { stub = it }
+        manager.portField = server.port
+        var fakeNanos = 0L
+        manager.nanoClock = { fakeNanos += 1_000_000_000L; fakeNanos }
+
+        val startedAt = System.nanoTime()
+        val ready = runBlocking { manager.waitForReady(timeoutMs = 10_000, pollIntervalMs = 20) }
+        val realMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAt)
+
+        assertFalse(ready, "403 is not readiness; the fixture would prove nothing otherwise")
+        assertNotNull(server.lastRequestLine(), "the poll must actually have asked")
+        assertTrue(
+            realMs < 3_000,
+            "a poll bounded by the clock it was given must not spend the wall's " +
+                "ten seconds; it spent ${realMs}ms",
+        )
+    }
+
+    @Test
+    fun `the clock it is given by default is not the wall clock`() {
+        // The other half. The seam above proves the loop reads the clock; this
+        // proves the clock production hands it is a monotonic one. Kills: a
+        // default of `{ System.currentTimeMillis() }`, whose readings are
+        // milliseconds, so a fiftieth of a second across the sleep reads as about
+        // 50 rather than as tens of millions.
+        val before = manager.nanoClock()
+        Thread.sleep(50)
+        val after = manager.nanoClock()
+
+        assertTrue(
+            after - before >= 20_000_000L,
+            "the default clock must tick in nanoseconds; it moved by ${after - before}",
+        )
+    }
+}
+
+/**
  * Adopting a server this instance did not start.
  *
  * The case: `assets/server.js` forks the editor server and forwards SIGTERM, but

--- a/android/app/src/test/kotlin/com/vscodroid/setup/AbandonedUnpackTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/AbandonedUnpackTest.kt
@@ -1,0 +1,386 @@
+package com.vscodroid.setup
+
+import android.content.Context
+import android.content.res.AssetManager
+import com.vscodroid.util.Logger
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.ByteArrayInputStream
+import java.io.File
+
+/**
+ * What happens to a bundled extension whose unpack is never allowed to finish.
+ *
+ * The failure this covers is not an exception. `extractBundledExtensions`
+ * already deletes what a failed attempt created and throws, so the retry works.
+ * A process kill runs none of that: setup lives in SplashActivity's scope with
+ * no foreground service holding it, so swiping the task away or a low-memory
+ * kill during the 57 MB extension copy ends the process where it stands. What
+ * it leaves is a directory holding some of an extension, and for one fetched at
+ * a pinned version the directory's presence was the whole staleness test. The
+ * next run therefore read a few hundred of 3787 files as an install, dropped it
+ * from the list, threw nothing, and let `markSetupComplete()` certify the run.
+ * Nothing on the device would touch it again: no per-launch repair reads the
+ * extensions directory, and the three sweeps all refuse a name this build still
+ * bundles. Clear Data or an app update were the only ways out.
+ *
+ * So these pin the two halves that make presence truthful again: the directory
+ * carries [UNPACK_MARKER_NAME] for as long as the copy is in flight, and a
+ * directory carrying it (or carrying no `package.json`, which is the same
+ * answer for the installs broken before the mark existed) is unpacked again.
+ *
+ * Driven through the real private method against a real temporary tree, in the
+ * shape [BundledExtensionRefreshTest] established, because what is under test
+ * is which bytes are on disk afterwards.
+ */
+class AbandonedUnpackTest {
+
+    @TempDir
+    lateinit var filesDir: File
+
+    private lateinit var context: Context
+    private lateinit var assets: AssetManager
+
+    /** Fetched at a pinned version, so presence is what decides its fate. */
+    private val fetched = "PKief.material-icon-theme-5.37.0"
+
+    private val shippedSource = "// the icon theme this APK carries\n"
+    private val shippedManifest =
+        """{"publisher":"PKief","name":"material-icon-theme","version":"5.37.0"}"""
+
+    private val extensionsDir by lazy { File(filesDir, "home/.vscodroid/extensions") }
+    private val installed by lazy { File(extensionsDir, fetched) }
+    private val marker by lazy { File(installed, UNPACK_MARKER_NAME) }
+
+    /** Set by the stubbed stream, so the copy can be observed while it runs. */
+    private var markedWhileCopying: Boolean? = null
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(Logger)
+        every { Logger.d(any(), any()) } just Runs
+        every { Logger.i(any(), any()) } just Runs
+        every { Logger.w(any(), any(), any()) } just Runs
+        every { Logger.e(any(), any(), any()) } just Runs
+
+        assets = mockk()
+        every { assets.list("extensions") } returns arrayOf(fetched)
+        every { assets.list("extensions/$fetched") } returns arrayOf("package.json", "extension.js")
+        // Empty is how extractAssetDir recognises a leaf and switches to copying.
+        every { assets.list("extensions/$fetched/package.json") } returns emptyArray()
+        every { assets.list("extensions/$fetched/extension.js") } returns emptyArray()
+        every { assets.open("extensions/$fetched/package.json") } answers
+            { ByteArrayInputStream(shippedManifest.toByteArray()) }
+        // answers, not returns: a stream is consumed, and a second call in the
+        // same test would otherwise read an exhausted one. The look at the mark
+        // rides along here because this is the only moment inside the copy the
+        // test can reach.
+        every { assets.open("extensions/$fetched/extension.js") } answers {
+            markedWhileCopying = marker.isFile
+            ByteArrayInputStream(shippedSource.toByteArray())
+        }
+
+        context = mockk(relaxed = true)
+        every { context.filesDir } returns filesDir
+        every { context.assets } returns assets
+
+        extensionsDir.mkdirs()
+    }
+
+    @AfterEach
+    fun tearDown() = unmockkObject(Logger)
+
+    private fun extractBundledExtensions() {
+        FirstRunSetup::class.java
+            .getDeclaredMethod("extractBundledExtensions")
+            .apply { isAccessible = true }
+            .invoke(FirstRunSetup(context))
+    }
+
+    /** The state a kill during the copy leaves: some files, and the mark. */
+    private fun stageKilledUnpack() {
+        assertTrue(installed.mkdirs(), "could not stage the half-unpacked directory")
+        // The manifest landed, which is the worse of the two shapes: it is what
+        // gets the wreckage listed as an installed extension.
+        File(installed, "package.json").writeText(shippedManifest)
+        assertTrue(marker.createNewFile(), "could not stage the unpacking mark")
+    }
+
+    /**
+     * The defect, end to end.
+     *
+     * NEGATIVE CONTROL: in `bundledDirsToExtract`, restore the test to
+     * `if (dir in present) return@filter false`. The directory is present, so
+     * the extension is dropped from the list, nothing is copied and this fails
+     * on the missing `extension.js`.
+     */
+    @Test
+    fun `a fetched extension a kill left half copied is unpacked again`() {
+        stageKilledUnpack()
+
+        extractBundledExtensions()
+
+        assertEquals(
+            shippedSource,
+            File(installed, "extension.js").readText(),
+            "the half-unpacked extension was read as installed and skipped; nothing on the " +
+                "device would ever have written the rest of it",
+        )
+    }
+
+    /**
+     * The mark has to be written BEFORE the first file, not after the last.
+     *
+     * Written afterwards it would be a record of success, and a kill during the
+     * copy is precisely the case where nothing gets to write anything: the
+     * directory would be back to answering "installed" on its own.
+     *
+     * NEGATIVE CONTROL: move the `marker.createNewFile()` block in
+     * `extractBundledExtensions` below the `extractAssetDir` call. The stream
+     * stub then sees no mark and this fails.
+     */
+    @Test
+    fun `the mark is on disk while the copy is running`() {
+        extractBundledExtensions()
+
+        assertEquals(
+            true,
+            markedWhileCopying,
+            "the directory was being written with nothing on it to say so; a kill at that " +
+                "moment leaves a partial extension that reads as installed",
+        )
+    }
+
+    /**
+     * And it has to be gone afterwards, or the fix costs what it saves: every
+     * later run would re-copy 57 MB, and the on-device file count
+     * (`ExtractionOnDeviceTest.extractsTheRealBundledTree`) would find one file
+     * per extension that the APK does not carry.
+     *
+     * NEGATIVE CONTROL: delete the `marker.delete()` block. This fails, and so
+     * does the fetched-extension control below it.
+     */
+    @Test
+    fun `the mark is gone once the unpack lands`() {
+        extractBundledExtensions()
+
+        assertFalse(
+            marker.exists(),
+            "the unpacking mark outlived the unpack, so every later run re-copies the tree",
+        )
+    }
+
+    /**
+     * The control, and it is the whole reason the mark exists rather than a
+     * blanket re-copy. A fetched extension that is genuinely installed must
+     * still be left alone: its bytes cannot have changed under a pinned
+     * version, and copying over it discards whatever it has generated inside
+     * its own directory since install (`PKief.material-icon-theme` rewrites a
+     * 450 KB icon definition there).
+     *
+     * NEGATIVE CONTROL: make `unpackWasAbandoned` return true unconditionally.
+     * The generated file is overwritten and this fails.
+     */
+    @Test
+    fun `a finished fetched extension is still left alone`() {
+        assertTrue(installed.mkdirs())
+        File(installed, "package.json").writeText(shippedManifest)
+        val generated = File(installed, "extension.js")
+        generated.writeText("// regenerated on the device")
+
+        extractBundledExtensions()
+
+        assertEquals(
+            "// regenerated on the device",
+            generated.readText(),
+            "a complete fetched extension was re-copied over its own generated state",
+        )
+    }
+
+    /**
+     * The installs this app has already broken, which carry no mark whatever
+     * state they are in.
+     *
+     * An extension directory with no `package.json` is loadable by nothing:
+     * `manifestEntryFor` declines it and the workbench's scanner cannot see it.
+     * Reading that as unfinished costs a copy the extension needed anyway.
+     *
+     * NEGATIVE CONTROL: drop the `|| !File(dir, "package.json").isFile` half of
+     * `unpackWasAbandoned`. The directory is present and unmarked, so nothing
+     * is copied and this fails.
+     */
+    @Test
+    fun `a directory with no manifest is unpacked again even with no mark`() {
+        assertTrue(installed.mkdirs())
+        File(installed, "extension.js").writeText("// half of a copy from an older release")
+
+        extractBundledExtensions()
+
+        assertEquals(
+            shippedManifest,
+            File(installed, "package.json").readText(),
+            "a directory holding no manifest was treated as an install; it can never load, " +
+                "and no sweep here would ever reclaim it",
+        )
+    }
+
+    /**
+     * The failure path, for the class of directory the mark itself created.
+     *
+     * Selecting a present-but-abandoned fetched directory widened this loop, and
+     * it left the failure branch behind: that branch skips the delete for any
+     * directory that was already there, on the reasoning that a fetched one is
+     * only ever in the list because it was ABSENT, which stopped being true in
+     * the same change. For those the mark is then the whole of the retry, and
+     * the mark is written best-effort. When both fail together the directory is
+     * present, holds the manifest that did land and carries no mark, so
+     * `unpackWasAbandoned` answers no, `bundledDirsToExtract` drops it, the loop
+     * does not touch it, nothing throws, and `markSetupComplete()` certifies a
+     * half-unpacked extension: listed in `extensions.json`, dead on every
+     * activation, and reachable by no sweep here.
+     *
+     * Driven as two runs, because "the retry retries" is the property and one
+     * run cannot show it. The mark is refused by putting a DIRECTORY at its
+     * path, which `createNewFile()` declines, and the copy is failed by putting
+     * one at `extension.js`, which the rename inside `writeAtomically` cannot
+     * replace. Both go with the tree the first run removes, so the second run
+     * finds nothing in its way.
+     *
+     * NEGATIVE CONTROL, measured: restore `if (!existedBefore &&
+     * !dest.deleteRecursively())` in `extractBundledExtensions`. The first run
+     * leaves the wreckage, the second reads it as installed and copies nothing,
+     * and the assertion on `extension.js` goes red.
+     */
+    @Test
+    fun `an unmarked fetched directory whose unpack failed is cleared for the retry`() {
+        assertTrue(installed.mkdirs(), "could not stage the wreckage")
+        // No package.json, which is what makes it abandoned on a device that
+        // predates the mark: the state a kill during a pre-marker release left.
+        assertTrue(File(installed, UNPACK_MARKER_NAME).mkdirs(), "could not block the mark")
+        assertTrue(File(installed, "extension.js").mkdirs(), "could not block the copy")
+
+        val failed = runCatching { extractBundledExtensions() }
+        assertTrue(
+            failed.isFailure,
+            "an unpack that could not copy its files reported success, so setup certifies it",
+        )
+        assertFalse(
+            installed.exists(),
+            "the failed unpack left a directory that carries the manifest and no mark, so " +
+                "nothing on the device names it again: it is listed as installed and is dead " +
+                "on every activation",
+        )
+
+        extractBundledExtensions()
+
+        assertEquals(
+            shippedSource,
+            File(installed, "extension.js").readText(),
+            "the retry did not unpack the extension, so the first attempt was the only one",
+        )
+        assertEquals(shippedManifest, File(installed, "package.json").readText())
+    }
+
+    /**
+     * The three answers the failure branch has to give, without a tree.
+     *
+     * The middle one is why this is not simply "delete whatever is there": a
+     * directory that was already there and IS marked is named again by
+     * [unpackWasAbandoned], and what it holds is the previous release's install
+     * with part of this one merged over it, every file written through a rename.
+     * Deleting that would spend the copy again and leave the user with no
+     * extension at all in between. The same reasoning covers ours unmarked,
+     * which [bundledDirsToExtract] re-unpacks unconditionally.
+     *
+     * NEGATIVE CONTROL, measured: return `!existedBefore` from
+     * [failedUnpackMustBeRemoved], which is what the branch tested before, and
+     * the fetched-unmarked case goes red while the other three stay green.
+     */
+    @Test
+    fun `the failure branch removes only what nothing else would name again`() {
+        val ours = "vscodroid.vscodroid-saf-bridge-1.4.0"
+
+        assertTrue(
+            failedUnpackMustBeRemoved(fetched, existedBefore = false, marked = true),
+            "a directory this attempt created has to go: present is the whole of the test a " +
+                "fetched extension gets, and the manifest that landed lists it as installed",
+        )
+        assertFalse(
+            failedUnpackMustBeRemoved(fetched, existedBefore = true, marked = true),
+            "the mark names it again, so what is on disk is the previous release's install " +
+                "with part of this one merged over it, and removing it costs the copy twice",
+        )
+        assertTrue(
+            failedUnpackMustBeRemoved(fetched, existedBefore = true, marked = false),
+            "a fetched directory that was already here and could not be marked is named by " +
+                "nothing: the retry has no way back to it",
+        )
+        assertFalse(
+            failedUnpackMustBeRemoved(ours, existedBefore = true, marked = false),
+            "ours are re-unpacked on every run, so the previous release's copy is worth more " +
+                "kept than deleted",
+        )
+    }
+
+    @Test
+    fun `the decision names an abandoned directory and not a finished one`() {
+        // The pure half, so the two cases can be told apart without a tree.
+        assertEquals(
+            listOf(fetched),
+            bundledDirsToExtract(
+                present = listOf(fetched),
+                bundled = listOf(fetched),
+                abandoned = setOf(fetched),
+            ),
+        )
+        assertTrue(
+            bundledDirsToExtract(present = listOf(fetched), bundled = listOf(fetched)).isEmpty(),
+            "an unqualified call must keep the behaviour it had before the third argument",
+        )
+    }
+
+    /**
+     * A user's own newer install still wins, and that is deliberate rather than
+     * an oversight in the widening. The copy the user chose is the one that
+     * runs either way, so unpacking beside it writes 29 MiB that nothing loads
+     * and nothing removes; the wreckage is unlisted and inert. Re-copying it
+     * would spend the transfer to change neither.
+     */
+    @Test
+    fun `a newer install still suppresses an abandoned bundled copy`() {
+        val theirs = "PKief.material-icon-theme-9.99.0"
+
+        assertTrue(
+            bundledDirsToExtract(
+                present = listOf(fetched, theirs),
+                bundled = listOf(fetched),
+                abandoned = setOf(fetched),
+            ).isEmpty(),
+        )
+    }
+
+    @Test
+    fun `the mark and the missing manifest each answer on their own`() {
+        val dir = File(filesDir, "probe")
+        assertTrue(File(dir, "sub").mkdirs())
+
+        assertTrue(unpackWasAbandoned(dir), "no manifest, so nothing there can load")
+
+        File(dir, "package.json").writeText("{}")
+        assertFalse(unpackWasAbandoned(dir), "a manifest and no mark is what every install has")
+
+        File(dir, UNPACK_MARKER_NAME).writeText("")
+        assertTrue(unpackWasAbandoned(dir), "the mark must outweigh a manifest that did land")
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/setup/BundledExtensionRefreshTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/BundledExtensionRefreshTest.kt
@@ -171,6 +171,13 @@ class BundledExtensionRefreshTest {
 
         val dir = File(extensionsDir, fetched)
         dir.mkdirs()
+        // Its own manifest, which every installed extension has and which this
+        // fixture did not: a directory holding none is now read as the wreckage
+        // of an unpack that never finished ([unpackWasAbandoned]), so without it
+        // the case below would be the abandoned one rather than this one.
+        File(dir, "package.json").writeText(
+            """{"publisher":"PKief","name":"material-icon-theme","version":"5.37.0"}""",
+        )
         val generated = File(dir, "extension.js")
         generated.writeText("// regenerated on the device")
 

--- a/android/app/src/test/kotlin/com/vscodroid/setup/LoginShellFilesAtomicityTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/LoginShellFilesAtomicityTest.kt
@@ -1,0 +1,150 @@
+package com.vscodroid.setup
+
+import android.content.Context
+import com.vscodroid.util.Logger
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.io.IOException
+import java.lang.reflect.InvocationTargetException
+
+/**
+ * `.bash_profile` and `.tmux.conf`, the two setup files that were still written
+ * straight to their destination.
+ *
+ * Both are guarded by their own existence and both are reached only from
+ * `runSetupLocked`, which `isFirstRun()` gates on versionName or versionCode:
+ * no per-launch repair reads either path, and `repairTruncatedSetupFiles`
+ * covers `.bashrc` and settings.json alone. `writeText` creates and truncates
+ * before writing a byte, so a write that failed left a file that satisfied the
+ * guard for the life of the install, and one Retry tap cemented it.
+ *
+ * What that costs is confined to INTERACTIVE LOGIN shells, which is what a tmux
+ * window is: they read `.bash_profile` and never `.bashrc` or `BASH_ENV`, so
+ * they come up with no prompt block, no aliases and no `npm`/`npx`/`claude`,
+ * while the editor's own terminals (profile args are empty, so not login
+ * shells) and `bash -c` (covered by `createBashEnvFile` through `BASH_ENV`) are
+ * unaffected, and `PROJECTS_DIR` still arrives through the process
+ * environment.
+ *
+ * The failure is arranged as in [BashrcAtomicityTest]: by occupying the
+ * temporary path [writeAtomically] derives from the destination. That path only
+ * exists to be occupied once the writer goes through it, which is the point.
+ */
+class LoginShellFilesAtomicityTest {
+
+    @TempDir
+    lateinit var filesDir: File
+
+    private lateinit var context: Context
+
+    private val bashProfile by lazy { File(filesDir, "home/.bash_profile") }
+    private val tmuxConf by lazy { File(filesDir, "home/.tmux.conf") }
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(Logger)
+        every { Logger.d(any(), any()) } just Runs
+        every { Logger.i(any(), any()) } just Runs
+        every { Logger.w(any(), any(), any()) } just Runs
+        every { Logger.e(any(), any(), any()) } just Runs
+
+        context = mockk(relaxed = true)
+        every { context.filesDir } returns filesDir
+
+        File(filesDir, "home").mkdirs()
+    }
+
+    @AfterEach
+    fun tearDown() = unmockkObject(Logger)
+
+    private fun invoke(name: String) {
+        FirstRunSetup::class.java
+            .getDeclaredMethod(name)
+            .apply { isAccessible = true }
+            .invoke(FirstRunSetup(context))
+    }
+
+    /** Non-empty, so the cleanup `delete()` cannot quietly reclaim it. */
+    private fun block(dest: File) {
+        val blocker = File(dest.parentFile, "${dest.name}.tmp~")
+        assertTrue(blocker.mkdirs(), "could not stage the blocked temp path")
+        File(blocker, "occupied").writeText("x")
+    }
+
+    @Test
+    fun `the login shell profile is written on a first run`() {
+        // The control. Both failure assertions below would also hold for a
+        // writer that had stopped doing anything at all.
+        invoke("createBashProfile")
+
+        assertTrue(bashProfile.readText().contains(". \"\$HOME/.bashrc\""))
+    }
+
+    /**
+     * NEGATIVE CONTROL: put `bashProfile.writeText(content)` back in place of
+     * the atomic write. Nothing then goes near the temp path, the write
+     * succeeds, and both assertions fail: no exception is thrown and a file is
+     * left behind.
+     */
+    @Test
+    fun `a failed profile write leaves nothing behind and fails loudly`() {
+        block(bashProfile)
+
+        val thrown = assertThrows(InvocationTargetException::class.java) { invoke("createBashProfile") }
+
+        assertTrue(
+            thrown.cause is IOException,
+            "the failure must reach runSetupLocked's catch, which is what offers the Retry; " +
+                "it surfaced as ${thrown.cause}",
+        )
+        assertFalse(
+            bashProfile.exists(),
+            "a truncated .bash_profile was left behind, and its own exists() guard means no " +
+                "retry and no later launch would ever replace it",
+        )
+    }
+
+    @Test
+    fun `the tmux configuration is written on a first run`() {
+        invoke("createTmuxConf")
+
+        assertTrue(tmuxConf.readText().contains("set -g mouse on"))
+    }
+
+    /**
+     * The one place these two part company. A lost `.tmux.conf` costs the
+     * mouse, the colours and the scrollback, and tmux starts perfectly well
+     * without them, so failing an 875 MB unpack over five options would cost
+     * the user more than the options are worth.
+     *
+     * NEGATIVE CONTROL: restore `tmuxConf.writeText(content)`. The write then
+     * succeeds past the blocked temp path and the file exists, so the assertion
+     * that nothing partial was left fails. Making it throw instead reddens the
+     * first half.
+     */
+    @Test
+    fun `a failed tmux write is quiet and leaves nothing behind`() {
+        block(tmuxConf)
+
+        // Must not throw: it runs between createBashrc and the extension unpack.
+        invoke("createTmuxConf")
+
+        assertFalse(
+            tmuxConf.exists(),
+            "a truncated .tmux.conf was left behind; tmux reads it on every start and " +
+                "nothing here would ever rewrite it",
+        )
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/setup/PickerAccessibilityWiringTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/PickerAccessibilityWiringTest.kt
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test
 import java.io.File
 
 /**
- * The accessibility wiring on the first-run picker, and the one on the Toolchains
+ * The accessibility wiring on the toolchain cards, and the one on the Toolchains
  * toolbar, kept from being deleted by someone who cannot see what it does.
  *
  * Both are invisible to a sighted reviewer and to every other test here. Selection
@@ -192,6 +192,74 @@ class PickerAccessibilityWiringTest {
             calls[0].contains(","),
             "${calls[0]} passes no payload, so the default change animation runs and " +
                 "drops accessibility focus off the card that was just tapped",
+        )
+    }
+
+    /**
+     * The same question of the channel that fires hardest, which had the same
+     * answer written for it and did not get it.
+     *
+     * `updateState` is where every download report lands: once per 8 KB read on
+     * the HTTP path, so thousands of times for one 55 MB toolchain, on the card
+     * whose Cancel button is the only way to stop that transfer. Without a payload
+     * each one runs the default change animation, swaps the item view and takes
+     * accessibility focus with it, so a user who has just reached Cancel is thrown
+     * off it again for the whole of the download. Nothing in this app customises
+     * the item animator or supplies stable ids, so the default behaviour is what
+     * runs.
+     *
+     * NEGATIVE CONTROL: drop the payload argument from `notifyItemChanged` in
+     * `updateState` and this goes red. Measured.
+     */
+    @Test
+    fun `the progress rebind carries a payload`() {
+        val body = bodyOf(adapter, "fun updateState(")
+
+        // Anchored to the start of a line, with an `if (...)` allowed in front:
+        // the call sits behind the position guard. A substring search would be
+        // satisfied by a commented-out call, which is how a developer disables
+        // something while debugging.
+        val calls = Regex("""(?m)^\s*(?:if\s*\([^)]*\)\s*)?(notifyItemChanged\([^)]*\))""")
+            .findAll(body).map { it.groupValues[1] }.toList()
+
+        assertEquals(
+            1, calls.size,
+            "expected exactly one notifyItemChanged in updateState, found $calls",
+        )
+        assertTrue(
+            calls[0].contains(","),
+            "${calls[0]} passes no payload, so every download report runs the default " +
+                "change animation and drops accessibility focus off Cancel",
+        )
+    }
+
+    /**
+     * The second channel into the same cards, on the same screen.
+     *
+     * `ToolchainActivity` re-asks the process what is downloading once a second
+     * while it is in front, and pushes the answer through here whenever it has
+     * changed, which during a transfer is every time. `notifyDataSetChanged`
+     * rebinds every card with no payload at all, so it costs the same focus for
+     * the same reason. The item list is fixed, so a range covers it.
+     *
+     * NEGATIVE CONTROL: put `notifyDataSetChanged()` back in `setDownloading` and
+     * this goes red on both assertions. Measured.
+     */
+    @Test
+    fun `the download snapshot is pushed without the change animation`() {
+        val body = bodyOf(adapter, "fun setDownloading(")
+
+        assertTrue(
+            !Regex("""(?m)^\s*notifyDataSetChanged\(""").containsMatchIn(body),
+            "setDownloading rebinds every card with notifyDataSetChanged, once a " +
+                "second for the length of a download, and each rebind takes " +
+                "accessibility focus off whatever button the user is on",
+        )
+        assertTrue(
+            Regex("""(?m)^\s*notifyItemRangeChanged\([^)]*PAYLOAD_[A-Z_]+\)""")
+                .containsMatchIn(body),
+            "setDownloading does not push its snapshot as a payloaded range, so " +
+                "whatever it does instead runs the change animation",
         )
     }
 

--- a/android/app/src/test/kotlin/com/vscodroid/setup/PickerInstalledStateTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/PickerInstalledStateTest.kt
@@ -104,6 +104,56 @@ class PickerInstalledStateTest {
     }
 
     /**
+     * The reading is repeated when the screen comes back, because one reading
+     * describes the moment it was taken.
+     *
+     * The picker is offered on any launch that has not answered it, and by then
+     * the launcher shortcut to `ToolchainActivity` is published, so the user can
+     * leave these cards on screen, install a toolchain from there, and come back.
+     * A card built from the older reading carries no badge and still takes a tick.
+     *
+     * NEGATIVE CONTROL: delete `onStart` from SplashActivity, or the
+     * `pickerAdapter?.setInstalled(` line inside it, and this goes red. The
+     * activity had no lifecycle callback other than onCreate and onDestroy when
+     * this was written, which is how the staleness went unnoticed.
+     */
+    @Test
+    fun `the picker's installed set is read again when the screen comes back`() {
+        val body = code(bodyOf("override fun onStart("))
+
+        assertTrue(
+            Regex("""(?m)^\s*pickerAdapter\?\.setInstalled\(""").containsMatchIn(body),
+            "nothing refreshes the picker's installed set, so the refusal in " +
+                "ToolchainCardState reads a snapshot taken before the user left for the " +
+                "Toolchains screen and installed something",
+        )
+    }
+
+    /**
+     * And asked once more at the point the download is spent.
+     *
+     * The refresh above cannot cover everything: replacing the installed set
+     * unticks nothing, so a pack ticked before it was installed keeps its tick
+     * behind its own badge, and `reconcileDeliveredPacks` writes the record from
+     * the toolchain I/O thread with no lifecycle callback to hang a re-read on.
+     *
+     * NEGATIVE CONTROL: put `val selected = adapter.getSelectedPackNames()` back
+     * in the Continue handler and this goes red. `PickerSpendGuardTest` covers
+     * what the filter itself decides.
+     */
+    @Test
+    fun `Continue filters the choice against the record rather than trusting the cards`() {
+        val body = code(bodyOf("private fun showToolchainPicker("))
+
+        assertTrue(
+            Regex("""(?m)^\s*val selected = notYetInstalled\(""").containsMatchIn(body),
+            "Continue starts a download for everything ticked, including a toolchain " +
+                "installed while these cards were on screen, which spends the transfer " +
+                "and the copy a second time",
+        )
+    }
+
+    /**
      * The control for the extraction, because a body that quietly ran past its
      * function would satisfy the case above by finding the call somewhere else.
      * `startDownloads` is the declaration after `showToolchainPicker`, so its name

--- a/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainCardStateTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainCardStateTest.kt
@@ -104,6 +104,33 @@ class ToolchainCardStateTest {
             }
         }
 
+        /**
+         * The one status that had been left out of that list.
+         *
+         * Play emits REQUIRES_USER_CONFIRMATION for a pack it will not start
+         * without the user answering a system dialog, and then waits: dismissing
+         * the dialog leaves the pack queued for as long as the user leaves it.
+         * The card fell through to a plain Install for all of that time, which
+         * both says nothing is happening and withholds the only route this app
+         * has to `assetPackManager.cancel`. `isTerminalPackStatus`, the project's
+         * other predicate for the same question, has always counted it unsettled.
+         *
+         * NEGATIVE CONTROL: take REQUIRES_USER_CONFIRMATION back out of
+         * `ToolchainCardState.IN_FLIGHT` and this goes red. Measured.
+         */
+        @Test
+        fun `a pack waiting for the confirmation dialog still offers Cancel`() {
+            val state = manager()
+            state.updateState(go, AssetPackStatus.REQUIRES_USER_CONFIRMATION, 0)
+
+            val card = state.card(go)
+            assertEquals(
+                ToolchainAction.CANCEL, card.action,
+                "a pack Play is holding for confirmation offered no way to stop it",
+            )
+            assertEquals(ToolchainBadge.NONE, card.badge)
+        }
+
         @Test
         fun `a download in progress shows the percent last reported for it`() {
             val state = manager()

--- a/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainDigestInstallTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainDigestInstallTest.kt
@@ -195,15 +195,32 @@ class ToolchainDigestInstallTest {
     private val manifestPath get() = "$releaseDir/toolchains.sha256"
 
     /** A minimal but real pack: [ToolchainManager.installFromDirectory] needs this manifest. */
-    private val zipBytes: ByteArray = ByteArrayOutputStream().also { out ->
+    private fun packZip(payloadBytes: Int = 0): ByteArray = ByteArrayOutputStream().also { out ->
         ZipOutputStream(out).use { zip ->
             zip.putNextEntry(ZipEntry("toolchain_test.json"))
             zip.write("""{"name":"test","installRoot":"usr/opt/test"}""".toByteArray())
             zip.closeEntry()
+            if (payloadBytes > 0) {
+                // Random bytes from a fixed seed, so the entry deflates to
+                // roughly its own size: a compressible filler would leave the
+                // transfer several times shorter than the test asked for, and
+                // every count below is against what crossed the socket.
+                zip.putNextEntry(ZipEntry("usr/opt/test/payload.bin"))
+                zip.write(ByteArray(payloadBytes).also { java.util.Random(7).nextBytes(it) })
+                zip.closeEntry()
+            }
         }
     }.toByteArray()
 
-    private val zipDigest: String = MessageDigest.getInstance("SHA-256")
+    /**
+     * What the release serves for the ZIP. A `var` because one case needs a
+     * transfer long enough to be read more than once, and everything derived from
+     * it -- the digest, and the sizes the registry fixture quotes -- is computed
+     * from whatever it holds at the time.
+     */
+    private var zipBytes: ByteArray = packZip()
+
+    private val zipDigest: String get() = MessageDigest.getInstance("SHA-256")
         .digest(zipBytes)
         .joinToString("") { "%02x".format(it) }
 
@@ -549,8 +566,10 @@ class ToolchainDigestInstallTest {
         manager.cancel("toolchain_test")
         release.countDown()
 
-        // A cancellation reports no status, so the task's own bookkeeping is
-        // what says it finished: downloadViaHttp drops its token in a finally.
+        // Waited on the task's own bookkeeping rather than on its CANCELED
+        // report: downloadViaHttp drops its token in the same finally that makes
+        // that report, and drops it first, so the token going is the earlier of
+        // the two signals and this waits for the whole task either way.
         val tokens = outstanding()
         val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10)
         while (tokens.containsKey("toolchain_test") && System.nanoTime() < deadline) Thread.sleep(20)
@@ -558,6 +577,67 @@ class ToolchainDigestInstallTest {
 
         assertEquals(0, timesRequested(manifestPath), "a cancelled install still fetched the manifest")
         assertEquals(0, timesRequested(zipPath), "a cancelled install still fetched the payload")
+    }
+
+    /**
+     * A cancelled transfer says so, to the manager that began it.
+     *
+     * Every read of the cancellation flag leaves through a bare `return@execute`,
+     * so the download used to end in silence, and silence reaches the one party
+     * nothing else can speak for: a report goes to the manager that began the
+     * download and to no other. The toolchain screen takes the pack out of its
+     * own outstanding set when Cancel is tapped, but that set belongs to the
+     * screen the tap happened on, while the cancel token is process-wide so that
+     * a rebuilt screen can stop a transfer the destroyed one began. Cancelled
+     * that way, the destroyed screen's set kept the pack and the Play Core
+     * registration `ToolchainActivity.shouldReleaseSubscription` hands back only
+     * when that set empties, for the life of the process and once per repetition.
+     * The first-run queue is the other reader: `handleDownloadState` advances on
+     * a terminal status, so a pack cancelled from the toolchain screen left its
+     * row where it was and every pack queued behind it waiting.
+     *
+     * Blocked inside the disk-space pre-flight rather than raced against the
+     * executor, exactly as the queued-cancel case above.
+     *
+     * NEGATIVE CONTROL: drop the `report(packName, AssetPackStatus.CANCELED, 0)`
+     * from the `finally` in `downloadViaHttp` and this goes red on a status list
+     * that ends at the PENDING the request was published with.
+     */
+    @Test
+    fun `a cancelled download reports that it stopped`() {
+        publishManifest("$zipDigest  toolchain_test.zip\n")
+
+        val reachedPreflight = CountDownLatch(1)
+        val release = CountDownLatch(1)
+        every { anyConstructed<StatFs>().availableBytes } answers {
+            reachedPreflight.countDown()
+            release.await(10, TimeUnit.SECONDS)
+            8L * 1024 * 1024 * 1024
+        }
+
+        val manager = manager()
+        manager.install("toolchain_test")
+        assertTrue(reachedPreflight.await(10, TimeUnit.SECONDS), "the task never reached the pre-flight")
+
+        manager.cancel("toolchain_test")
+        release.countDown()
+
+        // The report is the last thing the task does, after the token it is
+        // waited on elsewhere has already gone, so this waits for the report
+        // itself rather than for the bookkeeping that precedes it.
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10)
+        while (!statuses().contains(AssetPackStatus.CANCELED) && System.nanoTime() < deadline) {
+            Thread.sleep(20)
+        }
+        assertTrue(
+            statuses().contains(AssetPackStatus.CANCELED),
+            "the cancelled download reported nothing, so the screen that began it keeps the " +
+                "pack outstanding and its Play Core listener with it: $events",
+        )
+        assertFalse(
+            statuses().contains(AssetPackStatus.COMPLETED),
+            "the cancelled download installed the toolchain anyway: $events",
+        )
     }
 
     @Test
@@ -811,6 +891,125 @@ class ToolchainDigestInstallTest {
             listOf(ToolchainFailure.NOT_PUBLISHED),
             synchronized(reasons) { reasons.toList() },
             "a file the release never published is not a network fault",
+        )
+    }
+
+    // -- what the transfer reports, and what it does when it is stopped --
+
+    /**
+     * Serves a pack big enough to be read many times over, and publishes the
+     * digest for it. [publishFrom] is called again because the registry fixture
+     * quotes the payload's size, and it was built for the small one.
+     */
+    private fun serveLargePack(payloadBytes: Int) {
+        zipBytes = packZip(payloadBytes)
+        publishFrom(releaseDir)
+        publishManifest("$zipDigest  toolchain_test.zip\n")
+    }
+
+    /**
+     * Progress is a figure, not a heartbeat.
+     *
+     * The read loop reports into a 8 KB buffer, and the percentage it carries has
+     * 86 values to take, so a 55 MB toolchain reported 6,763 times to say 86
+     * different things. Every one of those is posted to the main thread by both
+     * consumers: `ToolchainActivity` rebinds the card and the first-run row
+     * re-formats its text, neither of which returns early on an unchanged value.
+     *
+     * The two assertions are independent. The first says the loop no longer
+     * reports per read -- the transfer is at least [minimumReads] reads long, and
+     * it cannot be shortened, because a socket read may return less than the
+     * buffer but never more. The second says nothing repeats.
+     *
+     * NEGATIVE CONTROL: drop the `if (percent != lastReported)` guard in
+     * `downloadFile` and this goes red on both. Measured.
+     */
+    @Test
+    fun `a long transfer reports each percentage once rather than each read`() {
+        serveLargePack(1_400_000)
+
+        installAndWait()
+
+        val downloading = synchronized(events) {
+            events.filter { it.second == AssetPackStatus.DOWNLOADING }.map { it.third }
+        }
+        // 8192 is DOWNLOAD_BUFFER_SIZE. Named here rather than read from the
+        // class because it is the figure the assertion is about.
+        val minimumReads = zipBytes.size / 8192
+        assertTrue(
+            minimumReads > 100,
+            "the fixture served ${zipBytes.size} bytes, which is not a transfer worth counting",
+        )
+        assertTrue(
+            downloading.size >= 50,
+            "only ${downloading.size} progress reports for a ${zipBytes.size}-byte transfer; " +
+                "this case cannot tell a dedupe from a progress channel that went silent",
+        )
+        assertTrue(
+            downloading.size < minimumReads,
+            "${downloading.size} reports for at least $minimumReads reads: the loop is " +
+                "still reporting per read rather than per percentage",
+        )
+        assertEquals(
+            downloading.distinct(), downloading,
+            "the same percentage was reported more than once, and each one costs a main " +
+                "thread post and a card rebind",
+        )
+    }
+
+    /**
+     * Cancel is honoured after the payload has arrived, not only during it.
+     *
+     * The flag was read three times on the success path and all three sat before
+     * the digest check, so a cancel from that point on was collected by nobody:
+     * the archive was hashed, expanded and copied into `usr/` -- about 155 MB for
+     * Java 17 -- and recorded as installed. The card offers Cancel throughout,
+     * because TRANSFERRING is one of the states that draws it.
+     *
+     * Deterministic without a race: the cancel is issued from inside the report
+     * that opens the window. `downloadViaHttp` reports TRANSFERRING once, on the
+     * download's own thread, between the digest check and the extraction, so by
+     * the time it returns the flag is set and every later read of it is under
+     * test.
+     *
+     * NEGATIVE CONTROL: remove the `if (download.cancelled)` check that precedes
+     * `installFromDirectory` and this goes red -- COMPLETED is reported and the
+     * record names the toolchain. Measured. The sibling check one step earlier,
+     * between the digest and the extraction, is the same predicate at the other
+     * expensive boundary and nothing here can land a cancel inside the digest
+     * hash, which emits no report to fire from.
+     */
+    @Test
+    fun `a cancel after the payload arrives installs nothing`() {
+        publishManifest("$zipDigest  toolchain_test.zip\n")
+
+        val manager = ToolchainManager(context)
+        manager.onStateChange = { pack, status, percent, why ->
+            if (why != null) reasons.add(why)
+            events.add(Triple(pack, status, percent))
+            // The user's own tap, through the same call the Cancel button makes.
+            if (status == AssetPackStatus.TRANSFERRING) manager.cancel("toolchain_test")
+        }
+        manager.install("toolchain_test")
+
+        // The task's own bookkeeping is what says it finished, exactly as the
+        // queued-cancel case above waits, and for the reason given there.
+        val tokens = outstanding()
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(30)
+        while (tokens.containsKey("toolchain_test") && System.nanoTime() < deadline) Thread.sleep(20)
+        assertFalse(tokens.containsKey("toolchain_test"), "the cancelled task never finished")
+
+        assertTrue(
+            statuses().contains(AssetPackStatus.TRANSFERRING),
+            "the download never reached the window this case is about: ${statuses()}",
+        )
+        assertFalse(
+            statuses().contains(AssetPackStatus.COMPLETED),
+            "a cancelled install reported itself complete: $events",
+        )
+        assertFalse(
+            recorded().contains("\"test\""),
+            "the toolchain the user cancelled was installed anyway: ${recorded()}",
         )
     }
 

--- a/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainStateIntegrityTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainStateIntegrityTest.kt
@@ -3,6 +3,7 @@ package com.vscodroid.setup
 import android.content.Context
 import android.content.res.AssetManager
 import com.google.android.play.core.assetpacks.AssetPackManagerFactory
+import com.google.android.play.core.assetpacks.model.AssetPackStatus
 import com.vscodroid.util.Logger
 import io.mockk.Runs
 import io.mockk.every
@@ -15,6 +16,7 @@ import org.json.JSONArray
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -80,11 +82,11 @@ class ToolchainStateIntegrityTest {
             .invoke(manager(), state)
     }
 
-    private fun uninstallSync(name: String) {
+    private fun uninstallSync(name: String, on: ToolchainManager = manager()) {
         ToolchainManager::class.java
             .getDeclaredMethod("uninstallSync", String::class.java)
             .apply { isAccessible = true }
-            .invoke(manager(), name)
+            .invoke(on, name)
     }
 
     private fun namesInState(): List<String> {
@@ -187,6 +189,75 @@ class ToolchainStateIntegrityTest {
     fun `an unknown name is passed through untouched`() {
         assertEquals("rust", toolchainShortName("rust"))
         assertEquals("toolchain_rust", toolchainShortName("toolchain_rust"))
+    }
+
+    /** Every state a removal reported, in order, with the reason each carried. */
+    private fun reportsFrom(name: String): List<Pair<Int, ToolchainFailure?>> {
+        val seen = mutableListOf<Pair<Int, ToolchainFailure?>>()
+        val m = manager().apply { onStateChange = { _, status, _, why -> seen.add(status to why) } }
+        uninstallSync(name, m)
+        return seen
+    }
+
+    /**
+     * A removal that could not write the record must not be reported as done.
+     *
+     * The write is the last step and the files are already gone by then, so the
+     * only thing left to get right is what the user is told. NOT_INSTALLED is
+     * this app's word for a completed uninstall: the card drops the toolchain
+     * from its installed set on it. Reported over a record that still names the
+     * toolchain, it leaves the next launch drawing the card as Installed and
+     * `getAllToolchainEnv` exporting JAVA_HOME for a directory that no longer
+     * exists, and nothing reconciles the two afterwards -- the launch repair pass
+     * only checks execute bits.
+     *
+     * The failure is arranged the way the atomicity case above arranges it, and
+     * for the same reason: a directory sits where the temporary file wants to be,
+     * so opening it throws and `writeAtomically` returns false with the previous
+     * record still in place.
+     *
+     * NEGATIVE CONTROL: make the write in `uninstallLocked` a bare
+     * `writeState(state)` again and this goes red on the first assertion.
+     * Measured.
+     */
+    @Test
+    fun `a removal whose record write fails is not reported as a removal`() {
+        val blocker = File(filesDir, "home/.vscodroid/toolchains.json.tmp~")
+        blocker.mkdirs()
+        // Non-empty, so the cleanup delete cannot quietly remove it and let the
+        // write through.
+        File(blocker, "occupied").writeText("x")
+
+        val reports = reportsFrom("ruby")
+
+        assertTrue(
+            reports.none { it.first == AssetPackStatus.NOT_INSTALLED },
+            "the removal was reported as done while $existingRecord still names the " +
+                "toolchain, so the card reads Installed again on the next launch: $reports",
+        )
+        assertEquals(
+            listOf(AssetPackStatus.FAILED to ToolchainFailure.STORAGE), reports,
+            "a removal that could not be recorded said nothing the user can act on",
+        )
+        assertEquals(
+            listOf("ruby"), namesInState(),
+            "the blocked write is the premise of this test and it did not happen",
+        )
+    }
+
+    /**
+     * The other direction, and it is what stops the case above from passing
+     * against a removal that reports nothing at all.
+     */
+    @Test
+    fun `a removal that lands is still reported as one`() {
+        val reports = reportsFrom("ruby")
+
+        assertEquals(
+            listOf(AssetPackStatus.NOT_INSTALLED to null), reports,
+            "a completed removal has to say so: the card is holding a Remove button " +
+                "for a toolchain that is gone",
+        )
     }
 
     /**

--- a/android/app/src/test/kotlin/com/vscodroid/setup/TruncatedRepairRetryTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/TruncatedRepairRetryTest.kt
@@ -1,0 +1,232 @@
+package com.vscodroid.setup
+
+import android.content.Context
+import android.content.pm.ApplicationInfo
+import com.vscodroid.util.Environment
+import com.vscodroid.util.Logger
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+/**
+ * What `repairTruncatedSetupFiles` must leave behind when its rewrite fails.
+ *
+ * The repair exists for an install an older release left with a zero-byte
+ * `.bashrc` or settings.json, and the condition that produced those is a full
+ * disk, which is still the condition when the repair runs. So the rewrite
+ * failing is not an exotic case here, it is the expected one, and until now it
+ * was the one path that could make the install permanently worse: the file was
+ * deleted first to satisfy the writers' `!exists()` guards, and a rewrite that
+ * then failed left nothing. Absence is outside the repair's own re-entry test,
+ * outside every per-launch appender (`createNpmWrappers`,
+ * `ensureToolchainEnvSourcing`, `ensurePromptFix`, `ensureStartupDirGuard`,
+ * `updateSettingsNativeLibPaths`, all `exists()`-gated) and outside
+ * `createBashrc`/`createDefaultSettings`, which `runSetupLocked` reaches only
+ * when versionName or versionCode moves. One launch that could not write turned
+ * a self-healing install into one that recovers at the next app update or not
+ * at all.
+ *
+ * Writing through [writeAtomically]'s rename instead of deleting first is the
+ * whole fix, and what these measure is the property that follows from it: after
+ * a failed rewrite the broken file is still there, so the repair fires again on
+ * the next launch and freeing space is enough. The last test here is where that
+ * property stops being unconditional: the appenders behind the repair can see a
+ * file it could not rewrite, and for one of the two shapes what they add takes
+ * the retry away. `repairTruncatedSetupFiles` documents which and why.
+ *
+ * The failure is arranged as in [BashrcAtomicityTest]: by occupying the
+ * temporary path [writeAtomically] derives from the destination.
+ */
+class TruncatedRepairRetryTest {
+
+    @TempDir
+    lateinit var filesDir: File
+
+    private lateinit var context: Context
+
+    private val bashrc by lazy { File(filesDir, "home/.bashrc") }
+    private val settings by lazy { File(Environment.getMachineSettingsPath(context)) }
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(Logger)
+        every { Logger.d(any(), any()) } just Runs
+        every { Logger.i(any(), any()) } just Runs
+        every { Logger.w(any(), any(), any()) } just Runs
+        every { Logger.e(any(), any(), any()) } just Runs
+
+        context = mockk(relaxed = true)
+        every { context.filesDir } returns filesDir
+        every { context.applicationInfo } returns ApplicationInfo().apply {
+            nativeLibraryDir = "/data/app/~~hash==/com.vscodroid-hash==/lib/arm64"
+        }
+        // Pinned so the files these writers produce do not depend on what a
+        // relaxed mock invents for the projects directory.
+        every { context.getExternalFilesDir(null) } returns File(filesDir, "external")
+
+        bashrc.parentFile?.mkdirs()
+        settings.parentFile?.mkdirs()
+    }
+
+    @AfterEach
+    fun tearDown() = unmockkObject(Logger)
+
+    /** Non-empty, so the cleanup `delete()` cannot quietly reclaim it. */
+    private fun block(dest: File): File =
+        File(dest.parentFile, "${dest.name}.tmp~").also {
+            assertTrue(it.mkdirs(), "could not stage the blocked temp path")
+            File(it, "occupied").writeText("x")
+        }
+
+    /**
+     * NEGATIVE CONTROL: restore `&& bashrc.delete()` to the branch condition in
+     * `repairTruncatedSetupFiles`. The blocked launch then removes the file and
+     * writes nothing, so `bashrc.isFile` fails; keep the delete and skip the
+     * blocker and the second launch never re-enters the branch, so the healing
+     * assertion fails too.
+     */
+    @Test
+    fun `a blocked bashrc rewrite keeps the broken file and heals on the next launch`() {
+        bashrc.writeText("")
+        val blocker = block(bashrc)
+
+        FirstRunSetup(context).repairTruncatedSetupFiles()
+
+        assertTrue(
+            bashrc.isFile,
+            "the repair deleted the .bashrc it could not rewrite; nothing writes one again " +
+                "until the app updates",
+        )
+        assertEquals("", bashrc.readText(), "the destination is supposed to be untouched")
+
+        // The user frees space and launches again. That is the whole value of
+        // leaving the empty file: it is what the repair re-enters through.
+        assertTrue(blocker.deleteRecursively(), "could not free the temp path")
+        FirstRunSetup(context).repairTruncatedSetupFiles()
+
+        assertTrue(
+            bashrc.readText().contains("export PROJECTS_DIR"),
+            "the install did not heal once there was room to write",
+        )
+    }
+
+    /**
+     * The settings half, which cannot even buy space by clearing: deleting a
+     * zero-byte file frees nothing, so the disk that emptied it is still full
+     * when the rewrite runs.
+     *
+     * NEGATIVE CONTROL: restore `&& settings.delete()` to the condition in
+     * `repairTruncatedSetupFiles`. The first assertion fails on the blocked
+     * launch, and with the blocker removed the second launch finds no file to
+     * classify and writes nothing.
+     */
+    @Test
+    fun `a blocked settings rewrite keeps the empty file and heals on the next launch`() {
+        settings.writeText("")
+        val blocker = block(settings)
+
+        FirstRunSetup(context).repairTruncatedSetupFiles()
+
+        assertTrue(
+            settings.isFile,
+            "the repair deleted the settings.json it could not rewrite, which is outside " +
+                "every guard that would have tried again",
+        )
+
+        assertTrue(blocker.deleteRecursively(), "could not free the temp path")
+        FirstRunSetup(context).repairTruncatedSetupFiles()
+
+        assertTrue(
+            settings.readText().contains("terminal.integrated.profiles.linux"),
+            "the managed settings did not come back once there was room to write",
+        )
+    }
+
+    /**
+     * The half of the retry that survives the appenders, which is what turns the
+     * KDoc's bound into a measured one.
+     *
+     * SplashActivity runs this repair immediately before `createNpmWrappers` and
+     * `ensureToolchainEnvSourcing`, and not deleting is what lets those two see a
+     * file the repair judged unusable and could not rewrite. For the header shape
+     * their append changes nothing the classification reads: the header is still
+     * first and `PROJECTS_DIR` is still absent, so the next launch repairs it
+     * anyway. The empty shape is where that stops being true, and the KDoc says
+     * where the line is and why widening the test to reach it would cost more
+     * than it buys.
+     *
+     * The blocker is freed before the append on purpose. It is the only route to
+     * a failed rewrite followed by a successful append: both writes derive the
+     * same temporary path from the same destination, so whatever stops one stops
+     * the other.
+     *
+     * NEGATIVE CONTROL: change `text.startsWith(BASHRC_HEADER)` in
+     * `repairTruncatedSetupFiles` to `text.trim() == BASHRC_HEADER`, the same
+     * classification asked of the whole file rather than of its opening.
+     * Measured: the append then de-classifies the file and the last assertion
+     * below fails on its own, with the other three tests in this class green.
+     * Restoring `&& bashrc.delete()` to the branch condition reddens this test
+     * as well, at the "untouched" assertion rather than the healing one, since
+     * `readText` is then left with no file to read.
+     */
+    @Test
+    fun `an append between launches leaves the header shape repairable`() {
+        // createNpmWrappers returns early unless npm was extracted, and an
+        // appender that does not run would satisfy every assertion below.
+        File(filesDir, "usr/lib/node_modules/npm/bin").mkdirs()
+        File(filesDir, "usr/lib/node_modules/npm/bin/npm-cli.js").writeText("//")
+
+        val header = "# VSCodroid bash configuration\n"
+        bashrc.writeText(header)
+        val blocker = block(bashrc)
+        val setup = FirstRunSetup(context)
+
+        setup.repairTruncatedSetupFiles()
+        assertEquals(header, bashrc.readText(), "the destination is supposed to be untouched")
+
+        // Room appears between the two calls. Nothing else lets the append below
+        // succeed where the rewrite above failed.
+        assertTrue(blocker.deleteRecursively(), "could not free the temp path")
+        setup.createNpmWrappers()
+        assertTrue(bashrc.readText().contains("npm()"), "the append under test never ran")
+        assertFalse(
+            bashrc.readText().contains("export PROJECTS_DIR"),
+            "the append was supposed to leave the file still needing repair",
+        )
+
+        setup.repairTruncatedSetupFiles()
+        assertTrue(
+            bashrc.readText().contains("export PROJECTS_DIR"),
+            "an append behind the repair cost the header shape its retry",
+        )
+    }
+
+    /**
+     * The control for both, and it is not decoration: a repair that had stopped
+     * doing anything would satisfy every "the file is still there" assertion
+     * above.
+     */
+    @Test
+    fun `files that are fine are not rewritten`() {
+        val theirs = "# my own shell setup\nalias g='git'\n"
+        bashrc.writeText(theirs)
+        val theirSettings = """{"editor.fontSize": 20}"""
+        settings.writeText(theirSettings)
+
+        FirstRunSetup(context).repairTruncatedSetupFiles()
+
+        assertEquals(theirs, bashrc.readText(), "a file the user wrote was replaced")
+        assertEquals(theirSettings, settings.readText(), "a settings file with content was replaced")
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/storage/MirrorListingTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/MirrorListingTest.kt
@@ -74,6 +74,10 @@ class MirrorListingTest {
         resolver = mockk(relaxed = true)
         context = mockk<Context>(relaxed = true)
         every { context.filesDir } returns filesDir
+        // The manager unwraps whatever it is given to the application context, so a
+        // relaxed mock that answers a different object for it hands the manager a
+        // filesDir that is not the one below.
+        every { context.applicationContext } returns context
         every { context.contentResolver } returns resolver
         every { context.getSharedPreferences(any(), any()) } returns fakePrefs()
         // The recent list is stored as JSON and read back through Uri.parse, so a

--- a/android/app/src/test/kotlin/com/vscodroid/storage/MirrorReclaimRefusedRenameTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/MirrorReclaimRefusedRenameTest.kt
@@ -69,6 +69,10 @@ class MirrorReclaimRefusedRenameTest {
         resolver = mockk(relaxed = true)
         context = mockk<Context>(relaxed = true)
         every { context.filesDir } returns filesDir
+        // The manager unwraps whatever it is given to the application context, so a
+        // relaxed mock that answers a different object for it hands the manager a
+        // filesDir that is not the one below.
+        every { context.applicationContext } returns context
         every { context.contentResolver } returns resolver
         every { context.getSharedPreferences(any(), any()) } returns fakePrefs()
         mockkStatic(Uri::class)

--- a/android/app/src/test/kotlin/com/vscodroid/storage/MirrorReclaimRegrantRaceTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/MirrorReclaimRegrantRaceTest.kt
@@ -70,6 +70,10 @@ class MirrorReclaimRegrantRaceTest {
         resolver = mockk(relaxed = true)
         context = mockk<Context>(relaxed = true)
         every { context.filesDir } returns filesDir
+        // The manager unwraps whatever it is given to the application context, so a
+        // relaxed mock that answers a different object for it hands the manager a
+        // filesDir that is not the one below.
+        every { context.applicationContext } returns context
         every { context.contentResolver } returns resolver
 
         manager = SafStorageManager(context)

--- a/android/app/src/test/kotlin/com/vscodroid/storage/MirrorReclaimTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/MirrorReclaimTest.kt
@@ -65,6 +65,10 @@ class MirrorReclaimTest {
         resolver = mockk(relaxed = true)
         context = mockk<Context>(relaxed = true)
         every { context.filesDir } returns filesDir
+        // The manager unwraps whatever it is given to the application context, so a
+        // relaxed mock that answers a different object for it hands the manager a
+        // filesDir that is not the one below.
+        every { context.applicationContext } returns context
         every { context.contentResolver } returns resolver
         every { context.getSharedPreferences(any(), any()) } returns fakePrefs()
         // The recent list is stored as JSON and read back through Uri.parse, so a

--- a/android/app/src/test/kotlin/com/vscodroid/storage/RecentFolderGrantLookupTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/RecentFolderGrantLookupTest.kt
@@ -1,0 +1,225 @@
+package com.vscodroid.storage
+
+import android.content.ContentResolver
+import android.content.Context
+import android.content.SharedPreferences
+import android.content.UriPermission
+import android.net.Uri
+import android.provider.DocumentsContract
+import com.vscodroid.util.Logger
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.thread
+
+/**
+ * What reading the recent-folder list costs the thread that asks and the threads that wait.
+ *
+ * `getPersistedFolders` prunes the entries whose grant the user has revoked, so it has to
+ * ask the system server what is still granted, and the prune is a read-modify-write of one
+ * preference so it has to hold `recentFoldersLock` while it rewrites. Asking per entry put
+ * a chain of binder round trips inside that monitor, and the monitor is process-wide: the
+ * bridge's disk-work executor, a sync on `Dispatchers.IO`, the reclaim thread and the
+ * page-load lookup all wait on it from one side or the other.
+ *
+ * `persistedUriPermissions` answers for every grant at once, so one call answers for the
+ * whole list, and taking it before the lock keeps a listing's round trip off the critical
+ * section. One reading also judges every entry against one answer, which the per-entry
+ * version could not promise.
+ *
+ * Scope, so the second case below is not read for more than it measures: this is a
+ * listing that arrives with the monitor free. A call nested inside one of the
+ * read-modify-writes (`releaseGrantFor`, `addToRecentFolders`, `updateLastOpened`) still
+ * makes its round trip with the monitor held, which is why the second case parks only the
+ * FIRST lookup: the writer thread it starts reaches the provider again and must not be
+ * gated there, or it would be measuring the gate rather than the monitor. What the hoist
+ * bounds is that cost, one round trip rather than one per entry, and the thread paying it
+ * is a background one in every case (`DeviceFolderOpenThreadTest` pins the hops that keep
+ * the activity's three callers off the main thread), so it is a wait and not a freeze.
+ *
+ * These are the two halves of it, measured separately: how many round trips a listing
+ * costs, and whether an uncontended listing holds the monitor while it makes them.
+ */
+class RecentFolderGrantLookupTest {
+
+    @TempDir
+    lateinit var filesDir: File
+
+    private lateinit var manager: SafStorageManager
+    private lateinit var resolver: ContentResolver
+    private lateinit var prefs: SharedPreferences
+
+    private var recentJson = "[]"
+
+    /** How many times the system server was asked which trees are still granted. */
+    private val lookups = AtomicInteger(0)
+
+    /** Counted down once a caller is parked inside that lookup. */
+    private val entered = CountDownLatch(1)
+
+    /** Held closed until the test lets that caller finish. */
+    private val release = CountDownLatch(1)
+
+    /**
+     * Only the first lookup is gated; every later one answers at once.
+     *
+     * Which is what makes the second case a statement about the monitor and nothing
+     * else: `releaseGrantFor` asks the provider twice of its own accord, once directly
+     * and once through the listing it makes with the lock held, and gating either of
+     * those would park the writer thread on this latch rather than on the monitor the
+     * case exists to measure.
+     */
+    private var gated = false
+
+    private val names = listOf("Alpha", "Beta", "Gamma")
+    private val uris = names.associateWith { mockk<Uri>() }
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(Logger)
+        every { Logger.i(any(), any()) } just Runs
+        every { Logger.d(any(), any()) } just Runs
+        every { Logger.w(any(), any()) } just Runs
+        every { Logger.e(any(), any()) } just Runs
+
+        mockkStatic(Uri::class)
+        names.forEach { name ->
+            val uri = uris.getValue(name)
+            every { uri.toString() } returns text(name)
+            every { uri.lastPathSegment } returns "primary:$name"
+            every { Uri.parse(text(name)) } returns uri
+        }
+
+        mockkStatic(DocumentsContract::class)
+        every { DocumentsContract.getTreeDocumentId(any()) } returns "root"
+        every { DocumentsContract.buildDocumentUriUsingTree(any(), any()) } returns
+            mockk(relaxed = true)
+
+        resolver = mockk(relaxed = true)
+        every { resolver.persistedUriPermissions } answers {
+            lookups.incrementAndGet()
+            if (gated) {
+                gated = false
+                entered.countDown()
+                release.await(5, TimeUnit.SECONDS)
+            }
+            names.map { permissionFor(uris.getValue(it)) }
+        }
+
+        prefs = fakePrefs()
+        val context = mockk<Context>(relaxed = true)
+        every { context.filesDir } returns filesDir
+        // The manager unwraps whatever it is given to the application context, so a
+        // relaxed mock that answers a different object for it hands the manager a
+        // filesDir that is not the one below.
+        every { context.applicationContext } returns context
+        every { context.contentResolver } returns resolver
+        every { context.getSharedPreferences(any(), any()) } returns prefs
+
+        recentJson = names.joinToString(",", "[", "]") {
+            """{"uri":"${text(it)}","name":"$it","lastOpened":1}"""
+        }
+        manager = SafStorageManager(context)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        // However the assertions ended, no case may leave a thread parked in the gate.
+        release.countDown()
+        unmockkAll()
+    }
+
+    private fun text(name: String) = "content://tree/primary%3A$name"
+
+    private fun fakePrefs(): SharedPreferences {
+        val editor = mockk<SharedPreferences.Editor>(relaxed = true)
+        val written = slot<String>()
+        every { editor.putString(any(), capture(written)) } answers {
+            recentJson = written.captured
+            editor
+        }
+        return mockk<SharedPreferences>(relaxed = true).also {
+            every { it.getString(any(), any()) } answers { recentJson }
+            every { it.edit() } returns editor
+        }
+    }
+
+    private fun permissionFor(granted: Uri): UriPermission = mockk<UriPermission> {
+        every { uri } returns granted
+        every { isReadPermission } returns true
+    }
+
+    /**
+     * NEGATIVE CONTROL, run by hand: put `hasPersistedPermission(uri)` back in the prune
+     * in place of the `uri !in granted` test. The count is then one per entry and this
+     * goes red at three.
+     */
+    @Test
+    fun `listing the recent folders asks for the grants once, not once per folder`() {
+        assertEquals(
+            names.size, manager.getPersistedFolders().size,
+            "the fixture left nothing in the list, so the count below measures nothing",
+        )
+
+        assertEquals(
+            1, lookups.get(),
+            "one listing cost one binder round trip per entry, and every one of them is " +
+                "made with the recent list's lock held",
+        )
+    }
+
+    /**
+     * The half the count cannot show: where those round trips happen.
+     *
+     * `releaseGrantFor` is the second thread here because its whole body is inside the
+     * monitor, so its finishing is a statement about the monitor rather than about
+     * timing. It is parked deterministically, inside the provider rather than after a
+     * sleep.
+     *
+     * NEGATIVE CONTROL, run by hand: move the lookup back inside the lock, by having
+     * `getPersistedFolders` wrap `readAndPruneRecentFolders(persistedReadUris())` in the
+     * `synchronized` block instead of taking the snapshot before it. The second thread
+     * then waits on a monitor held across the system server's answer and this goes red on
+     * `isAlive`.
+     */
+    @Test
+    fun `the grant lookup does not hold the recent list's lock`() {
+        val hash = manager.getMirrorDir(uris.getValue("Alpha")).name
+        gated = true
+
+        val reader = thread(isDaemon = true) { manager.getPersistedFolders() }
+        assertTrue(
+            entered.await(5, TimeUnit.SECONDS),
+            "setup failed: the listing never reached the system server, so nothing below " +
+                "is measuring what another thread waits for",
+        )
+
+        val writer = thread(isDaemon = true) { manager.releaseGrantFor(hash) }
+        writer.join(2_000)
+        assertFalse(
+            writer.isAlive,
+            "a thread that only needs the recent list waited on a monitor a plain " +
+                "listing was holding across a binder round trip, for as long as the " +
+                "system server took to answer somebody else",
+        )
+
+        release.countDown()
+        reader.join(5_000)
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/storage/RecentFolderPruneSnapshotTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/RecentFolderPruneSnapshotTest.kt
@@ -1,0 +1,244 @@
+package com.vscodroid.storage
+
+import android.content.ContentResolver
+import android.content.Context
+import android.content.SharedPreferences
+import android.content.UriPermission
+import android.net.Uri
+import android.provider.DocumentsContract
+import com.vscodroid.util.Logger
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
+
+/**
+ * How old the grants a listing prunes against are allowed to be.
+ *
+ * `getPersistedFolders` asks the system server which trees are still granted, and then
+ * deletes from the saved list every row that reading does not name, and saves what is
+ * left. The reading is taken before `recentFoldersLock` on purpose, so that the monitor
+ * three threads share is never held across a binder round trip; what that costs is the
+ * one ordering the lock used to make impossible. A reading can now predate the list it
+ * judges: the user confirms the picker in between, `persistPermission` takes the grant
+ * and saves the row, and the listing then arrives at the monitor holding a reading from
+ * before the grant existed.
+ *
+ * Pruning against it deletes the folder the user has just picked while its grant stays
+ * held, and nothing puts it back. The mirror is then opened by the workbench's own recent
+ * list with no watcher behind it, so saves stop reaching the device folder with nothing on
+ * screen saying so, the folder is refused a reopen on the next cold start, and the storage
+ * screen shows an unnamed granted hash the reclaim pass will not touch.
+ *
+ * Deterministic rather than a race: the gate is inside the fake system server, so the
+ * reader is parked with its reading already taken while the pick is made, and it computes
+ * from what it read rather than from what the server holds when it is let go.
+ */
+class RecentFolderPruneSnapshotTest {
+
+    @TempDir
+    lateinit var filesDir: File
+
+    private lateinit var manager: SafStorageManager
+    private lateinit var resolver: ContentResolver
+    private lateinit var prefs: SharedPreferences
+
+    private var recentJson = "[]"
+
+    private val existingText = "content://tree/primary%3AExisting"
+    private val pickedText = "content://tree/primary%3APicked"
+    private val revokedText = "content://tree/primary%3ARevoked"
+    private val existing = mockk<Uri>()
+    private val picked = mockk<Uri>()
+    private val revoked = mockk<Uri>()
+
+    /** The trees the system server still answers for, as the test moves them. */
+    private val grants = mutableListOf<Uri>()
+
+    /** Counted down once the listing is parked with its reading already taken. */
+    private val entered = CountDownLatch(1)
+
+    /** Held closed until the test lets that listing finish. */
+    private val release = CountDownLatch(1)
+
+    /** Set by a case just before the reading it wants parked; only that one is gated. */
+    @Volatile
+    private var gated = false
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(Logger)
+        every { Logger.i(any(), any()) } just Runs
+        every { Logger.d(any(), any()) } just Runs
+        every { Logger.w(any(), any()) } just Runs
+        every { Logger.e(any(), any()) } just Runs
+        every { Logger.e(any(), any(), any()) } just Runs
+
+        every { existing.toString() } returns existingText
+        every { existing.lastPathSegment } returns "primary:Existing"
+        every { picked.toString() } returns pickedText
+        every { picked.lastPathSegment } returns "primary:Picked"
+        every { revoked.toString() } returns revokedText
+        every { revoked.lastPathSegment } returns "primary:Revoked"
+
+        mockkStatic(Uri::class)
+        every { Uri.parse(existingText) } returns existing
+        every { Uri.parse(pickedText) } returns picked
+        every { Uri.parse(revokedText) } returns revoked
+
+        mockkStatic(DocumentsContract::class)
+        every { DocumentsContract.getTreeDocumentId(any()) } returns "root"
+        every { DocumentsContract.buildDocumentUriUsingTree(any(), any()) } returns
+            mockk(relaxed = true)
+
+        resolver = mockk(relaxed = true)
+        // The answer is taken before the gate, not after it: a reading that parks and
+        // then reports what the server holds on the way out is not a stale reading at
+        // all, and every case here turns on the reading being older than the list.
+        every { resolver.persistedUriPermissions } answers {
+            val answer = synchronized(grants) { grants.toList() }.map { permissionFor(it) }
+            if (gated) {
+                gated = false
+                entered.countDown()
+                release.await(5, TimeUnit.SECONDS)
+            }
+            answer
+        }
+        // Taking the grant is what the picker's confirmation does, and the row the
+        // manager saves next is what a stale reading prunes away.
+        every { resolver.takePersistableUriPermission(any(), any()) } answers {
+            synchronized(grants) { grants.add(firstArg()) }
+            Unit
+        }
+
+        prefs = fakePrefs()
+        val context = mockk<Context>(relaxed = true)
+        every { context.filesDir } returns filesDir
+        // The manager unwraps whatever it is given to the application context, so a
+        // relaxed mock that answers a different object for it hands the manager a
+        // filesDir that is not the one below.
+        every { context.applicationContext } returns context
+        every { context.contentResolver } returns resolver
+        every { context.getSharedPreferences(any(), any()) } returns prefs
+
+        manager = SafStorageManager(context)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        // However the assertions ended, no case may leave a thread parked in the gate.
+        release.countDown()
+        unmockkAll()
+    }
+
+    private fun fakePrefs(): SharedPreferences {
+        val editor = mockk<SharedPreferences.Editor>(relaxed = true)
+        val written = slot<String>()
+        every { editor.putString(any(), capture(written)) } answers {
+            recentJson = written.captured
+            editor
+        }
+        return mockk<SharedPreferences>(relaxed = true).also {
+            every { it.getString(any(), any()) } answers { recentJson }
+            every { it.edit() } returns editor
+        }
+    }
+
+    private fun permissionFor(granted: Uri): UriPermission = mockk<UriPermission> {
+        every { uri } returns granted
+        every { isReadPermission } returns true
+    }
+
+    private fun rowFor(uri: String, name: String) = """{"uri":"$uri","name":"$name","lastOpened":1}"""
+
+    /**
+     * NEGATIVE CONTROL, run by hand: have `getPersistedFolders` pass its reading straight
+     * to `readAndPruneRecentFolders` again, dropping the `takeIf` that compares
+     * `grantsTaken`. The listing then judges the just-saved row against a reading taken
+     * before the grant, prunes it and writes the list back without it, and both
+     * assertions below go red. Removing only the `grantsTaken.incrementAndGet()` from
+     * `persistPermission` reddens them the same way, which is what says the counter has
+     * to be bumped at the grant rather than anywhere later.
+     */
+    @Test
+    fun `a listing does not prune away a folder granted after it read the grants`() {
+        recentJson = "[${rowFor(existingText, "Existing")}]"
+        synchronized(grants) { grants.add(existing) }
+        assertEquals(
+            listOf(existing), manager.getPersistedFolders().map { it.uri },
+            "the fixture left nothing in the list, so what follows is not measuring a prune",
+        )
+
+        gated = true
+        val reader = thread(isDaemon = true) { manager.getPersistedFolders() }
+        assertTrue(
+            entered.await(5, TimeUnit.SECONDS),
+            "setup failed: the listing never reached the system server, so its reading " +
+                "was not taken before the pick below",
+        )
+
+        manager.persistPermission(picked)
+        assertTrue(
+            pickedText in recentJson,
+            "setup failed: the pick never reached the saved list, so the listing has " +
+                "nothing to prune away",
+        )
+
+        release.countDown()
+        reader.join(5_000)
+        assertFalse(reader.isAlive, "the listing never finished, so nothing below is settled")
+
+        assertTrue(
+            pickedText in recentJson,
+            "the listing judged the saved list against grants read before the pick and " +
+                "wrote it back without the folder the user had just picked, whose grant " +
+                "is still held: it is gone from Open Recent, reopens with no watcher " +
+                "behind it, and the reclaim pass will not touch its mirror",
+        )
+        assertTrue(
+            picked in manager.getPersistedFolders().map { it.uri },
+            "the folder the user just picked is not in the recent list",
+        )
+    }
+
+    /**
+     * The control, and the half that says the guard above is not simply "never prune".
+     *
+     * A grant the user revoked in system settings is exactly what the prune is for, and
+     * no grant has been taken here, so the reading cannot be older than the list.
+     *
+     * NEGATIVE CONTROL, run by hand: have `getPersistedFolders` pass `null` in place of
+     * its reading, which is the shape that makes the case above pass by pruning nothing
+     * at all. Both assertions here go red, while the case above stays green.
+     */
+    @Test
+    fun `a listing still prunes and saves away a folder whose grant is gone`() {
+        recentJson = "[${rowFor(existingText, "Existing")},${rowFor(revokedText, "Revoked")}]"
+        synchronized(grants) { grants.add(existing) }
+
+        assertEquals(
+            listOf(existing), manager.getPersistedFolders().map { it.uri },
+            "a folder whose grant the user revoked is still offered in Open Recent",
+        )
+        assertFalse(
+            revokedText in recentJson,
+            "the pruned list was not written back, so the revoked row returns on the " +
+                "next listing and on the next launch",
+        )
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/storage/RecentFolderUpdateTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/RecentFolderUpdateTest.kt
@@ -111,6 +111,10 @@ class RecentFolderUpdateTest {
         prefs = fakePrefs()
         val context = mockk<Context>(relaxed = true)
         every { context.filesDir } returns filesDir
+        // The manager unwraps whatever it is given to the application context, so a
+        // relaxed mock that answers a different object for it hands the manager a
+        // filesDir that is not the one below.
+        every { context.applicationContext } returns context
         every { context.contentResolver } returns resolver
         every { context.getSharedPreferences(any(), any()) } returns prefs
 

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafCreateIdempotencyTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafCreateIdempotencyTest.kt
@@ -134,7 +134,9 @@ class SafCreateIdempotencyTest {
         create("notes.txt", "brand new")
 
         verify(exactly = 1) {
-            DocumentsContract.createDocument(any(), any(), "text/plain", "notes.txt")
+            DocumentsContract.createDocument(
+                any(), any(), SafSyncEngine.CREATED_FILE_MIME_TYPE, "notes.txt"
+            )
         }
         assertEquals("brand new", written.toString())
     }

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafCreatedDocumentNameTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafCreatedDocumentNameTest.kt
@@ -1,0 +1,276 @@
+package com.vscodroid.storage
+
+import android.content.ContentResolver
+import android.content.Context
+import android.database.Cursor
+import android.net.Uri
+import android.provider.DocumentsContract
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.ByteArrayOutputStream
+import java.io.File
+
+/**
+ * That a file created in the editor reaches the device folder under the name it was
+ * given.
+ *
+ * `createDocument` takes a name and a MIME type, and the platform provider settles a
+ * disagreement between them by rewriting the NAME. The rule below is not a guess about
+ * it: it is `android.os.FileUtils.splitFileName` as disassembled from an API 33
+ * emulator's own `framework.jar`, with the extension tables that ship inside the same
+ * file. This app used to answer `text/plain` for `.kt`, `.java` and `.md`, none of which
+ * those tables give to `text/plain`, so `Main.kt` was created on the device as
+ * `Main.kt.txt`, the editor showed both names on the next open, and the one after that
+ * made a third.
+ *
+ * The fixture is the provider rather than an assertion about the argument, because what
+ * has to hold is what the device ends up holding. [CREATED_FILE_MIME_TYPE] is one way to
+ * get there and the tests below would still pass if a later change found another.
+ */
+class SafCreatedDocumentNameTest {
+
+    @TempDir
+    lateinit var workspace: File
+
+    private lateinit var engine: SafSyncEngine
+    private lateinit var resolver: ContentResolver
+
+    private val parentUri = mockk<Uri>(relaxed = true)
+    private val treeUri = mockk<Uri>(relaxed = true)
+    private val childrenUri = mockk<Uri>(relaxed = true)
+    private val createdUri = mockk<Uri>(relaxed = true)
+
+    /** Every name the fixture's provider actually stored, in the order it stored them. */
+    private val stored = mutableListOf<String>()
+
+    /** Every string that reached `android.util.Log`. */
+    private val logged = mutableListOf<String>()
+
+    /**
+     * A name the provider rewrites whatever it is asked, or null to let it behave.
+     *
+     * The residual case: the platform runs every display name through
+     * `buildValidFatFilename` first, so a name holding a character FAT cannot store comes
+     * back changed however honest the MIME type was.
+     */
+    private var alwaysStoreAs: String? = null
+
+    @BeforeEach
+    fun setUp() {
+        stored.clear()
+        logged.clear()
+        alwaysStoreAs = null
+
+        mockkStatic(android.util.Log::class)
+        every { android.util.Log.i(any(), any()) } answers { logged += secondArg<String>(); 0 }
+        every { android.util.Log.d(any(), any()) } answers { logged += secondArg<String>(); 0 }
+        every { android.util.Log.w(any(), any<String>()) } answers { logged += secondArg<String>(); 0 }
+        every { android.util.Log.w(any(), any<String>(), any<Throwable>()) } answers {
+            logged += secondArg<String>(); 0
+        }
+        every { android.util.Log.e(any(), any()) } answers { logged += secondArg<String>(); 0 }
+
+        mockkStatic(DocumentsContract::class)
+        every { DocumentsContract.getDocumentId(parentUri) } returns "parent-doc"
+        every { DocumentsContract.getDocumentId(createdUri) } returns "created-doc"
+        every { DocumentsContract.buildChildDocumentsUriUsingTree(any(), any()) } returns childrenUri
+        every { DocumentsContract.buildDocumentUriUsingTree(any(), any()) } returns createdUri
+        every { DocumentsContract.createDocument(any(), any(), any(), any()) } answers {
+            stored += alwaysStoreAs ?: platformNameFor(arg(2), arg(3))
+            createdUri
+        }
+
+        resolver = mockk(relaxed = true)
+        every { resolver.openOutputStream(any(), "wt") } returns ByteArrayOutputStream()
+        every { resolver.query(childrenUri, any(), any(), any(), any()) } returns emptyFolder()
+        every { resolver.query(createdUri, any(), any(), any(), any()) } answers {
+            cursorNaming(stored.last())
+        }
+
+        val context = mockk<Context>(relaxed = true)
+        every { context.contentResolver } returns resolver
+        engine = SafSyncEngine(context)
+    }
+
+    @AfterEach
+    fun tearDown() = unmockkAll()
+
+    /**
+     * What the platform provider stores a document as, given the type and the name it was
+     * asked for.
+     *
+     * `FileSystemProvider.createDocument` (framework.jar, classes4.dex) hands both to
+     * `FileUtils.buildUniqueFile`, whose `splitFileName` (classes2.dex, source lines
+     * 1201-1222) keeps the requested extension only while the type is the one the
+     * platform's table gives that extension, or the extension is the one it gives that
+     * type, and otherwise appends the type's own extension to the whole display name.
+     * `buildFile` joins the two with a dot, or returns the name alone when the extension
+     * is empty.
+     */
+    private fun platformNameFor(mimeType: String, displayName: String): String {
+        val dot = displayName.lastIndexOf('.')
+        val name = if (dot >= 0) displayName.substring(0, dot) else displayName
+        val ext = if (dot >= 0) displayName.substring(dot + 1) else null
+        val mimeTypeFromExt = ext?.let { TYPE_OF_EXTENSION[it.lowercase()] } ?: DEFAULT_TYPE
+        val extFromMimeType = if (mimeType == DEFAULT_TYPE) null else EXTENSION_OF_TYPE[mimeType]
+        return if (mimeType == mimeTypeFromExt || ext == extFromMimeType) {
+            if (ext == null) name else "$name.$ext"
+        } else {
+            if (extFromMimeType == null) displayName else "$displayName.$extFromMimeType"
+        }
+    }
+
+    /** A cursor over a device folder holding nothing. */
+    private fun emptyFolder(): Cursor = mockk(relaxed = true) {
+        every { getColumnIndexOrThrow(DocumentsContract.Document.COLUMN_DOCUMENT_ID) } returns 0
+        every { getColumnIndexOrThrow(DocumentsContract.Document.COLUMN_DISPLAY_NAME) } returns 1
+        every { moveToNext() } returns false
+        every { close() } just Runs
+    }
+
+    /** A one-row cursor answering `COLUMN_DISPLAY_NAME` with [name]. */
+    private fun cursorNaming(name: String): Cursor = mockk(relaxed = true) {
+        every { getColumnIndex(DocumentsContract.Document.COLUMN_DISPLAY_NAME) } returns 0
+        every { moveToFirst() } returns true
+        every { getString(0) } returns name
+        every { close() } just Runs
+    }
+
+    /** Runs the real create for a local file of [contents] named [name]. */
+    private fun create(name: String, contents: String = "the only copy") {
+        val localFile = File(workspace, name).apply { writeText(contents) }
+        SafSyncEngine::class.java
+            .getDeclaredMethod(
+                "createInSaf", File::class.java, Uri::class.java, Uri::class.java
+            )
+            .apply { isAccessible = true }
+            .invoke(engine, localFile, parentUri, treeUri)
+    }
+
+    /**
+     * Negative control for every case below it: put `"text/plain"` back in place of
+     * [SafSyncEngine.CREATED_FILE_MIME_TYPE] and the three source files go red while
+     * `notes.txt` stays green, which is the pair that distinguishes a fixed type from a
+     * fixture that cannot rewrite anything.
+     */
+    @Test
+    fun `a Kotlin source file is stored under its own name`() {
+        create("Main.kt")
+
+        assertEquals(listOf("Main.kt"), stored)
+    }
+
+    @Test
+    fun `a Java source file is stored under its own name`() {
+        create("App.java")
+
+        assertEquals(listOf("App.java"), stored)
+    }
+
+    @Test
+    fun `a Markdown file is stored under its own name`() {
+        create("README.md")
+
+        assertEquals(listOf("README.md"), stored)
+    }
+
+    /**
+     * The other side of the same rule: an extension the platform does know still comes
+     * through unchanged, so the fix is not paid for by the files it used to get right.
+     */
+    @Test
+    fun `a plain text file is stored under its own name`() {
+        create("notes.txt")
+
+        assertEquals(listOf("notes.txt"), stored)
+    }
+
+    /**
+     * That the fixture can mangle a name at all.
+     *
+     * Without this the four cases above would pass just as well against a provider model
+     * that returned the display name whatever it was handed, and the defect they exist
+     * for would be undetectable by all of them.
+     */
+    @Test
+    fun `the provider this models does rewrite a name it is given the wrong type for`() {
+        assertEquals("Main.kt.txt", platformNameFor("text/plain", "Main.kt"))
+        assertEquals("README.md.txt", platformNameFor("text/plain", "README.md"))
+        assertEquals("App.java.txt", platformNameFor("text/plain", "App.java"))
+    }
+
+    /**
+     * The name is read back, because the type is not the only way a provider can decide
+     * to store a document as something else.
+     *
+     * Negative control: drop the `?.also { warnIfNameNotHonoured(it, localFile.name) }`
+     * from `createOneInSaf` and this goes red while the case below it stays green.
+     */
+    @Test
+    fun `a provider that stores another name says so`() {
+        alwaysStoreAs = "a_b.txt"
+
+        create("a:b.txt")
+
+        assertTrue(
+            logged.any { it.contains("a:b.txt") && it.contains("a_b.txt") },
+            "the device folder holds the file under a name nothing here mentions, so " +
+                "the duplicate it produces on the next open has no explanation: $logged",
+        )
+    }
+
+    /**
+     * The control for the read-back. A check that announced a rename on every create
+     * would pass the case above and say nothing true, and the wording it prints is the
+     * one a bug report is read with.
+     *
+     * The name is deliberately one the modelled provider keeps whatever type it is
+     * handed, so that this stays green under the mutation the cases above are controlled
+     * by and answers for the check rather than for the type.
+     */
+    @Test
+    fun `a provider that honours the name says nothing about it`() {
+        create("notes.txt")
+
+        assertTrue(logged.isNotEmpty(), "nothing was logged at all, so this proves nothing")
+        assertTrue(
+            logged.none { it.contains("stored notes.txt as") },
+            "an ordinary create was reported as a rename: $logged",
+        )
+    }
+
+    private companion object {
+        const val DEFAULT_TYPE = "application/octet-stream"
+
+        /**
+         * The extension table that ships inside the emulator's own `framework.jar`, for
+         * the entries these cases turn on: `res/android.mime.types:85` `text/plain txt`,
+         * `res/debian.mime.types:360` `text/markdown md markdown`, `:382` `text/x-java
+         * java`, and no `kt` anywhere in any of the three files.
+         */
+        val TYPE_OF_EXTENSION = mapOf(
+            "txt" to "text/plain",
+            "md" to "text/markdown",
+            "java" to "text/x-java",
+            "json" to "application/json",
+        )
+
+        /** The same table read the other way, which is the direction that renames. */
+        val EXTENSION_OF_TYPE = mapOf(
+            "text/plain" to "txt",
+            "text/markdown" to "md",
+            "text/x-java" to "java",
+            "application/json" to "json",
+        )
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafFolderPathLoggingTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafFolderPathLoggingTest.kt
@@ -81,6 +81,10 @@ class SafFolderPathLoggingTest {
         every { resolver.query(any(), any(), any(), any(), any()) } returns null
         context = mockk(relaxed = true)
         every { context.filesDir } returns filesDir
+        // The manager unwraps whatever it is given to the application context, so a
+        // relaxed mock that answers a different object for it hands the manager a
+        // filesDir that is not the one below.
+        every { context.applicationContext } returns context
         every { context.contentResolver } returns resolver
         every { context.getSharedPreferences(any(), any()) } returns fakePrefs()
     }
@@ -171,7 +175,7 @@ class SafFolderPathLoggingTest {
      * before phase 2 exists, so `copyDocumentToLocal` is never reached and the gate's
      * coverage became the reviewer's coverage.
      */
-    private fun deviceHoldingOneFile() {
+    private fun deviceHoldingOneFile(lastModified: Long = 1_700_000_000_000L) {
         val docId = "primary:Documents/$folderName/notes.txt"
         val docUri = mockk<Uri>(relaxed = true)
         every { docUri.lastPathSegment } returns docId
@@ -194,7 +198,7 @@ class SafFolderPathLoggingTest {
         every { cursor.getString(1) } returns "notes.txt"
         every { cursor.getString(2) } returns "text/plain"
         every { cursor.getLong(3) } returns 12L
-        every { cursor.getLong(4) } returns 1_700_000_000_000L
+        every { cursor.getLong(4) } returns lastModified
         every { resolver.query(any(), any(), any(), any(), any()) } answers {
             row = -1
             cursor
@@ -232,6 +236,35 @@ class SafFolderPathLoggingTest {
         syncOneFolder()
 
         assertFolderNotNamed()
+    }
+
+    /**
+     * The line the copy path's redaction does not cover, on the branch that only exists
+     * for providers reporting no `COLUMN_LAST_MODIFIED` (MTP, some USB-OTG bridges, some
+     * network providers). With no clock to compare, the sync reads both sides and asks
+     * whether they hold the same bytes, and that read comes from the provider too.
+     */
+    @Test
+    fun `a comparison that throws does not repeat the provider's own message`() {
+        val mirrorDir = File(filesDir, "saf-mirrors/abc123def456").apply { mkdirs() }
+        // The same length the document reports, which is what gets the comparison as far
+        // as opening the device copy at all.
+        File(mirrorDir, "notes.txt").writeText("123456789012")
+        deviceHoldingOneFile(lastModified = 0L)
+        every { resolver.openInputStream(any()) } throws java.io.FileNotFoundException(
+            "open failed for $treeUri/document/primary%3ADocuments%2FClientProject%2Fnotes.txt"
+        )
+
+        runBlocking { SafSyncEngine(context).initialSync(folderUri, mirrorDir) { _, _ -> } }
+
+        assertFolderNotNamed()
+        assertTrue(
+            emitted.any {
+                it.contains("Could not compare notes.txt") &&
+                    it.contains("FileNotFoundException")
+            },
+            "the comparison never ran, so this case is asserting nothing: $emitted",
+        )
     }
 
     @Test

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafManagerContextTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafManagerContextTest.kt
@@ -1,0 +1,143 @@
+package com.vscodroid.storage
+
+import android.content.Context
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+/**
+ * What a [SafStorageManager] is allowed to hold.
+ *
+ * Both production callers build one with an Activity, and `SplashActivity` then calls
+ * `reclaimRevokedMirrors`, which starts a detached daemon thread. That thread runs an
+ * instance method, so it captures the manager and through it whatever Context the
+ * manager holds, and the file already states that the thread outlives the activity that
+ * started it. Its duration is a recursive delete of a mirror, which the same file puts
+ * at seconds to tens of seconds for a project tree, and that window is precisely when
+ * `MainActivity`, the WebView renderer and the Node server are all starting: the
+ * tightest memory moment the app has, with a finished Activity and its ContextImpl held
+ * reachable through it.
+ *
+ * Asked of the object graph rather than of the constructor argument, which is the lesson
+ * `ToolchainManagerContextTest` records after a fix that named the right argument and
+ * left the leak intact one link along. Here that second link is real and is a language
+ * trap rather than a lambda: a constructor parameter shadows a property of the same name
+ * inside an initialiser, so `SafSyncEngine(context)` written next to a
+ * `context.applicationContext` property hands the engine the Activity while the code
+ * reads as though it does not.
+ *
+ * Negative controls, both measured:
+ *  - `private val context: Context = context` in place of the unwrapping makes
+ *    `the Activity is not reachable` red.
+ *  - `SafSyncEngine(context)` in place of `SafSyncEngine(this.context)` makes the same
+ *    case red, which is what says this reads the graph and not one field.
+ */
+class SafManagerContextTest {
+
+    @TempDir
+    lateinit var filesDir: File
+
+    private lateinit var activity: Context
+    private lateinit var application: Context
+
+    @BeforeEach
+    fun setUp() {
+        application = mockk(relaxed = true)
+        every { application.filesDir } returns filesDir
+        every { application.applicationContext } returns application
+
+        activity = mockk(relaxed = true)
+        every { activity.filesDir } returns filesDir
+        every { activity.applicationContext } returns application
+    }
+
+    @AfterEach
+    fun tearDown() = unmockkAll()
+
+    @Test
+    fun `the Activity is not reachable from the manager`() {
+        // The fixture is its own control: two distinct Contexts, and the Activity
+        // answers `applicationContext` with the other one, so a pass has actually
+        // told them apart.
+        assertNotSame(activity, application, "the fixture handed out one Context")
+
+        val manager = SafStorageManager(activity)
+
+        // Runs first. The manager is supposed to hold the application context, so a
+        // walk that cannot find that one is broken and every assertion after it would
+        // pass by seeing nothing.
+        assertTrue(
+            reaches(manager, application),
+            "the walk cannot find the Context the manager is meant to hold, so it " +
+                "proves nothing about the one it must not",
+        )
+
+        assertFalse(
+            reaches(manager, activity),
+            "the Activity is reachable from the SafStorageManager, so the detached " +
+                "saf-reclaim thread started from SplashActivity keeps the finished " +
+                "Activity and its ContextImpl alive for the whole of a project-sized " +
+                "recursive delete, while MainActivity and the WebView are starting",
+        )
+    }
+
+    /**
+     * Whether [target] is reachable from [root] by strong references alone.
+     *
+     * Lifted from `ToolchainManagerContextTest`, whose reasoning applies unchanged: a
+     * weak reference is not retention and is not followed, the walk sees declared
+     * fields and so cannot speak for a native or `ThreadLocal` route, and [NODE_CAP]
+     * bounds it so a cycle cannot hang the suite.
+     */
+    private fun reaches(root: Any, target: Any): Boolean {
+        val seen = java.util.Collections.newSetFromMap(java.util.IdentityHashMap<Any, Boolean>())
+        val queue = ArrayDeque<Any>()
+        queue.add(root)
+        seen.add(root)
+        var visited = 0
+
+        while (queue.isNotEmpty() && visited < NODE_CAP) {
+            val node = queue.removeFirst()
+            visited++
+            if (node === target) return true
+
+            if (node is java.lang.ref.Reference<*>) continue
+
+            if (node is Array<*>) {
+                node.filterNotNull().forEach { if (seen.add(it)) queue.add(it) }
+                continue
+            }
+
+            var cls: Class<*>? = node.javaClass
+            while (cls != null && cls != Any::class.java) {
+                for (f in cls.declaredFields) {
+                    if (java.lang.reflect.Modifier.isStatic(f.modifiers)) continue
+                    if (f.type.isPrimitive) continue
+                    val v = try {
+                        f.isAccessible = true
+                        f.get(node)
+                    } catch (e: Throwable) {
+                        null
+                    } ?: continue
+                    if (v === target) return true
+                    if (seen.add(v)) queue.add(v)
+                }
+                cls = cls.superclass
+            }
+        }
+        return false
+    }
+
+    private companion object {
+        /** Enough for this graph; a bound so a cycle cannot hang the suite. */
+        const val NODE_CAP = 20_000
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafMirrorReclamationTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafMirrorReclamationTest.kt
@@ -64,6 +64,10 @@ class SafMirrorReclamationTest {
         resolver = mockk(relaxed = true)
         context = mockk<Context>(relaxed = true)
         every { context.filesDir } returns filesDir
+        // The manager unwraps whatever it is given to the application context, so a
+        // relaxed mock that answers a different object for it hands the manager a
+        // filesDir that is not the one below.
+        every { context.applicationContext } returns context
         every { context.contentResolver } returns resolver
 
         manager = SafStorageManager(context)

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafRenamePairingTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafRenamePairingTest.kt
@@ -26,8 +26,11 @@ class SafRenamePairingTest {
     private val window = SafSyncEngine.RENAME_PAIR_WINDOW_MS
     private val now = 1_000_000L
 
+    // The mirror path is the record's other half, and it is not what is being decided
+    // here: it names the upload records that follow the directory, while the pairing
+    // reads the mirror-relative path and the clock.
     private fun vanished(path: String, ago: Long) =
-        VanishedDirectory(path, now - ago)
+        VanishedDirectory(path, now - ago, "/mirror/$path")
 
     private fun sourceFor(newPath: String, vararg vanished: VanishedDirectory): String? =
         SafSyncEngine.renameSourceFor(vanished.toList(), newPath, now)

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafRenamedUploadRecordTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafRenamedUploadRecordTest.kt
@@ -27,6 +27,10 @@ import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.IOException
+import java.io.OutputStream
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
 
 /**
  * What a directory rename does to the upload records of the files beneath it.
@@ -52,12 +56,18 @@ import java.io.IOException
  * changes nothing about what is asserted here, because moving the records is a rewrite of
  * strings that reads no directory.
  *
+ * The last three cases are the same window with the write still streaming through it,
+ * which is where the two records of one write can come apart, the third of them with the
+ * journal rewrite refused; each carries its own control.
+ *
  * NEGATIVE CONTROL, run by hand: delete the single `renameUploadsUnder` call from
- * `handleMirrorEvent`'s claim. The first three cases go red on the journal assertions and
- * the last goes red with the mirror reading "TRUNC", while `a directory that simply
- * appears takes nothing with it` stays green, which is what makes it a control rather
- * than a second copy of the first case. A second control, for the decision not to
- * condition the move on the device: narrowing the guard to
+ * `handleMirrorEvent`'s claim. The three cases that follow a stranded line to its new
+ * path go red on the journal assertions, `a sync keeps the mirror of a file whose directory was
+ * renamed after a failed upload` goes red with the mirror reading "TRUNC", and `a write
+ * that fails during the rename keeps its record at the new path` goes red too, while
+ * `a directory that simply appears takes nothing with it` stays green, which is what makes
+ * it a control rather than a second copy of the first case. A second control, for the
+ * decision not to condition the move on the device: narrowing the guard to
  * `renamedFrom != null && renamedFromUri != null`, which is the mutation a developer
  * copying the neighbouring `forgetCachedSubtree` guard would make, reddens only
  * `the records move even when the device holds nothing under the old name`.
@@ -79,15 +89,32 @@ class SafRenamedUploadRecordTest {
     private val hash = "abc123def456"
 
     /** Set to have every write-back attempt fail the way a provider out of space does. */
+    @Volatile
     private var refuseWrites = false
 
     /** Document writes the provider accepted, so a case can count the ones it caused. */
     private var writesAccepted = 0
 
+    /** Set to park the next write inside the copy, so a rename can land while it streams. */
+    @Volatile
+    private var holdNextWrite = false
+
+    /** Set to have the parked write fail once it is let go rather than land. */
+    @Volatile
+    private var failHeldWrite = false
+
+    /** Counted down once a write-back thread is parked inside the provider. */
+    private val writeStarted = CountDownLatch(1)
+
+    /** Held closed until the test lets that write finish. */
+    private val releaseWrite = CountDownLatch(1)
+
     @BeforeEach
     fun setUp() {
         refuseWrites = false
         writesAccepted = 0
+        holdNextWrite = false
+        failHeldWrite = false
 
         mockkObject(Logger)
         every { Logger.i(any(), any()) } just Runs
@@ -109,8 +136,13 @@ class SafRenamedUploadRecordTest {
         resolver = mockk(relaxed = true)
         every { resolver.openOutputStream(any(), any()) } answers {
             if (refuseWrites) throw IOException("no space left on device")
-            writesAccepted++
-            ByteArrayOutputStream()
+            if (holdNextWrite) {
+                holdNextWrite = false
+                heldStream()
+            } else {
+                writesAccepted++
+                ByteArrayOutputStream()
+            }
         }
 
         val context = mockk<Context>(relaxed = true)
@@ -125,7 +157,38 @@ class SafRenamedUploadRecordTest {
     }
 
     @AfterEach
-    fun tearDown() = unmockkAll()
+    fun tearDown() {
+        // However the assertions ended, no case may leave a thread parked in the gate.
+        releaseWrite.countDown()
+        // Nor with the temporary directory still refusing writes: one case takes that
+        // away to refuse a journal rewrite, and the directory has to be deletable
+        // whatever that case's assertions did.
+        filesDir.setWritable(true)
+        unmockkAll()
+    }
+
+    /**
+     * A document stream that parks inside the copy until the test lets it go.
+     *
+     * The window it holds open is the one the fix is about: between the journal line this
+     * write took and the release that retires it, on the write-back thread, while the
+     * observer thread renames the directory the file sits in.
+     */
+    private fun heldStream(): OutputStream = object : OutputStream() {
+        override fun write(b: Int) = write(byteArrayOf(b.toByte()), 0, 1)
+
+        override fun write(b: ByteArray, off: Int, len: Int) {
+            writeStarted.countDown()
+            // Uninterruptible: the point is a write that is still in flight.
+            while (releaseWrite.count > 0L) {
+                try {
+                    releaseWrite.await()
+                } catch (_: InterruptedException) {
+                }
+            }
+            if (failHeldWrite) throw IOException("no space left on device")
+        }
+    }
 
     /** One child of a device folder, with the columns a sync reads as well as a lookup's. */
     private class Child(
@@ -399,6 +462,194 @@ class SafRenamedUploadRecordTest {
         assertEquals(
             1, writesAccepted,
             "the repair upload never reached the provider inside the sync",
+        )
+    }
+
+    /**
+     * A save of [path] parked inside the provider, with the write-back thread that owns
+     * it, so the caller can move the directory under it and then let it finish.
+     */
+    private fun startHeldWrite(path: String): Thread {
+        val file = File(mirror, path)
+        file.parentFile?.mkdirs()
+        file.writeText("the whole edit")
+        holdNextWrite = true
+        observe(FileObserver.MODIFY, path)
+        val writer = thread(isDaemon = true) { drain() }
+        assertTrue(
+            writeStarted.await(5, TimeUnit.SECONDS),
+            "setup failed: the save never reached the provider, so the rename below did " +
+                "not land inside a write that was still streaming",
+        )
+        assertTrue(
+            file.absolutePath in engine.uploadsInFlight(),
+            "setup failed: the write in flight recorded no line for the rename to move",
+        )
+        return writer
+    }
+
+    /**
+     * The rename lands while the write is streaming, and the write then lands.
+     *
+     * The journal line and the writer's own claim are two records of one write, and they
+     * are made on different threads' schedules: the rename runs on the observer thread
+     * while the copy runs on the write-back thread. Move only the line and the writer
+     * releases a name nothing is filed under, so a save that DID reach the device is
+     * recorded for ever as one that did not. That record is not inert: the storage screen
+     * calls the mirror unreclaimable and refuses the removal the user asks for, and the
+     * next open of the folder takes the interrupted-upload repair branch and writes the
+     * mirror over the device document with no timestamp compared.
+     *
+     * NEGATIVE CONTROL, run by hand: delete the `uploadClaims.forEach` that moves the
+     * claims in `renameUploadsUnder`. The landed write then retires a line spelled
+     * `src/App.kt` while the line stands at `lib/App.kt`, and both assertions go red,
+     * while every other case in this class stays green.
+     */
+    @Test
+    fun `a write that lands during the rename of its directory retires its own record`() {
+        deviceTree(
+            mapOf(
+                "root" to listOf(Child("src", isDirectory = true)),
+                "doc:src" to listOf(Child("App.kt")),
+            )
+        )
+        val writer = startHeldWrite("src/App.kt")
+
+        observe(FileObserver.MOVED_FROM or isDirFlag, "src")
+        observe(FileObserver.MOVED_TO or isDirFlag, "lib")
+        File(mirror, "src").renameTo(File(mirror, "lib"))
+
+        releaseWrite.countDown()
+        writer.join(5_000)
+
+        val listed = engine.uploadsInFlight()
+        assertTrue(
+            listed.isEmpty(),
+            "the save reached the device and could not retire its own record, because " +
+                "the rename moved the record and left the writer holding the old name: " +
+                "$listed",
+        )
+        assertTrue(
+            SafStorageManager.mayReclaim(hash, listed, mirrorsRoot.absolutePath),
+            "a mirror whose every write landed is refused the removal the user asks for",
+        )
+    }
+
+    /**
+     * The other half of that window, and why the answer is not "leave a line alone while
+     * someone is writing it".
+     *
+     * A write that FAILS across the rename must keep its protection, and it has to keep
+     * it under the NEW path: the file is there now, and the sync's repair branch is gated
+     * on finding the file the line names.
+     *
+     * NEGATIVE CONTROL, run by hand: make `renameUploadsUnder` skip any line a live claim
+     * names, which is the shape that fixes the case above by itself. The record then
+     * stands under `src/App.kt`, a path nothing can consume, and both assertions go red.
+     */
+    @Test
+    fun `a write that fails during the rename keeps its record at the new path`() {
+        deviceTree(
+            mapOf(
+                "root" to listOf(Child("src", isDirectory = true)),
+                "doc:src" to listOf(Child("App.kt")),
+            )
+        )
+        val writer = startHeldWrite("src/App.kt")
+
+        observe(FileObserver.MOVED_FROM or isDirFlag, "src")
+        observe(FileObserver.MOVED_TO or isDirFlag, "lib")
+        File(mirror, "src").renameTo(File(mirror, "lib"))
+
+        // Both the parked write and the retry that follows it fail, which is the state a
+        // provider out of space leaves: the edit exists in the mirror alone.
+        failHeldWrite = true
+        refuseWrites = true
+        releaseWrite.countDown()
+        writer.join(5_000)
+
+        val listed = engine.uploadsInFlight()
+        assertTrue(
+            File(mirror, "lib/App.kt").absolutePath in listed,
+            "the edit reached no device and its record did not follow the file, so the " +
+                "next sync copies the truncated device document over the only complete " +
+                "copy: $listed",
+        )
+        assertFalse(
+            File(mirror, "src/App.kt").absolutePath in listed,
+            "the record stands under a path that no longer exists, which no sync can " +
+                "consume and which refuses the removal the user asks for",
+        )
+    }
+
+    /**
+     * The same window with the journal rewrite refused, which is the one failure the two
+     * records can survive only by staying together.
+     *
+     * Moving the line is best effort by design and it is swallowed at warn level, and it
+     * fails in precisely the state that fills the journal in the first place:
+     * `rewriteJournal` writes a temporary file in `filesDir`, so internal storage that has
+     * run out refuses it. Move the claim regardless and the two records of one write end
+     * up under different names for good: the writer that lands retires a line nobody ever
+     * wrote, and the real line stands under a path that has gone, where nothing can ever
+     * consume it (a claimed departure never reaches `consumeStaleUploadsUnder`, and the
+     * sync's repair needs the file the line names to be there). `mayReclaim` then refuses
+     * that mirror for a save that did reach the device, so the storage screen describes it
+     * as holding work the device folder does not have and the launch pass keeps it.
+     *
+     * The refusal is injected by taking write permission off the directory rather than by
+     * mocking, so it does not depend on the temporary file's name; and the setup assertion
+     * below fails loudly if it did not take, rather than letting the case pass on a rewrite
+     * that quietly succeeded.
+     *
+     * NEGATIVE CONTROL, run by hand: move the `uploadClaims.forEach` in
+     * `renameUploadsUnder` back above the `try`, which is where it was. The claim then
+     * moves although the line did not, the landed write retires `lib/App.kt` which was
+     * never written, and both assertions below go red while every other case in this class
+     * stays green.
+     */
+    @Test
+    fun `a rename whose journal rewrite is refused leaves both records at the old name`() {
+        deviceTree(
+            mapOf(
+                "root" to listOf(Child("src", isDirectory = true)),
+                "doc:src" to listOf(Child("App.kt")),
+            )
+        )
+        val writer = startHeldWrite("src/App.kt")
+        val stranded = File(mirror, "src/App.kt").absolutePath
+
+        observe(FileObserver.MOVED_FROM or isDirFlag, "src")
+        assertTrue(
+            filesDir.setWritable(false),
+            "setup failed: the directory kept its write permission, so the journal " +
+                "rewrite below is not being refused",
+        )
+        try {
+            observe(FileObserver.MOVED_TO or isDirFlag, "lib")
+        } finally {
+            filesDir.setWritable(true)
+        }
+        File(mirror, "src").renameTo(File(mirror, "lib"))
+
+        assertTrue(
+            stranded in engine.uploadsInFlight(),
+            "setup failed: the journal rewrite was not refused after all, so the two " +
+                "records of this write never came apart and nothing below is measured",
+        )
+
+        releaseWrite.countDown()
+        writer.join(5_000)
+
+        val listed = engine.uploadsInFlight()
+        assertTrue(
+            listed.isEmpty(),
+            "the save reached the device and retired a record nothing had written, " +
+                "because its claim moved with a line that stayed behind: $listed",
+        )
+        assertTrue(
+            SafStorageManager.mayReclaim(hash, listed, mirrorsRoot.absolutePath),
+            "a mirror whose every write landed is refused the removal the user asks for",
         )
     }
 }

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafSyncEngineTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafSyncEngineTest.kt
@@ -83,68 +83,6 @@ class SafSyncEngineTest {
         }
     }
 
-    // ── guessMimeType ───────────────────────────────────────────────────
-
-    @Nested
-    inner class GuessMimeTypeTest {
-
-        @Test
-        fun `text files`() {
-            assertEquals("text/plain", SafSyncEngine.guessMimeType("readme.txt"))
-            assertEquals("text/plain", SafSyncEngine.guessMimeType("CHANGELOG.md"))
-        }
-
-        @Test
-        fun `web files`() {
-            assertEquals("text/html", SafSyncEngine.guessMimeType("index.html"))
-            assertEquals("text/css", SafSyncEngine.guessMimeType("styles.css"))
-            assertEquals("text/javascript", SafSyncEngine.guessMimeType("app.js"))
-            assertEquals("text/javascript", SafSyncEngine.guessMimeType("main.ts"))
-        }
-
-        @Test
-        fun `data files`() {
-            assertEquals("application/json", SafSyncEngine.guessMimeType("package.json"))
-            assertEquals("text/xml", SafSyncEngine.guessMimeType("AndroidManifest.xml"))
-        }
-
-        @Test
-        fun `programming language files`() {
-            assertEquals("text/x-python", SafSyncEngine.guessMimeType("script.py"))
-            assertEquals("text/plain", SafSyncEngine.guessMimeType("Main.kt"))
-            assertEquals("text/plain", SafSyncEngine.guessMimeType("App.java"))
-            assertEquals("text/x-shellscript", SafSyncEngine.guessMimeType("deploy.sh"))
-        }
-
-        @Test
-        fun `unknown extensions fall back to octet-stream`() {
-            assertEquals("application/octet-stream", SafSyncEngine.guessMimeType("binary.dat"))
-            assertEquals("application/octet-stream", SafSyncEngine.guessMimeType("archive.zip"))
-            assertEquals("application/octet-stream", SafSyncEngine.guessMimeType("image.png"))
-            assertEquals("application/octet-stream", SafSyncEngine.guessMimeType("noext"))
-        }
-
-        @Test
-        fun `extension matching is case-sensitive`() {
-            // .TXT != .txt: this is the current behavior (could be a limitation)
-            assertEquals("application/octet-stream", SafSyncEngine.guessMimeType("README.TXT"))
-            assertEquals("application/octet-stream", SafSyncEngine.guessMimeType("APP.JS"))
-        }
-
-        @Test
-        fun `handles dotfiles without real extension`() {
-            assertEquals("application/octet-stream", SafSyncEngine.guessMimeType(".gitignore"))
-            assertEquals("application/octet-stream", SafSyncEngine.guessMimeType(".dockerignore"))
-        }
-
-        @Test
-        fun `handles files with multiple dots`() {
-            assertEquals("text/javascript", SafSyncEngine.guessMimeType("app.config.js"))
-            assertEquals("text/javascript", SafSyncEngine.guessMimeType("vite.config.ts"))
-            assertEquals("application/json", SafSyncEngine.guessMimeType("tsconfig.build.json"))
-        }
-    }
-
     // ── shouldOverwriteMirror ───────────────────────────────────────────
 
     @Nested

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafUploadRecordRetirementTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafUploadRecordRetirementTest.kt
@@ -34,10 +34,11 @@ import java.io.IOException
  *
  * A stranded line is not inert. [SafStorageManager.mayReclaim] reads any line under a
  * mirror as that mirror holding a write the device never received, so from then on the
- * launch pass keeps the mirror, the device-folder screen describes it as holding work
- * that exists nowhere else, and the removal the user asks for is refused with a sentence
- * about files that are not there. What is pinned here is the consequence rather than the
- * bookkeeping: the gate that reads the journal.
+ * launch pass keeps the mirror and the device-folder screen describes it as holding work
+ * that exists nowhere else, on the strength of a file that is not there. The removal is
+ * not refused: the bridge extension forces exactly these rows, so what the user gets is
+ * that warning and then the deletion. What is pinned here is the consequence rather than
+ * the bookkeeping: the gate that reads the journal.
  */
 class SafUploadRecordRetirementTest {
 
@@ -52,6 +53,9 @@ class SafUploadRecordRetirementTest {
     private lateinit var journal: File
 
     private val hash = "abc123def456"
+
+    /** inotify's "the entry this event is about is a directory", as the kernel sends it. */
+    private val isDirFlag = 0x40000000
 
     /** Set to have every write-back attempt fail the way a provider out of space does. */
     private var refuseWrites = false
@@ -101,18 +105,26 @@ class SafUploadRecordRetirementTest {
     @AfterEach
     fun tearDown() = unmockkAll()
 
-    private fun deviceHolding(name: String) {
+    /**
+     * A device folder that answers for every one of [names], whatever directory it is
+     * asked about.
+     *
+     * Crude on purpose: what a write-back needs from the provider here is a document to
+     * fail to write into, and every name in a path has to resolve for the deepest one to
+     * be reached at all.
+     */
+    private fun deviceHolding(vararg names: String) {
         val cursor = mockk<Cursor>(relaxed = true)
         var row = -1
-        every { cursor.moveToNext() } answers { ++row == 0 }
+        every { cursor.moveToNext() } answers { ++row < names.size }
         every {
             cursor.getColumnIndexOrThrow(DocumentsContract.Document.COLUMN_DOCUMENT_ID)
         } returns 0
         every {
             cursor.getColumnIndexOrThrow(DocumentsContract.Document.COLUMN_DISPLAY_NAME)
         } returns 1
-        every { cursor.getString(0) } returns "doc:$name"
-        every { cursor.getString(1) } returns name
+        every { cursor.getString(0) } answers { "doc:${names[row]}" }
+        every { cursor.getString(1) } answers { names[row] }
         every { resolver.query(any(), any(), any(), any(), any()) } answers {
             row = -1
             cursor
@@ -188,6 +200,185 @@ class SafUploadRecordRetirementTest {
             mayReclaim(),
             "an unrelated delete retired a record that still names a file holding the " +
                 "user's only copy",
+        )
+    }
+
+    /** A save the provider refuses, for a file one directory down. */
+    private fun strandOneWriteUnder(directory: String, name: String) {
+        deviceHolding("App.kt", *directory.split("/").toTypedArray(), name)
+        val file = File(File(mirror, directory).apply { mkdirs() }, name)
+        file.writeText("edited in the editor")
+        refuseWrites = true
+        deliver(FileObserver.MODIFY, "$directory/$name")
+        refuseWrites = false
+        assertTrue(
+            file.absolutePath in engine.uploadsInFlight(),
+            "no record was stranded, so nothing below is being tested",
+        )
+        assertFalse(mayReclaim(), "the stranded record did not reach the gate")
+    }
+
+    /**
+     * The case a delete never arrives for.
+     *
+     * A directory that leaves the mirror is held back for a rename to claim rather than
+     * queued as a delete, and inotify raises nothing at all for the entries beneath it, so
+     * the one live retirement point is never reached for any of them. Nothing else could
+     * reach them either, and a line that outlives the mirror path it names is not inert:
+     * every launch from then on keeps that mirror and the device-folder screen reports it
+     * as holding work the device folder does not have.
+     *
+     * NEGATIVE CONTROL: drop the `dropVanished { true }` from `stopWatching` back to
+     * `synchronized(vanishedLock) { vanishedDirectories.clear() }` and this goes red,
+     * while the two cases below it stay green.
+     */
+    @Test
+    fun `moving a directory away lets its mirror be reclaimed again`() {
+        strandOneWriteUnder("src/util", "helper.ts")
+
+        File(mirror, "src/util").deleteRecursively()
+        engine.handleMirrorEvent(
+            FileObserver.MOVED_FROM or isDirFlag, File(mirror, "src/util"), mirror, treeUri
+        )
+        engine.stopWatching()
+
+        assertTrue(
+            mayReclaim(),
+            "the records under a departed directory stand for ever, so this mirror can " +
+                "never be reclaimed and its row is permanently mislabelled",
+        )
+    }
+
+    /**
+     * The same, retired by the session rather than by its end, and the first half of it is
+     * the complement: while the rename can still be claimed the records have to stand,
+     * because a claim is what moves them to the directory's new path.
+     *
+     * NEGATIVE CONTROL: put the prune in `hasVanishedCandidate` back on the list itself
+     * (`vanishedDirectories.removeAll { ... }`) and the last assertion goes red while the
+     * first stays green.
+     */
+    @Test
+    fun `a departure nobody claimed retires its records when its window closes`() {
+        strandOneWriteUnder("src/util", "helper.ts")
+
+        File(mirror, "src/util").deleteRecursively()
+        engine.handleMirrorEvent(
+            FileObserver.MOVED_FROM or isDirFlag, File(mirror, "src/util"), mirror, treeUri
+        )
+        // Read after the event, never before it: the entry is stamped from the engine's
+        // own clock inside the call, so a bound taken on the other side of it is short by
+        // however long the call took and the expiry never happens. Measured here once,
+        // as SafVanishedCandidateWindowTest records measuring it.
+        val stampedBy = System.currentTimeMillis()
+        assertFalse(
+            mayReclaim(),
+            "the records were retired while a rename could still have claimed the " +
+                "directory, so nothing would have moved them to its new path",
+        )
+
+        engine.hasVanishedCandidate(stampedBy + SafSyncEngine.RENAME_PAIR_WINDOW_MS + 1)
+
+        assertTrue(mayReclaim(), "the expired departure left its records standing")
+    }
+
+    /**
+     * The control for the one thing that keeps a line: the file being there.
+     *
+     * A directory that left and came back under the same name (a checkout, a swap that
+     * lost its pairing) holds files again, and a line for one of them still records an
+     * edit the device never received. Retiring on the event alone rather than on the path
+     * being empty would throw that away.
+     */
+    @Test
+    fun `a record whose file is still there survives its directory leaving`() {
+        strandOneWriteUnder("src/util", "helper.ts")
+
+        engine.handleMirrorEvent(
+            FileObserver.MOVED_FROM or isDirFlag, File(mirror, "src/util"), mirror, treeUri
+        )
+        engine.stopWatching()
+
+        assertFalse(
+            mayReclaim(),
+            "a record naming a file that is still in the mirror was retired, so the " +
+                "next sync will copy the device's own interrupted upload over it",
+        )
+    }
+
+    /**
+     * The other side of that deferral: the writer it defers to.
+     *
+     * The pass above keeps a line some writer holds a claim on, because taking it would
+     * be the defect the claims exist to prevent. That leaves the writer holding the only
+     * knowledge that the line is unowned, and a write-back which fails is exactly where
+     * this arrives: the directory left the mirror while the stream ran, so the two
+     * attempts find nothing to read and the writer gives up. Its release used to drop the
+     * claim and leave the line, deliberately, so that the next sync retries the edit; but
+     * the file holding that edit has gone, there is no edit to retry, and by then the
+     * vanished entry has been dropped too, so no later pass revisits the prefix.
+     *
+     * What that costs is bounded but real. The device still holds its own copy of the
+     * document, because an unclaimed departure is never propagated, so reopening the
+     * folder copies it back and the reopen after that consumes the line through the
+     * initial sync's repair. Until then, and for ever where that copy cannot come back
+     * (the folder is not opened again, the document is past the size cap or outside the
+     * enumeration cap, the user deleted the stale old-named copy first), the launch pass
+     * keeps this mirror and the storage screen reports it as holding work the device
+     * folder does not have.
+     *
+     * NEGATIVE CONTROL, measured both ways: put `releaseUploadClaim` back to
+     * `uploadClaims.remove` alone and this case is the only one of the eight here that
+     * goes red. Drop the file test instead, retiring on every release, and the other
+     * seven go red while this one stays green, which is the complement: a failed write
+     * whose file is still in the mirror has to keep its line, and those cases all begin
+     * by stranding one.
+     */
+    @Test
+    fun `a write that fails onto a departed directory retires its own record`() {
+        deviceHolding("App.kt", "src", "util", "helper.ts")
+        val directory = File(mirror, "src/util").apply { mkdirs() }
+        val file = File(directory, "helper.ts")
+        file.writeText("edited in the editor")
+
+        // Read from inside the provider, which is the only place the deferral is
+        // observable: the claim is live exactly while this write is in the provider.
+        var deferred = false
+        every { resolver.openOutputStream(any(), any()) } answers {
+            // The directory leaves the mirror mid-write, and nothing claims the
+            // departure as the other half of a rename.
+            directory.deleteRecursively()
+            engine.handleMirrorEvent(
+                FileObserver.MOVED_FROM or isDirFlag, directory, mirror, treeUri
+            )
+            // The window closes, which is one of the three ways the entry is dropped and
+            // the one that needs no folder switch. Its retirement pass runs here, and
+            // keeps this file's line because the claim below it is live.
+            engine.hasVanishedCandidate(
+                System.currentTimeMillis() + SafSyncEngine.RENAME_PAIR_WINDOW_MS + 1
+            )
+            // Both halves, because either one alone would be satisfied by the pass
+            // never running at all: the departure is consumed, and the line it would
+            // have retired is still standing.
+            val consumed = !engine.hasVanishedCandidate(System.currentTimeMillis())
+            deferred = consumed && file.absolutePath in engine.uploadsInFlight()
+            throw IOException("no space left on device")
+        }
+
+        deliver(FileObserver.MODIFY, "src/util/helper.ts")
+
+        assertTrue(
+            deferred,
+            "the retirement pass never ran, or did not defer to this writer, so " +
+                "nothing below is testing what happens when the writer it deferred " +
+                "to fails",
+        )
+        assertTrue(
+            mayReclaim(),
+            "the write that failed onto a path its file had left kept its record, and " +
+                "nothing else can reach that record now: this mirror is refused every " +
+                "reclaim and mislabelled on the storage screen until the device copy " +
+                "happens to be downloaded again",
         )
     }
 

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafWatchHandoffTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafWatchHandoffTest.kt
@@ -46,6 +46,10 @@ import kotlin.concurrent.thread
  * Closing that needs the capture to move into the observer and be passed in, which
  * changes the signature every test in this package calls.
  *
+ * The offer that arrives once every drain has ended is not silent either. The stop's own
+ * count cannot reach that one: it reads the queue and clears it while the event is still
+ * inside the provider, so what is left to report is reported by the offer itself.
+ *
  * NEGATIVE CONTROL, run by hand: put the offer back on the mutable field
  * (`target.queue.offer` to `session.queue.offer`). The first case goes red on both
  * assertions and in opposite directions, the closing queue empty and the newly opened one
@@ -203,6 +207,45 @@ class SafWatchHandoffTest {
             emitted.any { it.contains("arrived after the drain ended") },
             "a save that never reached the device was dropped without a word, and a user " +
                 "asking why needs this line to exist in a bug report: $emitted",
+        )
+    }
+
+    /**
+     * The drop the capture itself creates, made visible where the count cannot see it.
+     *
+     * The count above reads a queue and clears it. On an ordinary folder switch the idle
+     * drain exits in microseconds while this event is still inside the provider, so the
+     * count runs first, reports nothing, and the save arrives afterwards into a queue with
+     * no worker: exactly the interleaving the capture produces, and the one the count is
+     * blind to. Nothing is destroyed, the mirror keeps the file, but the save is not on
+     * the device and only reopening the folder puts it there.
+     *
+     * NEGATIVE CONTROL, run by hand: delete the `if (target.abandoned)` warning at the
+     * offer in `handleMirrorEvent`, or stop `stopWatching`'s no-worker branch setting
+     * `abandoned`. This case goes red while the two above stay green, since neither reads
+     * a line that names a file.
+     */
+    @Test
+    fun `a save that arrives after the drain has ended says so`() {
+        File(mirror, "notes.txt").writeText("a save mid-flight")
+
+        val observer = thread(isDaemon = true) {
+            engine.handleMirrorEvent(FileObserver.MODIFY, File(mirror, "notes.txt"), mirror, treeUri)
+        }
+        assertTrue(
+            entered.await(5, TimeUnit.SECONDS),
+            "setup failed: the event never reached the provider, so the stop below did " +
+                "not land inside the window this case is about",
+        )
+
+        engine.stopWatching()
+        release.countDown()
+        observer.join(5_000)
+
+        assertTrue(
+            emitted.any { it.contains("Write-back of notes.txt arrived after the drain ended") },
+            "the save reached no device, nothing will retry it, and no line says so: " +
+                "$emitted",
         )
     }
 }

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafWriteBackPathLoggingTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafWriteBackPathLoggingTest.kt
@@ -1,0 +1,259 @@
+package com.vscodroid.storage
+
+import android.content.ContentResolver
+import android.content.Context
+import android.net.Uri
+import android.provider.DocumentsContract
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.io.FileNotFoundException
+
+/**
+ * That a write-back the provider refuses does not put the user's directory into logcat.
+ *
+ * The sibling of [SafFolderPathLoggingTest], for the other direction and for the reason
+ * the leak got in: that suite drives opening a folder, so the copy path is redacted and
+ * asserted while the four calls that carry a change back to the device were never
+ * exercised. A document id is the user's own path on the platform provider, a
+ * `FileNotFoundException` or `SecurityException` from these calls quotes the whole
+ * document URI in its own message, and `Logger.w` is not gated on a debuggable build, so
+ * interpolating `e.message` ships that string.
+ *
+ * Every case here is an everyday provider failure rather than an exotic one: the document
+ * was deleted on the device, the grant was revoked in Settings, the volume is full or
+ * read-only, the card was ejected.
+ *
+ * Asserted at `android.util.Log`, like the suite it is modelled on, because there are two
+ * routes for the same string and only the sink sees both.
+ */
+class SafWriteBackPathLoggingTest {
+
+    @TempDir
+    lateinit var mirror: File
+
+    private lateinit var resolver: ContentResolver
+    private lateinit var engine: SafSyncEngine
+
+    private val treeUriText =
+        "content://com.android.externalstorage.documents/tree/primary%3ADocuments%2FClientProject"
+
+    /** The part of that URI a reader could turn back into a place on the device. */
+    private val folderName = "ClientProject"
+
+    /** What a provider puts in its own exception when it cannot answer for a document. */
+    private val providerRefusal = FileNotFoundException(
+        "open failed for $treeUriText/document/primary%3ADocuments%2FClientProject%2Fnotes.txt"
+    )
+
+    private val treeUri = mockk<Uri>(relaxed = true)
+    private val docUri = mockk<Uri>(relaxed = true)
+    private val parentUri = mockk<Uri>(relaxed = true)
+    private val sourceParentUri = mockk<Uri>(relaxed = true)
+
+    /** Every string the app handed the log, message and throwable alike. */
+    private val emitted = mutableListOf<String>()
+
+    @BeforeEach
+    fun setUp() {
+        emitted.clear()
+
+        mockkStatic(android.util.Log::class)
+        every { android.util.Log.i(any(), any()) } answers { note(args); 0 }
+        every { android.util.Log.d(any(), any()) } answers { note(args); 0 }
+        every { android.util.Log.w(any(), any<String>()) } answers { note(args); 0 }
+        every { android.util.Log.w(any(), any<String>(), any<Throwable>()) } answers { note(args); 0 }
+        every { android.util.Log.e(any(), any()) } answers { note(args); 0 }
+        every { android.util.Log.e(any(), any<String>(), any<Throwable>()) } answers { note(args); 0 }
+
+        mockkStatic(DocumentsContract::class)
+        every { treeUri.toString() } returns treeUriText
+        every { DocumentsContract.getTreeDocumentId(any()) } returns
+            "primary:Documents/$folderName"
+        every { DocumentsContract.getDocumentId(any()) } returns
+            "primary:Documents/$folderName"
+        every { DocumentsContract.buildChildDocumentsUriUsingTree(any(), any()) } returns
+            mockk(relaxed = true)
+        every { DocumentsContract.buildDocumentUriUsingTree(any(), any()) } returns docUri
+
+        resolver = mockk(relaxed = true)
+        every { resolver.query(any(), any(), any(), any(), any()) } returns null
+
+        val context = mockk<Context>(relaxed = true)
+        every { context.contentResolver } returns resolver
+        every { context.filesDir } returns mirror
+        engine = SafSyncEngine(context)
+    }
+
+    @AfterEach
+    fun tearDown() = unmockkAll()
+
+    /**
+     * Records a log call's arguments, a throwable included as the text it would print.
+     * The tag is recorded too: it is written by the same statement and is as capable of
+     * carrying an interpolation.
+     */
+    private fun note(args: List<Any?>) {
+        args.forEach { arg ->
+            emitted += when (arg) {
+                is Throwable -> arg.toString() + (arg.message ?: "")
+                else -> arg.toString()
+            }
+        }
+    }
+
+    /**
+     * That the line under test was actually written, and that what it carries instead of
+     * the provider's message is the exception's class.
+     *
+     * Without it every case here would pass just as well against a write-back that never
+     * reached the call at all, which is how the first version of the guard this suite
+     * extends came to cover four sites it never ran.
+     */
+    private fun assertSaid(fragment: String) {
+        assertTrue(
+            emitted.any { it.contains(fragment) && it.contains("FileNotFoundException") },
+            "no line said \"$fragment\", so this case is asserting nothing: $emitted",
+        )
+    }
+
+    private fun assertFolderNotNamed() {
+        assertTrue(
+            emitted.isNotEmpty(),
+            "nothing reached the log at all, so this run proves nothing about what does",
+        )
+        val leaked = emitted.filter { it.contains(folderName) || it.contains("tree/primary") }
+        assertTrue(leaked.isEmpty(), "the user's device folder reached release logcat: $leaked")
+    }
+
+    /** Puts one job through the real write-back, the way the drain does. */
+    private fun writeBack(job: SyncJob) {
+        engine.session.queue.offer(job)
+        engine.runWriteBackLoop { false }
+    }
+
+    @Test
+    fun `a create the provider refuses does not repeat its message`() {
+        every { DocumentsContract.createDocument(any(), any(), any(), any()) } throws
+            providerRefusal
+        File(mirror, "notes.txt").writeText("the only copy")
+
+        writeBack(
+            SyncJob(
+                type = SyncType.CREATE,
+                localPath = File(mirror, "notes.txt").absolutePath,
+                safDocUri = null,
+                safParentUri = parentUri,
+                safTreeUri = treeUri,
+                timestamp = 1L,
+                relativePath = "notes.txt",
+            )
+        )
+
+        assertFolderNotNamed()
+        assertSaid("Failed to create notes.txt in SAF")
+    }
+
+    @Test
+    fun `a delete the provider refuses does not repeat its message`() {
+        every { DocumentsContract.deleteDocument(any(), any()) } throws providerRefusal
+
+        writeBack(
+            SyncJob(
+                type = SyncType.DELETE,
+                localPath = File(mirror, "notes.txt").absolutePath,
+                safDocUri = docUri,
+                safParentUri = null,
+                safTreeUri = treeUri,
+                timestamp = 1L,
+                relativePath = "notes.txt",
+            )
+        )
+
+        assertFolderNotNamed()
+        assertSaid("Failed to delete from SAF")
+    }
+
+    /**
+     * The local file is deliberately absent, so the create fallback a refused rename
+     * falls into is not taken: what is under test is the rename's own line.
+     */
+    @Test
+    fun `a rename the provider refuses does not repeat its message`() {
+        every { DocumentsContract.renameDocument(any(), any(), any()) } throws providerRefusal
+
+        writeBack(
+            SyncJob(
+                type = SyncType.RENAME,
+                localPath = File(mirror, "renamed.txt").absolutePath,
+                safDocUri = docUri,
+                safParentUri = parentUri,
+                safTreeUri = treeUri,
+                timestamp = 1L,
+                previousName = "notes.txt",
+                relativePath = "renamed.txt",
+            )
+        )
+
+        assertFolderNotNamed()
+        assertSaid("Could not rename a document to renamed.txt")
+    }
+
+    @Test
+    fun `a move the provider refuses does not repeat its message`() {
+        every { DocumentsContract.moveDocument(any(), any(), any(), any()) } throws providerRefusal
+
+        writeBack(
+            SyncJob(
+                type = SyncType.RENAME,
+                localPath = File(mirror, "legacy/util").absolutePath,
+                safDocUri = docUri,
+                safParentUri = parentUri,
+                safTreeUri = treeUri,
+                timestamp = 1L,
+                safSourceParentUri = sourceParentUri,
+                previousName = "util",
+                relativePath = "legacy/util",
+            )
+        )
+
+        assertFolderNotNamed()
+        assertSaid("Could not move a document between directories")
+    }
+
+    /**
+     * The control, in the same spirit as the one in [SafFolderPathLoggingTest]. Redaction
+     * that leaves nothing behind is deletion: a bug report still has to be able to say
+     * which file the device folder would not take.
+     */
+    @Test
+    fun `a refused create still says which file it was`() {
+        every { DocumentsContract.createDocument(any(), any(), any(), any()) } throws
+            providerRefusal
+        File(mirror, "notes.txt").writeText("the only copy")
+
+        writeBack(
+            SyncJob(
+                type = SyncType.CREATE,
+                localPath = File(mirror, "notes.txt").absolutePath,
+                safDocUri = null,
+                safParentUri = parentUri,
+                safTreeUri = treeUri,
+                timestamp = 1L,
+                relativePath = "notes.txt",
+            )
+        )
+
+        assertTrue(
+            emitted.any { it.contains("notes.txt") },
+            "the redaction removed the record rather than the secret: $emitted",
+        )
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/storage/WriteBackNoticeWiringTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/WriteBackNoticeWiringTest.kt
@@ -145,9 +145,12 @@ class WriteBackNoticeWiringTest {
     @Test
     fun `the first failure is announced and a prompt second one is not`() {
         val interval = SafStorageManager.FAILURE_NOTICE_INTERVAL_MS
-        // A wall-clock value, because that is what the caller passes. Toy numbers put
-        // the first failure inside the interval of a zero last-announced time and made
-        // this assert the opposite of the shipped behaviour.
+        // A reading well past the interval. Toy numbers put the first failure inside
+        // the interval of a zero last-announced time and made this assert the opposite
+        // of the shipped behaviour; the clause named in `the first failure is said even
+        // seconds after boot` is what settles that case now, and it is asserted there
+        // rather than smuggled in here. The caller supplies this from the monotonic
+        // clock, not the wall clock.
         val now = 1_700_000_000_000L
 
         assertTrue(
@@ -161,6 +164,73 @@ class WriteBackNoticeWiringTest {
         assertTrue(
             SafStorageManager.shouldAnnounce(now = now + interval, lastAnnouncedAt = now),
             "the notice has to come back, or a later failure is silent again",
+        )
+    }
+
+    /**
+     * That the reading the throttle subtracts from cannot move backwards.
+     *
+     * ⚠️ Source text, because the reading is taken inside the lambda this method installs
+     * on a private [SafSyncEngine], which no JVM test here can make fire. The behaviour
+     * either side of it is covered: the rule by the cases above, and the clock by the one
+     * below.
+     *
+     * The stamp lives in an `AtomicLong` for the life of the manager, and the rule is a
+     * subtraction against it, so a wall clock corrected backwards by more than the
+     * interval (NTP after a drifted RTC, or the user setting the date) makes every
+     * later difference negative and silences the notice until the clock catches up. A
+     * folder whose provider is refusing every save then stops saying so, which is the
+     * failure this notice exists to prevent. `AuthTabWindow` states the same reasoning
+     * one file over and takes `SystemClock.elapsedRealtime()`.
+     *
+     * Negative control, measured: put `System.currentTimeMillis()` back and this goes red.
+     */
+    @Test
+    fun `the write-back throttle reads the monotonic clock`() {
+        assertTrue(manager.isFile, "SafStorageManager.kt is not where this test expects it")
+        val body = manager.readText()
+            .substringAfter("fun onWriteBackFailed(", "")
+            .substringBefore("\n    }")
+        assertTrue(
+            body.contains("claimAnnouncement("),
+            "onWriteBackFailed is not where this test expects it, so the assertions below " +
+                "would be asked of nothing",
+        )
+
+        assertTrue(
+            Regex("""(?m)^\s*if \(claimAnnouncement\(SystemClock\.elapsedRealtime\(\)""")
+                .containsMatchIn(body),
+            "the throttle no longer reads the monotonic clock, so a device clock moved " +
+                "backwards silences every write-back failure notice for the rest of the " +
+                "session",
+        )
+        assertFalse(
+            body.contains("System.currentTimeMillis()"),
+            "the throttle reads wall time, which can move backwards under it",
+        )
+    }
+
+    /**
+     * The first notice of a session is given however recently the device booted.
+     *
+     * The clock above is milliseconds since boot, not since 1970, so "nothing announced
+     * yet" stopped being a reading further back than any interval and became one that
+     * can sit inside it. A device a few seconds up, with a provider already refusing,
+     * would have swallowed the one notice that always has to be given.
+     *
+     * Negative control, measured: drop the `lastAnnouncedAt == NEVER_ANNOUNCED` clause
+     * from `shouldAnnounce` and this goes red while every case above stays green, which
+     * is why it is a case of its own.
+     */
+    @Test
+    fun `the first failure is said even seconds after boot`() {
+        assertTrue(
+            SafStorageManager.shouldAnnounce(
+                now = 3_000L,
+                lastAnnouncedAt = SafStorageManager.NEVER_ANNOUNCED,
+            ),
+            "a folder that started failing before the device had been up for one " +
+                "interval said nothing at all",
         )
     }
 

--- a/android/app/src/test/kotlin/com/vscodroid/util/ClearableStorageTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/util/ClearableStorageTest.kt
@@ -165,6 +165,82 @@ class ClearableStorageTest {
         assertTrue(!abandoned.exists(), "$abandoned belongs to no download and should have gone")
     }
 
+    /**
+     * The row's arithmetic, which the two behavioural cases above do not touch: they
+     * plant the `cache` sample inside `npm-cache`, so they pin the row's name rather
+     * than what it adds up.
+     *
+     * Every directory the row counts has to be one the action empties. The row is
+     * offered to that action by [StorageManager.CLEARABLE_KEYS], and a figure that
+     * counts bytes the action cannot reach is the same "the report is not about the row
+     * you picked" failure that set exists to end, surviving inside the one row still
+     * offered.
+     *
+     * Negative control, measured: add a name to `CLEARABLE_CACHE_DIRS` that
+     * `clearCaches` does not delete and this goes red.
+     */
+    @Test
+    fun `every directory the cache row counts is one the clear empties`() {
+        assertTrue(
+            StorageManager.CLEARABLE_CACHE_DIRS.isNotEmpty(),
+            "the row counts nothing, so this proves nothing",
+        )
+        for (name in StorageManager.CLEARABLE_CACHE_DIRS) {
+            val planted = File(cacheDir, "$name/planted.bin").apply {
+                parentFile?.mkdirs()
+                writeText("x".repeat(4096))
+            }
+            val counted = StorageManager.getStorageBreakdown(context).getLong("cache")
+            assertTrue(counted >= 4096, "'$name' is not even counted, so this proves nothing")
+
+            StorageManager.clearCaches(context)
+
+            assertTrue(
+                !planted.exists(),
+                "the cache row counts $planted, which the clear it is offered to leaves " +
+                    "behind, so the figure the user picked does not move",
+            )
+        }
+    }
+
+    /**
+     * And the other half: the cache directory is not this app's alone.
+     *
+     * The platform WebView keeps its own store there, named after
+     * `WebView.setDataDirectorySuffix("vscodroid")`, and on a debug install after one
+     * short editor session that was 9356 KiB of the 9428 KiB in the directory, against
+     * 40 KiB the action could reach. Counting it made a user out of disk tap a button
+     * that could not move the figure it had just shown them.
+     *
+     * The second assertion is the reason the fix is on the row rather than on the
+     * action: Chromium holds that store open in a live renderer, so emptying it is not
+     * this app's to do.
+     *
+     * Negative control, measured: restore `put("cache", dirSize(cacheDir))` and the
+     * first assertion goes red.
+     */
+    @Test
+    fun `the cache row leaves out the bytes the clear cannot free`() {
+        val webview = File(cacheDir, "webview_vscodroid/Default/HTTP Cache/data_0").apply {
+            parentFile?.mkdirs()
+            writeText("x".repeat(8192))
+        }
+
+        assertEquals(
+            0L, StorageManager.getStorageBreakdown(context).getLong("cache"),
+            "the cache row counts the WebView's own store, which the clear action it is " +
+                "offered to cannot free",
+        )
+
+        StorageManager.clearCaches(context)
+
+        assertTrue(
+            webview.exists(),
+            "the clear deleted the platform WebView's store, which a live renderer holds " +
+                "open and which this app does not own",
+        )
+    }
+
     @Test
     fun `the breakdown carries the set the screen has to branch on`() {
         val json = StorageManager.getStorageBreakdown(context)

--- a/android/app/src/test/kotlin/com/vscodroid/util/CrashReporterTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/util/CrashReporterTest.kt
@@ -184,6 +184,100 @@ class CrashReporterTest {
             assertTrue(shown.contains("tkn=<redacted>"), "the parameter stays visible:\n$shown")
             assertTrue(shown.contains("java.io.IOException"), "the failure itself has to survive:\n$shown")
         }
+
+        /**
+         * The token is not the only credential this text can carry, and the two
+         * places it lands, the dialog and `AndroidBridge.getLastCrash`, are the
+         * same places the report goes.
+         *
+         * NEGATIVE CONTROL: put `getLastCrash` back to `redactToken(it.readText())`
+         * without [redactSecrets] and the password below is handed to the page.
+         */
+        @Test
+        fun `the crash offered on screen carries no named credential`() {
+            val crashDir = initCrashDir()
+            File(crashDir, "crash_20260214_120000.txt").writeText(
+                "Thread: main (id=1)\n" +
+                    "java.lang.IllegalStateException: spawn failed for " +
+                    "DB_PASSWORD=hunter2hunter2\n"
+            )
+
+            val shown = CrashReporter.getLastCrash()
+
+            assertNotNull(shown, "there is a crash log on disk to read")
+            assertFalse(
+                shown!!.contains("hunter2hunter2"),
+                "the page can call this method, and the dialog offers it to be pasted:\n$shown",
+            )
+            assertTrue(
+                shown.contains("java.lang.IllegalStateException"),
+                "the failure itself has to survive:\n$shown",
+            )
+        }
+
+        /**
+         * The directory is listed and then the newest entry is read, and those are
+         * two operations. `cacheDir` is evictable by the OS at any moment, and the
+         * app's own `clearCaches` and `clearCrashLogs` empty it from other threads
+         * with no lock shared with this reader, so the entry can be gone by the
+         * time it is read. `MainActivity.checkPreviousCrash` calls this on the main
+         * thread from `onCreate` with no try anywhere on the path, so the throw
+         * used to kill the process.
+         *
+         * A directory stands in for the vanished file, because both arrive here the
+         * same way: an IOException out of `readText` on something `listFiles`
+         * handed back, and unlike a race it happens on every run.
+         *
+         * NEGATIVE CONTROL: inline `readOrNull` back to `it.readText()` and this
+         * case reddens with FileNotFoundException rather than returning null.
+         */
+        @Test
+        fun `a crash log that cannot be read answers instead of throwing`() {
+            val crashDir = initCrashDir()
+            File(crashDir, "crash_20260214_120000.txt").mkdirs()
+
+            assertNull(
+                CrashReporter.getLastCrash(),
+                "an unreadable entry has to read as no crash, not as an exception on " +
+                    "the main thread",
+            )
+        }
+
+        /**
+         * A crash log is many lines and [redactSecrets] is written against one, so
+         * the text handed to the dialog and to `AndroidBridge.getLastCrash` is
+         * where a rule that crosses a newline is first noticed by a user: the
+         * dialog offers a preview cut at 500 characters, and a trace that stops at
+         * its first frame reads as a crash with nothing to say.
+         *
+         * NEGATIVE CONTROL: make `redactSecrets` one pass over the whole text
+         * again (`redactOneLine(text)` with no split) and everything from
+         * `Authorization:` to the end of the file becomes one `<redacted>`, so
+         * both frames below are gone and this case reddens.
+         */
+        @Test
+        fun `the crash offered on screen keeps the frames under a redaction`() {
+            val crashDir = initCrashDir()
+            File(crashDir, "crash_20260214_120000.txt").writeText(
+                "Thread: main (id=1)\n" +
+                    "java.io.IOException: Authorization: Bearer rejected by the proxy\n" +
+                    "\tat com.vscodroid.service.ProcessManager.startServer(ProcessManager.kt:119)\n" +
+                    "Caused by: java.net.SocketException: Socket is closed\n"
+            )
+
+            val shown = CrashReporter.getLastCrash()
+
+            assertNotNull(shown, "there is a crash log on disk to read")
+            assertFalse(
+                shown!!.contains("Bearer rejected"),
+                "the header value still has to go:\n$shown",
+            )
+            assertTrue(
+                shown.contains("ProcessManager.startServer(ProcessManager.kt:119)") &&
+                    shown.contains("Caused by: java.net.SocketException"),
+                "the trace under the match was swallowed:\n$shown",
+            )
+        }
     }
 
     @Nested
@@ -388,6 +482,115 @@ class CrashReporterTest {
             )
         }
 
+        /**
+         * The crash section crosses the same boundary as the server section: it is
+         * put on the clipboard for the user to paste somewhere public. What has to
+         * be taken out of a text follows from where the text is going, so both
+         * sections take both scrubbers.
+         *
+         * NEGATIVE CONTROL: drop [redactSecrets] from the crash-log branch of
+         * `generateBugReport`, leaving `redactToken(text)`, and the password below
+         * is copied to the clipboard verbatim.
+         */
+        @Test
+        fun `a named credential in a crash log does not reach the report`() {
+            val crashDir = initCrashDir()
+            File(crashDir, "crash_20260214_120000.txt").writeText(
+                "Thread: main (id=1)\n" +
+                    "java.lang.IllegalStateException: env was NPM_TOKEN=npm_AAAABBBBCCCCDDDD\n" +
+                    "\tat com.vscodroid.service.ProcessManager.startServer(ProcessManager.kt:119)\n"
+            )
+
+            val report = CrashReporter.generateBugReport(context)
+
+            assertFalse(
+                report.contains("npm_AAAABBBBCCCCDDDD"),
+                "the clipboard is readable by anything the user pastes into:\n$report",
+            )
+            assertTrue(
+                report.contains(
+                    "at com.vscodroid.service.ProcessManager.startServer(ProcessManager.kt:119)"
+                ),
+                "this is the only diagnostic channel there is; the trace has to survive:\n$report",
+            )
+        }
+
+        /**
+         * The section the count above promises, kept whole.
+         *
+         * The crash text goes through the same scrubbers as the server section
+         * now, and it is the one that arrives as a whole file. A rule that spans
+         * a newline turns the promised log into a single truncated line under a
+         * header that still reads `--- Crash Logs (1) ---`, which is worse than a
+         * missing section: it reads as a complete crash log that had nothing to
+         * say, and the clipboard is the only diagnostic channel there is.
+         *
+         * NEGATIVE CONTROL: make `redactSecrets` one pass over the whole text
+         * again (`redactOneLine(text)` with no split). Everything from
+         * `Authorization:` onwards collapses into one `<redacted>`, since a Java
+         * stack trace carries no quote, comma or brace to stop at, and this case
+         * reddens on the first frame.
+         */
+        @Test
+        fun `a redaction in a crash log does not swallow the trace under it`() {
+            val crashDir = initCrashDir()
+            File(crashDir, "crash_20260214_120000.txt").writeText(
+                "Thread: main (id=1)\n" +
+                    "java.io.IOException: Authorization: Bearer rejected by the proxy\n" +
+                    "\tat com.vscodroid.webview.DownloadCoordinator.hold(DownloadCoordinator.kt:214)\n" +
+                    "\tat com.vscodroid.service.ProcessManager.startServer(ProcessManager.kt:119)\n" +
+                    "Caused by: java.net.SocketException: Socket is closed\n"
+            )
+
+            val report = CrashReporter.generateBugReport(context)
+
+            assertFalse(
+                report.contains("Bearer rejected"),
+                "the credential shape still has to go:\n$report",
+            )
+            for (kept in listOf(
+                "at com.vscodroid.webview.DownloadCoordinator.hold(DownloadCoordinator.kt:214)",
+                "at com.vscodroid.service.ProcessManager.startServer(ProcessManager.kt:119)",
+                "Caused by: java.net.SocketException: Socket is closed",
+            )) {
+                assertTrue(
+                    report.contains(kept),
+                    "\"$kept\" was swallowed by the redaction, and the header still " +
+                        "promises a whole crash log:\n$report",
+                )
+            }
+        }
+
+        /**
+         * The same two-step read as `getLastCrash`, on the path that runs on the
+         * main thread behind the dialog's Copy Report button, where an exception
+         * kills the process and loses the report the user was trying to send.
+         *
+         * NEGATIVE CONTROL: inline `readOrNull` back to `log.readText()` and this
+         * case reddens with FileNotFoundException instead of producing a report.
+         */
+        @Test
+        fun `a crash log that cannot be read leaves the rest of the report intact`() {
+            val crashDir = initCrashDir()
+            val readable = File(crashDir, "crash_20260214_120000.txt")
+            readable.writeText("the crash that can still be read")
+            readable.setLastModified(1000L)
+            val unreadable = File(crashDir, "crash_20260214_120001.txt")
+            unreadable.mkdirs()
+            unreadable.setLastModified(2000L)
+
+            val report = CrashReporter.generateBugReport(context)
+
+            assertTrue(
+                report.contains("the crash that can still be read"),
+                "one unreadable entry took the whole section with it:\n$report",
+            )
+            assertTrue(
+                report.contains("(crash_20260214_120001.txt could not be read)"),
+                "the count above promised this log, so a silent hole reads as no crash:\n$report",
+            )
+        }
+
         @Test
         fun `the crash section says so when there is nothing to report`() {
             initCrashDir()
@@ -454,6 +657,52 @@ class CrashReporterTest {
                 boom, chained.get(),
                 "the handler that was there before still has to run, or the process never dies",
             )
+        }
+
+        /**
+         * A cascade is two threads faulting in quick succession, and the file name
+         * only resolves to a second.
+         *
+         * This handler is the process-wide default and runs before the chain to the
+         * handler that kills the process, so nothing about dying serializes two
+         * threads that fault together. Both crashes used to compute the same name
+         * and `writeText` truncates, so what was lost was the first one: the crash
+         * that started the cascade, leaving the report holding only the downstream
+         * symptom.
+         *
+         * Aligned to the start of a wall-clock second first, so both writes land
+         * inside one second, which is the state the defect needs. Without that a
+         * run that straddled the boundary would pass on a broken build by picking
+         * two names honestly.
+         *
+         * NEGATIVE CONTROL: put `writeCrashLog` back to
+         * `val file = File(crashDir, "crash_$timestamp.txt")` with no
+         * `createNewFile` loop; the directory then holds one file and this case
+         * reddens on the count, and on the first exception being gone.
+         */
+        @Test
+        fun `a second crash in the same second does not overwrite the first`() {
+            val intoTheSecond = System.currentTimeMillis() % 1000
+            if (intoTheSecond > 500) Thread.sleep(1000 - intoTheSecond)
+            Thread.setDefaultUncaughtExceptionHandler { _, _ -> }
+            val context = mockk<Context>(relaxed = true)
+            every { context.cacheDir } returns tempDir
+
+            CrashReporter.init(context)
+
+            val installed = Thread.getDefaultUncaughtExceptionHandler()!!
+            installed.uncaughtException(Thread("worker-1"), IllegalStateException("the cause"))
+            installed.uncaughtException(Thread("worker-2"), IllegalStateException("the symptom"))
+
+            val written = File(tempDir, "crash-logs").listFiles()?.toList().orEmpty()
+            assertEquals(2, written.size, "two crashes, two logs: $written")
+            val all = written.joinToString("\n") { it.readText() }
+            assertTrue(
+                all.contains("the cause"),
+                "the crash that started the cascade was overwritten by the one it " +
+                    "caused, which is the only one worth reading:\n$all",
+            )
+            assertTrue(all.contains("the symptom"), "the second crash is missing:\n$all")
         }
     }
 }

--- a/android/app/src/test/kotlin/com/vscodroid/util/ServerLogTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/util/ServerLogTest.kt
@@ -361,6 +361,84 @@ class ServerLogTest {
     }
 
     /**
+     * The name beside the credential is almost never the bare keyword.
+     *
+     * A Node server prints environment variables, an extension dumps its own
+     * configuration, and a dotenv parse error quotes the line it choked on, so
+     * what reaches this file is `NPM_TOKEN=`, `DB_PASSWORD:` or
+     * `AWS_SECRET_ACCESS_KEY=`. The rule was anchored with `\b`, which
+     * java.util.regex defines over `[A-Za-z0-9_]`: an underscore is a word
+     * character, so the boundary never held next to one and every name in this
+     * case was written to disk verbatim and copied into a bug report.
+     *
+     * NEGATIVE CONTROL: put the `\b` back around the keyword alternation in the
+     * third entry of `SECRET_PATTERNS` (`\b(?:api[_-]?key|...|token)\b` in place
+     * of the two lookarounds). Every line below is then written unchanged and this
+     * case reddens on the first of them.
+     */
+    @Test
+    fun `a credential named like an environment variable is redacted too`() {
+        val file = logFile()
+        val log = ServerLog(file)
+        val secrets = mapOf(
+            "<4242><stderr> NPM_TOKEN=npm_AAAABBBBCCCCDDDDEEEE" to "npm_AAAABBBBCCCCDDDDEEEE",
+            "<4242><stderr> DB_PASSWORD: hunter2hunter2" to "hunter2hunter2",
+            "<4242><stderr>   \"DB_PASSWORD\": \"correct-horse\"" to "correct-horse",
+            "<4242><stderr> MY_API_KEY=AKIAIOSFODNN7EXAMPLE" to "AKIAIOSFODNN7EXAMPLE",
+            "<4242><stderr> AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfi" to
+                "wJalrXUtnFEMI/K7MDENG/bPxRfi",
+            "<4242><stderr> VSCODE_AGENT_TOKEN=1234567890abcdef" to "1234567890abcdef",
+            "<4242><stderr> export user_token=abc123def456" to "abc123def456",
+        )
+        secrets.keys.forEach { log.append(it) }
+
+        val written = file.readText()
+        for ((line, secret) in secrets) {
+            assertFalse(
+                secret in written,
+                "\"$secret\" survived from \"$line\", so a bug report carries it:\n$written",
+            )
+        }
+        assertEquals(
+            secrets.size,
+            written.lines().count { "<redacted>" in it },
+            "one line was left with nothing replaced:\n$written",
+        )
+    }
+
+    /**
+     * The other side of the same boundary: the keyword has to be a segment of the
+     * name, not any occurrence of those letters.
+     *
+     * Widening the rule until it fires wherever `token` or `secret` appears would
+     * eat the diagnostics this file exists for, and an exception class or a
+     * source file is exactly where those letters turn up innocently.
+     *
+     * NEGATIVE CONTROL: one mutation per boundary, because two different things
+     * hold these lines. Drop `(?<![A-Za-z0-9])` from the third entry of
+     * `SECRET_PATTERNS` and the last line reddens, `notasecret=` and `mytoken=`
+     * both read as names. Make the separator optional in the same entry, `[:=]?`
+     * for `[:=]`, and the middle two redden instead: nothing else stops a keyword
+     * with letters welded onto its right, because it can then reach a value with
+     * no separator in between. The first line takes both mutations together,
+     * which is what makes it the one worth keeping when the rule is next widened.
+     */
+    @Test
+    fun `a keyword welded into a longer word is not a credential name`() {
+        val file = logFile()
+        val log = ServerLog(file)
+        val lines = listOf(
+            "<4242><stderr> InvalidTokenError: unexpected end of input",
+            "<4242><stderr> SecretStorageService: initialised",
+            "<4242> at Tokenizer.scan (/data/user/0/x/tokenizer.js:12:3)",
+            "<4242> notasecret=1 mytoken=diagnostic",
+        )
+        lines.forEach { log.append(it) }
+
+        assertEquals(lines, file.readLines(), "diagnostics were eaten by the redaction")
+    }
+
+    /**
      * The control for the case above. A redaction wide enough to swallow the
      * output makes the file useless for the one thing it exists for, and a
      * `<redacted>` in place of every line would satisfy that test perfectly.
@@ -379,6 +457,204 @@ class ServerLogTest {
         lines.forEach { log.append(it) }
 
         assertEquals(lines, file.readLines(), "diagnostics were eaten by the redaction")
+    }
+
+    /**
+     * The table this rule set is meant to satisfy, in one case: what has to go,
+     * what has to survive, and what the multi-word and segmented shapes do.
+     *
+     * Kept as one table because the rules are one rule set. A case per shape
+     * hides the thing that goes wrong here, which is that widening the pattern
+     * for a name in the first column quietly moves a line out of the second.
+     *
+     * NEGATIVE CONTROL: three mutations of the third entry of `SECRET_PATTERNS`,
+     * two for the first column and one for the second. Drop `pgpassword|` and the
+     * `PGPASSWORD` row survives; put the value back to `["']?[^\s"',}&]+` with no
+     * quoted alternative and `DB_PASSWORD="correct horse battery staple"` keeps
+     * everything after its first word. Drop `(?<![A-Za-z0-9])` and the second
+     * column's `notasecret=1 mytoken=diagnostic` is redacted instead. Measured:
+     * each of the three reddens this case on its own.
+     */
+    @Test
+    fun `the redaction table holds in both directions`() {
+        val mustGo = mapOf(
+            "<4242><stderr> request failed: {\"authorization\":\"Bearer abcd1234efgh5678\"}" to
+                "abcd1234efgh5678",
+            "<4242> GET /v1/models api_key=super-secret-value" to "super-secret-value",
+            "<4242><stderr> NPM_TOKEN=npm_AAAABBBBCCCCDDDDEEEE" to "npm_AAAABBBBCCCCDDDDEEEE",
+            "<4242><stderr> AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG" to "wJalrXUtnFEMI",
+            "<4242><stderr> x_api_key_v2: abcdef0123456789" to "abcdef0123456789",
+            "<4242><stderr> PGPASSWORD=s3cr3tpassword psql -h db" to "s3cr3tpassword",
+            "<4242><stderr> DB_PASSWORD=\"correct horse battery staple\"" to "battery staple",
+            "<4242><stderr> export MY_SECRET='hunter 2 three'" to "2 three",
+            "<4242> using key sk-abcdefghijklmnopqrstuvwxyz" to "sk-abcdefghijklmnopqrstuvwxyz",
+        )
+        val mustSurvive = listOf(
+            "Extension host agent listening on 41003",
+            "[error] Error: listen EADDRINUSE: address already in use 127.0.0.1:41003",
+            "Authorization failed for a request that carried no header",
+            "FATAL ERROR: JavaScript heap out of memory",
+            "<4242><stderr> InvalidTokenError: unexpected end of input",
+            "<4242><stderr> SecretStorageService: initialised",
+            "<4242> at Tokenizer.scan (/data/user/0/x/tokenizer.js:12:3)",
+            "<4242> notasecret=1 mytoken=diagnostic",
+        )
+
+        for ((line, secret) in mustGo) {
+            val redacted = redactSecrets(line)
+            assertFalse(
+                secret in redacted,
+                "\"$secret\" survived from \"$line\", so a bug report carries it: $redacted",
+            )
+            assertTrue("<redacted>" in redacted, "nothing was replaced in \"$line\"")
+        }
+        for (line in mustSurvive) {
+            assertEquals(line, redactSecrets(line), "a diagnostic was eaten by the redaction")
+        }
+    }
+
+    /**
+     * What accepting a name's remaining segments costs, pinned to the character.
+     *
+     * The note above `SECRET_PATTERNS` bounds the cost, and a bound nobody
+     * measures drifts: it said "a hyphenated ordinary word ending in a colon"
+     * loses "the one word after it", while the rule also fires on `_` segments
+     * and after a flag's `=`, and the value class does not stop at a `:`, so the
+     * punctuation goes with the value. Asserting the exact output is what makes
+     * the next widening of that rule visible instead of silent.
+     *
+     * NEGATIVE CONTROL: drop `(?:[_-][A-Za-z0-9_-]*)?` from the third entry of
+     * `SECRET_PATTERNS`. All three lines are then returned unchanged, which
+     * reddens here and reddens `x_api_key_v2` in the table above, and those two
+     * together are the trade being made.
+     */
+    @Test
+    fun `a segmented ordinary name costs exactly the run after its separator`() {
+        val file = logFile()
+        val log = ServerLog(file)
+        val lines = listOf(
+            "<4242><stderr> secret-storage: initialised at 12:00",
+            "<4242><stderr> password_hash_algorithm: bcrypt",
+            "<4242><stderr> fatal: --secret-file=/etc/k.pem: no such file",
+        )
+        lines.forEach { log.append(it) }
+
+        assertEquals(
+            listOf(
+                "<4242><stderr> secret-storage: <redacted> at 12:00",
+                "<4242><stderr> password_hash_algorithm: <redacted>",
+                "<4242><stderr> fatal: --secret-file=<redacted> no such file",
+            ),
+            file.readLines(),
+            "the cost of the segment rule is not what the note beside it says",
+        )
+    }
+
+    /**
+     * A crash log is a whole file, and every pattern here is written against one
+     * line.
+     *
+     * `CrashReporter` now runs this over the text of a crash log rather than over
+     * one line of server output, and the header rule's value class excludes
+     * quotes, commas and braces but not newlines, while the `\s*` and `\s+` in
+     * the header and scheme rules match a newline like any other space. Given a
+     * whole file, one `authorization:` in a throwable's message took everything
+     * under it as far as the next quote, comma or brace, and a Java stack trace
+     * has none of those, so the report kept five lines of eleven while still
+     * announcing a complete crash log.
+     *
+     * NEGATIVE CONTROL: make `redactSecrets` one pass over the whole text again
+     * (`redactOneLine(text)` with no split). The trace below collapses to the
+     * `IOException` line and this case reddens on the first frame.
+     */
+    @Test
+    fun `redaction of a whole crash log keeps the trace under the match`() {
+        val crash = listOf(
+            "Crash at 2026-08-22 10:02:11 +0700",
+            "Thread: main (id=2)",
+            "",
+            "java.io.IOException: Authorization: Bearer rejected by the proxy",
+            "\tat com.vscodroid.service.ProcessManager.startServer(ProcessManager.kt:119)",
+            "Caused by: java.net.SocketException: Socket is closed",
+            "\tat java.net.Socket.getOutputStream(Socket.java:1030)",
+        ).joinToString("\n", postfix = "\n")
+
+        val redacted = redactSecrets(crash)
+
+        assertEquals(
+            crash.count { it == '\n' },
+            redacted.count { it == '\n' },
+            "the redaction swallowed lines of the trace:\n$redacted",
+        )
+        assertFalse(
+            "Bearer rejected" in redacted,
+            "the header value still has to go:\n$redacted",
+        )
+        for (kept in listOf(
+            "ProcessManager.startServer(ProcessManager.kt:119)",
+            "Caused by: java.net.SocketException: Socket is closed",
+            "java.net.Socket.getOutputStream(Socket.java:1030)",
+        )) {
+            assertTrue(kept in redacted, "\"$kept\" was eaten:\n$redacted")
+        }
+    }
+
+    /**
+     * The other cross-line shape, which excluding a newline from one value class
+     * would not have closed: the scheme rule's `\s+` and the named rule's `\s*`
+     * match a newline, so both could reach into the line below and replace its
+     * first word.
+     *
+     * NEGATIVE CONTROL: the same mutation as the case above. Both lines then lose
+     * their first frame to a `<redacted>` and this reddens.
+     */
+    @Test
+    fun `a keyword at the end of a line does not reach the frame below it`() {
+        val text = "java.lang.IllegalStateException: basic\n" +
+            "\tat com.vscodroid.util.Thing.doIt(Thing.kt:1)\n" +
+            "java.lang.IllegalStateException: password:\n" +
+            "\tat com.vscodroid.MainActivity.onCreate(MainActivity.kt:1)\n"
+
+        assertEquals(text, redactSecrets(text), "a rule reached across a newline")
+    }
+
+    /**
+     * A pathological name cannot take the process with it.
+     *
+     * java.util.regex compiles a quantified group into a `Loop` that recurses
+     * once per repetition, so the segment suffix written as `(?:[_-][A-Za-z0-9]+)*`
+     * raised StackOverflowError on a long enough name. That is an `Error`: it
+     * passes through the `IOException` catch in `append` and the `Exception` catch
+     * in `ProcessManager.startOutputReader`, reaches the default handler and kills
+     * the process the editor runs in, with the log line never written.
+     *
+     * Run on a thread with a 1 MiB stack, which is the order of the drain thread's
+     * own, because the default stack of whatever JVM runs the suite is not the
+     * property under test.
+     *
+     * NEGATIVE CONTROL: put `(?:[_-][A-Za-z0-9]+)*` back in place of
+     * `(?:[_-][A-Za-z0-9_-]*)?` in the third entry of `SECRET_PATTERNS`. Measured:
+     * this case then fails with StackOverflowError, at 2000 segments as well as at
+     * the 20000 below, and no other case in this file changes.
+     */
+    @Test
+    fun `a name made of thousands of segments does not overflow the stack`() {
+        val line = "<4242><stderr> token" + "_a".repeat(20_000) + "=hunter2"
+        var thrown: Throwable? = null
+        var out: String? = null
+
+        val worker = Thread(null, {
+            try {
+                out = redactSecrets(line)
+            } catch (t: Throwable) {
+                thrown = t
+            }
+        }, "redaction-1m-stack", 1L shl 20)
+        worker.start()
+        worker.join()
+
+        assertEquals(null, thrown, "the redaction threw on a long name, killing the process")
+        assertFalse("hunter2" in out!!, "the long name is still a credential name: $out")
     }
 
     /**

--- a/android/app/src/test/kotlin/com/vscodroid/webview/CdnUrlInjectionTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/CdnUrlInjectionTest.kt
@@ -1,0 +1,243 @@
+package com.vscodroid.webview
+
+import android.net.Uri
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import com.vscodroid.util.Logger
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.Socket
+import kotlin.concurrent.thread
+
+/**
+ * What a rendered page can make the CDN rewrite ask our own server for.
+ *
+ * The entry test is the hostname and nothing else: `interceptCdnRequest` accepts
+ * any `*.vscode-cdn.net` address, and `shouldOverrideUrlLoading` lets those
+ * through, so the whole of the path and the query belong to whatever document is
+ * on screen. That includes an extension webview, notebook output and any site
+ * open in the bundled Simple Browser. `withToken` then signs the result with the
+ * server's connection token, which authenticates every route but `/version`,
+ * `/delay-shutdown` and `/callback`.
+ *
+ * `Uri.getPath()` hands this code the DECODED path, so `%3F` arrives as a real
+ * `?` and `%2E%2E%2F` as a real `../`. Concatenated into a URL string, both stop
+ * being text and become syntax: the first opens a query the page wrote and the
+ * token is appended to it with `&`, the second walks out of
+ * `/{quality}-{commit}/static/` onto any route the server has, and
+ * `/vscode-remote-resource?path=<absolute>` reads any file the server can read.
+ * The two sibling arms of `interceptResourceRequest` were deleted for exactly
+ * this, and their comments in the source are the record of it.
+ *
+ * Driven against a real loopback server so the assertion is on the request line
+ * the server actually receives, not on a string this file rebuilds. That matters
+ * for the traversal case in particular: whether the dot segments are collapsed by
+ * the client (Android's HttpURLConnection is OkHttp-backed and canonicalises
+ * them) or left for the server to trip over is not this app's to rely on, so what
+ * is asserted is that the request is never made at all.
+ *
+ * NEGATIVE CONTROL, measured for each case:
+ *  - drop the dot-segment refusal from `rewriteCdnUrl` and
+ *    `a traversal out of the static prefix is never requested` goes red;
+ *  - build the URL by concatenation again (`"http://127.0.0.1:$port$localPath" +
+ *    queryPart`) and `a query injected into the path does not become a query`
+ *    goes red, while the ordinary-asset case stays green in both.
+ */
+class CdnUrlInjectionTest {
+
+    /** Hex, so that `Uri.encode` being the identity below is faithful to production. */
+    private val token = "0123456789abcdef0123456789abcdef"
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(Logger)
+        every { Logger.d(any(), any()) } just Runs
+        every { Logger.i(any(), any()) } just Runs
+        every { Logger.w(any(), any()) } just Runs
+
+        // A stub under the unit-test android.jar, and the token is a hex string in
+        // production, so identity encoding is faithful.
+        mockkStatic(Uri::class)
+        every { Uri.encode(any()) } answers { firstArg<String>() }
+
+        // Cannot be constructed under the stub android.jar. Mocked purely so the
+        // function runs to its end; nothing is asserted about it.
+        mockkConstructor(WebResourceResponse::class)
+    }
+
+    @AfterEach
+    fun tearDown() = unmockkAll()
+
+    private fun request(path: String, query: String?): WebResourceRequest {
+        val uri = mockk<Uri>(relaxed = true)
+        every { uri.host } returns "0f7c2b1a.vscode-cdn.net"
+        every { uri.path } returns path
+        every { uri.query } returns query
+        every { uri.toString() } returns
+            "https://0f7c2b1a.vscode-cdn.net$path" + if (query != null) "?$query" else ""
+        val request = mockk<WebResourceRequest>(relaxed = true)
+        every { request.url } returns uri
+        every { request.method } returns "GET"
+        return request
+    }
+
+    private fun intercept(server: Recorder, path: String, query: String? = null) =
+        VSCodroidWebViewClient.interceptCdnRequest(
+            request(path, query), server.port, token, emptyList(), emptyList(), { null }
+        )
+
+    /**
+     * The control the two cases below rest on: an ordinary workbench asset still
+     * reaches the server unchanged, token and all.
+     *
+     * Without it, a `rewriteCdnUrl` that refused everything would satisfy both of
+     * them while emptying the editor of every asset it loads.
+     */
+    @Test
+    fun `an ordinary asset is still rewritten and still carries the token`() {
+        Recorder().use { server ->
+            assertNotNull(
+                intercept(server, "/stable/deadbeef/out/vs/workbench/workbench.js"),
+                "the rewrite refused an asset the workbench asks for on every load",
+            )
+
+            assertEquals(
+                "/stable-deadbeef/static/out/vs/workbench/workbench.js?tkn=$token",
+                server.target,
+                "the local URL is no longer the one the server's static route answers",
+            )
+        }
+    }
+
+    /**
+     * A `?` the page percent-encoded into its path must stay a character in a path
+     * segment, never the start of a query the token then authenticates.
+     */
+    @Test
+    fun `a query injected into the path does not become a query`() {
+        Recorder().use { server ->
+            intercept(
+                server,
+                // What `%3Fpath%3D...` decodes to by the time this code sees it.
+                "/stable/deadbeef/vscode-remote-resource?path=/data/data/com.vscodroid/" +
+                    "files/home/.ssh/id_ed25519",
+            )
+
+            val target = server.target
+            assertNotNull(target, "no request reached the server at all")
+            assertEquals(
+                "tkn=$token",
+                target!!.substringAfter('?', ""),
+                "the page wrote part of the query on a request signed with the server's " +
+                    "connection token. Request line target: $target",
+            )
+            assertTrue(
+                target.startsWith("/stable-deadbeef/static/"),
+                "the request left the static prefix: $target",
+            )
+        }
+    }
+
+    /**
+     * And a `../` it encoded the same way must not walk out of the static prefix.
+     *
+     * Asserted as "no request", because the collapse happens in the client on
+     * Android and in neither on the desktop JVM this test runs on. A request that
+     * depends on which end resolves the dot segments is one this app should not be
+     * making.
+     */
+    @Test
+    fun `a traversal out of the static prefix is never requested`() {
+        Recorder().use { server ->
+            val response = intercept(
+                server,
+                "/stable/deadbeef/../../vscode-remote-resource",
+                query = "path=/data/data/com.vscodroid/files/home/.ssh/id_ed25519",
+            )
+
+            assertNull(
+                server.target,
+                "a token-authenticated request left the app for a route the page chose: " +
+                    "${server.target}",
+            )
+            assertNotNull(
+                response,
+                "the refusal handed the address back to the WebView, which then fetches it " +
+                    "from the real CDN over the device's network",
+            )
+        }
+    }
+}
+
+/**
+ * A loopback server that answers one empty 200 and remembers the request target.
+ *
+ * `ConnectionTokenLoggingTest` has a sibling that deliberately records nothing,
+ * because it reads the log. This one exists for the opposite reason: the request
+ * line is the only place the URL this app built can be observed after
+ * `HttpURLConnection` has had it.
+ */
+private class Recorder : AutoCloseable {
+
+    private val socket = ServerSocket(0, 0, InetAddress.getByName("127.0.0.1"))
+
+    @Volatile
+    private var running = true
+
+    /** The path and query of the last request, or null if none was made. */
+    @Volatile
+    var target: String? = null
+        private set
+
+    val port: Int get() = socket.localPort
+
+    init {
+        thread(name = "cdn-injection-stub", isDaemon = true) {
+            while (running) {
+                try {
+                    socket.accept().use(::answer)
+                } catch (e: Exception) {
+                    if (!running) break
+                }
+            }
+        }
+    }
+
+    private fun answer(client: Socket) {
+        val reader = client.getInputStream().bufferedReader()
+        // "GET <target> HTTP/1.1", recorded before the response so that it is
+        // written by the time the caller's readResponseCode() returns.
+        target = reader.readLine()?.split(" ")?.getOrNull(1)
+        while (true) {
+            val line = reader.readLine()
+            if (line.isNullOrEmpty()) break
+        }
+        client.getOutputStream().apply {
+            write(
+                ("HTTP/1.1 200 Stub\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+                    .toByteArray()
+            )
+            flush()
+        }
+    }
+
+    override fun close() {
+        running = false
+        socket.close()
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/webview/DownloadCoordinatorTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/DownloadCoordinatorTest.kt
@@ -18,6 +18,7 @@ import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.io.OutputStream
 import java.util.Base64
+import java.util.concurrent.Executor
 
 /**
  * That a download either arrives complete or is visibly not there.
@@ -35,6 +36,14 @@ import java.util.Base64
  * what reached the file, whether the file survived, and what was reported. Any
  * one of them alone is satisfiable by an implementation that is wrong about the
  * other two.
+ *
+ * The provider work is driven where it is handed over, which is the one thing
+ * here that is not how the coordinator ships: closing a document and deleting it
+ * go to a thread of its own, because both are unbounded calls into another app
+ * and every teardown decides on the UI thread. That property is not this file's
+ * to check and cannot be checked from a single-threaded case at all;
+ * `DownloadWriteBlockingTest` owns it. What is wanted here is for the outcome to
+ * have finished by the time a case asserts on it.
  */
 class DownloadCoordinatorTest {
 
@@ -55,6 +64,9 @@ class DownloadCoordinatorTest {
 
     /** URLs the page was asked to read, paired with the request id. */
     private val readRequests = mutableListOf<Pair<String, String>>()
+
+    /** URLs the page was told it may stop holding the bytes of, in order. */
+    private val released = mutableListOf<String>()
 
     /** Whether the fake picker reports that it opened. */
     private var pickerOpens = true
@@ -122,6 +134,10 @@ class DownloadCoordinatorTest {
             readRequests += requestId to url
         }
 
+        override fun releaseBytes(url: String) {
+            released += url
+        }
+
         override fun report(outcome: DownloadOutcome, fileName: String, detail: String?) {
             reported += outcome to fileName
         }
@@ -148,11 +164,20 @@ class DownloadCoordinatorTest {
         discarded.clear()
         reported.clear()
         readRequests.clear()
+        released.clear()
         pickerOpens = true
         destinationOpens = true
         writesFail = false
         closeFails = false
-        coordinator = DownloadCoordinator(host)
+        // Both executors run where they are handed over, so the whole of a
+        // download settles inside the call that started it and every case below
+        // reads state that has stopped moving. Which thread each one really is
+        // belongs to DownloadWriteBlockingTest.
+        coordinator = DownloadCoordinator(
+            host,
+            providerWork = Executor { it.run() },
+            mainThread = Executor { it.run() },
+        )
     }
 
     @AfterEach
@@ -441,6 +466,62 @@ class DownloadCoordinatorTest {
         assertEquals(listOf(DownloadOutcome.FAILED to FALLBACK_DOWNLOAD_NAME), reported,
             "a download that will never be started has to say so")
         assertEquals(1, asked.size, "and nothing ahead of it in the queue was disturbed")
+    }
+
+    /**
+     * The bytes the page is left holding for a download that will never be read.
+     *
+     * The page pins a download's blob from the click that started it and keeps
+     * it for the whole hold budget, because up to `MAX_QUEUED` pickers can stand
+     * between that click and anyone asking for the bytes. Nothing else can free
+     * it: the only reason the capture script gives up a hold on its own is that
+     * the bytes are being read, and these three downloads are exactly the ones
+     * that are never read. So a multi-select whose tail the queue turns away
+     * pins every one of those files in the renderer for minutes after the user
+     * was told they are not coming.
+     *
+     * NEGATIVE CONTROL for the three cases below, one each: delete
+     * `host.releaseBytes(request.url)` from the `MAX_QUEUED` refusal in
+     * `onDownloadStart`, from the cancelled branch of `onDestinationChosen`, or
+     * from `fail`.
+     */
+    @Test
+    fun `a download refused for being one too many lets go of its bytes`() {
+        coordinator.onDownloadStart("blob:live", null)
+        repeat(MAX_QUEUED) { coordinator.onDownloadStart("blob:queued$it", null) }
+
+        coordinator.onDownloadStart("blob:overflow", null)
+
+        assertEquals(listOf("blob:overflow"), released,
+            "only the refused download is done with. The one at the picker and the " +
+                "eight behind it are still going to be asked for their bytes, and a " +
+                "hold released under them is a download that fails when its turn comes")
+    }
+
+    @Test
+    fun `cancelling at the picker lets go of the bytes it was holding`() {
+        coordinator.onDownloadStart("blob:x", null)
+
+        chooseDestination(null)
+
+        assertEquals(listOf("blob:x"), released,
+            "the user said no, so nothing will ever read this blob and the page is " +
+                "holding a file the download it belonged to is over")
+    }
+
+    @Test
+    fun `a download that fails before it is read lets go of its bytes`() {
+        destinationOpens = false
+        coordinator.onDownloadStart("blob:x", null)
+
+        chooseDestination(destination())
+
+        assertEquals(listOf(DownloadOutcome.FAILED to FALLBACK_DOWNLOAD_NAME), reported,
+            "the control: a failure that was not reported would satisfy the line below " +
+                "by never having been a download at all")
+        assertEquals(listOf("blob:x"), released,
+            "the document would not open, so the page was never asked to read anything " +
+                "and its hold has nothing left to wait for")
     }
 
     /**

--- a/android/app/src/test/kotlin/com/vscodroid/webview/DownloadHoldBudgetTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/DownloadHoldBudgetTest.kt
@@ -28,6 +28,14 @@ import java.io.File
  * cases in `DownloadListenerWiringTest`. It is deliberately a floor rather than
  * an equality: what matters is the relation between the two, so raising the
  * queue without raising the budget is what has to go red.
+ *
+ * The budget being a floor is what makes the other direction matter. A download
+ * Android has finished with and never read holds its file for the whole of it,
+ * and the page cannot know: the capture script gives a hold up only when the
+ * bytes are being read, which is the one thing that never happens to a download
+ * refused for being one of too many, cancelled at the picker, or failed before
+ * anyone asked. So the release has to be told, and the last two cases here are
+ * the page's half of that. `DownloadCoordinatorTest` owns the Kotlin half.
  */
 class DownloadHoldBudgetTest {
 
@@ -63,6 +71,8 @@ class DownloadHoldBudgetTest {
     }
 
     private val readerFor by lazy { script("function readerFor(url) {") }
+
+    private val release by lazy { script("release: function(url) {") }
 
     @Test
     fun `the script being checked was actually found`() {
@@ -113,6 +123,45 @@ class DownloadHoldBudgetTest {
             "the release sits on the fetch path rather than the blob path. The fetch " +
                 "has not read anything yet, so revoking there refuses the very request " +
                 "the hold exists for."
+        }
+    }
+
+    /**
+     * NEGATIVE CONTROL: delete the `release` entry from the injected
+     * `window.__vscodroidDownload`, and this case fails at the extraction rather
+     * than at the assertion, saying so.
+     */
+    @Test
+    fun `the page gives up a hold Android has finished with`() {
+        assertTrue(release.contains("held.delete(url)") && release.contains("revoke(url)")) {
+            "the page-side release does not let the blob go. A download that is never " +
+                "read has no other way out of the map: its hold sits there for the whole " +
+                "budget above, holding the file's bytes in the renderer long after the " +
+                "user was told the download failed.\n$release"
+        }
+    }
+
+    /**
+     * NEGATIVE CONTROL: drop the `d.release(...)` call from the `releaseBytes`
+     * override in `MainActivity`'s `DownloadHost`. The page-side function above
+     * then has no caller at all, which is exactly the state this pair exists to
+     * rule out.
+     */
+    @Test
+    fun `the release the page offers is the one Android calls`() {
+        val override = withoutComments(source)
+            .lines()
+            .dropWhile { !it.contains("override fun releaseBytes(") }
+            .takeWhile { !it.contains("override fun report(") }
+
+        assertTrue(override.isNotEmpty()) {
+            "MainActivity no longer answers DownloadHost.releaseBytes where this looks. " +
+                "If it moved, point this at wherever the page is told to let go now."
+        }
+        val body = override.joinToString("\n")
+        assertTrue(body.contains("__vscodroidDownload") && body.contains(".release(")) {
+            "releaseBytes does not reach the capture script's release, so every download " +
+                "that dies before it is read keeps its bytes pinned in the page:\n$body"
         }
     }
 }

--- a/android/app/src/test/kotlin/com/vscodroid/webview/DownloadProviderFailureTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/DownloadProviderFailureTest.kt
@@ -1,0 +1,236 @@
+package com.vscodroid.webview
+
+import android.net.Uri
+import com.vscodroid.util.Logger
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.OutputStream
+import java.util.Base64
+import java.util.concurrent.Executor
+
+/**
+ * That what the provider throws ends the download and nothing else.
+ *
+ * Every call this class makes on a document is a binder call into another app,
+ * and another app is free to be missing. A provider force-stopped, updated or
+ * revoked between the picker answering and the document being opened answers
+ * with `SecurityException` or `IllegalArgumentException`, neither of which is an
+ * `IOException`; a provider whose process dies mid-transfer can raise either
+ * from a write or from a close.
+ *
+ * Two different costs, and both are worse than the failed download they hide
+ * inside. `onDestinationChosen` runs bare in the activity-result callback with
+ * nothing above it to catch anything, so a throw there is the app disappearing
+ * while the user watches a save. A throw out of `onBytes` or `onComplete` costs
+ * something quieter and longer lived: those two give the claim on the stream
+ * back on their way out, so an exception that skips that leaves the download
+ * marked busy for ever. Every teardown then defers to a writer that is gone,
+ * the document is never removed, and the queue behind it never moves again, so
+ * the feature is dead for the life of the Activity.
+ *
+ * Each case therefore asserts the download failed *and* that the coordinator is
+ * still able to take the next one.
+ */
+class DownloadProviderFailureTest {
+
+    /** What the fake picker was asked to create, one entry per request. */
+    private val asked = mutableListOf<String>()
+
+    /** The request each of those pickers was opened for, in the same order. */
+    private val pickerIds = mutableListOf<String>()
+
+    /** Documents removed through [DownloadHost.discardDestination]. */
+    private val discarded = mutableListOf<Uri>()
+
+    /** Every outcome reported, in order. */
+    private val reported = mutableListOf<Pair<DownloadOutcome, String>>()
+
+    /** URLs the page was asked to read, paired with the request id. */
+    private val readRequests = mutableListOf<Pair<String, String>>()
+
+    /** What [DownloadHost.openDestination] throws, or null to answer a stream. */
+    private var openThrows: Exception? = null
+
+    /** What a write to the opened document throws, or null to accept it. */
+    private var writeThrows: Exception? = null
+
+    /** What closing the opened document throws, or null to accept it. */
+    private var closeThrows: Exception? = null
+
+    private lateinit var coordinator: DownloadCoordinator
+
+    private inner class FailingStream : OutputStream() {
+        override fun write(b: Int) = write(byteArrayOf(b.toByte()), 0, 1)
+
+        override fun write(b: ByteArray, off: Int, len: Int) {
+            writeThrows?.let { throw it }
+        }
+
+        override fun close() {
+            closeThrows?.let { throw it }
+        }
+    }
+
+    private val host = object : DownloadHost {
+        override fun askDestination(requestId: String, fileName: String) {
+            asked += fileName
+            pickerIds += requestId
+        }
+
+        override fun openDestination(destination: Uri): OutputStream {
+            openThrows?.let { throw it }
+            return FailingStream()
+        }
+
+        override fun discardDestination(destination: Uri) {
+            discarded += destination
+        }
+
+        override fun requestBytes(requestId: String, url: String) {
+            readRequests += requestId to url
+        }
+
+        override fun releaseBytes(url: String) = Unit
+
+        override fun report(outcome: DownloadOutcome, fileName: String, detail: String?) {
+            reported += outcome to fileName
+        }
+    }
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(Logger)
+        every { Logger.d(any(), any()) } just Runs
+        every { Logger.w(any(), any()) } just Runs
+        every { Logger.w(any(), any(), any()) } just Runs
+        // Driven where it is handed over, so a document discarded by the
+        // teardown has been discarded by the time a case reads the list.
+        // DownloadWriteBlockingTest owns the question of which thread it runs on.
+        coordinator = DownloadCoordinator(
+            host,
+            providerWork = Executor { it.run() },
+            mainThread = Executor { it.run() },
+        )
+    }
+
+    @AfterEach
+    fun tearDown() = unmockkAll()
+
+    private fun destination(name: String = "doc"): Uri = mockk<Uri>(relaxed = true, name = name)
+
+    private fun encode(text: String): String =
+        Base64.getEncoder().encodeToString(text.toByteArray())
+
+    /** Starts a download and answers its picker with [target]. */
+    private fun startAndChoose(target: Uri, url: String = "blob:x"): String {
+        coordinator.onDownloadStart(url, null)
+        coordinator.onDestinationChosen(pickerIds.last(), target)
+        return pickerIds.last()
+    }
+
+    /**
+     * NEGATIVE CONTROL: narrow the catch around `host.openDestination` in
+     * `onDestinationChosen` back to `catch (e: IOException)`. The
+     * `SecurityException` below then leaves the coordinator, and this case fails
+     * carrying it, which is what the user gets in the activity-result callback
+     * as well: no toast, no download, no app.
+     */
+    @Test
+    fun `a provider that refuses to open the document fails the download, not the app`() {
+        val target = destination()
+        openThrows = SecurityException("Permission Denial: opening provider")
+
+        startAndChoose(target)
+
+        assertEquals(
+            listOf(DownloadOutcome.FAILED to FALLBACK_DOWNLOAD_NAME), reported,
+            "a download that cannot be opened has to be reported like any other failure",
+        )
+        assertEquals(
+            listOf(target), discarded,
+            "the picker already created the file, so it is sitting in the user's folder " +
+                "empty and wearing the name of the one they wanted",
+        )
+        assertEquals(emptyList<Pair<String, String>>(), readRequests)
+    }
+
+    /**
+     * NEGATIVE CONTROL: narrow the catch around `chunk.stream.write` in
+     * `onBytes` back to `catch (e: IOException)`. The `IllegalStateException`
+     * then escapes before `request.busy` is cleared, so this case fails carrying
+     * it, and the two assertions after the throw are the ones that describe what
+     * that costs.
+     */
+    @Test
+    fun `a write that throws something other than IOException gives the claim back`() {
+        val target = destination()
+        writeThrows = IllegalStateException("the provider process is gone")
+
+        val id = startAndChoose(target)
+        val accepted = coordinator.onBytes(id, encode("payload"))
+
+        assertFalse(accepted, "the page has to be told to stop reading a download that failed")
+        assertEquals(listOf(DownloadOutcome.FAILED to FALLBACK_DOWNLOAD_NAME), reported)
+        assertEquals(listOf(target), discarded, "and the file it was filling goes with it")
+
+        coordinator.onDownloadStart("blob:next", null)
+        assertEquals(
+            2, asked.size,
+            "the next download never got a picker, so the claim was never given back: " +
+                "every teardown from here defers to a writer that is gone and every " +
+                "later download queues behind a download that can never end",
+        )
+    }
+
+    /**
+     * NEGATIVE CONTROL: narrow the catch around `request.stream?.close()` in
+     * `onComplete` back to `catch (e: IOException)`, with the same shape of
+     * failure as the case above.
+     */
+    @Test
+    fun `a close that throws something other than IOException gives the claim back`() {
+        val target = destination()
+        closeThrows = SecurityException("the grant was revoked")
+
+        val id = startAndChoose(target)
+        coordinator.onBytes(id, encode("payload"))
+        coordinator.onComplete(id, null)
+
+        assertEquals(
+            listOf(DownloadOutcome.FAILED to FALLBACK_DOWNLOAD_NAME), reported,
+            "the close is what commits the bytes, so a close that failed is a file with " +
+                "a hole in it and must never be reported as a save",
+        )
+        assertEquals(listOf(target), discarded)
+
+        coordinator.onDownloadStart("blob:next", null)
+        assertEquals(2, asked.size, "the claim taken for the close was never given back")
+    }
+
+    /**
+     * The control for all three: nothing about this fake refuses downloads by
+     * itself, so a coordinator that failed every one of them would satisfy the
+     * cases above without any provider throwing anything.
+     */
+    @Test
+    fun `a provider that throws nothing saves the file`() {
+        val target = destination()
+
+        val id = startAndChoose(target)
+        coordinator.onBytes(id, encode("payload"))
+        coordinator.onComplete(id, null)
+
+        assertEquals(listOf(DownloadOutcome.SAVED to FALLBACK_DOWNLOAD_NAME), reported)
+        assertTrue(discarded.isEmpty(), "a completed download keeps its file")
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/webview/DownloadProviderThreadTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/DownloadProviderThreadTest.kt
@@ -1,0 +1,132 @@
+package com.vscodroid.webview
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * That the thread a download borrows is given back.
+ *
+ * The provider calls nobody waits for (closing a document, deleting it, opening
+ * the one the picker just made) are handed to a thread of the coordinator's own,
+ * and there is one coordinator per Activity. Nothing tells that thread to stop:
+ * a shutdown from `onDestroy` would refuse the hand-off that a thread still
+ * inside the provider makes on its way out, and the user's part-written document
+ * would stay in their folder, which is the one thing that hand-off exists to
+ * remove. So the ending is the idle timeout, and these cases measure it rather
+ * than trusting the constructor's argument list.
+ *
+ * A parked thread is not free on a device this app is trying to leave memory on,
+ * and it used to last until the coordinator was garbage collected, which for a
+ * living Activity that ran one download is never.
+ *
+ * NEGATIVE CONTROLS, measured rather than assumed:
+ *  - `allowCoreThreadTimeOut(false)` in [providerWorkExecutor] reddens `the
+ *    provider thread ends when the work does` and nothing else.
+ *  - restoring `Executors.newSingleThreadExecutor { ... }` as the pool reddens
+ *    both `the provider thread ends when the work does` and `the coordinator
+ *    ships the executor these cases measure`.
+ *  - dropping the queue and starting a thread per hand-off reddens `work handed
+ *    over after the thread has gone still runs, and in order` and nothing else:
+ *    such a thread does end, so the timeout case cannot speak for the ordering.
+ */
+class DownloadProviderThreadTest {
+
+    /** Long enough that a scheduling hiccup is not read as a leak. */
+    private val patienceMs = 10_000L
+
+    private fun awaitDeath(thread: Thread) {
+        val deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(patienceMs)
+        while (thread.isAlive && System.nanoTime() < deadline) Thread.sleep(10)
+    }
+
+    /** The thread the given executor ran its first piece of work on. */
+    private fun workerOf(executor: java.util.concurrent.Executor): Thread {
+        val seen = ArrayBlockingQueue<Thread>(1)
+        executor.execute { seen.put(Thread.currentThread()) }
+        return seen.poll(patienceMs, TimeUnit.MILLISECONDS)
+            ?: throw AssertionError("the provider executor never ran anything")
+    }
+
+    @Test
+    fun `the provider thread ends when the work does`() {
+        val worker = workerOf(providerWorkExecutor(idleMs = 50))
+
+        assertEquals("download-provider", worker.name) {
+            "the thread is no longer the one this case is about"
+        }
+        assertTrue(worker.isDaemon) {
+            "a non-daemon provider thread holds the process up on its way out"
+        }
+
+        awaitDeath(worker)
+        assertFalse(worker.isAlive) {
+            "the provider thread is still parked ${patienceMs}ms after the last download, " +
+                "so every Activity that ever saved a file leaves one behind in a process " +
+                "the foreground service keeps alive"
+        }
+    }
+
+    @Test
+    fun `work handed over after the thread has gone still runs, and in order`() {
+        // The other half of the timeout. A pool that lets its thread go has to
+        // make another one for the next download, and the ordering the callers
+        // rely on has to survive that: a close is handed over before the discard
+        // of the same document, and neither waits for the other.
+        val executor = providerWorkExecutor(idleMs = 50)
+        awaitDeath(workerOf(executor))
+
+        val order = CopyOnWriteArrayList<String>()
+        val done = CountDownLatch(2)
+        // The first hand-off is made slow on purpose. Two tasks on two threads
+        // come out in the right order most of the time by luck, and a control
+        // that only sometimes reddens measures nothing; a serial executor is the
+        // only one that still answers "close" first with this here.
+        executor.execute { Thread.sleep(50); order.add("close"); done.countDown() }
+        executor.execute { order.add("discard"); done.countDown() }
+
+        assertTrue(done.await(patienceMs, TimeUnit.MILLISECONDS)) {
+            "the executor stopped running work once its thread timed out, so a download " +
+                "after an idle spell is never closed and its document never removed"
+        }
+        assertEquals(listOf("close", "discard"), order.toList()) {
+            "the two provider calls no longer keep the order they were handed over in, " +
+                "so a document can be deleted while it is still being closed"
+        }
+    }
+
+    @Test
+    fun `the coordinator ships the executor these cases measure`() {
+        // The cases above build their own, so this is what ties them to the
+        // default a real Activity gets. Read off the source because the field is
+        // private and its type is the Executor interface, which is deliberate:
+        // that is what lets a test hand the class an inline one.
+        //
+        // Comment lines are dropped first: the function these cases measure
+        // explains at length which pool it is replacing and why, and a search
+        // over the raw text is answered by that explanation rather than by the
+        // code under it.
+        val source = File("src/main/kotlin/com/vscodroid/webview/DownloadCoordinator.kt")
+            .readLines()
+            .filterNot {
+                val t = it.trimStart()
+                t.startsWith("//") || t.startsWith("*") || t.startsWith("/*")
+            }
+            .joinToString("\n")
+
+        assertTrue(source.contains("private val providerWork: Executor = providerWorkExecutor()")) {
+            "the coordinator's default provider executor is no longer the one measured " +
+                "here, so these cases are testing a function nothing uses"
+        }
+        assertFalse(source.contains("newSingleThreadExecutor")) {
+            "the pool is back to one whose thread parks until the coordinator is " +
+                "collected, which for a living Activity that ran one download is never"
+        }
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/webview/DownloadWriteBlockingTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/DownloadWriteBlockingTest.kt
@@ -18,6 +18,10 @@ import java.io.ByteArrayOutputStream
 import java.io.OutputStream
 import java.util.Base64
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executor
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 
 /**
@@ -44,6 +48,16 @@ import java.util.concurrent.TimeUnit
  * download is claimed for the length of the call, so the file the teardown could
  * not remove is removed by the thread that was inside the provider, and a save
  * that finished during a teardown is kept rather than deleted.
+ *
+ * The claim covers only the window in which a write or a close is outstanding,
+ * and that is a minority of a transfer's wall time: the page yields between
+ * pieces, and nothing at all is claimed between the picker answering and the
+ * first piece arriving. On that far larger half the teardown does the work
+ * itself, so the close that commits the bytes and the delete that follows it
+ * have to leave the caller's thread outright. That is what the coordinator's
+ * own executor is for, and why the cases here drive a real one on a thread of
+ * its own rather than a direct executor: with the hand-off run inline, "the
+ * caller waited" and "the caller was quick" are the same measurement.
  */
 class DownloadWriteBlockingTest {
 
@@ -75,6 +89,45 @@ class DownloadWriteBlockingTest {
     /** Set to make closing the opened document stop until [release]. */
     @Volatile
     private var blockCloses = false
+
+    /** Set to make deleting a document stop until [release]. */
+    @Volatile
+    private var blockDiscards = false
+
+    /** Set to make opening the chosen document stop until [release]. */
+    @Volatile
+    private var blockOpens = false
+
+    /**
+     * Whether the stream to a document had been closed when it was deleted.
+     *
+     * One entry per delete. The order matters on its own: a document deleted
+     * while a stream to it is still open is a delete racing a provider that has
+     * not finished with the file, which is what the claim over the open exists
+     * to rule out.
+     */
+    private val closedWhenDiscarded = mutableListOf<Boolean>()
+
+    /**
+     * Where the coordinator's answer to an open is applied, held when
+     * [holdMainThread] is set so a case can run a teardown inside the hand-off.
+     */
+    private val mainQueue = LinkedBlockingQueue<Runnable>()
+
+    /** Set to divert the coordinator's main-thread hand-offs into [mainQueue]. */
+    @Volatile
+    private var holdMainThread = false
+
+    /**
+     * The coordinator's own provider thread, real rather than direct.
+     *
+     * Single, as the one it ships with is, so a close still precedes the delete
+     * of the same document. [awaitProviderIdle] is how a case waits for what was
+     * handed to it, and every case that asserts on a discarded document calls it
+     * first: without that the assertion races the hand-off and passes or fails
+     * on the runner's mood.
+     */
+    private lateinit var providerWork: ExecutorService
 
     /** Counted down by whichever call is holding the provider. */
     private val insideCall = CountDownLatch(1)
@@ -125,14 +178,23 @@ class DownloadWriteBlockingTest {
         }
 
         override fun openDestination(destination: Uri): OutputStream {
+            if (blockOpens) {
+                insideCall.countDown()
+                release.await(5, TimeUnit.SECONDS)
+            }
             stream = BlockingStream()
             documents[destination] = stream
             return stream
         }
 
         override fun discardDestination(destination: Uri) {
+            if (blockDiscards) {
+                insideCall.countDown()
+                release.await(5, TimeUnit.SECONDS)
+            }
             synchronized(discarded) {
                 discarded += destination
+                closedWhenDiscarded += documents[destination]?.closed ?: false
                 documents.remove(destination)
             }
         }
@@ -140,6 +202,8 @@ class DownloadWriteBlockingTest {
         override fun requestBytes(requestId: String, url: String) {
             readRequests += requestId to url
         }
+
+        override fun releaseBytes(url: String) = Unit
 
         override fun report(outcome: DownloadOutcome, fileName: String, detail: String?) {
             synchronized(reported) { reported += outcome to fileName }
@@ -158,14 +222,29 @@ class DownloadWriteBlockingTest {
         discarded.clear()
         reported.clear()
         readRequests.clear()
+        closedWhenDiscarded.clear()
+        mainQueue.clear()
         blockWrites = false
         blockCloses = false
-        coordinator = DownloadCoordinator(host)
+        blockDiscards = false
+        blockOpens = false
+        holdMainThread = false
+        providerWork = Executors.newSingleThreadExecutor()
+        // Inline unless a case says otherwise: the coordinator brings the answer
+        // to an open back to the thread the picker answered on, and running that
+        // where it is handed over keeps every case below reading state that has
+        // settled. `an open whose answer is held` is the one that drives it.
+        coordinator = DownloadCoordinator(
+            host,
+            providerWork = providerWork,
+            mainThread = Executor { work -> if (holdMainThread) mainQueue.put(work) else work.run() },
+        )
     }
 
     @AfterEach
     fun tearDown() {
         release.countDown()
+        providerWork.shutdownNow()
         unmockkAll()
     }
 
@@ -179,6 +258,9 @@ class DownloadWriteBlockingTest {
         coordinator.onDownloadNamed("blob:x", name)
         coordinator.onDownloadStart("blob:x", null)
         coordinator.onDestinationChosen(pickerIds.last(), target)
+        // The document is opened on the provider thread now, so the page has not
+        // been asked for anything yet when the picker's answer returns.
+        awaitProviderIdle()
         return readRequests.last().first
     }
 
@@ -191,6 +273,23 @@ class DownloadWriteBlockingTest {
         insideCall.await(5, TimeUnit.SECONDS),
         "nothing ever reached the blocking stream, so no call was contended and " +
             "the timing below would be measuring an idle coordinator",
+    )
+
+    /**
+     * Waits for everything handed to the provider thread up to this point.
+     *
+     * A barrier rather than a sleep: the thread is single, so work queued behind
+     * the hand-off cannot run in front of it. Every case that asserts on a
+     * discarded document goes through here first, or the assertion races the
+     * hand-off and answers differently on a loaded runner.
+     */
+    private fun awaitProviderIdle() = assertTrue(
+        CountDownLatch(1).let { drained ->
+            providerWork.execute { drained.countDown() }
+            drained.await(5, TimeUnit.SECONDS)
+        },
+        "the provider thread never got through what it was handed, so what follows " +
+            "would be reading the state of a teardown that has not happened yet",
     )
 
     /** How long [work] took, in milliseconds. */
@@ -234,6 +333,7 @@ class DownloadWriteBlockingTest {
 
         release.countDown()
         writer.join(5_000)
+        awaitProviderIdle()
 
         assertEquals(
             listOf(target), discarded,
@@ -279,6 +379,7 @@ class DownloadWriteBlockingTest {
 
         release.countDown()
         closer.join(5_000)
+        awaitProviderIdle()
 
         assertEquals(
             emptyList<Uri>(), discarded,
@@ -308,6 +409,7 @@ class DownloadWriteBlockingTest {
 
         release.countDown()
         writer.join(5_000)
+        awaitProviderIdle()
 
         assertEquals(
             listOf(DownloadOutcome.FAILED to "report.pdf"), reported,
@@ -341,6 +443,243 @@ class DownloadWriteBlockingTest {
     }
 
     /**
+     * The teardown with nothing claimed, which is most of a transfer's wall
+     * time.
+     *
+     * The claim only covers a write or a close that is actually outstanding.
+     * Between two pieces the page yields, and between the picker answering and
+     * the first piece there is a whole trip through the bridge, so a teardown
+     * arriving at any of those moments finds `busy` false and does the work
+     * itself: the close that commits the buffered bytes to the provider, and
+     * the delete behind it. On the UI thread that is the same ANR the claim was
+     * written to remove, reached by the other half of the same window.
+     *
+     * NEGATIVE CONTROL: in `closeAndDiscard`, replace the
+     * `offThread("close") { it.close() }` hand-off with a plain `it.close()`.
+     * This case then waits the blocked close out and fails on the elapsed time.
+     */
+    @Test
+    fun `a teardown between two pieces does not wait for the close that commits them`() {
+        val target = destination()
+        val id = startAndChoose(target)
+        // Returns, so nothing is claimed when the teardown arrives. This is the
+        // ordinary state of a transfer, not a corner of one.
+        coordinator.onBytes(id, encode("payload"))
+        blockCloses = true
+
+        val waitedMs = timed { coordinator.onPageGone() }
+        awaitInsideProvider()
+
+        assertTrue(
+            waitedMs < 1_000,
+            "the teardown waited ${waitedMs}ms for the close to commit. Closing a " +
+                "content:// stream is what pushes the buffered bytes into the provider, " +
+                "so it costs whatever the provider costs, and onPageGone runs on the UI " +
+                "thread from onDestroy, from every finished main-frame load and from " +
+                "recreateWebView",
+        )
+    }
+
+    /**
+     * The other half of the case above: not waiting is easy by doing nothing.
+     *
+     * NEGATIVE CONTROL: drop either hand-off from `closeAndDiscard` entirely and
+     * this goes red on the stream or on the document.
+     */
+    @Test
+    fun `the document a teardown handed over is still closed and removed`() {
+        val target = destination()
+        val id = startAndChoose(target)
+        coordinator.onBytes(id, encode("payload"))
+        blockCloses = true
+
+        coordinator.onPageGone()
+        awaitInsideProvider()
+        release.countDown()
+        awaitProviderIdle()
+
+        assertTrue(stream.closed, "the stream was left open on a download that is over")
+        assertEquals(
+            listOf(target), discarded,
+            "the picker's file is still in the user's folder, part-written and wearing " +
+                "the name of the file they asked for, which is indistinguishable from a " +
+                "finished save until they open it",
+        )
+    }
+
+    /**
+     * The delete, which is a second trip into the same provider and just as
+     * unbounded as the close.
+     *
+     * NEGATIVE CONTROL: replace the `offThread("discard")` hand-off in
+     * `closeAndDiscard` with a direct `host.discardDestination(it)`. The close
+     * being handed over does not save it: this case leaves the close free to
+     * return and blocks only the delete.
+     */
+    @Test
+    fun `a teardown does not wait for the document to be deleted either`() {
+        val target = destination()
+        val id = startAndChoose(target)
+        coordinator.onBytes(id, encode("payload"))
+        blockDiscards = true
+
+        val waitedMs = timed { coordinator.onPageGone() }
+        awaitInsideProvider()
+
+        assertTrue(
+            waitedMs < 1_000,
+            "the teardown waited ${waitedMs}ms inside DocumentsContract.deleteDocument, " +
+                "which is a synchronous call into the provider that owns the document",
+        )
+    }
+
+    /**
+     * The picker outliving the download it was opened for, which is the one
+     * path here that needs no second thread at all: the result arrives on the
+     * UI thread, the document it created belongs to nobody, and the delete of
+     * it used to run right there.
+     *
+     * NEGATIVE CONTROL: restore the direct `host.discardDestination(it)` in the
+     * "belongs to no download in flight" branch of `onDestinationChosen`.
+     */
+    @Test
+    fun `a picker answering for a download that is gone deletes off the caller's thread`() {
+        val target = destination()
+        coordinator.onDownloadNamed("blob:x", "report.pdf")
+        coordinator.onDownloadStart("blob:x", null)
+        val requestId = pickerIds.last()
+        // The renderer died under the picker. The result still arrives, having
+        // already created a document nobody now owns.
+        coordinator.onPageGone()
+        blockDiscards = true
+
+        val waitedMs = timed { coordinator.onDestinationChosen(requestId, target) }
+        awaitInsideProvider()
+
+        assertTrue(
+            waitedMs < 1_000,
+            "the activity result callback waited ${waitedMs}ms deleting a document, on " +
+                "the UI thread, with no other thread involved at all",
+        )
+    }
+
+    /**
+     * Opening the chosen document is the first trip into the provider and was
+     * the last one still made on the UI thread, under the monitor.
+     *
+     * `onDestinationChosen` runs in the activity-result callback, so a provider
+     * whose process has to be cold-started, or that answers over a network,
+     * froze the editor from the moment the picker closed; past five seconds the
+     * system offers to close the app, taking the editor session with it.
+     *
+     * NEGATIVE CONTROL: put the open back inline, replacing the
+     * `providerWork.execute { ... }` hand-off in `onDestinationChosen` with the
+     * open and a direct call to `onDestinationOpened`. This goes red on the
+     * elapsed time.
+     */
+    @Test
+    fun `the picker's answer does not wait for the document to open`() {
+        val target = destination()
+        coordinator.onDownloadNamed("blob:x", "report.pdf")
+        coordinator.onDownloadStart("blob:x", null)
+        blockOpens = true
+
+        val waitedMs = timed { coordinator.onDestinationChosen(pickerIds.last(), target) }
+        awaitInsideProvider()
+
+        release.countDown()
+        assertTrue(
+            waitedMs < 1_000,
+            "the activity result callback waited ${waitedMs}ms inside the provider, on " +
+                "the UI thread. openOutputStream cold-starts the provider's process and " +
+                "has no timeout, so that wait is the editor frozen and then an ANR",
+        )
+    }
+
+    /**
+     * And the monitor is not held across it either, which is the half the timing
+     * above cannot see: a caller that does not wait for the provider is worth
+     * nothing if every other caller waits for it instead.
+     *
+     * NEGATIVE CONTROL: the same restoration as the case above. The open then
+     * runs under `@Synchronized`, so this teardown waits for the whole of it.
+     */
+    @Test
+    fun `a teardown does not wait for a document that is still opening`() {
+        val target = destination()
+        coordinator.onDownloadNamed("blob:x", "report.pdf")
+        coordinator.onDownloadStart("blob:x", null)
+        blockOpens = true
+        // On a thread of its own, so that restoring the inline open leaves this
+        // case measuring a monitor a blocked caller is holding rather than a
+        // provider that has already returned.
+        val chooser = Thread { coordinator.onDestinationChosen(pickerIds.last(), target) }
+            .apply { start() }
+        awaitInsideProvider()
+
+        val waitedMs = timed { coordinator.onPageGone() }
+
+        release.countDown()
+        chooser.join(5_000)
+        awaitProviderIdle()
+        assertTrue(
+            waitedMs < 1_000,
+            "the teardown waited ${waitedMs}ms for a document to open. onPageGone is " +
+                "called from onDestroy, from every finished main-frame load and from " +
+                "recreateWebView, all on the UI thread",
+        )
+        assertEquals(
+            listOf(target), discarded,
+            "the download was abandoned while its document was opening, and the empty " +
+                "file the picker created for it stayed in the user's folder wearing the " +
+                "name of the file they asked for",
+        )
+    }
+
+    /**
+     * The claim over the open, which is what orders the delete after the close.
+     *
+     * A teardown that lands while the answer to an open is still in the air
+     * finds the download claimed and leaves the document to the thread that
+     * opened it, so the stream is closed before the delete goes in. Without the
+     * claim the teardown deletes first and the close follows it, which is a
+     * delete racing a provider that has not finished with the file.
+     *
+     * NEGATIVE CONTROL: delete `request.busy = true` from `onDestinationChosen`.
+     * The teardown below then discards immediately, with no stream to close yet,
+     * and this goes red on `closedWhenDiscarded`.
+     */
+    @Test
+    fun `a document opened into a teardown is closed before it is deleted`() {
+        val target = destination()
+        coordinator.onDownloadNamed("blob:x", "report.pdf")
+        coordinator.onDownloadStart("blob:x", null)
+        // Held so the teardown lands in the gap between the provider answering
+        // and the coordinator acting on the answer.
+        holdMainThread = true
+        coordinator.onDestinationChosen(pickerIds.last(), target)
+        awaitProviderIdle()
+        assertTrue(
+            readRequests.isEmpty(),
+            "the page was asked for the bytes from the provider thread. requestBytes " +
+                "reaches the page through evaluateJavascript, which the WebView refuses " +
+                "from any thread but its own",
+        )
+
+        coordinator.onPageGone()
+        holdMainThread = false
+        mainQueue.poll(5, TimeUnit.SECONDS)?.run()
+        awaitProviderIdle()
+
+        assertEquals(listOf(target), discarded, "the abandoned document was left behind")
+        assertEquals(
+            listOf(true), closedWhenDiscarded,
+            "the document was deleted with the stream to it still open, so the delete " +
+                "raced a provider that had not finished with the file",
+        )
+    }
+
+    /**
      * The control that stops every case above from passing over a coordinator
      * that stopped writing altogether.
      */
@@ -352,6 +691,7 @@ class DownloadWriteBlockingTest {
         coordinator.onBytes(id, encode("fun main"))
         coordinator.onBytes(id, encode("() {}"))
         coordinator.onComplete(id, null)
+        awaitProviderIdle()
 
         assertEquals("fun main() {}", stream.written.toString())
         assertTrue(stream.closed, "the document is closed, which is what commits it")

--- a/android/app/src/test/kotlin/com/vscodroid/webview/ProxiedAssetSuffixTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/ProxiedAssetSuffixTest.kt
@@ -1,0 +1,91 @@
+package com.vscodroid.webview
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * The two suffix tests that decide a proxied asset's cache header and its
+ * fallback MIME type, asked the way `proxyToLocalhost` asks them.
+ *
+ * That arm is handed the rewritten URL, not a path, and every such URL has ended
+ * in `tkn=<hex>` since the editor server began requiring a connection token
+ * (`rewriteCdnUrl` closes with `withToken`). A plain `endsWith(".js")` over that
+ * string is false for every asset there is, so both fallbacks had quietly stopped
+ * being answerable: no caller changed and no branch was deleted, the question
+ * simply became one the string could not answer.
+ *
+ * Nothing user-visible rested on it, and that is stated rather than glossed: the
+ * `/{quality}-{commit}/static/...` route this arm proxies answers with a
+ * `Cache-Control` and a `Content-Type` of its own, so both fallbacks are expected
+ * to stay quiet. What is worth holding is that they CAN fire, because the day the
+ * server stops sending one of those headers is not the day anyone will think to
+ * re-read a suffix test.
+ *
+ * NEGATIVE CONTROL: drop `.substringBefore('?')` from
+ * `VSCodroidWebViewClient.assetPathOf` and every case naming a token below goes
+ * red, while the bare-path case stays green.
+ */
+class ProxiedAssetSuffixTest {
+
+    private val token = "0123456789abcdef0123456789abcdef"
+    private val staticRoot = "http://127.0.0.1:41293/stable-cd4ee3b1/static"
+
+    @Test
+    fun `a proxied script is still a static asset with the token appended`() {
+        assertTrue(
+            VSCodroidWebViewClient.isStaticAsset("$staticRoot/out/vs/workbench/workbench.js?tkn=$token"),
+            "the workbench's own scripts are versioned by commit hash and are the whole " +
+                "reason the immutable cache header exists",
+        )
+        assertTrue(
+            VSCodroidWebViewClient.isStaticAsset("$staticRoot/out/vs/workbench/workbench.css?tkn=$token"),
+        )
+    }
+
+    @Test
+    fun `a proxied script keeps its MIME type with the token appended`() {
+        assertEquals(
+            "application/javascript",
+            VSCodroidWebViewClient.guessMimeType("$staticRoot/out/vs/workbench/workbench.js?tkn=$token"),
+            "handed to the WebView as application/octet-stream, a script does not run",
+        )
+    }
+
+    @Test
+    fun `dropping the query does not make everything an asset`() {
+        // The other half. Without it, an assetPathOf that answered with a
+        // constant `.js` would satisfy both cases above.
+        assertFalse(
+            VSCodroidWebViewClient.isStaticAsset("$staticRoot/out/vs/code/browser/index.html?tkn=$token"),
+            "a document is not versioned by commit hash and must not be cached forever",
+        )
+        assertEquals(
+            "text/html",
+            VSCodroidWebViewClient.guessMimeType("$staticRoot/out/vs/code/browser/index.html?tkn=$token"),
+        )
+    }
+
+    @Test
+    fun `a bare path answers exactly as it did before`() {
+        // The second caller, `interceptResourceRequest`, passes `uri.path`, which
+        // has no query on it. Stripping one must leave that answer alone, or a
+        // fix aimed at the proxy would change what every extension webview
+        // resource is served as. That arm asks for the MIME type only: it stopped
+        // asking whether a file is a static asset when it stopped declaring one
+        // immutable, since the paths it resolves are the user's own and carry no
+        // version. The suffix answer is pinned here all the same, because the
+        // question is the same one either caller asks.
+        assertTrue(VSCodroidWebViewClient.isStaticAsset("/data/user/0/extensions/md/media/m.css"))
+        assertFalse(VSCodroidWebViewClient.isStaticAsset("/data/user/0/projects/app/notes.md"))
+        assertEquals(
+            "image/svg+xml",
+            VSCodroidWebViewClient.guessMimeType("/data/user/0/extensions/md/media/icon.svg"),
+        )
+        assertEquals(
+            "application/octet-stream",
+            VSCodroidWebViewClient.guessMimeType("/data/user/0/projects/app/notes.md"),
+        )
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/webview/ResourceInterceptionWiringTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/ResourceInterceptionWiringTest.kt
@@ -108,9 +108,10 @@ class ResourceInterceptionWiringTest {
      * answer to "who may read this" was anybody who could reach the interceptor -- and
      * a remote page in the bundled Simple Browser can, with no network involved.
      *
-     * Proved by making the file unreadable rather than by the log alone, the same way
-     * `a refused resource is never opened` does: if the refusal did not happen, the open
-     * would, and the fixture would throw.
+     * The fixture is unreadable so that letting it through cannot look like a refusal:
+     * a gate that stopped refusing would reach the open, and the open failure logs a
+     * line of its own that names the open rather than the origin, so the assertion
+     * below still tells the two apart.
      */
     @Test
     fun `a foreign origin is refused before the file is opened`() {
@@ -241,10 +242,10 @@ class ResourceInterceptionWiringTest {
      * larger failure than the one being prevented.
      *
      * Asserted against the path this test is about rather than against an empty
-     * list, because it cannot be empty: the refusal of the workspace is
-     * reported on every resource request for as long as that folder stays open,
-     * so a successful serve arrives with that warning already sitting there.
-     * `isEmpty` reads the same and asks a different question.
+     * list, because it need not be empty: the refusal of the workspace is
+     * reported once for the folder, and this is the first request naming it, so a
+     * successful serve arrives with that warning already sitting there. `isEmpty`
+     * reads the same and asks a different question.
      */
     @Test
     fun `a refused workspace leaves the published roots serving`() {
@@ -267,10 +268,14 @@ class ResourceInterceptionWiringTest {
      * served satisfied all four.
      *
      * What separates the two without touching the response is whether the file is
-     * opened. The serve branch calls `FileInputStream(file)` with no `try` around
-     * it and nothing catching upstream, so making the key unreadable turns any
-     * attempt to serve it into a thrown `FileNotFoundException`. Refusing never
-     * reaches that line and returns normally.
+     * opened, and the key is made unreadable so that an attempt to open it cannot
+     * pass unnoticed. The instrument used to be the crash itself: the serve branch
+     * called `FileInputStream(file)` with no `try` around it, so serving an
+     * unreadable file threw `FileNotFoundException` out of the whole callback.
+     * That throw was a defect of its own and is now caught, which is why the two
+     * outcomes are told apart by WHICH warning arrives rather than by whether one
+     * arrives at all: a refusal names the roots, an open failure names the open.
+     * Both quote the path, so the path alone no longer discriminates.
      *
      * [ResourceOutcomeTest] covers the same decision as a value; this is the half
      * that proves the interceptor obeys it.
@@ -282,13 +287,49 @@ class ResourceInterceptionWiringTest {
             "the fixture is still readable, so this test would pass without proving anything"
         }
 
-        // Throws if the interceptor reaches FileInputStream on it.
         intercept(sshKey.path, openFolder = null)
 
         assertTrue(
-            warnings.any { it.contains(sshKey.path) },
-            "the private key was neither refused nor opened, which is a third outcome " +
-                "this test does not understand: $warnings",
+            warnings.any { it.contains("outside the published roots") && it.contains(sshKey.path) },
+            "the private key was not refused: $warnings",
+        )
+        assertTrue(
+            warnings.none { it.contains("could not be opened") },
+            "the interceptor tried to open the private key and only failed because the " +
+                "fixture is unreadable: $warnings",
+        )
+    }
+
+    /**
+     * A file that resolves inside a root, exists, and still cannot be opened.
+     *
+     * `resourceOutcome` answers `Serve` from `exists()` and `isFile`, and the open
+     * is a second syscall: a watch build or a `git checkout` can unlink the file in
+     * the gap, and a file with no read permission fails there every time with no
+     * race at all. Nothing on the path from either entry point catches, so the
+     * `FileNotFoundException` left `shouldInterceptRequest` for the WebView's own
+     * callback, where `CrashReporter` recorded the process death rather than
+     * preventing it. The population is every webview resource request.
+     *
+     * NEGATIVE CONTROL: remove the `try` around `FileInputStream(file)` in
+     * `interceptResourceRequest` and this case goes red with the exception it
+     * describes.
+     */
+    @Test
+    fun `a resource that cannot be opened is answered rather than thrown`() {
+        val locked = File(serverTree, "extensions/md/media/locked.css").apply {
+            writeText("body{}")
+            check(setReadable(false, false)) { "could not make the fixture unreadable" }
+        }
+        check(!locked.canRead()) {
+            "the fixture is still readable, so this test would pass without proving anything"
+        }
+
+        intercept(locked.path, openFolder = null)
+
+        assertTrue(
+            warnings.any { it.contains("could not be opened") && it.contains(locked.path) },
+            "the open failure was neither reported nor recognisable in the log: $warnings",
         )
     }
 

--- a/android/app/src/test/kotlin/com/vscodroid/webview/WebViewTeardownSymmetryTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/WebViewTeardownSymmetryTest.kt
@@ -1,0 +1,95 @@
+package com.vscodroid.webview
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * That both ways a WebView is destroyed drop what still calls into it.
+ *
+ * There are two, and they were written years apart. `recreateWebView` replaces a
+ * renderer that died; `onDestroy` ends the Activity. Only the first cleared the
+ * extra key row's `KeyInjector`, and the row's modifier poll is what makes the
+ * difference visible: while a modifier is latched it re-posts itself every
+ * 200 ms through the view's own handler, so a tick queued before the Activity
+ * goes still runs after `onDestroy` has returned. With the injector left in
+ * place that tick asks a destroyed WebView, which answers by logging and never
+ * calling back.
+ *
+ * That costs a warning and a dead entry in a run queue nothing will drain, and
+ * it is put here as symmetry rather than as a repair: the asymmetry is what
+ * makes the next reader of either method believe the other one is doing
+ * something it is not.
+ *
+ * Source-reading, and in this package rather than beside the row, for the reason
+ * `ExtraKeyModifierSyncTest` sets out at length: `MainActivity` and `ExtraKeyRow`
+ * are both unbuildable on the JVM, so no test can run a `postDelayed` and the
+ * timing is argued rather than executed. What is checked is the shape carrying
+ * it, in both places at once, which is the half no per-method case can see.
+ */
+class WebViewTeardownSymmetryTest {
+
+    private val file = File("src/main/kotlin/com/vscodroid/MainActivity.kt")
+
+    private val source by lazy {
+        check(file.isFile) {
+            "MainActivity.kt not found at ${file.absolutePath}; this test would " +
+                "otherwise pass by looking at nothing"
+        }
+        file.readText()
+    }
+
+    /**
+     * The lines of one method, comments dropped.
+     *
+     * By indentation rather than by brace matching: every rule here is argued in
+     * prose beside the line it governs, and a comment is not a call.
+     */
+    private fun code(declaration: String): List<String> {
+        val lines = source.lines()
+        val start = lines.indexOfFirst { it.contains(declaration) }
+        assertTrue(start >= 0) {
+            "`$declaration` is gone from MainActivity.kt, so this test is measuring " +
+                "nothing. If it moved or was renamed, point this at the new site rather " +
+                "than deleting it."
+        }
+        return lines.drop(start + 1)
+            .takeWhile { it != "    }" }
+            .filterNot {
+                val t = it.trimStart()
+                t.startsWith("//") || t.startsWith("*") || t.startsWith("/*")
+            }
+    }
+
+    /**
+     * NEGATIVE CONTROL: delete `extraKeyRow?.keyInjector = null` from either
+     * method and the matching half goes red naming that method. Move it below
+     * the destroy in either and the ordering assertion goes red instead.
+     */
+    @Test
+    fun `every path that destroys the WebView drops the key row's injector first`() {
+        val paths = listOf(
+            "override fun onDestroy()" to "webView?.destroy()",
+            "private fun recreateWebView()" to "wv.destroy()",
+        )
+
+        for ((declaration, destroy) in paths) {
+            val body = code(declaration)
+            val destroyed = body.indexOfFirst { it.contains(destroy) }
+            assertTrue(destroyed >= 0) {
+                "`$destroy` is gone from $declaration, so this half is measuring nothing"
+            }
+            val cleared = body.indexOfFirst { it.contains("extraKeyRow?.keyInjector = null") }
+            assertTrue(cleared >= 0) {
+                "$declaration destroys the WebView without dropping the key row's " +
+                    "injector, so a modifier poll already queued calls into a destroyed " +
+                    "WebView after this method has returned"
+            }
+            assertTrue(cleared < destroyed) {
+                "$declaration drops the injector after destroying the view it wraps, " +
+                    "which leaves the window between them holding exactly what the " +
+                    "clearing exists to prevent"
+            }
+        }
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/webview/WorkspaceAssetCachingTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/WorkspaceAssetCachingTest.kt
@@ -1,0 +1,132 @@
+package com.vscodroid.webview
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * That a file served from the filesystem is not declared cacheable forever.
+ *
+ * The arm that serves one, `interceptResourceRequest`, resolves it against roots
+ * that include the projects tree, the SAF mirrors and whatever folder the user
+ * has open. Those paths carry no version: they are the user's own files at fixed
+ * absolute paths, and the user rewrites them in place from the terminal or with
+ * `git pull`. `public, max-age=31536000, immutable` forbids revalidation, so an
+ * edited image went on rendering from the old bytes in the markdown preview for
+ * the life of the WebView renderer, with nothing in the app able to force a
+ * refetch: that extension emits query-less resource URLs, unlike `media-preview`,
+ * which appends a `version=` of its own. Reopening the preview, reloading and
+ * switching folders all leave it stale.
+ *
+ * The commit hash that made the header safe belongs to the OTHER arm's URL,
+ * `/{quality}-{commit}/static/...`, where it stays: `proxyToLocalhost` is the
+ * positive control below, which is what makes a search finding nothing here a
+ * measurement rather than a broken search.
+ *
+ * Read from the source, for the reason `SafFolderLogCallSiteTest` gives: there is
+ * no seam. `WebResourceResponse` cannot be constructed under the stub
+ * `android.jar` and its constructor is mocked in every test that reaches this
+ * code, so the header map handed to it can be observed nowhere. Comments are
+ * stripped first, because the rule is explained at length beside the very line it
+ * governs and a search over the raw text would be satisfied by the explanation.
+ *
+ * NEGATIVE CONTROL: put `if (isStaticAsset(path)) put("Cache-Control",
+ * CACHE_IMMUTABLE)` back into the response `interceptResourceRequest` builds and
+ * `a served file is not declared immutable` goes red, while the proxy control
+ * stays green.
+ */
+class WorkspaceAssetCachingTest {
+
+    private val source =
+        File("src/main/kotlin/com/vscodroid/webview/VSCodroidWebViewClient.kt").readText()
+
+    /** The body of a `private fun name(` declaration, to its closing brace. */
+    private fun body(name: String): String {
+        val start = source.indexOf("private fun $name(")
+        assertTrue(start >= 0) {
+            "$name is gone from VSCodroidWebViewClient.kt, so this test is measuring " +
+                "nothing. If it moved or was renamed, point this at the new site rather " +
+                "than deleting it."
+        }
+        val open = source.indexOf('{', start)
+        var depth = 0
+        var i = open
+        while (i < source.length) {
+            if (source[i] == '{') depth += 1
+            if (source[i] == '}') {
+                depth -= 1
+                if (depth == 0) return source.substring(open, i + 1)
+            }
+            i += 1
+        }
+        throw AssertionError("Could not find the end of $name in VSCodroidWebViewClient.kt")
+    }
+
+    /**
+     * Comments removed, so prose about the rule cannot satisfy a search for the
+     * rule. Both forms, because both disable code, and a block counts as a comment
+     * only where it opens a line.
+     */
+    private fun withoutComments(text: String): String {
+        var inBlock = false
+        return text.lines().joinToString("\n") { raw ->
+            var line = raw
+            if (inBlock) {
+                val close = line.indexOf("*/")
+                if (close < 0) return@joinToString ""
+                inBlock = false
+                line = line.substring(close + 2)
+            }
+            while (line.trimStart().startsWith("/*")) {
+                val open = line.indexOf("/*")
+                val close = line.indexOf("*/", open + 2)
+                if (close < 0) {
+                    inBlock = true
+                    return@joinToString line.substring(0, open)
+                }
+                line = line.substring(0, open) + line.substring(close + 2)
+            }
+            val marker = line.indexOf("//")
+            if (marker >= 0) line.substring(0, marker) else line
+        }
+    }
+
+    private val served by lazy { withoutComments(body("interceptResourceRequest")) }
+    private val proxied by lazy { withoutComments(body("proxyToLocalhost")) }
+
+    @Test
+    fun `the body being checked was actually found`() {
+        assertTrue(served.contains("FileInputStream") && served.contains("resourceOutcome")) {
+            "interceptResourceRequest no longer looks like the function this was written " +
+                "against, so the search below is running over the wrong text and would " +
+                "pass over anything. Point it at wherever a resource is served from the " +
+                "filesystem now."
+        }
+    }
+
+    /**
+     * The positive control. The header is still set where a commit hash makes it
+     * true, so a search that finds nothing in the arm above is a fact about that
+     * arm and not about the search.
+     */
+    @Test
+    fun `the proxied static route still caches`() {
+        assertTrue(proxied.contains("CACHE_IMMUTABLE")) {
+            "nothing sets the immutable cache header any more, so the case below cannot " +
+                "tell a fix from a rename. If the constant moved, follow it."
+        }
+    }
+
+    @Test
+    fun `a served file is not declared immutable`() {
+        val offenders = served.lines()
+            .filter { it.contains("CACHE_IMMUTABLE") || it.contains("Cache-Control") }
+
+        assertTrue(offenders.isEmpty()) {
+            "a file resolved from the filesystem is served with a cache header, and the " +
+                "roots it resolves against include the open workspace, the projects tree " +
+                "and the SAF mirrors, which the user edits in place. Found:\n" +
+                offenders.joinToString("\n") { "  ${it.trim()}" }
+        }
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/webview/WorkspaceRefusalLogTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/WorkspaceRefusalLogTest.kt
@@ -1,0 +1,125 @@
+package com.vscodroid.webview
+
+import com.vscodroid.util.Logger
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * How often the refusal of a workspace is reported, which is a different question
+ * from whether it is reported.
+ *
+ * `resourceRootsInForce` is called per webview resource request, not per
+ * navigation: `interceptCdnRequest` invokes the open-folder supplier on the
+ * extension-resource arm, and one markdown preview or notebook render makes
+ * dozens to hundreds of those. The refusal itself is sticky, because the supplier
+ * answers the same folder for as long as it stays open, so a user who opens `~`
+ * (the terminal's own cwd, and where the workbench's Open Folder dialog starts)
+ * turned every preview into a burst of identical `Logger.w` lines, each
+ * repeating the absolute path. `Logger.w` is not gated on a debuggable build, so
+ * that shipped, and unbounded log growth driven by page activity is what a bug
+ * report has to be read out of.
+ *
+ * Each case uses a path of its own. The memo lives for the life of the process
+ * and is keyed on the candidate, so two cases sharing a folder would be one case
+ * with a hidden dependency on the order they ran in.
+ *
+ * NEGATIVE CONTROL: drop the `candidate != lastRefusedWorkspace` test in
+ * `resourceRootsInForce` and `a refused workspace is reported once` goes red at
+ * three lines instead of one, while the two cases below it stay green.
+ */
+class WorkspaceRefusalLogTest {
+
+    private val logged = mutableListOf<String>()
+
+    @BeforeEach
+    fun setUp() {
+        logged.clear()
+        mockkObject(Logger)
+        every { Logger.w(any(), any()) } answers { logged += secondArg<String>() }
+    }
+
+    @AfterEach
+    fun tearDown() = unmockkAll()
+
+    /** A folder holding a sensitive location, so every call refuses it. */
+    private fun refuse(home: String, times: Int) = repeat(times) {
+        val roots = resourceRootsInForce(
+            listOf("/nowhere/published"), listOf("$home/.ssh"), home
+        )
+        assertEquals(
+            listOf("/nowhere/published"), roots,
+            "the fixture stopped refusing the workspace, so the count below means nothing",
+        )
+    }
+
+    @Test
+    fun `a refused workspace is reported once`() {
+        refuse("/x/once/home", times = 3)
+
+        assertEquals(
+            1, logged.size,
+            "the refusal is reported per resource request rather than per folder, and a " +
+                "preview makes hundreds of those:\n" + logged.joinToString("\n") { "  $it" },
+        )
+        assertTrue(
+            logged.single().contains("/x/once/home"),
+            "the one line left has to say which folder was refused: ${logged.single()}",
+        )
+    }
+
+    /**
+     * The complement, and the half that a memo is easy to get wrong: a second
+     * folder is a second thing to explain.
+     */
+    @Test
+    fun `a different workspace is reported on its own`() {
+        refuse("/x/first/home", times = 2)
+        refuse("/x/second/home", times = 2)
+
+        assertEquals(
+            2, logged.size,
+            "one folder's refusal silenced another's:\n" + logged.joinToString("\n") { "  $it" },
+        )
+    }
+
+    /**
+     * And reopening the same folder after closing it, which is what clearing the
+     * memo on an accepted or absent candidate is for. Without it the explanation
+     * is given once per process and never again, which is worse than the noise it
+     * replaced.
+     */
+    @Test
+    fun `reopening a refused workspace is reported again`() {
+        refuse("/x/reopened/home", times = 1)
+        // The folder closed: the supplier answers null until the next navigation.
+        resourceRootsInForce(listOf("/nowhere/published"), listOf("/x/reopened/home/.ssh"), null)
+        refuse("/x/reopened/home", times = 1)
+
+        assertEquals(
+            2, logged.size,
+            "the user was told once and then met with silence:\n" +
+                logged.joinToString("\n") { "  $it" },
+        )
+    }
+
+    /** The control: an ordinary folder is still silent, which is the whole point. */
+    @Test
+    fun `an accepted workspace says nothing`() {
+        val roots = resourceRootsInForce(
+            listOf("/nowhere/published"), listOf("/x/accepted/home/.ssh"),
+            "/x/accepted/home/projects/app",
+        )
+
+        assertTrue(
+            roots.contains("/x/accepted/home/projects/app"),
+            "the fixture refused the workspace, so its silence proves nothing",
+        )
+        assertTrue(logged.isEmpty(), "an ordinary folder was reported: $logged")
+    }
+}

--- a/scripts/check-binary-lists.py
+++ b/scripts/check-binary-lists.py
@@ -14,17 +14,39 @@ count as a literal. Nothing failed, because nothing was reading the directory.
 
 BOTH DIRECTIONS ARE CHECKED, and the second is the one that earns its place:
 
-  * every `.so` in the directory is named by both documents, which catches a
+  * every `.so` in the directory is listed by both documents, which catches a
     binary that arrived without its documentation;
-  * every binary the documents name is in the directory, which catches one that
+  * every binary the documents list is in the directory, which catches one that
     was withdrawn and left behind in prose, and which is also what stops this
     gate passing over a stub. `lint.yml` creates a four-byte `libnode.so` so
     Gradle will run, and a one-direction check would call that tree documented
     and exit 0. This gate is deliberately NOT wired into that job; the second
     direction is what makes running it there fail loudly rather than lie.
 
-An empty directory is refused outright for the same reason: no files means no
-disagreement, which is the most comfortable wrong answer a checker can give.
+WHAT A DOCUMENT LISTS, NOT WHAT IT MENTIONS, and that distinction is the whole
+of the second direction. Both files also write `lib*.so` in prose about other
+things: `libtool.so` and `libdep.so` in a worked example of adding a tool,
+`libpython3.x.so` for a version this build detects rather than pins, and about
+fifty shared libraries that live in `assets/usr/lib` and were never in this
+directory. So a name only answers for the directory when the document presents
+it as a list entry, which is what [enumerated] reads: a mermaid label opening
+with it, a line break inside one starting it, a tree listing marking it, or a
+comma continuing a run that began one of those ways.
+
+That rule is read off the documents' own structure. The withdrawal direction
+used to filter against a hand-written set of names this directory had held, and
+a hand-written set is the one thing a gate cannot check: a binary added after
+that set was written was forced into both documents by the first direction,
+whose failure never mentions the set, so nothing would ask for the set to be
+edited, and the day that binary was withdrawn the second direction would look
+straight past it and print `ok`. The exact drift this file exists to refuse,
+inside the file itself.
+
+Because both directions now read the same list, a parse that stops matching is
+its own failure rather than a quiet pass: a document whose enumeration this
+cannot find is refused, the same way an empty directory is. No files and no
+list both mean no disagreement, which is the most comfortable wrong answer a
+checker can give.
 
 Deliberately not checking the COUNT anywhere. `docs/06-SECURITY.md` used to state
 one and it drifted; it now says the sweep covers every binary and prints how many,
@@ -52,14 +74,39 @@ DOCUMENTS = (
 # a document and a name on disk compare as one string with no normalising.
 NAMED = re.compile(r"\blib[A-Za-z0-9._+-]*\.so\b")
 
+# What opens a list entry: a mermaid label, a line break inside one, or a tree
+# listing's branch. Markdown formats, not names, so nothing here has to be
+# revisited when a binary comes or goes.
+MARKERS = ('["', "<br/>", "── ")
+
+# What continues one. A run of names separated by exactly this counts as long as
+# the run began at a marker, which is what tells `["libgit.so,
+# libgit-remote-curl.so"]` apart from `usr/lib/ (libpython3.x.so, ICU, OpenSSL,
+# libc++_shared.so ...)`: the second is a sentence about a different directory
+# and starts inside a parenthesis rather than at an entry.
+CONTINUATION = ", "
+
 
 def packaged() -> set:
     """Every binary the APK carries in `jniLibs`, by file name."""
     return {p.name for p in JNILIBS.glob("*.so")}
 
 
-def documented(path: pathlib.Path) -> set:
-    return set(NAMED.findall(path.read_text(encoding="utf-8")))
+def enumerated(path: pathlib.Path) -> set:
+    """The binaries a document lists, ignoring the ones it merely mentions."""
+    text = path.read_text(encoding="utf-8")
+    names = set()
+    previous_end = 0
+    previous_was_entry = False
+    for match in NAMED.finditer(text):
+        is_entry = text[: match.start()].endswith(MARKERS) or (
+            previous_was_entry
+            and text[previous_end:match.start()] == CONTINUATION
+        )
+        if is_entry:
+            names.add(match.group(0))
+        previous_end, previous_was_entry = match.end(), is_entry
+    return names
 
 
 def main() -> int:
@@ -81,44 +128,27 @@ def main() -> int:
             failed = True
             continue
 
-        named = documented(path)
-        undocumented = sorted(present - named)
-        # Restricted to the names this directory has ever held rather than to
-        # every lib*.so a document mentions: `assets/usr/lib` holds about fifty
-        # more, and several are named in these same files for other reasons.
-        withdrawn = sorted(n for n in named if n.startswith("lib") and n in KNOWN - present)
+        listed = enumerated(path)
+        if not listed:
+            print(f"  FAIL   {where} lists no binary this check can read. It enumerates the")
+            print("         directory in a mermaid label or a tree listing; if that shape has")
+            print("         changed, this gate now agrees with anything. Teach it the new one.")
+            failed = True
+            continue
+
+        undocumented = sorted(present - listed)
+        withdrawn = sorted(listed - present)
 
         if undocumented:
-            print(f"  FAIL   {where} does not name: {', '.join(undocumented)}")
+            print(f"  FAIL   {where} does not list: {', '.join(undocumented)}")
             failed = True
         if withdrawn:
-            print(f"  FAIL   {where} still names binaries no longer packaged: {', '.join(withdrawn)}")
+            print(f"  FAIL   {where} still lists binaries no longer packaged: {', '.join(withdrawn)}")
             failed = True
         if not undocumented and not withdrawn:
-            print(f"  ok     {where} names all {len(present)} packaged binaries")
+            print(f"  ok     {where} lists all {len(present)} packaged binaries")
 
     return 1 if failed else 0
-
-
-# What the directory has held, so the withdrawal half compares against binaries
-# rather than against every shared library a document happens to mention. A name
-# leaves this set only when nothing describes it any more, which is the same edit
-# as removing it from the documents.
-KNOWN = {
-    "libbash.so",
-    "libexec-trampoline.so",
-    "libgit-remote-curl.so",
-    "libgit.so",
-    "libgo.so",
-    "libldmusl.so",
-    "libmake.so",
-    "libnode.so",
-    "libpython.so",
-    "libripgrep.so",
-    "libssh-keygen.so",
-    "libssh.so",
-    "libtmux.so",
-}
 
 
 if __name__ == "__main__":

--- a/scripts/check-bundled-extensions.py
+++ b/scripts/check-bundled-extensions.py
@@ -14,21 +14,31 @@ extracted tree and asks two questions, whether `engines.vscode` outruns the
 server and whether a glibc payload came along; neither of those is "may this be
 redistributed, and on what terms".
 
-Three rules:
+Four rules:
 
   * every entry in `EXTENSIONS` has a row in the notices table and every row has
     an entry, matched on the extension id;
   * the licence each row records is one this project can redistribute;
   * where the extracted tree is on disk, its `package.json` declares that same
-    licence and the tree carries the licence text itself.
+    licence and the tree carries the licence text itself;
+  * the extracted trees on disk are all of them or none of them.
 
 The third rule is the one that reads a build product, so it runs where build
 products exist. `download-extensions.sh` calls this after extracting, and
 `build.yml` calls it again once the asset cache has been restored, because that
 download step is skipped on a cache hit and the restored trees are still on
 disk to be read. A checkout with no trees, which is what `lint.yml` has, gets
-the first two rules and a count naming how many of the five were read, so a run
-that examined nothing cannot be read as one that examined all of them.
+the first two rules and a note saying that none was read, so a run that examined
+nothing cannot be read as one that examined all of them.
+
+None and all are the two states a checkout can honestly be in, and a count was
+all that separated them from every state in between. `download-extensions.sh`
+places all five or exits non-zero, so a partial set is not a checkout that has
+not downloaded yet: it is a tree that was built and then lost, which is what
+ships an APK missing an extension `NOTICE.md` still attributes. So the fourth
+rule fails. Zero trees stays a note, because it is the ordinary state of a
+source-only checkout, and `--require-trees` is how a caller that has just built
+them says that zero is wrong there too.
 
 Matched on the id, not on the display name. The names in the table are the ones
 a reader recognises and are not what the extensions call themselves: the table
@@ -131,7 +141,20 @@ def check_tree(ext_id, version, licence, failures):
     return True
 
 
-def main() -> int:
+USAGE = "usage: check-bundled-extensions.py [--require-trees]"
+
+
+def main(argv) -> int:
+    # Refused rather than ignored: a caller that means --require-trees and
+    # mistypes it would otherwise get the tolerant run it was trying to escape.
+    require_trees = False
+    for arg in argv:
+        if arg == "--require-trees":
+            require_trees = True
+        else:
+            print(f"::error::unknown argument {arg!r}\n{USAGE}")
+            return 2
+
     pinned = pinned_extensions()
     if not pinned:
         print(f"::error::no EXTENSIONS array found in {DOWNLOAD_SCRIPT}; the "
@@ -166,10 +189,36 @@ def main() -> int:
                 f"decision to take deliberately rather than by adding a row"
             )
 
+    # Counted rather than subtracted from the pinned total: an id with no
+    # notices row is not read and is not missing a tree either, it is the
+    # failure two blocks up, and taking it off the total would blame the wrong
+    # rule for it.
     trees_read = 0
+    unread = []
     for ext_id in sorted(set(pinned) & set(rows)):
         if check_tree(ext_id, pinned[ext_id], rows[ext_id], failures):
             trees_read += 1
+        else:
+            unread.append(ext_id)
+
+    # Some but not all, or none where the caller has just built them. Held here
+    # with the other failures rather than reported as a count, because the count
+    # was the whole defect: a run that lost a tree printed the same "note" as a
+    # checkout that never had one, and every workflow stayed green.
+    if unread and (require_trees or trees_read):
+        failures.append(
+            f"{trees_read} of {len(pinned)} extracted trees are on disk; "
+            f"{', '.join(unread)} left no package.json to read. "
+            + (
+                "The caller says every one of them was just placed"
+                if require_trees
+                else "download-extensions.sh places all of them or exits "
+                "non-zero, so a partial set is a tree that was built and then "
+                "lost, not a checkout that has not downloaded yet"
+            )
+            + f"; an APK built from this tree ships missing what "
+            f"{NOTICE.name} still attributes"
+        )
 
     for f in failures:
         print(f"::error::{f}")
@@ -184,12 +233,12 @@ def main() -> int:
         print(f"  ok     all {trees_read} extracted trees declare that licence "
               f"and carry its text")
     else:
-        print(f"  note   {trees_read} of {len(pinned)} extracted trees on "
-              f"disk; the licence the other {len(pinned) - trees_read} declare "
-              f"was not read here. That half runs wherever the trees exist, "
-              f"which is build.yml and release.yml")
+        print(f"  note   no extracted trees on disk; the licence all "
+              f"{len(pinned)} declare was not read here. That half runs "
+              f"wherever the trees exist, which is build.yml and from "
+              f"download-extensions.sh")
     return 0
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/download-extensions.sh
+++ b/scripts/download-extensions.sh
@@ -25,6 +25,18 @@ WORK_DIR="$ROOT_DIR/toolchains/extensions"
 # this change.
 #
 # Every step here must be safe to run twice, because on a cached tree it is.
+#
+# A non-zero return from this is fatal to the whole run, and the tree it failed
+# on is left where it is. Both halves are deliberate. Each caller used to answer
+# a failure with `rm -rf "$DEST_DIR"; continue`, which reported success for a run
+# that had just dropped an extension: the summary at the bottom listed the four
+# trees that remained, check-bundled-extensions.py called the fifth a note, and
+# the APK shipped with no Python support at all. Deleting is also precisely what
+# disarms the gate that would have caught it, because `verifyPythonPlatform` in
+# android/app/build.gradle.kts is armed by the tree's presence
+# (`onlyIf { tree != null }`): an unrewritten tree fails the build, an absent one
+# skips the task. Leaving it also leaves the bundle a maintainer has to read to
+# update the pattern, which is what a pin bump most often needs.
 apply_tree_rewrites() {
     local dir_name="$1" dest="$2"
     case "$dir_name" in
@@ -296,9 +308,10 @@ for EXT_SPEC in "${EXTENSIONS[@]}"; do
             # registered, never activates, and logs nothing.
             python3 "$SCRIPT_DIR/check-extension.py" "$DEST_DIR" "$ROOT_DIR/VSCODE_VERSION"
             apply_tree_rewrites "$DIR_NAME" "$DEST_DIR" || {
-                echo "  ERROR: could not rewrite the cached $DIR_NAME tree" >&2
-                rm -rf "$DEST_DIR" "$STAMP"
-                continue
+                echo "  FAIL   could not rewrite the cached $DIR_NAME tree" >&2
+                echo "         The tree is left on disk unrewritten, which is what the" >&2
+                echo "         packaging gate refuses and what says where the shape moved." >&2
+                exit 1
             }
             continue
         fi
@@ -345,9 +358,13 @@ for EXT_SPEC in "${EXTENSIONS[@]}"; do
     if [ -d "$TEMP_EXTRACT/extension" ]; then
         cp -a "$TEMP_EXTRACT/extension/." "$DEST_DIR/"
     else
-        echo "  ERROR: No extension/ directory in VSIX"
+        # Nothing was copied, so unlike the rewrite failures around it this
+        # one has no tree to read or to refuse: the destination is the empty
+        # directory made two lines up. It goes, and the run stops rather than
+        # carrying on to report the extensions it did place.
+        echo "  FAIL   No extension/ directory in $VSIX_FILE" >&2
         rm -rf "$DEST_DIR"
-        continue
+        exit 1
     fi
     rm -rf "$TEMP_EXTRACT"
 
@@ -381,9 +398,10 @@ for EXT_SPEC in "${EXTENSIONS[@]}"; do
     # input is not rebuilt: the VSIX is pinned by sha256 above, so the shape is
     # fixed until the pin moves, and both checks fail loudly when it does.
     apply_tree_rewrites "$DIR_NAME" "$DEST_DIR" || {
-        echo "  ERROR: could not rewrite the $DIR_NAME tree" >&2
-        rm -rf "$DEST_DIR"
-        continue
+        echo "  FAIL   could not rewrite the $DIR_NAME tree" >&2
+        echo "         The tree is left on disk unrewritten, which is what the" >&2
+        echo "         packaging gate refuses and what says where the shape moved." >&2
+        exit 1
     }
 
     # Last, so a tree that failed any step above carries no record saying it
@@ -398,8 +416,13 @@ done
 # of this can run: the extracted directories are gitignored, so on a pull request
 # there is nothing to read. lint.yml runs the same script for the half that reads
 # committed sources.
+#
+# --require-trees because "every" above is a claim this call site can make and
+# the workflow ones cannot: the loop has just placed all five or exited. It is
+# the sweep for any future path that ends a run with an extension unplaced,
+# rather than a restatement of the exits above, which stop long before here.
 echo ""
-python3 "$SCRIPT_DIR/check-bundled-extensions.py"
+python3 "$SCRIPT_DIR/check-bundled-extensions.py" --require-trees
 
 # Summary
 echo ""

--- a/scripts/test-bridge-relay.js
+++ b/scripts/test-bridge-relay.js
@@ -172,8 +172,10 @@ const bridgeCalls = [];
 // wants an answer has to post one.
 let listAnswer = '';
 let reclaimAnswer = '';
+let breakdownAnswer = '';
 const listCalls = [];
 const reclaimCalls = [];
+const breakdownCalls = [];
 
 const AndroidBridge = {
     openExternalUrl(url, token) {
@@ -187,6 +189,10 @@ const AndroidBridge = {
     reclaimSafMirror(token, hash, force, replyId) {
         reclaimCalls.push({ token, hash, force, replyId });
         return reclaimAnswer;
+    },
+    getStorageBreakdown(token, replyId) {
+        breakdownCalls.push({ token, replyId });
+        return breakdownAnswer;
     },
 };
 
@@ -625,6 +631,71 @@ async function main() {
     );
     quickPickChoice = null;
     warningChoice = null;
+
+    // The storage screen's Total row, which is the first and largest thing a
+    // person sees on the screen they open because they are out of disk.
+    //
+    // It is the one item built without a key, so it reaches the picker's final
+    // arm. That arm used to close the picker in silence, which reads as a screen
+    // that does not work; the sentence put there instead said Total was the sum
+    // of the rows below it, and it is not. Total is every byte under the app's
+    // data and cache directories, and the rows name the subtrees that can be
+    // identified: the cache row alone was narrowed to the four directories the
+    // clear action reaches, while the whole cache directory stays in Total.
+    //
+    // So this drives the real command with a breakdown whose rows deliberately
+    // do NOT add up, and asserts the two figures are BOTH named. Numbers rather
+    // than wording, because a check on the phrasing is one a synonym walks past.
+    //
+    // NEGATIVE CONTROL, measured: restore 'That is the sum of the rows below it.
+    // Pick one of those to see what can be freed.' and the second assertion goes
+    // red -- the sentence names neither figure.
+    const showStorageUsage = commands.get('vscodroid.showStorageUsage');
+    assert.ok(showStorageUsage, 'the bundled extension no longer registers vscodroid.showStorageUsage');
+
+    const MB = 1024 * 1024;
+    // Two rows of 512 MB inside a 3 GB total: the rows add to 1.0 GB, a figure
+    // that is neither the total nor any single row, so naming it cannot be
+    // satisfied by echoing something already on the screen.
+    const breakdown = {
+        vscode_server: 512 * MB,
+        extensions: 512 * MB,
+        total: 3 * 1024 * MB,
+        clearable: ['cache', 'logs'],
+    };
+    let offered = null;
+    quickPickChoice = (items) => { offered = items; return items[0]; };
+    shown.info.length = 0; shown.error.length = 0; breakdownCalls.length = 0;
+    const usage = showStorageUsage();
+    await settle();
+    assert.strictEqual(breakdownCalls.length, 1, 'the relay never reached getStorageBreakdown');
+    relayWindow.__vscodroidBridgeReply(
+        breakdownCalls[0].replyId, true, JSON.stringify(breakdown),
+    );
+    await usage;
+    quickPickChoice = null;
+
+    assert.ok(
+        offered && offered[0] && offered[0].key === undefined,
+        'the first item is no longer the keyless Total row, so this drove some other arm: ' +
+        JSON.stringify(offered),
+    );
+    assert.strictEqual(
+        shown.info.length, 1,
+        'the Total row said nothing at all, so the screen reads as one that does not work: ' +
+        JSON.stringify(shown),
+    );
+    const totalSaid = shown.info[0];
+    assert.ok(
+        totalSaid.includes('3.0 GB'),
+        'the Total row does not name the figure it is showing: ' + totalSaid,
+    );
+    assert.ok(
+        totalSaid.includes('1.0 GB'),
+        'the Total row does not say how much of itself the rows below account for. They add ' +
+        'to 1.0 GB of a 3.0 GB total, and a person out of disk adds them up: any claim that ' +
+        'the rows come to the total is one this breakdown does not support. Saw: ' + totalSaid,
+    );
 
     const unused = coverage.unused.length
         ? `; ${coverage.unused.length} relay branches have no sender (${coverage.unused.join(', ')})`

--- a/scripts/test-process-monitor-extension.js
+++ b/scripts/test-process-monitor-extension.js
@@ -191,34 +191,158 @@ function snapshot(total, terminals, langservers, budget = { idle: 5, soft: 8, er
         return shown.slice();
     };
 
-    const moved = { idle: 3, soft: 4, error: 6 };
-    assert.strictEqual(poll(snapshot(4, 1, 1, moved)).length, 1, 'no warning at the soft budget');
+    // Spread wider than the shipped budget on purpose: the re-arm is at the
+    // idle baseline and the tier above it is the soft budget, so a fixture
+    // whose two numbers are adjacent has no count between them to probe with.
+    const moved = { idle: 3, soft: 6, error: 9 };
+    assert.strictEqual(poll(snapshot(6, 1, 1, moved)).length, 1, 'no warning at the soft budget');
     assert.deepStrictEqual(
-        poll(snapshot(4, 1, 1, moved)), [],
+        poll(snapshot(6, 1, 1, moved)), [],
         'the same warning was raised twice, so it is not latched and this check cannot tell a ' +
             'cleared latch from one that was never set',
     );
 
-    // Three is this snapshot's idle baseline, not below it, so the latch must
-    // hold. It IS below the 5 that used to be written here, which is the whole
-    // discrimination: nothing else in this file can tell the two apart.
-    assert.deepStrictEqual(poll(snapshot(3, 1, 0, moved)), [], 'a device at its baseline was interrupted');
+    // Four is above this snapshot's idle baseline of three, so the warning latch
+    // must hold. It is at or below the 5 that used to be written here, which is
+    // the whole discrimination: nothing else in this file can tell a reset
+    // measured against the budget from one measured against that literal.
+    assert.deepStrictEqual(poll(snapshot(4, 1, 0, moved)), [], 'a settling device was interrupted');
     assert.deepStrictEqual(
-        poll(snapshot(4, 1, 1, moved)), [],
-        'a count of 3 is not below the idle baseline of 3 this snapshot names, yet the latch was ' +
-            'cleared and the same warning raised again, so the reset is measured against a ' +
+        poll(snapshot(6, 1, 1, moved)), [],
+        'a count of 4 is above the idle baseline of 3 this snapshot names, yet the warning latch ' +
+            'was cleared and the same warning raised again, so the reset is measured against a ' +
             'literal rather than against the budget',
     );
 
     // The other direction, so the assertion above is not satisfied by a latch
-    // that never clears at all: below the baseline it must, and the warning
-    // must come back.
-    assert.deepStrictEqual(poll(snapshot(2, 1, 0, moved)), [], 'a quiet device was interrupted');
+    // that never clears at all: AT the baseline it must clear, and the warning
+    // must come back. At, not below: the baseline is what the app costs with
+    // nothing happening, so asking for fewer asks for a count no session with
+    // the workbench open can reach, and the tier was one-shot for the life of
+    // the extension host.
+    assert.deepStrictEqual(poll(snapshot(3, 1, 0, moved)), [], 'a quiet device was interrupted');
     assert.strictEqual(
-        poll(snapshot(4, 1, 1, moved)).length, 1,
-        'the warning never returns after the count fell below the idle baseline, so the latch is ' +
-            'permanent and the check above would pass on an extension that warns exactly once',
+        poll(snapshot(6, 1, 1, moved)).length, 1,
+        'the warning never returns after the count fell back to the idle baseline, so the latch ' +
+            'is permanent and the check above would pass on an extension that warns exactly once',
     );
+
+    fs.rmSync(tmp, { recursive: true, force: true });
+}
+
+// One reading raises one notification, and the tier it raises is the severe one.
+//
+// The three tiers are an if/else-if chain over two independent latches, and the
+// critical arm used to set only its own. So the poll after a critical one, at a
+// count that had not moved, fell through to the soft arm and raised 'above the
+// target' on top of the error already on screen: two notifications about one
+// reading, the second the less severe, and both permanent afterwards because
+// only a count below the idle baseline clears either. Measured against the
+// shipped file at 3, 20, 20, 20: nothing, the error, the warning, nothing.
+//
+// Driven on ONE copy across polls, like the block above, because a fresh copy
+// starts with both latches false and can only ever show the first of them.
+//
+// NEGATIVE CONTROL: drop `warningShownAtThreshold = true` from the critical arm
+// of updateStatusBar() and the third poll raises the warning again, which is
+// what the first assertion below refuses.
+{
+    const tmp = fs.mkdtempSync(path.join(BASE_TMP, 'vscodroid-tier-'));
+    process.env.TMPDIR = tmp;
+    delete require.cache[require.resolve(EXTENSION)];
+    const extension = require(EXTENSION);
+    const poll = (snap) => {
+        fs.writeFileSync(path.join(tmp, 'vscodroid-processes.json'), JSON.stringify(snap));
+        shown.length = 0;
+        extension.activate({ subscriptions: [] });
+        extension.deactivate();
+        return shown.slice();
+    };
+
+    // A jump straight past the error budget, which is what a project opening
+    // with a terminal and two language servers does between two 10 s polls.
+    assert.deepStrictEqual(poll(snapshot(3, 1, 0)), [], 'a quiet device was interrupted');
+    const raised = poll(snapshot(20, 9, 6));
+    assert.strictEqual(raised.length, 1, `one reading raised ${raised.length} notifications`);
+    assert.strictEqual(raised[0].level, 'error', `expected the error tier at 20, got ${raised[0].level}`);
+
+    assert.deepStrictEqual(
+        poll(snapshot(20, 9, 6)), [],
+        'the poll after a critical one, at a count that had not moved, raised a second ' +
+            'notification: the warning tier fires behind the error tier because the critical ' +
+            'arm leaves the warning latch unset, and the user reads the milder of the two last',
+    );
+
+    // The other direction, so the assertion above is not met by an extension
+    // that has simply gone quiet for good: at the baseline both latches clear,
+    // and the tiers must still work afterwards.
+    assert.deepStrictEqual(poll(snapshot(2, 1, 0)), [], 'a quiet device was interrupted');
+    const again = poll(snapshot(20, 9, 6));
+    assert.strictEqual(
+        again.length, 1,
+        'the critical tier never returns after the count fell to the idle baseline, so the ' +
+            'assertion above would pass on an extension that notifies exactly once',
+    );
+    assert.strictEqual(again[0].level, 'error', `expected the error tier again, got ${again[0].level}`);
+
+    fs.rmSync(tmp, { recursive: true, force: true });
+}
+
+// Each tier re-arms at the tier below it, and the two are not the same count.
+//
+// Both latches used to clear together and only below the idle baseline, which
+// process-monitor.js measures as what the app costs doing nothing: five, the
+// bootstrap, the server, the file watcher, the agent host and the chat backend.
+// No session with the workbench open goes under that, so on a device neither
+// tier ever came back and both were one-shot for the life of the extension
+// host. A recovery that a user can actually produce -- close the extra
+// terminals, let the language servers idle-kill -- lands at 6 or 7, which is
+// where the error tier has to re-arm if it is to fire on the next project that
+// runs the count away.
+//
+// The warning tier deliberately does NOT re-arm there: 7 is still above the
+// target that warning names, so repeating it says nothing the user did not act
+// on. That is the second assertion, and it is the one that fails on the obvious
+// over-correction of clearing both flags below the soft budget.
+//
+// NEGATIVE CONTROL: restore `} else if (total < idle) {` with both flags cleared
+// inside it. The last assertion goes red -- 7 is not below 5, so the error tier
+// never returns.
+{
+    const tmp = fs.mkdtempSync(path.join(BASE_TMP, 'vscodroid-rearm-'));
+    process.env.TMPDIR = tmp;
+    delete require.cache[require.resolve(EXTENSION)];
+    const extension = require(EXTENSION);
+    const poll = (snap) => {
+        fs.writeFileSync(path.join(tmp, 'vscodroid-processes.json'), JSON.stringify(snap));
+        shown.length = 0;
+        extension.activate({ subscriptions: [] });
+        extension.deactivate();
+        return shown.slice();
+    };
+
+    assert.deepStrictEqual(poll(snapshot(3, 1, 0)), [], 'a quiet device was interrupted');
+    assert.strictEqual(poll(snapshot(20, 9, 6)).length, 1, 'the critical tier raised nothing at 20');
+
+    // The recovery: under the soft budget of 8, and nowhere near the idle
+    // baseline of 5.
+    assert.deepStrictEqual(poll(snapshot(7, 2, 1)), [], 'a recovering device was interrupted');
+
+    assert.deepStrictEqual(
+        poll(snapshot(10, 4, 2)), [],
+        'the warning tier came back at a count that never returned to the idle baseline, so a ' +
+            'user who has already been told once and acted on it is told again for a count ' +
+            'they have improved',
+    );
+
+    const back = poll(snapshot(20, 9, 6));
+    assert.strictEqual(
+        back.length, 1,
+        'the critical tier never returned after the count fell below the soft budget, so the ' +
+            'notification carrying the Kill Idle Servers button is raised once per extension ' +
+            'host however often the count runs away afterwards',
+    );
+    assert.strictEqual(back[0].level, 'error', `expected the error tier again, got ${back[0].level}`);
 
     fs.rmSync(tmp, { recursive: true, force: true });
 }

--- a/scripts/test-process-monitor.js
+++ b/scripts/test-process-monitor.js
@@ -18,7 +18,8 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-const monitor = require('../android/app/src/main/assets/process-monitor.js');
+const MONITOR = require.resolve('../android/app/src/main/assets/process-monitor.js');
+const monitor = require(MONITOR);
 
 const UID = process.getuid();
 
@@ -48,7 +49,12 @@ const NODE = '/data/data/com.vscodroid/lib/arm64/libnode.so';
 // python.defaultInterpreterPath, which is what ms-python launches its server
 // with. Not every language server is a Node one, and the two rules differ there.
 const PY = '/data/user/0/com.vscodroid/files/usr/bin/python3';
-const REH = '/data/user/0/com.vscodroid/files/server/vscode-reh';
+// Taken from the monitor, not written out here. The chat-backend rule is
+// anchored to this directory, and the monitor derives it from where it sits, so
+// a fixture spelling the device's path itself would answer for a monitor whose
+// anchor had moved away from it. Which directory this is does not matter to any
+// case below; that they are the SAME directory is the whole of it.
+const REH = monitor.REH_ROOT;
 // Marketplace and bundled-by-us extensions are extracted here, which is a
 // different tree from the editor's own extensions under REH.
 const EXT = '/data/user/0/com.vscodroid/files/home/.vscodroid/extensions';
@@ -57,6 +63,10 @@ const EXT = '/data/user/0/com.vscodroid/files/home/.vscodroid/extensions';
 // is the argument that used to be the only thing the details view printed.
 const HEAP = '--max-old-space-size=488';
 const DATA = '/data/user/0/com.vscodroid/files/home/.vscodroid/data';
+// The local copy of one folder opened through the SAF picker, named by the hash
+// Environment.getSafMirrorDir builds. It is where the editor is pointed, so
+// every path under it is a workspace path the user chose.
+const MIRROR = '/data/user/0/com.vscodroid/files/saf-mirrors/a1b2c3';
 
 const MAIN_ACTIVITY = path.join(
     __dirname, '../android/app/src/main/kotlin/com/vscodroid/MainActivity.kt',
@@ -327,6 +337,257 @@ function checkPressureContract(tmp) {
     return { critical, moderate, filename };
 }
 
+/**
+ * The chat backend is found wherever the editor tree is, not where it once was.
+ *
+ * That rule is the only one in classify() anchored to a directory rather than to
+ * a program name, and the directory belongs to the Kotlin side, which names it
+ * in five places. Renaming the leaf is loud -- server.js builds the same leaf
+ * from __dirname and drops the app into its minimal health-check server -- but
+ * moving the PARENT, files/server to files/editor or under a versioned
+ * directory, leaves every __dirname-relative path in server.js working and would
+ * silently stop this rule matching. The 226 MB backend then returns to
+ * 'unknown', outside lsCpuTracker and outside the 'Kill Idle Servers' filter.
+ *
+ * Measured by moving it: a copy of the monitor is loaded from a directory of its
+ * own and asked about two processes, one under the copy's tree and one under the
+ * path the rule used to name. Both are the same command line otherwise, so what
+ * separates the answers is the anchor alone.
+ *
+ * NEGATIVE CONTROL: put the literal back -- `script.includes('/server/vscode-reh/')`
+ * in place of `script.startsWith(REH_PREFIX)` -- and the two assertions below
+ * swap answers, the moved tree going 'unknown' and the abandoned path
+ * 'langserver'.
+ */
+function checkRehAnchorFollowsTheTree(baseTmp) {
+    // A capital in the directory on purpose. classify() lower-cases the command
+    // line before comparing, so an anchor taken from a path and not lower-cased
+    // matches nothing on any checkout carrying one, which is every CI runner
+    // this repository builds on.
+    const moved = fs.mkdtempSync(path.join(baseTmp, 'Editor-Moved-'));
+    const copy = path.join(moved, 'process-monitor.js');
+    fs.copyFileSync(MONITOR, copy);
+    const relocated = require(copy);
+
+    // Resolved, because Node's loader hands a module a real path and macOS puts
+    // its temporary directories behind a symlink: comparing the two spellings
+    // would fail here for a reason that has nothing to do with the anchor.
+    assert.strictEqual(
+        relocated.REH_ROOT, path.join(fs.realpathSync(moved), 'vscode-reh'),
+        'the monitor does not take the editor tree from its own directory, so a copy of it ' +
+            'somewhere else still answers for wherever the original was unpacked',
+    );
+    assert.notStrictEqual(
+        relocated.REH_ROOT, monitor.REH_ROOT,
+        'the copy resolved the same tree as the original, so nothing below can tell an anchor ' +
+            'that moved with the monitor from one that stayed where it was written',
+    );
+
+    const proc = path.join(moved, 'proc');
+    const tail = 'node_modules/@github/copilot-android-arm64/index.js';
+    writeProc(proc, 2001, [NODE, `${relocated.REH_ROOT}/${tail}`, '--stdio']);
+    // The tree this rule used to name, now holding nothing this app unpacked.
+    writeProc(proc, 2002, [NODE, `/data/user/0/com.vscodroid/files/server/vscode-reh/${tail}`, '--stdio']);
+
+    const out = path.join(moved, 'tmp');
+    fs.mkdirSync(out);
+    process.env.TMPDIR = out;
+    relocated.start(2001, { procRoot: proc });
+    relocated.stop();
+
+    const snapshot = JSON.parse(fs.readFileSync(path.join(out, 'vscodroid-processes.json'), 'utf8'));
+    const type = (pid) => (snapshot.tree.find((e) => e.pid === pid) || {}).type;
+    assert.strictEqual(
+        type(2001), 'langserver',
+        "the chat agent's model backend under the tree the monitor was loaded from is " +
+            `${type(2001)}: the rule names a directory this build no longer uses, so the ` +
+            'largest process the app owns is in neither reclaim path',
+    );
+    assert.strictEqual(
+        type(2002), 'unknown',
+        'a backend under the directory the editor was moved OUT of is still claimed as ours, ' +
+            'so the anchor is a literal rather than the tree beside the monitor',
+    );
+    return relocated.REH_ROOT;
+}
+
+/**
+ * The snapshot comes back after the directory it is written into is reclaimed.
+ *
+ * TMPDIR is cacheDir/tmp, and Android deletes an app's cache directory under
+ * storage pressure while the app keeps running, so it can go mid-session. The
+ * write was a bare writeFileSync into a path resolved once at start(), inside a
+ * catch that only logs, and nothing here recreated the directory: one reclaim
+ * froze the status bar counter, its tooltip and the process tree on their last
+ * snapshot for the life of the server, and left 'Kill Idle Servers' SIGTERMing
+ * pids read out of it. Both Kotlin writers into that same directory recreate it
+ * on the way past; this one did not.
+ *
+ * NEGATIVE CONTROL: remove the `fs.mkdirSync(path.dirname(outputPath), ...)`
+ * line from scan() and the last assertion goes red, because no later scan can
+ * write the file again.
+ */
+function checkSnapshotSurvivesReclaim(baseTmp, proc) {
+    const out = path.join(baseTmp, 'reclaimed');
+    fs.mkdirSync(out);
+    process.env.TMPDIR = out;
+    const snapshotPath = path.join(out, 'vscodroid-processes.json');
+
+    monitor.start(1001, { procRoot: proc });
+    monitor.stop();
+    assert.ok(fs.existsSync(snapshotPath), 'the monitor wrote no snapshot at all, so this ' +
+        'check cannot tell a recreated directory from one that was never used');
+
+    fs.rmSync(out, { recursive: true, force: true });
+    assert.ok(!fs.existsSync(snapshotPath), 'the fixture directory did not go, so the write ' +
+        'below is not being asked the question this exists to ask');
+
+    monitor.start(1001, { procRoot: proc });
+    monitor.stop();
+    assert.ok(
+        fs.existsSync(snapshotPath),
+        'the snapshot was never written again after the directory holding it was reclaimed, ' +
+            'so the status bar counter, its tooltip and the process tree render the last one ' +
+            'for the life of the server and Kill Idle Servers signals pids out of it',
+    );
+}
+
+/**
+ * A language server that outlives its SIGTERM stays reclaimable, and the second
+ * signal is one it cannot refuse.
+ *
+ * The kill deleted its own tracker entry, and that entry was the only record
+ * that a signal had ever been sent. So a server that did not die was re-tracked
+ * by the next scan as a first sighting and bought itself another five idle
+ * minutes, over and over, while the warning the user reads had already said it
+ * was killed. Two things kept the delete from being harmless: scan()'s cleanup
+ * loop already drops the pids that really went, and runs before this in the same
+ * scan, so the delete only ever bit on a survivor; and answering a signal is
+ * itself CPU time, so the very act of ignoring a SIGTERM in a handler makes the
+ * idle test call the process busy.
+ *
+ * Driven with a stub process.kill, so nothing on the machine running this is
+ * ever signalled: what is asserted is which signal the monitor chose for which
+ * pid, and the fixture survives because it is a directory rather than a process.
+ *
+ * NEGATIVE CONTROLS, each measured:
+ *   - put `lsCpuTracker.delete(pid)` back after the successful kill: the row is
+ *     no longer idle at the third scan and no SIGKILL is ever sent.
+ *   - rebuild the entry in trackLangServer as `{ cpuTime, lastActive: now }`
+ *     instead of spreading `prev`: the pending signal is dropped the moment the
+ *     process burns a tick, same two failures.
+ *   - drop the `tracked.termSentAt` short-circuit from isIdle: the pending
+ *     signal is kept and then not read, same two failures.
+ *   - send 'SIGTERM' instead of 'SIGKILL' on the second pass: the escalation
+ *     assertion goes red.
+ *   - drop `|| cpuTime < prev.cpuTime` from trackLangServer: a recycled pid
+ *     inherits its predecessor's pending signal and is SIGKILLed on sight.
+ */
+function checkSurvivingServerStaysReclaimable(baseTmp, critical) {
+    const out = fs.mkdtempSync(path.join(baseTmp, 'idle-kill-'));
+    const proc = path.join(out, 'proc');
+    const VICTIM = 1500;
+    writeProc(proc, VICTIM, [
+        NODE, `${REH}/extensions/css-language-features/server/dist/node/cssServerMain`, '--node-ipc',
+    ]);
+    const statPath = path.join(proc, String(VICTIM), 'stat');
+    const setCpu = (utime, stime) => {
+        const before = fs.readFileSync(statPath, 'utf8');
+        fs.writeFileSync(statPath, `${VICTIM} (node) S 1 ${'0 '.repeat(9)}${utime} ${stime}\n`);
+        assert.notStrictEqual(
+            fs.readFileSync(statPath, 'utf8'), before,
+            `pid ${VICTIM}'s CPU reading did not move, so this step is not asking anything`,
+        );
+    };
+
+    process.env.TMPDIR = out;
+    const signals = [];
+    const realKill = process.kill;
+    const realNow = Date.now;
+    // Every signal is recorded and none is delivered. The stub is installed for
+    // the whole check rather than around each scan, so a pid the monitor picks
+    // that is not this fixture's is caught by the assertions rather than sent.
+    process.kill = (pid, signal) => { signals.push([pid, signal]); };
+    let sent = [];
+    try {
+        const scanAt = (offsetMs, pressure) => {
+            if (pressure) {
+                fs.writeFileSync(path.join(out, monitor.PRESSURE_FILENAME), `${critical}\n`);
+            }
+            Date.now = () => realNow() + offsetMs;
+            try {
+                monitor.start(VICTIM, { procRoot: proc });
+                monitor.stop();
+            } finally {
+                Date.now = realNow;
+            }
+            const snap = JSON.parse(
+                fs.readFileSync(path.join(out, 'vscodroid-processes.json'), 'utf8'),
+            );
+            return snap.tree.find((e) => e.pid === VICTIM) || {};
+        };
+
+        const IDLE = 6 * 60 * 1000;
+
+        // First sighting. It also purges every pid the scans above tracked,
+        // because the cleanup loop drops what this procRoot does not hold, which
+        // is what keeps the signals below attributable to this fixture alone.
+        const first = scanAt(0, false);
+        assert.strictEqual(
+            first.type, 'langserver',
+            `the fixture is classified ${first.type}, so it is never tracked and nothing below ` +
+                'is being measured',
+        );
+        assert.strictEqual(first.idle, false, 'a server seen once is reported idle');
+        assert.deepStrictEqual(signals, [], 'a scan without memory pressure signalled something');
+
+        // Five idle minutes and critical pressure: the first signal.
+        scanAt(IDLE, true);
+        assert.deepStrictEqual(
+            signals, [[VICTIM, 'SIGTERM']],
+            `the pressure kill signalled ${JSON.stringify(signals)} rather than one SIGTERM to ` +
+                'the idle server, so the escalation below would be measuring the wrong pass',
+        );
+
+        // The server is still there, and running its handler cost it a tick.
+        // That is the reading that used to hand it another five minutes.
+        setCpu(11, 5);
+        const after = scanAt(IDLE, false);
+        assert.strictEqual(
+            after.idle, true,
+            'a language server that outlived the SIGTERM sent to it is reported not idle again, ' +
+                'so the pressure kill leaves it alone for another five minutes and Kill Idle ' +
+                'Servers says none are idle, while the warning already told the user it was killed',
+        );
+
+        // The next pressure event, which must not be a repeat of a signal this
+        // process has already declined.
+        scanAt(IDLE, true);
+        assert.deepStrictEqual(
+            signals, [[VICTIM, 'SIGTERM'], [VICTIM, 'SIGKILL']],
+            'the second pass over a server that ignored SIGTERM sent ' +
+                `${JSON.stringify(signals)}: nothing here escalates, so the process holds its ` +
+                'slot against the 32-process limit for as long as it likes',
+        );
+
+        // A recycled pid is a different process, and CPU time that went
+        // backwards is how that shows. It must not inherit the signal its
+        // predecessor was refusing.
+        setCpu(3, 1);
+        scanAt(IDLE, true);
+        assert.strictEqual(
+            signals.length, 2,
+            `a freshly started server on a recycled pid was signalled ${JSON.stringify(signals[2])} ` +
+                "on the strength of its predecessor's record",
+        );
+        sent = signals.slice();
+    } finally {
+        process.kill = realKill;
+        Date.now = realNow;
+    }
+    return sent.length;
+}
+
 function main() {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'vscodroid-monitor-'));
     const proc = path.join(tmp, 'proc');
@@ -345,7 +606,26 @@ function main() {
         [1005, [NODE, '/data/user/0/com.vscodroid/files/home/projects/my-eslint-tool/index.js'], 'unknown'],
         [1006, [NODE, '/data/user/0/com.vscodroid/files/usr/share/reporter/index.js'], 'unknown'],
         [1007, [NODE, HEAP, `${REH}/out/bootstrap-fork`, '--type=fileWatcher'], 'fileWatcher'],
-        [1008, [NODE, '/data/user/0/com.vscodroid/files/saf-mirrors/a1b2c3/sync.js'], 'safSync'],
+        // A folder opened from device storage is copied under saf-mirrors, so
+        // everything below that path is the user's workspace. It used to be a
+        // classification of its own, matched on the whole command line, and the
+        // three fixtures here are the two directions of removing it. A script
+        // inside a copied folder is no more the sync engine than any other
+        // script the user runs; the engine is a thread inside the Android app
+        // process and never appears in /proc at all.
+        [1008, [NODE, `${MIRROR}/sync.js`], 'unknown'],
+        // The half that cost something. A language server whose own program
+        // path lies inside the copied folder returned 'safSync' before any
+        // pattern was read: the interpreter of a venv the user made there and
+        // selected, and the workspace TypeScript the built-in extension resolves
+        // under node_modules. Neither entered lsCpuTracker, so neither could be
+        // reclaimed under memory pressure or by 'Kill Idle Servers', while both
+        // held one of the 32 phantom slots and read as 'storage' in the tooltip.
+        [1034, [`${MIRROR}/.venv/bin/python`,
+            `${EXT}/ms-python.python-2026.4.0/python_files/run-jedi-language-server.py`],
+            'langserver'],
+        [1035, [NODE, `${MIRROR}/node_modules/typescript/lib/tsserver.js`,
+            '--useInferredProjectPerProjectRoot'], 'langserver'],
         // A marketplace language server, not one of the three bundled with the
         // editor, and the reason it is here: check-langserver-patterns.py globs
         // *ServerMain.js under vscode-reh/extensions and cannot see this file at
@@ -596,12 +876,24 @@ function main() {
     const labelled = checkLabelCoverage(snapshot);
     const named = checkCommandNames(snapshot, byPid);
 
+    // All three repoint TMPDIR, which start() resolves the snapshot and the
+    // pressure file from, so they run after everything that reads either. The
+    // kill check also empties the tracker of every pid above, since its own
+    // procRoot holds one process, which is what keeps the signals it counts
+    // attributable to its own fixture.
+    checkSnapshotSurvivesReclaim(tmp, proc);
+    const escalated = checkSurvivingServerStaysReclaimable(tmp, contract.critical);
+    const moved = checkRehAnchorFollowsTheTree(tmp);
+
     fs.rmSync(tmp, { recursive: true, force: true });
     console.log(
         `ok -- ${snapshot.total} processes counted, ${cases.length} classifications checked, ` +
         `${labelled.length} types all labelled by the status bar extension, ` +
         `${named} rows named after the program they run, ` +
-        `pressure contract agrees on ${JSON.stringify(contract.critical)} in ${contract.filename}`,
+        `pressure contract agrees on ${JSON.stringify(contract.critical)} in ${contract.filename}, ` +
+        `snapshot rewritten after its directory was reclaimed, ` +
+        `a server that outlived its SIGTERM took ${escalated} signals and no more, ` +
+        `chat backend still found under a tree moved to ${path.basename(path.dirname(moved))}`,
     );
 }
 


### PR DESCRIPTION
A sweep over every production file, rather than over a diff, turned up defects that
predate this release cycle and that no review of recent changes could have reached:
a file created in the editor arriving on the device as `Main.kt.txt`, a screen reader
unable to cancel a toolchain download, and a first run interrupted by the system
leaving a bundled extension permanently broken.

## What changed

**Device folders**

- `createDocument` may return a display name other than the one it was asked for, and
  the code assumed it did not, so a mime type the provider did not recognise appended
  `.txt` to files created in the editor.
- Renaming a directory inside a mirror moved the journal lines recording edits the
  device never received, but not the writer's in-memory claim, and both were keyed by
  the same absolute path. The writer's identity is an object now, and the rename moves
  both records in one critical section.
- A save observed as a folder closes is reported rather than dropped in silence.
- The recent-folder list takes one grant snapshot rather than one per entry, and its
  monitor no longer spans a system-server call on the listing path.

**First run**

- Extraction creates a bundled extension's directory before it copies into it, and
  directory presence was the only staleness test, so a Recents swipe during the copy
  left a half-populated directory that every later launch read as installed. A mark is
  written while the directory is filled and unlinked when the copy lands; a directory
  carrying the mark, or holding no manifest, is unpacked again. That second test also
  reaches installs already broken this way.
- The repair for a truncated `.bashrc` or `settings.json` no longer deletes before it
  rewrites, and the appenders behind it can no longer disarm the retry.

**Toolchains**

- Progress rebound the whole card five times a second, taking accessibility focus with
  it, so Cancel was unreachable under TalkBack. Progress goes through the payload path.
- Cancellation reached only as far as the checksum; it now stops extraction and the
  copy, and reports that it stopped, so the first-run queue does not stall on the pack
  or on anything behind it.

**Downloads and the editor page**

- The loading placeholder was truncated at its first `#`, so every cold start showed a
  blank white page until the server answered.
- Committing and deleting a download's document ran on the interface thread whenever no
  write happened to be in flight, which is most of a transfer. Opening the document ran
  there too and caught only `IOException`, while the call raises `SecurityException`
  when the provider named has gone away between the picker and the open, with no
  handler above it.
- Workspace assets were served with a one-year immutable cache header.
- The CDN rewrite interpolated a page-controlled decoded path into the proxied URL.

**Bug reports**

- The rule catching a named credential required the name to start at a word boundary,
  and an underscore is a word character, so `NPM_TOKEN`, `DB_PASSWORD`, `MY_API_KEY`
  and `VSCODE_AGENT_TOKEN` were written out in full into text the user is invited to
  paste in public. Measured before the fix: four of eight representative lines leaked.
- Widening it needed bounding as well: redaction runs a line at a time so a rule cannot
  eat the stack frame under its match, and the segment matcher is a character class
  rather than a repeated group, which the engine compiles to a loop rather than one
  stack frame per repetition. A long name previously threw `StackOverflowError`, which
  neither the log writer nor the reader draining the server's output catches.

**Keyboard, monitor, packaging**

- Two-modifier shortcuts lost the modifier just pressed to a reading taken before it.
- Anything whose command line mentioned the user's device folder was classified ahead
  of every language-server rule, and both reclaim paths read that classification.
- `download-extensions.sh` deleted a bundled extension and exited 0 when its tree
  rewrite failed, so a release could ship with one of the five absent while every
  workflow stayed green.

## Risk

`UploadClaim` replaces a per-path writer count, so the journal's identity model changes;
both directions are pinned by tests, including a write that lands and one that fails
across a rename. `FirstRunSetup` gains a marker file, which is new persistent state:
a directory from an older build carries no mark and is judged by its manifest instead.
The redaction patterns are wider, so the tests fix both directions, secrets that must be
caught and ordinary text and stack traces that must survive whole.

## Verification

- Unit suite 1909 tests, 0 failures, 0 skipped, from 1647 at v1.1.0. 28 new test files.
- Every `check-*.py` gate and `test-*.js` self-check exits 0.
- R8 and `lintVitalRelease` pass with `--rerun-tasks`; all 33 `@JavascriptInterface`
  methods survive minification in the release DEX, checked against a control.
- Each fix's negative control was applied to the production source and run, confirming
  it reddened its own test and nothing else, then restored from a copy.

Not covered: nothing here was run on a device. `build.yml` compiles the instrumented
tests and does not run them.
