### PR TITLE
fix(setup): find settings.json's own opening brace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Packaging refuses a release whose bundled extension tree failed to build, which previously deleted the extension and reported success.
 
 ### Fixed
+- A comment above settings.json's opening brace is no longer mistaken for the document itself when an upgrade adds a setting, which left the file unparseable and dropped every preference.
 - The setup screen now keeps the display awake while it unpacks the app, so a screen timeout can no longer strand a first run part-way through an 800 MB extraction.
 - Toolchain screen: a download already running is now shown with its progress and a Cancel button instead of an Install button that started nothing.
 - Clearing caches now frees the toolchain download staging directories it was already counting, leaving alone any directory a running download is still using.

--- a/android/app/src/androidTest/kotlin/com/vscodroid/setup/ExecTrampolineOnDeviceTest.kt
+++ b/android/app/src/androidTest/kotlin/com/vscodroid/setup/ExecTrampolineOnDeviceTest.kt
@@ -111,8 +111,8 @@ class ExecTrampolineOnDeviceTest {
      */
     @Test
     fun `the trampoline runs the same payload by bare name`() {
-        val result = run(
-            listOf("make", "--version"),
+        val result = runByName(
+            "make --version",
             mapOf(
                 "PATH" to tcBin.absolutePath,
                 "VSCODROID_EXEC_TABLE" to table.absolutePath,
@@ -136,14 +136,17 @@ class ExecTrampolineOnDeviceTest {
             arrayOf("/system/bin/ln", "-sf", trampoline.absolutePath, File(tcBin, "nosuch").absolutePath)
         ).waitFor()
 
-        val result = run(
-            listOf("nosuch"),
+        val result = runByName(
+            "nosuch",
             mapOf(
                 "PATH" to tcBin.absolutePath,
                 "VSCODROID_EXEC_TABLE" to table.absolutePath,
             ),
         )
 
+        // A shell answers 127 for a name it cannot find at all, which is the same
+        // status the trampoline answers with. The message below is what tells the
+        // two apart, so it is not decoration.
         assertEquals("an unlisted name did not report command-not-found: ${result.second}",
             127, result.first)
         assertTrue(
@@ -151,6 +154,27 @@ class ExecTrampolineOnDeviceTest {
             result.second.contains("no toolchain entry"),
         )
     }
+
+    /**
+     * Runs [command] the way a `make` recipe or an editor task does: as a bare
+     * name, left to a shell to resolve against the PATH it was handed.
+     *
+     * The shell has to be the one doing that lookup, because ProcessBuilder does
+     * not do it. Java resolves a bare program name against the PARENT process's
+     * PATH, not against the one placed in `builder.environment()`, so passing
+     * `listOf("make", ...)` never reached the trampoline directory at all: it
+     * failed with ENOENT, which [run]'s catch reports as 126, and the two tests
+     * above then read that as a refused execve rather than as a lookup that never
+     * happened. Both were failing for this reason and neither could ever pass,
+     * which nothing noticed because no workflow runs this suite (see the README
+     * beside this file). The trampoline itself was measured working at the same
+     * time, by hand, with the same table and the same PATH.
+     *
+     * The shell is named by absolute path so Java's own resolution is not involved
+     * in reaching it either.
+     */
+    private fun runByName(command: String, env: Map<String, String>): Pair<Int, String> =
+        run(listOf("/system/bin/sh", "-c", command), env)
 
     /** Exit status and merged output of one command, run with exactly [env] added. */
     private fun run(command: List<String>, env: Map<String, String>): Pair<Int, String> {

--- a/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
@@ -4216,10 +4216,48 @@ internal fun refreshManagedPaths(
  * settings, and the second one is not what any of these keys accept.
  */
 private fun insertSetting(content: String, key: String, value: String): String {
-    val brace = content.indexOf('{')
+    val brace = rootBraceIndex(content)
     if (brace < 0) return content
-    val indent = FIRST_PROPERTY.find(content)?.groupValues?.get(1) ?: "    "
+    val indent = FIRST_PROPERTY.find(content, brace)?.groupValues?.get(1) ?: "    "
     return content.substring(0, brace + 1) +
         "\n$indent\"$key\": $value," +
         content.substring(brace + 1)
+}
+
+/**
+ * The offset of the document's own opening brace, or -1 when there is not one.
+ *
+ * `indexOf('{')` answers a different question. This is JSONC, so comments may
+ * precede the root object, and a brace inside one is indistinguishable to a plain
+ * search: the line then lands in the middle of that comment. The cost is not the
+ * managed setting being missed. A document that no longer parses drops EVERY
+ * setting it holds, the user's theme and font size included, and the write is
+ * atomic, so the file it replaces is already gone.
+ *
+ * Only whitespace and comments are legal ahead of the root brace, so skipping
+ * exactly those two is the whole scan. Anything else means this is not a shape
+ * this app wrote or understands, and -1 leaves it untouched rather than guessing:
+ * declining to add a setting costs one default, and guessing wrong costs the file.
+ */
+private fun rootBraceIndex(content: String): Int {
+    var i = 0
+    while (i < content.length) {
+        val c = content[i]
+        when {
+            c == '{' -> return i
+            c.isWhitespace() -> i++
+            content.startsWith("//", i) -> {
+                val newline = content.indexOf('\n', i)
+                if (newline < 0) return -1
+                i = newline + 1
+            }
+            content.startsWith("/*", i) -> {
+                val end = content.indexOf("*/", i + 2)
+                if (end < 0) return -1
+                i = end + 2
+            }
+            else -> return -1
+        }
+    }
+    return -1
 }

--- a/android/app/src/test/kotlin/com/vscodroid/setup/SettingsPathsTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/SettingsPathsTest.kt
@@ -575,4 +575,72 @@ class SettingsPathsTest {
             )
         }
     }
+
+    /**
+     * Where the insertion point is measured from.
+     *
+     * JSONC allows comments ahead of the root object, and a brace inside one used
+     * to win the search. The managed line then landed in the middle of the comment
+     * and the document stopped parsing, which drops every setting it holds rather
+     * than only the managed ones.
+     *
+     * The document these use carries no `workbench.secondarySideBar.defaultVisibility`,
+     * which is what every install upgrading from 1.1.0 looks like, so the insertion
+     * branch is the one actually taken here rather than a shape invented for a test.
+     */
+    @Nested
+    inner class LeadingComments {
+
+        private fun documentUnder(comment: String) =
+            """
+            $comment
+            {
+                "editor.fontSize": 14,
+                "git.path": "$git",
+                "workbench.colorTheme": "Monokai"
+            }
+            """.trimIndent()
+
+        @Test
+        fun `a brace inside a leading comment is not the document's own`() {
+            val comment = "// theme overrides {see docs}"
+
+            val result = requireNotNull(
+                refreshManagedPaths(documentUnder(comment), shell, git, wrapper),
+            )
+
+            assertTrue(
+                result.startsWith("$comment\n{"),
+                "the comment was split open and the document no longer parses:\n$result",
+            )
+        }
+
+        @Test
+        fun `a leading comment without a brace still receives the insertion`() {
+            // The control. Without it the test above passes just as well on a build
+            // where the insertion stopped happening at all, which is the failure it
+            // would be least able to see.
+            val comment = "// theme overrides"
+
+            val result = requireNotNull(
+                refreshManagedPaths(documentUnder(comment), shell, git, wrapper),
+            )
+
+            assertTrue(result.startsWith("$comment\n{"), "the comment moved:\n$result")
+            assertTrue(
+                result.contains(""""workbench.secondarySideBar.defaultVisibility""""),
+                "nothing was inserted, so the case above proves nothing:\n$result",
+            )
+        }
+
+        @Test
+        fun `a document whose only brace sits in a comment is left alone`() {
+            // Declining costs one default. Guessing costs the file, because the
+            // write that follows is atomic and the original is gone by then.
+            assertNull(
+                refreshManagedPaths("// nothing here but a { in a comment\n", shell, git, wrapper),
+                "a document with no root object was edited anyway",
+            )
+        }
+    }
 }

--- a/docs/10-RELEASE_PLAN.md
+++ b/docs/10-RELEASE_PLAN.md
@@ -408,11 +408,15 @@ with no section naming the version a user installed.
 5. Upload the AAB to Play and start the staged rollout in 6.2
 ```
 
-No gate is planned for step 1. The only moment the heading is wrong is the
-moment a tag is taken, so a check on a pull request would fail every branch
-that correctly leaves the section open. Its one honest home is the tag path,
-beside the existing "Check the tag matches the app version" step, which
-already has the version in hand.
+Step 1 is gated on the tag path. The "Check the tag matches the app version"
+step in `release.yml` refuses a tag whose `versionName` has no `## [X.Y.Z]`
+heading in `CHANGELOG.md`, so a tag taken with the section still open fails
+before the build starts rather than publishing a version the file does not name.
+
+The tag is the only honest home for it. A check on a pull request would fail
+every branch that correctly leaves the section open, and the heading is wrong
+at no other moment; that step already holds the version to look for, which is
+why the two checks step 2 names live there as well.
 
 ---
 


### PR DESCRIPTION
`insertSetting` located its insertion point with `indexOf('{')`. settings.json is JSONC, so a comment can sit above the root object, and a brace inside that comment wins the search: the managed line is spliced into the middle of the comment and the document stops parsing.

The cost is not the setting that goes missing. An unparseable settings.json drops every preference it holds, the user's theme and font size included, and the rewrite is atomic, so the file it replaced is already gone. `workbench.secondarySideBar.defaultVisibility` is new in this release, so the insertion branch runs on every install upgrading from 1.1.0 rather than only on a hand-edited file.

## Changes

- `FirstRunSetup.rootBraceIndex` skips the two things legal ahead of the root brace, whitespace and comments, and answers -1 for anything else. `insertSetting` and the indentation lookup both anchor on it.
- `docs/10-RELEASE_PLAN.md` names the gate that holds checklist step 1. The document said no gate was planned and proposed the tag path as its home; the gate is already there, inside "Check the tag matches the app version".
- `ExecTrampolineOnDeviceTest` resolves the bare command name through `/system/bin/sh`. Java resolves a program name against the parent process's PATH, not against `ProcessBuilder.environment()`, so `make` never reached the probe directory: it failed with ENOENT, which the helper reports as 126, and the assertions read that as a refused execve. Neither case could pass on any device.

## Risk

`rootBraceIndex` answers -1 for a document it cannot read, where the previous code inserted anyway. That declines to add one default rather than rewriting a file it does not understand.

## Verified

- Unit suite: 1912 tests, 0 failures, up 3.
- With the brace fix reverted, both new defect tests fail and the control still passes, so neither passes vacuously.
- Instrumented suite on an API 33 arm64 emulator: 40 tests, 0 failures. Both trampoline cases failed before this change.
- The argument-free checker scripts, `verify-server-tree.py`, `check-patch-fingerprints.py` and `device-test.sh --self-check` all pass.
