### PR TITLE
fix: make menus, the side bar and the workspace usable on a phone

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -414,13 +414,20 @@ jobs:
       #
       # Compiled here, run by a person: `scripts/device-test.sh --instrumented`
       # is the only thing that executes them, and it needs an arm64 device or
-      # emulator attached. Measured 2026-08-23 against attached arm64 emulators,
-      # so the cost of doing it is on record: 40 tests, all green, 113 s on API
-      # 33 and 97 s on API 37. Cheap enough that skipping it before a tag is a
-      # choice rather than a constraint -- and the one case no other suite can
-      # replace is ExecTrampolineOnDeviceTest's control, which asserts that a
-      # payload under filesDir cannot be executed directly. That is a kernel
-      # policy decision, and the whole toolchain design rests on it.
+      # emulator attached. It is around a minute of wall clock, so skipping it
+      # before a tag is a choice rather than a constraint -- and the one case no
+      # other suite can replace is ExecTrampolineOnDeviceTest's control, which
+      # asserts that a payload under filesDir cannot be executed directly. That
+      # is a kernel policy decision, and the whole toolchain design rests on it.
+      #
+      # No count and no per-device timing here on purpose. Three of them were
+      # written down across this file and the README, all three went stale, and
+      # a figure in a comment is one nothing can check. The README carries them
+      # against the recorded run, and check-instrumented-inventory.py holds it
+      # to the sources.
+      #
+      # release.yml runs this same task, because a tag may name a commit that
+      # reached neither of this workflow's triggers.
       - name: Compile the instrumented tests
         working-directory: android
         run: ./gradlew assembleDebugAndroidTest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -118,6 +118,26 @@ jobs:
       - name: Check every workflow step is runnable and pinned
         run: python3 scripts/check-workflow-steps.py
 
+      # The same question asked of the build tool itself, which the step above
+      # cannot reach: `uses:` pinning covers the actions, and the wrapper
+      # downloads Gradle from a URL. Presence only, deliberately. A sum that is
+      # present and WRONG is not a silent failure -- the wrapper refuses the
+      # distribution on the next invocation and says so -- while a sum that is
+      # absent looks exactly like a pinned tree and runs whatever the URL
+      # serves. Absence is also how it comes back: `gradle wrapper
+      # --gradle-version X` regenerates that file from a fixed set of keys and
+      # drops the sum unless the bump passes --gradle-distribution-sha256-sum.
+      - name: Check the Gradle distribution is pinned to a digest
+        run: |
+          props=android/gradle/wrapper/gradle-wrapper.properties
+          if ! grep -q '^distributionSha256Sum=[0-9a-f]\{64\}$' "$props"; then
+            echo "::error file=$props::no distributionSha256Sum; the wrapper would" \
+                 "run whatever $(grep -m1 '^distributionUrl=' "$props") serves." \
+                 "Take the digest from that URL with .sha256 appended."
+            exit 1
+          fi
+          grep '^distributionUrl=\|^distributionSha256Sum=' "$props"
+
       # Same reasoning, one file further: reads two committed sources and no
       # assets. The contract an extension author writes against had never been
       # held to the bridge it describes, and one pass found fourteen
@@ -186,6 +206,15 @@ jobs:
       # pass covered everything, so a wrong count is a coverage claim nobody made.
       - name: Check the device-test checklist accounts for its own rows
         run: python3 scripts/check-checklist-totals.py
+
+      # The same question one directory over, and the answer had rotted twice.
+      # Nothing runs the instrumented suite -- no runner measured here can, and
+      # CI compiles it and stops -- so androidTest/README.md is the only account
+      # of what it covers, and it had the total wrong and three of its classes
+      # missing from the table. A directory nobody executes, described by a
+      # document nobody checks, reads as coverage twice over.
+      - name: Check the instrumented suite matches what documents it
+        run: python3 scripts/check-instrumented-inventory.py
 
       # Also in release.yml, where it is the last thing standing between a tag
       # and a published build. It ran there alone, and there is no cheaper place

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,29 @@ on:
   push:
     tags:
       - "v*"
+  # A build the signed artifacts can be exercised by without publishing one.
+  # Nothing else in this repository builds `assembleRelease` or `bundleRelease`
+  # with the real keystore: r8.yml runs the shrinker against a stub tree and
+  # stops short of signing, and build.yml builds debug. So the whole
+  # release-only half -- validateSigningRelease, packageRelease, bundleRelease,
+  # checkBundleSize, the symbol zip, the toolchain ZIPs and their digest
+  # manifest -- was reachable only by pushing a tag, which is to say only by
+  # publishing. A failure there is discovered on the one build that cannot be
+  # taken back.
+  #
+  # It cannot publish. `github-release` is the only job that writes anything
+  # outward, and it is gated on `github.event_name == 'push'`; the tag/version
+  # gate at the top of build-release is gated the same way, because there is no
+  # tag on this path to compare against. The gate is on the TRIGGER and not on
+  # the ref, and that distinction is the whole guarantee: a workflow_dispatch
+  # can be aimed at a tag ref, so `startsWith(github.ref, 'refs/tags/v')` would
+  # be true for a dispatched run and would publish from one. The ref test is
+  # kept beside it as the second half rather than the first.
+  #
+  # Its cost is a runner-hour and the artifacts it uploads expire; it holds the
+  # signing secrets, which is why it takes the same write access to start as
+  # pushing a tag does.
+  workflow_dispatch:
 
 # Read by default, raised to write on the one job that publishes. build-release
 # holds the signing secrets and runs by far the most foreign code in the
@@ -85,6 +108,16 @@ jobs:
       # say the name, and a tag that disagrees with it points them all at the
       # wrong commit.
       - name: Check the tag matches the app version
+        # Tag path only, because every question it asks needs a tag: the name to
+        # compare against versionName, the predecessor to compare versionCode
+        # against, and the CHANGELOG heading that has to have been renamed by
+        # the moment of tagging. On a dispatched run `github.ref_name` is a
+        # branch, so the first `case` would refuse it, and the CHANGELOG rule
+        # would refuse every branch that correctly still says Unreleased --
+        # which is the reason the step's own comment gives for not running it on
+        # a pull request. Nothing is lost: no dispatched run publishes, so there
+        # is no artefact for a wrong version to end up on.
+        if: github.event_name == 'push'
         env:
           TAG: ${{ github.ref_name }}
         run: |
@@ -262,6 +295,28 @@ jobs:
 
       - name: Check the device-test checklist accounts for its own rows
         run: python3 scripts/check-checklist-totals.py
+
+      # With the rest of this block, for the reason its header gives. This one
+      # covers the suite a person is told to run before tagging: its README is
+      # the only account of what it covers, and a tag is the moment that account
+      # is being acted on.
+      - name: Check the instrumented suite matches what documents it
+        run: python3 scripts/check-instrumented-inventory.py
+
+      # This job runs Gradle four times, so it is a place the wrapper actually
+      # downloads a distribution. Presence only: a sum that is present and wrong
+      # is refused by the wrapper itself on the next invocation, while an absent
+      # one runs whatever the URL serves and looks exactly like a pinned tree.
+      - name: Check the Gradle distribution is pinned to a digest
+        run: |
+          props=android/gradle/wrapper/gradle-wrapper.properties
+          if ! grep -q '^distributionSha256Sum=[0-9a-f]\{64\}$' "$props"; then
+            echo "::error file=$props::no distributionSha256Sum; the wrapper would" \
+                 "run whatever $(grep -m1 '^distributionUrl=' "$props") serves." \
+                 "Take the digest from that URL with .sha256 appended."
+            exit 1
+          fi
+          grep '^distributionUrl=\|^distributionSha256Sum=' "$props"
 
       # Needs real history, which both this job and lint.yml now take: in
       # actions/checkout's default single-commit clone `git log -1 -- <file>`
@@ -517,6 +572,34 @@ jobs:
       - name: Run lint
         working-directory: android
         run: ./gradlew lint
+
+      # The last thing build.yml does that a tag did not. Nothing runs the
+      # instrumented suite -- no runner measured here can, see
+      # androidTest/README.md -- so compiling it is the whole of what CI can
+      # offer, and that compile lived in build.yml's test job alone, which fires
+      # on pull_request and on push to main. A tag cut from a branch that
+      # reached neither got a signed build whose on-device suite may not even
+      # build, and the person told to run that suite before tagging finds out
+      # after the tag exists.
+      #
+      # Cheap here. The androidTest APK carries none of the bundled tree, which
+      # is measurable rather than assumed: its merged-asset directory
+      # (app/build/intermediates/assets/debugAndroidTest) is 0 B against 832 MB
+      # for the debug and release variants, and the APK it produces is 1.7 MB
+      # against the app's 334. The debug classes it compiles against were
+      # already compiled by the unit-test step above.
+      #
+      # Not measured: whether Gradle still schedules the app's own 832 MB asset
+      # merge as a dependency of this task even though nothing here consumes it.
+      # If it does, the cost is one more local copy of a tree this job already
+      # merges twice, for assembleRelease and bundleRelease, inside a 90 minute
+      # budget.
+      #
+      # Before the keystore, with the rest of the re-run block, so a failure
+      # here never reaches a step handling a secret.
+      - name: Compile the instrumented tests
+        working-directory: android
+        run: ./gradlew assembleDebugAndroidTest
 
       # Decode signing keystore from base64 secret
       #
@@ -823,6 +906,27 @@ jobs:
     name: GitHub Release
     runs-on: ubuntu-latest
     needs: build-release
+    # The one job that publishes, and the one gate that keeps a dispatched run
+    # from doing so. Everything outward-facing this workflow does happens here:
+    # the release is created, and every asset a device later resolves through
+    # `releases/latest` is attached to it -- the toolchain ZIPs and the
+    # toolchains.sha256 that non-Play installs verify against. So publishing
+    # from an arbitrary branch would not merely add a release, it would move
+    # that pointer for every sideloaded install, including ones already on a
+    # toolchain.
+    #
+    # Both halves are deliberate and neither is sufficient alone.
+    # `github.event_name == 'push'` is the one that holds, because the only
+    # push trigger this workflow declares is the `v*` tag filter; a
+    # workflow_dispatch can be aimed at a tag ref, so the ref test on its own
+    # would let a dispatched run publish. The ref test is kept because the
+    # trigger test alone would start passing the moment a branch push trigger
+    # were added above.
+    #
+    # A skipped job does not fail the run, so a dispatched build reports green
+    # having published nothing, and the write scope below is never granted on
+    # that path.
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     # The only job that writes. It builds nothing and downloads nothing beyond
     # the artifact build-release produced, so the write scope is held for the
     # few seconds it is used rather than for the ninety minutes above.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The Toolchains screen has a Command Palette entry, **VSCodroid: Manage Toolchains**. The launcher icon's shortcut was the only route to it.
 - **VSCodroid: About**, which carries the licence notices and the written offer of source, is now on the remote indicator in the status bar as well as in the Command Palette.
 - Files served to extension webviews answer byte-range requests, which is what seeking in a media preview needs.
+- The release build can be exercised without publishing one. It cannot publish: the job that writes is gated on the trigger, so a dispatched run reports green having released nothing.
+- A unit-test coverage report, on request: `./gradlew :app:createDebugUnitTestCoverageReport -PvscodroidCoverage`. Nothing gates on the figure and the suite CI runs stays uninstrumented.
 
 ### Changed
 - The toolchain picker is offered until you answer it. An interrupted first run used to skip it permanently, leaving the launcher shortcut as the only way to add a language.
@@ -50,6 +52,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The privacy policy now describes the sign-in callback window as the app enforces it: matched against the specific sign-in that produced it, not against the last browser launch.
 - The document-date and plain-punctuation checks now run on pull requests and on tags alike, so a documentation change no longer surfaces its first failure as an aborted release.
 - The process monitor's status bar no longer shows an internal identifier where a readable label belongs, and drops an entry for a process type the editor stopped creating.
+- The Gradle distribution is pinned to its published digest, and a build without one is refused. It was the only thing entering the build with nothing checking it.
+- The instrumented tests are compiled at tag time as well, so a tag cut from a branch that reached no other workflow cannot ship a suite that does not build.
+- The instrumented suite's own README is held to the sources it describes; its test count had been wrong twice.
 
 - Documentation, code comments and the Get Started walkthrough now use ordinary punctuation throughout, and a check keeps new text consistent with it.
 - Every dialog, toast and spoken description now comes from a string resource, so the app can be translated. No translation ships yet; sixty-nine texts were unreachable to one.
@@ -98,6 +103,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Packaging refuses a release whose bundled extension tree failed to build, which previously deleted the extension and reported success.
 
 ### Fixed
+- The primary side bar can be resized on a phone in portrait. Its minimum and its reachable maximum were the same number, so the divider had nowhere to travel and dragging it did nothing.
+- Dragging inside an open submenu scrolls it instead of closing it. The gesture reached the menu behind it as well, and a menu that scrolls dismisses the submenu anchored to it.
+- Menu dividers are drawn as lines again, not as blank bands. The touch-target floor applied to them too, which added about 400px to the File menu and is most of why it ran off the screen.
+- View dividers are 20px rather than 4px, which is the size the editor already uses on the other touch platform.
+- The default workspace is on internal storage. Shared storage cannot hold a symbolic link, so `npm install` failed on the first package shipping an executable, and npm blamed a path in `node_modules/.bin`. An install that already has projects on shared storage keeps them, and npm now says which of the two it hit.
 - Extensions survive a dropped connection. Backgrounding the app for a minute killed the extension host, and the workbench came back looking healthy with nothing loaded.
 - A first run interrupted part-way keeps the files it already unpacked, instead of writing the whole 800 MB tree again on the retry.
 - The storage check reserves enough for the filesystem overhead of an 800 MB tree, so an install can no longer pass it and then meet a full disk part-way through.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -241,6 +241,26 @@ android {
             isMinifyEnabled = false
             applicationIdSuffix = ".debug"
             versionNameSuffix = "-debug"
+            // Which of the 2000-odd unit tests actually reach a line, answered by
+            // the tooling already in the Android plugin rather than by adding a
+            // coverage plugin: this switch makes the debug unit-test task emit
+            // JaCoCo execution data and gives it a report task,
+            // `createDebugUnitTestCoverageReport`, writing HTML and XML under
+            // app/build/reports/coverage/.
+            //
+            // Behind a property because it is not free. Turning it on instruments
+            // every class the tests load, and an instrumented run is a different
+            // run: it is slower, and a timing-sensitive case can pass or fail on
+            // that alone. The suite CI gates on therefore stays uninstrumented and
+            // the report is asked for deliberately:
+            //
+            //   ./gradlew :app:createDebugUnitTestCoverageReport -PvscodroidCoverage
+            //
+            // No threshold and no gate. A number that fails the build invites
+            // tests written to move it, which is the opposite of what the suite
+            // here is for; this exists so an untested file can be found, not so a
+            // percentage can be defended.
+            enableUnitTestCoverage = providers.gradleProperty("vscodroidCoverage").isPresent
         }
     }
 
@@ -508,6 +528,15 @@ tasks.withType<Test> {
         .withPathSensitivity(PathSensitivity.RELATIVE)
     inputs.files(fileTree(rootProject.projectDir.parentFile.resolve("patches")))
         .withPropertyName("serverPatches")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
+    // One script, not the directory: MenuSeparatorFloorTest reads the block
+    // build-vscode-oss.sh appends to workbench.css, because the touch-target
+    // floors that block writes reach a menu separator and the exemption that
+    // keeps a 1px divider from being drawn as a 44px band lives there. Nothing
+    // else under scripts/ is opened by a test, and most of it is Python the
+    // Python gates already cover.
+    inputs.file(rootProject.projectDir.parentFile.resolve("scripts/build-vscode-oss.sh"))
+        .withPropertyName("codeOssBuildScript")
         .withPathSensitivity(PathSensitivity.RELATIVE)
     // The licence texts NoticesTest pins byte for byte. That pin exists for the
     // edit nobody means to make: a reflow, a re-wrap, an editor stripping the

--- a/android/app/src/androidTest/README.md
+++ b/android/app/src/androidTest/README.md
@@ -76,10 +76,18 @@ when the APKs can be built on Linux and only installed on the other runner.
 
 ## What CI does instead
 
-`build.yml` compiles them (`assembleDebugAndroidTest`). That is not a
-substitute for running them and is not offered as one; it catches only the
-second way they were rotting. Until it was added, nothing compiled them either,
-so they could drift out of the app's API and stay broken indefinitely.
+`build.yml` compiles them (`assembleDebugAndroidTest`), and `release.yml` runs
+the same task before it signs anything, because a tag may name a commit that
+reached neither of `build.yml`'s triggers. That is not a substitute for running
+them and is not offered as one; it catches only the second way they were
+rotting. Until it was added, nothing compiled them either, so they could drift
+out of the app's API and stay broken indefinitely.
+
+`lint.yml` and `release.yml` also run
+`scripts/check-instrumented-inventory.py`, which is what keeps this file
+truthful about the suite: the count below and the table of what each class
+covers are the only account of coverage anywhere, and both had gone stale
+against a directory nobody executes.
 
 ## How to run them
 
@@ -90,32 +98,30 @@ cd android
 ANDROID_SERIAL=emulator-5554 ./gradlew connectedDebugAndroidTest
 ```
 
+`scripts/device-test.sh --instrumented` is the same run with the preconditions
+checked first, and it writes what happened to
+`app/build/reports/device-run.txt`. Prefer it: the preconditions it checks both
+present as a timeout rather than as an error.
+
 Results land in `app/build/outputs/androidTest-results/connected/`. **Read that
 XML rather than the exit code**: a run that fails before reaching the tests
 writes no results at all, and its exit code is indistinguishable from a genuine
-failure.
+failure. It is also the only place the skip count appears, and a skipped test
+prints nothing in Gradle's console output.
 
-Read the times out of that XML rather than trusting a figure written here. The
-one recorded run in this checkout (a Pixel 9 Pro XL AVD on API 36) reports
-116.1 s of suite time for 22 tests, of which `firstRun_launchesWithoutCrash`
-alone was 60.686 s. That test is gone: it slept a flat 60 seconds and asserted
-nothing, so the only failure it could report was a throw out of `onCreate`,
-which `firstRun_extractionSetsVersion` reports as well in 11.7 s, and that one
-also catches a setup ending in `showSetupError()`.
+**At HEAD there are 50 tests across eleven classes.** That figure is not kept by
+hand: `scripts/check-instrumented-inventory.py` counts the sources with
+`grep -cE '^\s*@Test'` and fails the build when this file disagrees with them,
+because it had said 22 and then 37 while the suite was neither, and a stale
+count in a document whose subject is coverage is worse than no count.
 
-That accounted for 21 tests and roughly 52 s of test time. This paragraph claimed
-three minutes for a long time; the recorded run says otherwise, which is what
-reading the XML is for.
-
-**At HEAD there are 37 tests across eight classes**, counted from the sources rather
-than from any run, with `grep -cE '^\s*@Test'` over this directory:
-`KeyRowAccessibilityInstrumentedTest` arrived with the extra key row's accessibility
-work and adds eleven, `SafWatchWiringTest` arrived with the per-directory watch work
-and adds five, `ExtractionOnDeviceTest` arrived with the first-run setup work and
-adds four, and the classes have moved since besides. No recorded run covers
-this set, so there is no honest wall-clock figure to quote for it; the 52 s above
-measured a different suite and is kept only as the reason not to say "three
-minutes". Read the times out of your own run's XML.
+The recorded run in this checkout is a Pixel 7 Pro AVD on API 33, 2026-08-23:
+50 tests, no failures, no skips, **66.8 s** of suite time. Where it goes is
+lopsided and worth knowing before you wait on it: `SplashActivityTest` 21.4 s
+and `ServerHealthTest` 14.2 s are two thirds of it, both of them waiting on real
+extraction and a real server; `TextEntryInstrumentedTest` and
+`GestureTrackpadTouchInstrumentedTest` together cost 0.03 s. Read your own run's
+XML rather than trusting this paragraph, which is what it is here to encourage.
 
 ## What is here, and what it is worth
 
@@ -127,8 +133,11 @@ minutes". Read the times out of your own run's XML.
 | `FileObserverTreeSemanticsTest` | The platform behaviour the SAF write-back rests on: that a watch covers a directory and not a tree, that the path an event reports is the bare entry name, and that inotify's directory flag survives the trip through FileObserver. Needs no app state at all, so it has no precondition that a skip could hide. |
 | `SafWatchWiringTest` | That those semantics are wired up: a save two directories down and a `.vscode/` settings file are both queued for write-back, a scratch file beside an ordinary one is not, deleting a watched directory releases its watch, and a skipped directory is never watched at all. The layer above `FileObserverTreeSemanticsTest`: that one proves the platform behaves as assumed, this one proves the assumption was used. |
 | `ToolchainInsetsTest` | With edge-to-edge enforced, the Toolchains screen stays out of both system bars: toolbar below the status bar, grid above the navigation bar. The screen shipped drawing its title under the clock, so this is the regression the padding exists to prevent. |
+| `ExecTrampolineOnDeviceTest` | The one claim no JVM test can settle: that the trampoline starts a program the app is otherwise forbidden to run. SELinux denies `execute_no_trans` on `app_data_file`, so nothing under `filesDir` can be execve'd whatever its mode, and only a test running as the app itself can ask that -- `adb shell run-as` runs in a domain that is allowed to execute files this one may not, so it reports success for a binary that fails on the device. The control is asserted first and is not optional: if a direct execve of the copied payload SUCCEEDS here, nothing was being denied on this device, and the case that runs it through the trampoline would pass for a reason that has nothing to do with the trampoline. The whole toolchain design rests on this. |
 | `ExtractionOnDeviceTest` | The parts of bundled-extension extraction a JVM cannot answer: that `AssetManager.list()` returns an empty array for a leaf, which is the basis on which `extractAssetDir` decides file-or-directory and which every unit test stubs; that `deleteRecursively()` succeeds on app-private storage, which the retry after a failed unpack depends on; and the abort-and-retry itself, driven by a real out-of-space condition. Redirects `getFilesDir()` through a `ContextWrapper` so the real AssetManager stays in play, so it needs no server tree and no first-run setup. |
-| `KeyRowAccessibilityInstrumentedTest` | The extra key row and the trackpad as an accessibility service would find them: every key carries a content description, a latched modifier and the open alternates layer say so in their node state, a key with no alternates advertises no long click, each key clears 48dp on a mainstream phone, and the trackpad offers one action per arrow. It reads the `AccessibilityNodeInfo` and performs the actions it advertises by id rather than tapping. A `View` initialiser touches resources on its first line, so none of this is reachable from the JVM suite; the unit tests next door assert the wiring by reading the source instead. The view has to be inside a real window, because a detached one reports almost nothing. |
+| `TextEntryInstrumentedTest` | That the row actually types what it says: every character it can produce, taken from the row itself rather than from a list here, resolves to key presses that enter it, a shifted character is pressed with Shift held, and each press carries the layout it was resolved from and a current timestamp. `KeyCharacterMap` and `KeyEvent` are android.jar stubs that throw off a device, so every JVM case injects a fake and the real lookup is only exercised here. The failure that leaves has shipped once: `{` and `(` inserting nothing at all, with every JVM case green. |
+| `GestureTrackpadTouchInstrumentedTest` | What a second finger does to a drag. The pad reads deltas off pointer index 0, and once the first finger lifts that index becomes the finger left behind, so one frame reported the gap between two fingers as a single delta and the accumulator paid it out as a burst of arrows. Real multi-pointer `MotionEvent`s against a `View` whose initialiser reaches colours, strings and display metrics, so none of it is reachable from a JVM test. |
+| `KeyRowAccessibilityInstrumentedTest` | The extra key row and the trackpad as an accessibility service would find them: activating a key delivers its press and activating a modifier flips its state, a latched modifier says so on the node that speaks it, a plain key publishes none, a key with no alternates advertises no long click, a key and an alternate each call themselves a button, every key clears 48dp at each width the row is paged for, a resize repacks the row without spending a latched modifier or changing its height, the gap between keys is still drawn, and the trackpad offers one action per arrow and ends the drag when one is performed. It reads the `AccessibilityNodeInfo` and performs the actions it advertises by id rather than tapping. A `View` initialiser touches resources on its first line, so none of this is reachable from the JVM suite; the unit tests next door assert the wiring by reading the source instead. The view has to be inside a real window, because a detached one reports almost nothing. |
 
 ## A green run is not necessarily a run
 

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -2694,6 +2694,23 @@ class MainActivity : AppCompatActivity() {
                     '  .statusbar-item { min-height: 32px !important; padding: 0 8px !important; }',
                     '  .context-view .action-item { min-height: 40px !important; }',
                     '  .context-view .action-label { padding: 6px 12px !important; }',
+                    // The three floors above are for buttons, and a menu separator
+                    // is an .action-item too: it sits inside the activity bar when
+                    // the compact menubar is open and inside .context-view for a
+                    // right-click menu, so both floors land on a 1px divider and
+                    // render it as a blank band. Measured on an API 37 emulator at
+                    // 411px portrait, with the build-time menu CSS in play: the File
+                    // menu's seven separators were 71px each and the menu 1427px in
+                    // an 810px viewport, which is most of why it overflows at all.
+                    // Both halves have to go, the label's and the item's, because
+                    // either one alone still holds the row open.
+                    '  .activitybar .action-label.separator,',
+                    '  .context-view .action-label.separator { min-height: 0 !important; padding: 0 !important; line-height: normal !important; }',
+                    // Dropped whole by a WebView without :has() (Chromium 105; this
+                    // build floors at 107), which leaves the divider as it was rather
+                    // than breaking the rules around it.
+                    '  .activitybar .action-item:has(> .action-label.separator),',
+                    '  .context-view .action-item:has(> .action-label.separator) { min-height: 0 !important; }',
                     // Unprefixed, so it is wider than its name: the workbench also uses
                     // .slider for the colour picker, not only the scrollbar. Harmless
                     // there because that strip is already far wider than 12px, but

--- a/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
@@ -1556,7 +1556,11 @@ class FirstRunSetup(
             val content = String(existing, Charsets.ISO_8859_1)
             val additions = StringBuilder()
             val added = mutableListOf<String>()
-            if (!content.contains("npm()")) {
+            // [npmBlockMarker], not `npm()`, and the difference is what lets this
+            // block ever change again: every install that already has the pair
+            // matches `npm()`, so that guard froze whatever the release which
+            // first wrote the file happened to say.
+            if (!content.contains(npmBlockMarker)) {
                 additions.append(npmBashFunctions())
                 added += "npm/npx"
             }
@@ -1569,10 +1573,10 @@ class FirstRunSetup(
                 added += "claude"
             }
             // One rewrite through a temporary file rather than an append per
-            // block. Each guard above reads a string its own block opens with,
-            // so an append killed partway certified itself: `npm()` was there,
-            // its body was not, and no later launch would add the rest. The two
-            // decisions stay separate; only the write is shared.
+            // block. A guard that reads a string its own block opens with
+            // certifies a partial append: `claude()` is there, its body is not,
+            // and no later launch adds the rest. The two decisions stay
+            // separate; only the write is shared.
             if (additions.isNotEmpty()) {
                 val names = added.joinToString(" and ")
                 if (writeAtomically(bashrc) { it.write(existing); it.write(additions.toString().toByteArray()) }) {
@@ -2094,14 +2098,62 @@ class FirstRunSetup(
         Logger.i(tag, "Guarded the startup cd in .bashrc ($STARTUP_DIR_VERSION)")
     }
 
+    /**
+     * The marker [createNpmWrappers] guards the block below on.
+     *
+     * `npm()` was the guard until the note arrived, and it cannot be: an install
+     * that already has the pair matches it, so the block would never reach the
+     * devices the note is for. Keyed on the newest thing in the block instead,
+     * which leaves a `.bashrc` written by an older release carrying two `npm`
+     * definitions. bash takes the last one, so that is the one that runs, and
+     * appending is the only way to change a file the user is free to edit.
+     */
+    private val npmBlockMarker = "__vscodroid_symlink_note()"
+
     private fun npmBashFunctions(): String = """
 
 # npm/npx: shell functions (SELinux blocks exec of scripts under filesDir)
 # VSCODROID_PLATFORM_FIX=1: override process.platform to "linux" for npm only
 # (child processes like Rollup/esbuild see real "android" platform)
 # --prefer-offline: use local cache first, saves time on slow mobile connections
-npm() { VSCODROID_PLATFORM_FIX=1 node "${'$'}PREFIX/lib/node_modules/npm/bin/npm-cli.js" --prefer-offline "${'$'}@"; }
+npm() {
+    VSCODROID_PLATFORM_FIX=1 node "${'$'}PREFIX/lib/node_modules/npm/bin/npm-cli.js" --prefer-offline "${'$'}@"
+    # Captured before anything else runs, and handed back below, so wrapping the
+    # command cannot change what a script or a task sees.
+    local __npm_status=${'$'}?
+    [ ${'$'}__npm_status -eq 0 ] || __vscodroid_symlink_note
+    return ${'$'}__npm_status
+}
 npx() { VSCODROID_PLATFORM_FIX=1 node "${'$'}PREFIX/lib/node_modules/npm/bin/npx-cli.js" "${'$'}@"; }
+
+# One line of cause when npm fails somewhere that cannot hold a symbolic link.
+# npm writes node_modules/.bin/<name> as a link for every package that ships an
+# executable, which is most of them, and shared storage is served through FUSE,
+# which has no symlink(2) at all: the install dies with EPERM on a .bin path that
+# says nothing about where the folder lives. Measured on an API 37 emulator:
+# `ln -s` under Android/data answers "Permission denied" where the same call
+# under the app's own files directory succeeds.
+#
+# The directory is ASKED rather than its path matched, so this says nothing about
+# a workspace it does not recognise and nothing at all where links do work. Once
+# per shell, because it is a property of the folder rather than of the command,
+# and on stderr, because BASH_ENV is read by the shell behind every $(...) and
+# stdout there belongs to whoever wrote the substitution.
+__vscodroid_symlink_note() {
+    [ -n "${'$'}{__VSCODROID_SYMLINK_NOTED-}" ] && return 0
+    # A directory nobody may write refuses the probe for its own reason, and a
+    # note blaming symlinks for that would be wrong.
+    [ -w . ] || return 0
+    local probe=".vscodroid-symlink-probe.${'$'}${'$'}"
+    if ln -s . "${'$'}probe" 2>/dev/null; then
+        rm -f "${'$'}probe" 2>/dev/null
+        return 0
+    fi
+    __VSCODROID_SYMLINK_NOTED=1
+    echo "vscodroid: this folder is on shared storage, which cannot hold symbolic links," >&2
+    echo "vscodroid: so npm cannot create node_modules/.bin here. Move the project to" >&2
+    echo "vscodroid: internal storage and open it there:  mv \"${'$'}PWD\" ~/" >&2
+}
 """
 
     /**
@@ -2220,7 +2272,7 @@ claude() {
                 This is your default projects directory. Create folders here to start coding.
 
                 Your default projects are stored at:
-                `Android/data/${context.packageName}/files/projects/`
+                `${projectsDir.absolutePath}/`
 
                 The same directory is `~/projects` in the terminal, which is where
                 new terminals start.
@@ -2538,6 +2590,7 @@ claude() {
         val defaults = """
             {
                 "workbench.secondarySideBar.defaultVisibility": "hidden",
+                "workbench.sash.size": 20,
                 "workbench.startupEditor": "none",
                 "workbench.colorTheme": "Default Dark Modern",
                 "editor.fontSize": 14,
@@ -3868,6 +3921,13 @@ private val VERIFY_SIGNATURE = Regex(""""extensions\.verifySignature"\s*:""")
 private val SECONDARY_SIDE_BAR = Regex(""""workbench\.secondarySideBar\.defaultVisibility"\s*:""")
 
 /**
+ * Whether the user's settings already mention the sash size.
+ *
+ * Presence alone, either value, for the reason [VERIFY_SIGNATURE] gives.
+ */
+private val SASH_SIZE = Regex(""""workbench\.sash\.size"\s*:""")
+
+/**
  * The two settings that route Python environment discovery through `pet`, the
  * Python extension's native locator.
  *
@@ -4756,6 +4816,15 @@ internal fun refreshManagedPaths(
             "workbench.secondarySideBar.defaultVisibility",
             "\"hidden\"",
         )
+    }
+
+    // Same reach and the same one-way rule. Upstream registers this default as
+    // `isIOS ? 20 : 4`, and Android is in neither branch, so every view divider
+    // in this build is a 4px target for a finger. 20 is the maximum the setting
+    // registers and the value upstream already picked for the other touch
+    // platform, so this is that decision extended rather than a new one.
+    if (!SASH_SIZE.containsMatchIn(updated)) {
+        updated = insertSetting(updated, "workbench.sash.size", "20")
     }
 
     // Reaches installs that already have a settings.json, which is every device

--- a/android/app/src/main/kotlin/com/vscodroid/util/Environment.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/util/Environment.kt
@@ -2,6 +2,7 @@ package com.vscodroid.util
 
 import android.content.Context
 import android.net.Uri
+import android.system.Os
 import com.vscodroid.setup.ToolchainManager
 import java.io.File
 import java.security.MessageDigest
@@ -166,30 +167,63 @@ object Environment {
     fun getServerScript(context: Context): String =
         "${context.filesDir}/server/server.js"
 
+    /**
+     * The default workspace: internal storage, unless this install already put
+     * the user's work on shared storage.
+     *
+     * It used to be `getExternalFilesDir(null)/projects` for everyone, chosen so
+     * that a file manager could reach the code. That reachability is gone:
+     * Android 11 closed `Android/data` to other apps and to the system Files
+     * app, and minSdk here is 33, so no supported device has it. A few routes
+     * remain (MTP over USB, some OEM managers), which is how the folder gets
+     * deleted from outside at all, but nothing a user can rely on.
+     *
+     * What did not go away is the filesystem. Shared storage is served through
+     * FUSE, which does not implement `symlink(2)` at all, so every symlink an
+     * ordinary toolchain writes fails with EPERM: measured on an API 37
+     * emulator, `ln -s` under `Android/data/<pkg>/files/projects` answers
+     * "Permission denied" while the same call under `filesDir` succeeds. That
+     * cost `npm install` any package shipping an executable, because npm writes
+     * `node_modules/.bin/<name>` as a link and dies on the first one, and it
+     * costs pnpm, a Python venv without `--copies` and any build step that links.
+     * The npm failure names a `.bin` path and an EPERM, neither of which a user
+     * has any reason to connect to where the folder lives.
+     *
+     * An install that already has a projects directory on shared storage keeps
+     * it, and that is not caution for its own sake: `.bashrc` bakes
+     * `PROJECTS_DIR` in when it is first written and nothing rewrites it, so an
+     * answer that moved under an existing install would leave every terminal
+     * starting somewhere the editor is not. Moving the user's own files is not
+     * something to do behind their back either. The directory's own existence is
+     * the record, because nothing creates it any more: a fresh install never has
+     * one and an install that does can only have got it from a release where it
+     * was the default.
+     *
+     * Clear Data still wipes whichever of the two is in use, and work that has to
+     * stay reachable from outside the app still belongs in a folder opened
+     * through the SAF picker. Neither of those changed with the location.
+     */
     fun getProjectsDir(context: Context): String {
-        // App-external storage, which needs no permission.
-        // Path: /storage/emulated/0/Android/data/<pkg>/files/projects
-        //
-        // "visible in file managers" is what this comment claimed until
-        // 2026-08-16, and it is not something to rely on. Android 11 closed
-        // Android/data to other apps and to the system Files app, and minSdk
-        // here is 33, so no supported device has the unrestricted access the
-        // claim assumed. Some routes remain (MTP over USB, a few OEM managers),
-        // which is how the projects folder gets deleted from outside at all;
-        // see the CHANGELOG entry about surviving exactly that.
-        //
-        // The consequence that matters is the one for Clear Data: it wipes this
-        // directory, and a user cannot count on being able to copy anything out
-        // first. docs/USER_GUIDE.md carries the warning and the rescue steps
-        // where it recommends clearing. Work that has to stay reachable from
-        // outside the app belongs in a folder opened through the SAF picker.
-        val externalDir = context.getExternalFilesDir(null)
-        return if (externalDir != null) {
-            File(externalDir, "projects").absolutePath
-        } else {
-            // Fallback to internal storage if external unavailable
-            "${context.filesDir}/home/projects"
-        }
+        val filesDir = context.filesDir.absolutePath
+        val internal = "$filesDir/projects"
+        val externalDir = context.getExternalFilesDir(null) ?: return internal
+        val legacy = File(externalDir, "projects")
+        if (legacy.isDirectory) return legacy.absolutePath
+        // Answered before the link is read, so the ordinary case costs one stat
+        // and no syscall: once either directory is there, that is the answer.
+        if (File(internal).isDirectory) return internal
+        // Neither is on disk, which happens twice: on the first launch of a
+        // fresh install, and after something outside the app deleted the shared
+        // storage directory, which is what ensureProjectsDir() exists to repair.
+        // Telling those apart matters, because answering "internal" for the
+        // second would move an existing install's workspace on the strength of a
+        // deletion, with `.bashrc` still exporting the old path. `~/projects` is
+        // written beside the directory and outlives it, so its target is the
+        // record of which one this install has been using. Os.readlink throws off
+        // a device and on anything that is not a link, and both mean the same
+        // thing here: no such record.
+        val link = runCatching { Os.readlink("$filesDir/home/projects") }.getOrNull()
+        return if (link == legacy.absolutePath) legacy.absolutePath else internal
     }
 
     fun getHomeDir(context: Context): String =

--- a/android/app/src/test/kotlin/com/vscodroid/MenuSeparatorFloorTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/MenuSeparatorFloorTest.kt
@@ -1,0 +1,100 @@
+package com.vscodroid
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * That no touch-target floor this project writes lands on a menu separator.
+ *
+ * A separator in a Monaco menu is an `.action-item` like every other row, and
+ * its label carries `.separator`. Two places here raise a minimum height on
+ * `.action-item` so a finger has something to hit: the CSS `MainActivity`
+ * injects, and the block `scripts/build-vscode-oss.sh` appends to
+ * `workbench.css` at build time. Both floors reach the divider, and a 1px line
+ * held open to 44px is a blank band.
+ *
+ * Measured on an API 37 emulator at 411px portrait before the exemptions: each
+ * of the File menu's seven separators was 71px and the menu was 1427px tall in
+ * an 810px viewport. With them: 11px and 1007px, every real row still 44px.
+ * That is 420px of nothing, on the one menu that is the only route to File,
+ * Edit, Selection, View, Go, Run and Terminal on a phone.
+ *
+ * Reading source rather than rendering, because the property is a CSS rule
+ * inside a string literal in one file and inside a heredoc in another, and no
+ * JVM test can lay either out. So this cannot see a rule that is present and
+ * wrong, only one that is absent: what it defends against is the next floor
+ * being added without its exemption, which is exactly how these two arrived.
+ */
+class MenuSeparatorFloorTest {
+
+    private val injected: String =
+        SourceScan.body(
+            SourceScan.read("src/main/kotlin/com/vscodroid/MainActivity.kt"),
+            "private fun injectTouchTargetCSS(",
+        )
+
+    /** The repository root is two levels above `android/app`, this suite's working directory. */
+    private val buildScript: String = File("../../scripts/build-vscode-oss.sh").also {
+        check(it.isFile) {
+            "${it.absolutePath} not found; a case reading it would pass by looking at nothing"
+        }
+    }.readText()
+
+    private val mobileMenuBlock: String =
+        buildScript.substringAfter("/* VSCodroid: Mobile-friendly hamburger menu overrides */")
+            .substringBefore("CSSEOF")
+
+    @Test
+    fun `the injected floors exempt a separator label`() {
+        assertTrue(
+            injected.contains(".activitybar .action-label.separator") &&
+                injected.contains(".context-view .action-label.separator"),
+            "MainActivity raises .activitybar/.context-view .action-label to 44px and the " +
+                "compact menubar's menus render inside both, so a separator label needs the " +
+                "floor lifted or the divider is drawn as a blank band",
+        )
+    }
+
+    @Test
+    fun `the injected floors exempt the separator's own row`() {
+        assertTrue(
+            injected.contains(".activitybar .action-item:has(> .action-label.separator)") &&
+                injected.contains(".context-view .action-item:has(> .action-label.separator)"),
+            "the label exemption alone is not enough: the row's own min-height still holds " +
+                "it open, measured at 44px with the label already flat",
+        )
+    }
+
+    @Test
+    fun `the build-time menu block exempts a separator`() {
+        assertTrue(
+            mobileMenuBlock.contains(".action-label.separator") &&
+                mobileMenuBlock.contains("min-height: 0 !important"),
+            "the block appended to workbench.css floors .action-item at 44px and gives every " +
+                "label 8px of padding with a 28px line box; both reach the divider",
+        )
+        assertTrue(
+            mobileMenuBlock.contains(
+                ".monaco-menu .monaco-action-bar.vertical .action-item:has(> .action-label.separator)",
+            ),
+            "and so does the row's own floor",
+        )
+    }
+
+    @Test
+    fun `every action-item floor this project writes is paired with an exemption`() {
+        val floors = Regex("""\.action-item\s*\{[^}]*min-height:\s*(\d+)px""")
+        listOf("injected CSS" to injected, "build-time menu block" to mobileMenuBlock)
+            .forEach { (where, css) ->
+                floors.findAll(css).forEach { m ->
+                    val px = m.groupValues[1].toInt()
+                    assertTrue(
+                        px == 0 || css.contains(".action-item:has(> .action-label.separator)"),
+                        "$where floors .action-item at ${px}px with no separator exemption " +
+                            "beside it, which renders every menu divider as a ${px}px band",
+                    )
+                }
+            }
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/setup/BashrcAtomicityTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/BashrcAtomicityTest.kt
@@ -261,6 +261,51 @@ class BashrcAtomicityTest {
         assertTrue(written.contains("alias ll="), "the append lost what was already there")
     }
 
+    /**
+     * The block has to be able to change again, which `npm()` as its own guard
+     * made impossible: every install that has ever run this matches that string,
+     * so whatever the release which first wrote the file happened to say was
+     * frozen onto the device for good. What it says now includes the one line
+     * that explains an npm install failing in a folder on shared storage, which
+     * cannot hold the `node_modules/.bin` links npm writes, and those are exactly
+     * the installs that keep such a folder.
+     *
+     * Two definitions of `npm` in the file afterwards, and that is the trade:
+     * bash takes the last, and appending is the only way to touch a file the
+     * user is free to edit.
+     */
+    @Test
+    fun `an install that already has the old wrappers still gets the current block`() {
+        bundleNpm()
+        bashrc.appendText("\nnpm() { node /old/npm-cli.js; }\nnpx() { :; }\nclaude() { :; }\n")
+
+        FirstRunSetup(context).createNpmWrappers()
+
+        val written = bashrc.readText()
+        assertTrue(
+            written.contains("__vscodroid_symlink_note()"),
+            "an install with the older wrappers never receives a change to them",
+        )
+        assertTrue(
+            written.indexOf("/old/npm-cli.js") < written.lastIndexOf("npm()"),
+            "the current definition does not come last, so the older one is what bash runs",
+        )
+        assertTrue(written.contains("alias ll="), "the append lost what was already there")
+    }
+
+    /** Once it is there, a second launch must not append it again. */
+    @Test
+    fun `the block is not appended twice`() {
+        bundleNpm()
+        val setup = FirstRunSetup(context)
+
+        setup.createNpmWrappers()
+        val once = bashrc.readText()
+        setup.createNpmWrappers()
+
+        assertEquals(once, bashrc.readText(), "every launch appends the wrappers again")
+    }
+
     @Test
     fun `a failed npm wrapper append leaves the file as it was`() {
         bundleNpm()
@@ -271,7 +316,7 @@ class BashrcAtomicityTest {
         assertEquals(
             legacyBashrc,
             bashrc.readText(),
-            "a partial append survived; `npm()` opens this writer's own block, so a body " +
+            "a partial append survived; `claude()` opens this writer's own block, so a body " +
                 "cut short by process death would satisfy the guard and never be repaired",
         )
     }

--- a/android/app/src/test/kotlin/com/vscodroid/setup/NonInteractiveShellEnvTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/NonInteractiveShellEnvTest.kt
@@ -194,6 +194,85 @@ class NonInteractiveShellEnvTest {
         )
     }
 
+    /**
+     * What a user is told when npm fails in a folder that cannot hold a symlink.
+     *
+     * npm writes `node_modules/.bin/<name>` as a link for every package that
+     * ships an executable, and shared storage is served through FUSE, which has
+     * no `symlink(2)`: measured on an API 37 emulator, real npm in the default
+     * workspace exits 243 with `syscall: 'symlink'` and writes no `.bin` at all,
+     * while the same npm in the app's internal storage exits 0 and writes the
+     * link. New installs get internal storage; one that already put the user's
+     * work on shared storage keeps it, so this is the whole of what those
+     * installs have to go on, and without it the failure is a page of npm output
+     * with the cause nowhere in it.
+     *
+     * `ln` is overridden rather than a hostile filesystem arranged, because there
+     * is none to arrange on a build host. What that leaves untested is FUSE
+     * itself, which is what the device measurement covers; what it does test is
+     * every decision this makes around the probe.
+     */
+    @Test
+    fun `a folder that refuses a symlink gets one line of cause, once`() {
+        val bash = File("/bin/bash")
+        assumeTrue(bash.canExecute(), "no /bin/bash on this host to ask")
+
+        FirstRunSetup(context).createBashEnvFile()
+        val cwd = File(filesDir, "workspace").apply { mkdirs() }
+
+        val out = runBash(
+            cwd,
+            bashEnvFile().path,
+            """
+            node() { return 7; }
+            ln() { return 1; }
+            npm install; echo "first=${'$'}?"
+            npm install; echo "second=${'$'}?"
+            ls -a | grep probe || echo no-leftover-probe
+            """.trimIndent(),
+        )
+
+        assertEquals(
+            1, out.count { it.startsWith("vscodroid: this folder is on shared storage") },
+            "the cause was not named exactly once per shell: $out",
+        )
+        assertTrue(
+            out.any { it.contains("node_modules/.bin") },
+            "the note does not say what npm could not do: $out",
+        )
+        assertEquals(
+            listOf("first=7", "second=7"), out.filter { it.startsWith("first=") || it.startsWith("second=") },
+            "wrapping npm changed the exit status a script or a task sees: $out",
+        )
+        assertTrue(out.contains("no-leftover-probe"), "the probe was left in the user's folder: $out")
+    }
+
+    /**
+     * The control, and the reason the note tries a symlink rather than matching
+     * the path: a folder where links work must hear nothing, whatever npm did.
+     * Matching on a path would have to name the shared-storage layout, and would
+     * then be wrong for every workspace opened through the SAF picker, whose
+     * mirror is internal.
+     */
+    @Test
+    fun `a folder where symlinks work hears nothing about them`() {
+        val bash = File("/bin/bash")
+        assumeTrue(bash.canExecute(), "no /bin/bash on this host to ask")
+
+        FirstRunSetup(context).createBashEnvFile()
+        val cwd = File(filesDir, "workspace").apply { mkdirs() }
+
+        val failed = runBash(cwd, bashEnvFile().path, "node() { return 7; }\nnpm install; echo \"status=\$?\"")
+        assertFalse(
+            failed.any { it.startsWith("vscodroid:") },
+            "a folder that can hold links was told it cannot: $failed",
+        )
+        assertTrue(failed.contains("status=7"), "the exit status did not survive: $failed")
+
+        val ok = runBash(cwd, bashEnvFile().path, "node() { return 0; }\nnpm install; echo \"status=\$?\"")
+        assertEquals(listOf("status=0"), ok, "a successful npm said something: $ok")
+    }
+
     /** Non-empty lines of stdout+stderr from `bash -c $script`, run in [cwd]. */
     private fun runBash(cwd: File, bashEnv: String?, script: String): List<String> {
         val builder = ProcessBuilder("/bin/bash", "-c", script)

--- a/android/app/src/test/kotlin/com/vscodroid/setup/SettingsPathsTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/SettingsPathsTest.kt
@@ -45,9 +45,10 @@ class SettingsPathsTest {
         pythonLocator: String? = "js",
         envExtension: String? = "false",
         secondarySideBar: String? = "hidden",
+        sashSize: String? = "20",
     ) = """
         {
-        $preamble    "editor.fontSize": 14,${claudeWrapper?.let { "\n    \"claudeCode.claudeProcessWrapper\": \"$it\"," } ?: ""}${if (verifySignature) "\n        \"extensions.verifySignature\": false," else ""}${pythonLocator?.let { "\n        \"python.locator\": \"$it\"," } ?: ""}${envExtension?.let { "\n        \"python.useEnvironmentsExtension\": $it," } ?: ""}${secondarySideBar?.let { "\n        \"workbench.secondarySideBar.defaultVisibility\": \"$it\"," } ?: ""}
+        $preamble    "editor.fontSize": 14,${claudeWrapper?.let { "\n    \"claudeCode.claudeProcessWrapper\": \"$it\"," } ?: ""}${if (verifySignature) "\n        \"extensions.verifySignature\": false," else ""}${pythonLocator?.let { "\n        \"python.locator\": \"$it\"," } ?: ""}${envExtension?.let { "\n        \"python.useEnvironmentsExtension\": $it," } ?: ""}${secondarySideBar?.let { "\n        \"workbench.secondarySideBar.defaultVisibility\": \"$it\"," } ?: ""}${sashSize?.let { "\n        \"workbench.sash.size\": $it," } ?: ""}
             "terminal.integrated.profiles.linux": {
                 "bash": {
                     "path": "$bashPath",
@@ -310,6 +311,7 @@ class SettingsPathsTest {
                 """"extensions.verifySignature": false, "python.locator": "js", """ +
                 """"python.useEnvironmentsExtension": false, """ +
                 """"workbench.secondarySideBar.defaultVisibility": "hidden", """ +
+                """"workbench.sash.size": 20, """ +
                 """"editor.fontSize": 14 }"""
 
             assertNull(refreshManagedPaths(noGit, shell, git, wrapper))
@@ -325,6 +327,7 @@ class SettingsPathsTest {
                     "python.locator": "js",
                     "python.useEnvironmentsExtension": false,
                     "workbench.secondarySideBar.defaultVisibility": "hidden",
+                    "workbench.sash.size": 20,
                     "terminal.integrated.profiles.linux": {
                         "zsh": { "path": "$oldDir/libzsh.so" }
                     }
@@ -342,6 +345,74 @@ class SettingsPathsTest {
      * refreshed. Insertion touches a user's document, so what these cover is mostly
      * what must NOT change.
      */
+    /**
+     * The sash size, which reaches installs that already have a settings.json.
+     *
+     * Upstream registers the default as `isIOS ? 20 : 4` and Android is in
+     * neither branch, so every divider in this build is a 4px target for a
+     * finger. 20 is the maximum the setting registers and the value upstream
+     * already chose for the other touch platform. Insertion touches a user's
+     * document, so what these mostly cover is what must NOT change.
+     */
+    @Nested
+    inner class SashSize {
+
+        @Test
+        fun `adds the sash size when it is absent`() {
+            val result = refreshManagedPaths(
+                settings(shell, git, args = "[]", sashSize = null), shell, git, wrapper,
+            )
+
+            requireNotNull(result) { "a missing sash size must be added" }
+            assertTrue(
+                result.contains(""""workbench.sash.size": 20"""),
+                "sash size not inserted:\n$result",
+            )
+        }
+
+        @Test
+        fun `changes nothing else`() {
+            val before = settings(shell, git, args = "[]", sashSize = null)
+            val result = requireNotNull(refreshManagedPaths(before, shell, git, wrapper))
+
+            // The line is written with the first property's own indentation, so
+            // it is matched rather than spelled out; spelling it out asserted the
+            // indentation of this fixture and not the rule.
+            val stripped = result.lines().filterNot { it.trim().startsWith(""""workbench.sash.size"""") }
+            assertEquals(before, stripped.joinToString("\n"), "more than one line changed")
+        }
+
+        @Test
+        fun `leaves a size the user chose themselves`() {
+            // Presence alone decides, either value: someone who set 4 back meant to.
+            val before = settings(shell, git, args = "[]", sashSize = "8")
+            val result = refreshManagedPaths(before, shell, git, wrapper)
+
+            if (result != null) {
+                assertTrue(
+                    result.contains(""""workbench.sash.size": 8"""),
+                    "the user's size was overwritten:\n$result",
+                )
+                assertTrue(
+                    !result.contains(""""workbench.sash.size": 20"""),
+                    "the managed value was written beside it:\n$result",
+                )
+            }
+        }
+
+        @Test
+        fun `does not add a second key beside the user's own`() {
+            val before = settings(shell, git, args = "[]", sashSize = "8")
+            val result = refreshManagedPaths(before, shell, git, wrapper) ?: before
+
+            assertEquals(
+                1,
+                result.split(""""workbench.sash.size"""").size - 1,
+                "the key was written twice:\n$result",
+            )
+        }
+    }
+
     @Nested
     inner class ClaudeWrapper {
 

--- a/android/app/src/test/kotlin/com/vscodroid/util/EnvironmentTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/util/EnvironmentTest.kt
@@ -2,14 +2,21 @@ package com.vscodroid.util
 
 import android.content.Context
 import android.content.pm.ApplicationInfo
+import android.system.Os
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
 
 /**
  * Tests for [Environment]: path generation and environment configuration.
@@ -43,24 +50,101 @@ class EnvironmentTest {
         }
     }
 
+    /**
+     * Which filesystem a workspace lands on, which is not a matter of taste.
+     *
+     * Shared storage is served through FUSE and has no `symlink(2)`, so
+     * `npm install` cannot write `node_modules/.bin` for any package shipping an
+     * executable and dies with EPERM on a path that says nothing about storage.
+     * Measured on an API 37 emulator: `ln -s` under `Android/data` answers
+     * "Permission denied" and the same call under `filesDir` succeeds, and real
+     * npm reproduces both sides. So a new install gets internal storage.
+     *
+     * An install that already has a projects directory on shared storage keeps
+     * it. `.bashrc` exports `PROJECTS_DIR` when it is first written and nothing
+     * rewrites it, so an answer that moved under such an install would leave
+     * every terminal starting somewhere the editor is not, and the user's files
+     * would be somewhere neither of them looks.
+     *
+     * These cases were two assertions against fabricated paths, which could not
+     * see any of it: the decision is made of `isDirectory` questions, so the
+     * directories here are real.
+     */
     @Nested
     inner class ProjectsDirTest {
 
-        @Test
-        fun `getProjectsDir uses external storage when available`() {
-            val externalDir = File("/storage/emulated/0/Android/data/com.vscodroid/files")
-            every { context.getExternalFilesDir(null) } returns externalDir
+        @TempDir
+        lateinit var root: File
 
-            val result = Environment.getProjectsDir(context)
-            assertEquals("${externalDir.absolutePath}/projects", result)
+        private val projectsFilesDir by lazy { File(root, "files").apply { mkdirs() } }
+        private val externalDir by lazy { File(root, "external").apply { mkdirs() } }
+        private val legacy by lazy { File(externalDir, "projects") }
+
+        @BeforeEach
+        fun stubStorage() {
+            every { context.filesDir } returns projectsFilesDir
+            every { context.getExternalFilesDir(null) } returns externalDir
+            // Os throws off a device, and the production code reads that as "no
+            // link", so the case below would pass for the wrong reason. Routed to
+            // java.nio as [com.vscodroid.setup.ProjectsSymlinkTest] does, which
+            // makes the link and its target real.
+            mockkStatic(Os::class)
+            every { Os.readlink(any()) } answers {
+                Files.readSymbolicLink(Path.of(firstArg<String>())).toString()
+            }
+        }
+
+        @AfterEach
+        fun unstubOs() = unmockkStatic(Os::class)
+
+        @Test
+        fun `a fresh install gets internal storage, where a symlink can be made`() {
+            assertEquals("$projectsFilesDir/projects", Environment.getProjectsDir(context))
         }
 
         @Test
-        fun `getProjectsDir falls back to internal storage when external unavailable`() {
+        fun `an install that already has one on shared storage keeps it`() {
+            assertTrue(legacy.mkdirs(), "could not stage the directory an older release made")
+
+            assertEquals(legacy.absolutePath, Environment.getProjectsDir(context))
+        }
+
+        /**
+         * The deletion `FirstRunSetup.ensureProjectsDir` exists to repair: some
+         * routes outside the app still reach that directory. Answering "internal"
+         * for the launch after it would move an existing install's workspace on
+         * the strength of someone else's delete, and `.bashrc` would go on
+         * exporting the old path. `~/projects` is written beside the directory and
+         * outlives it, so it is the record of which one is in use.
+         */
+        @Test
+        fun `it keeps naming shared storage while the directory is missing`() {
+            val link = File(projectsFilesDir, "home/projects")
+            assertTrue(link.parentFile!!.mkdirs(), "could not stage the home directory")
+            Files.createSymbolicLink(link.toPath(), legacy.toPath())
+
+            assertEquals(legacy.absolutePath, Environment.getProjectsDir(context))
+        }
+
+        /**
+         * The control for the case above. A fresh install's `~/projects` names
+         * internal storage, so the link must not drag it back to the old place.
+         */
+        @Test
+        fun `a link into internal storage is not read as a shared-storage install`() {
+            val internal = File(projectsFilesDir, "projects")
+            val link = File(projectsFilesDir, "home/projects")
+            assertTrue(link.parentFile!!.mkdirs(), "could not stage the home directory")
+            Files.createSymbolicLink(link.toPath(), internal.toPath())
+
+            assertEquals(internal.absolutePath, Environment.getProjectsDir(context))
+        }
+
+        @Test
+        fun `it falls back to internal storage when shared storage is unavailable`() {
             every { context.getExternalFilesDir(null) } returns null
 
-            val result = Environment.getProjectsDir(context)
-            assertEquals("${mockFilesDir}/home/projects", result)
+            assertEquals("$projectsFilesDir/projects", Environment.getProjectsDir(context))
         }
     }
 

--- a/android/app/src/test/kotlin/com/vscodroid/webview/WebviewResourceRootsTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/WebviewResourceRootsTest.kt
@@ -40,7 +40,7 @@ private fun canonical(path: String) = File(path).canonicalPath
 private val ROOTS = listOf(
     "$FILES/server",
     "$FILES/home/.vscodroid/extensions",
-    "$FILES/home/projects",
+    "$FILES/projects",
     "$FILES/saf-mirrors",
 ).map(::canonical)
 
@@ -290,24 +290,44 @@ class PublishedResourceRootsTest {
             "a mirrored workspace"
         )
         assertNotNull(
-            resolveWebviewResource(File(externalDir, "projects/app/docs/diagram.png").path, roots),
+            resolveWebviewResource(File(filesDir, "projects/app/docs/diagram.png").path, roots),
             "the default workspace"
         )
     }
 
     /**
-     * Catches: covering the internal fallback by publishing its parent. When
-     * external storage is unavailable the projects directory moves to
-     * `<filesDir>/home/projects`, and the shortest root that covers it is
-     * `<filesDir>/home`, the directory holding `.ssh`.
+     * The other workspace location, which is not a variant but an install that
+     * predates the move: a projects directory already on shared storage keeps
+     * being the answer, so it has to keep being published or every image in a
+     * markdown preview stops loading for exactly the users who have one.
      */
     @Test
-    fun `the internal projects fallback does not publish the home directory`() {
+    fun `a workspace an existing install left on shared storage is still served`() {
+        File(externalDir, "projects").mkdirs()
+
+        val roots = publishedResourceRoots(contextWith(externalDir))
+
+        assertNotNull(
+            resolveWebviewResource(File(externalDir, "projects/app/docs/diagram.png").path, roots),
+            "the workspace an upgraded install is still using"
+        )
+    }
+
+    /**
+     * Catches: covering the internal workspace by publishing its parent. The
+     * default workspace is `<filesDir>/projects`, a sibling of `home` rather
+     * than a child of it, and that is load-bearing here: while it was
+     * `<filesDir>/home/projects` the shortest root covering it was
+     * `<filesDir>/home`, the directory holding `.ssh` and `.bashrc`. Moving it
+     * out took that widening off the table; this refuses its return.
+     */
+    @Test
+    fun `the internal workspace does not publish the home directory`() {
         val roots = publishedResourceRoots(contextWith(null))
 
         assertNotNull(
-            resolveWebviewResource(File(filesDir, "home/projects/app/docs/diagram.png").path, roots),
-            "the fallback workspace still has to work"
+            resolveWebviewResource(File(filesDir, "projects/app/docs/diagram.png").path, roots),
+            "the default workspace still has to work"
         )
         assertNull(resolveWebviewResource(File(filesDir, "home/.ssh/id_ed25519").path, roots))
         assertNull(resolveWebviewResource(File(filesDir, "home/.bashrc").path, roots))

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,25 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
+# The digest of the distribution named above, from Gradle's own publication of
+# it: services.gradle.org/distributions/gradle-9.7.1-bin.zip.sha256, which
+# redirects to downloads.gradle.org. Confirmed against the bytes rather than
+# copied from the checksum file alone -- the zip was downloaded and hashed, and
+# the two agree.
+#
+# Without this line the wrapper runs whatever the URL serves, which made the
+# build tool the one thing entering this tree with no digest behind it while
+# every GitHub Action is pinned by commit SHA and every Termux package is
+# checked against a signed index. Verification is the wrapper's own: a
+# distribution whose hash disagrees is refused before it is unpacked.
+#
+# Bumping Gradle means replacing this too. `gradle wrapper --gradle-version X`
+# rewrites this file from a fixed set of keys, so it drops the sum and these
+# lines with it unless the bump also passes
+# --gradle-distribution-sha256-sum <digest>. A missing sum is the silent half of
+# that mistake, which is why lint.yml refuses a tree without one; a wrong sum
+# fails loudly on the next invocation and needs no gate.
+distributionSha256Sum=acd53f1edaf02f1a8ff99879f8a34b302661a057d9b063ae9e35b552f804d20a
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/docs/07-TESTING_STRATEGY.md
+++ b/docs/07-TESTING_STRATEGY.md
@@ -97,12 +97,35 @@ temporary directory, and is executed directly by `node`.
 JavaScript runtime` step of `lint.yml`, and again in `release.yml`.
 
 **What is enforced**: the suites themselves. A single failing test fails the job.
-There is no coverage instrumentation in this project: no JaCoCo, no Kover, no
-coverage task, no threshold, and nothing in any workflow that reads one.
+No workflow reads a coverage figure, no threshold exists, and none is planned.
+That half of the position has not moved and is the half that matters: a number
+a build fails on is a number tests get written to move.
+
+What does exist is a report, on request and nowhere else:
+
+```bash
+./gradlew :app:createDebugUnitTestCoverageReport -PvscodroidCoverage
+```
+
+The switch is `enableUnitTestCoverage` on the debug build type, which is the
+Android plugin's own JaCoCo wiring rather than an added plugin, and it is behind
+a property because instrumenting every class the tests load makes for a slower
+and subtly different run. Without the property the task does not exist, so the
+suite CI gates on is the uninstrumented one.
+
+Read the output for which lines of a file are untested, never as a score. The
+recorded run in this checkout is 5,123 of 8,178 lines, 62.6 percent, and that
+denominator is JaCoCo's: it counts the classes the suite actually loads, so a
+class no JVM test can construct is absent from both halves rather than sitting
+in the miss column. The figure therefore moves with which classes the tests
+touch as much as with how well they touch them, which is why nothing gates on
+it. The question "is this file tested at all" is answered elsewhere and answers
+clean: every file under `android/app/src/main/kotlin` is named by at least one
+test source.
 
 ### 3.2 Instrumented Tests
 
-Forty-nine tests across eleven classes, in `android/app/src/androidTest/`. They
+Fifty tests across eleven classes, in `android/app/src/androidTest/`. They
 need an `arm64-v8a` device or emulator, because the app ships that ABI alone.
 Counted from the sources (`grep -cE '^\s*@Test'` over the directory), because no
 run covers the whole set and none of it is scheduled.

--- a/patches/0016-sidebar-sash-travel-on-narrow-viewports.patch
+++ b/patches/0016-sidebar-sash-travel-on-narrow-viewports.patch
@@ -1,0 +1,82 @@
+Give the side bar sash somewhere to travel on a phone-width viewport.
+
+The primary side bar cannot be resized in portrait. Its minimum width and its
+reachable maximum are the same number, so the sash between it and the editor is
+rendered disabled and dragging it does nothing.
+
+The editor part's minimum width is the smaller of its own 220px minimum and
+whatever the container has left once every other visible part sits at its own
+minimum. On a narrow viewport the second term wins, and that term is by
+construction "the container minus the side bar's minimum", so the side bar's
+reachable maximum comes out equal to its minimum and the split view has no range
+to offer. Lowering the side bar's own 170px minimum does not help: the collapse
+is structural and reproduces at any value.
+
+Measured in the shipped build on a 411px portrait viewport (activity bar 48,
+side bar 170): the editor reported 193, all three vertical sashes carried the
+disabled class, and a 122px drag on the side bar sash moved it by 0. Sweeping
+the viewport width put the boundary at 439px: 438 and below disabled, 439 and
+above enabled. A phone in portrait is 360 to 412.
+
+The fix splits the shortfall instead of handing all of it to the editor. When
+the container cannot afford the editor's own minimum, the editor asks for half
+of what is left. That is always a real reduction, so the sash always has
+somewhere to go, and it can never demand more room than exists. At 411px the
+side bar can now reach 266px rather than being pinned at 170.
+
+Wide windows keep the upstream behaviour: there the editor's own minimum is the
+smaller of the two and is returned unchanged, so the case the upstream min()
+exists to protect is untouched.
+
+Only the width is changed. minimumHeight has the same shape and is deliberately
+left alone: the editor's own minimum height is 70px, so the term that collapses
+the width never wins vertically on a phone. Nothing was measured about the panel
+sash and nothing here claims anything about it.
+
+One note for whoever tidies this later. this.centeredLayoutWidget.minimumWidth
+is read twice rather than hoisted into a local, and that is deliberate. The
+comparison against it is the token patches/fingerprints.txt matches to prove
+this patch reached the packaged bundle; a local name is minified away. If you
+hoist it, move that row to something the new shape introduces and check the
+replacement occurs zero times in an unpatched bundle first.
+
+diff --git a/src/vs/workbench/browser/parts/editor/editorPart.ts b/src/vs/workbench/browser/parts/editor/editorPart.ts
+index cd3ad87..6f056cd 100644
+--- a/src/vs/workbench/browser/parts/editor/editorPart.ts
++++ b/src/vs/workbench/browser/parts/editor/editorPart.ts
+@@ -1035,7 +1035,34 @@
+ 	//#region Part
+ 
+ 	// TODO @sbatten @joao find something better to prevent editor taking over #79897
+-	get minimumWidth(): number { return Math.min(this.centeredLayoutWidget.minimumWidth, this.layoutService.getMaximumEditorDimensions(this.layoutService.getContainer(getWindow(this.container))).width); }
++	get minimumWidth(): number {
++		// What is left for the editor once every other visible part is at ITS own
++		// minimum. Returning exactly that, which is what the line above did whenever
++		// it was the smaller of the two, keeps the layout satisfiable and at the same
++		// time pins the side bar: the side bar's reachable maximum is the container
++		// minus this number, so the two come out equal and the sash between them has
++		// nowhere to travel.
++		//
++		// Measured on a 411px portrait viewport, activity bar 48, side bar at its
++		// 170px minimum: the editor reported 193, the side bar's reachable maximum
++		// was 363 - 193 = 170, and all three vertical sashes rendered disabled.
++		// Dragging the side bar sash 122px moved it by 0. That held for every
++		// viewport narrower than 439px, which is every phone in portrait.
++		//
++		// Splitting what is left gives the sash somewhere to go and still never asks
++		// for more room than exists. Halving rather than clamping to a fixed floor,
++		// because a floor stops reducing anything once the leftover falls below it,
++		// and that is the narrow end where the pinning is worst.
++		//
++		// Wider viewports are untouched: there the editor's own minimum is the
++		// smaller of the two and is returned exactly as before.
++		//
++		// this.centeredLayoutWidget.minimumWidth is read twice rather than hoisted
++		// into a local. That comparison is what patches/fingerprints.txt matches to
++		// prove this reached the packaged bundle, and a local name is minified away.
++		const available = this.layoutService.getMaximumEditorDimensions(this.layoutService.getContainer(getWindow(this.container))).width;
++		return available < this.centeredLayoutWidget.minimumWidth ? available / 2 : this.centeredLayoutWidget.minimumWidth;
++	}
+ 	get maximumWidth(): number { return this.centeredLayoutWidget.maximumWidth; }
+ 	get minimumHeight(): number { return Math.min(this.centeredLayoutWidget.minimumHeight, this.layoutService.getMaximumEditorDimensions(this.layoutService.getContainer(getWindow(this.container))).height); }
+ 	get maximumHeight(): number { return this.centeredLayoutWidget.maximumHeight; }

--- a/patches/0017-menu-ignore-pan-started-in-submenu.patch
+++ b/patches/0017-menu-ignore-pan-started-in-submenu.patch
@@ -1,0 +1,95 @@
+Ignore a menu pan that started inside one of its own submenus.
+
+On a touch screen, dragging inside an open submenu closes it instead of
+scrolling it whenever the menu behind it can scroll as well. On a phone the
+application menu is the only route to File, Edit, Selection, View, Go, Run and
+Terminal, and its File submenu is taller than the screen, so scrolling it is the
+ordinary thing to do.
+
+The chain is short. A submenu container is appended inside the item that opens
+it, so it is a DOM descendant of the parent menu. Gesture dispatches a pan to
+every registered target that contains the touch's initial target, dispatching to
+each target separately, so the EventHelper.stop in the first handler cannot stop
+the second. The parent menu therefore scrolls from a finger that was inside the
+submenu, and a parent that scrolled dismisses its submenu, because the item the
+submenu is anchored to has moved.
+
+Patch 0014 does not cover this and is not made redundant by it. That one gates
+the dismissal on the parent having really scrolled, which saves the case where
+the parent cannot scroll at all and emits a scroll event anyway. Here the parent
+genuinely scrolls, so the dismissal is correct by its own rules and the submenu
+closes regardless.
+
+Measured in the shipped build on a 320px tall viewport, the application menu
+overflowing (360px of items in 250px) and the File submenu overflowing badly
+(1428px in 285px): one drag inside the submenu scrolled the parent menu 4px and
+the submenu was gone. The same drag with the parent short enough to fit scrolled
+the submenu 205px and kept it open, which is why a viewport that fits the parent
+hides this entirely. Menu.constructor caps a menu at innerHeight minus its own
+top minus 35, so the application menu with its eight items starts overflowing
+below about 430px of viewport height. Patch 0015 records that height measured at
+266 to 360 with the on-screen keyboard up.
+
+Gating on the initial target alone is not enough, and that was measured rather
+than assumed. The momentum events Gesture emits after the finger lifts carry no
+initial target at all: 15 of 18 events were ignored correctly, the remaining 3
+scrolled the parent 2.3px, and the submenu closed anyway. The answer is
+therefore remembered from the last event that carried a target, which is always
+a real finger movement, since momentum only ever follows one.
+
+With that in place the same drag ignored all 18 events, left the parent menu at
+0, and scrolled the submenu to 142px. A pan that started in the parent still
+scrolls the parent and still dismisses the submenu: measured on a viewport wide
+enough that the parent is not covered by the submenu, 0 events ignored, parent
+scrolled to its 110px maximum, submenu dismissed.
+
+diff --git a/src/vs/base/browser/ui/menu/menu.ts b/src/vs/base/browser/ui/menu/menu.ts
+index 7bb39f0..057fcaa 100644
+--- a/src/vs/base/browser/ui/menu/menu.ts
++++ b/src/vs/base/browser/ui/menu/menu.ts
+@@ -5,7 +5,7 @@
+ 
+ import { isFirefox } from '../../browser.js';
+ import { EventType as TouchEventType, Gesture } from '../../touch.js';
+-import { $, addDisposableListener, append, clearNode, Dimension, EventHelper, EventLike, EventType, getActiveElement, getWindow, IDomNodePagePosition, isAncestor, isInShadowDOM } from '../../dom.js';
++import { $, addDisposableListener, append, clearNode, Dimension, EventHelper, EventLike, EventType, getActiveElement, getWindow, IDomNodePagePosition, isAncestor, isHTMLElement, isInShadowDOM } from '../../dom.js';
+ import { createStyleSheet } from '../../domStylesheets.js';
+ import { StandardKeyboardEvent } from '../../keyboardEvent.js';
+ import { StandardMouseEvent } from '../../mouseEvent.js';
+@@ -265,8 +265,36 @@
+ 		this.styleScrollElement(scrollElement, menuStyles);
+ 
+ 		// Support scroll on menu drag
++		let panStartedInSubmenu = false;
+ 		this._register(addDisposableListener(menuElement, TouchEventType.Change, e => {
+ 			EventHelper.stop(e, true);
++
++			// A submenu is appended inside the item that opens it, so a pan that
++			// started in an open submenu is dispatched to this menu as well: the
++			// gesture goes to every registered target that DOM-contains the touch and
++			// each one is dispatched to separately, so the stop above cannot prevent
++			// it. Scrolling this menu then moves the item the submenu is anchored to,
++			// and an anchor that moved is exactly what dismisses a submenu, so one
++			// finger drag inside a long File menu closed it instead of scrolling it.
++			// Measured on a 320px tall viewport with the parent menu overflowing: this
++			// menu scrolled 4px and the submenu was gone.
++			//
++			// The momentum events that follow the finger up carry no initialTarget at
++			// all, so the answer is remembered from the last event that had one rather
++			// than recomputed per event. Deciding per event was measured too: the drag
++			// itself was ignored correctly and the momentum still scrolled this menu
++			// 2.3px and still closed the submenu.
++			//
++			// A pan that started in this menu still scrolls it and still dismisses the
++			// submenu, which is the case that dismissal exists for.
++			if (isHTMLElement(e.initialTarget)) {
++				const submenu = e.initialTarget.closest('.monaco-submenu');
++				panStartedInSubmenu = !!submenu && menuElement.contains(submenu);
++			}
++
++			if (panStartedInSubmenu) {
++				return;
++			}
+ 
+ 			const scrollTop = this.scrollableElement.getScrollPosition().scrollTop;
+ 			this.scrollableElement.setScrollPosition({ scrollTop: scrollTop - e.translationY });

--- a/patches/fingerprints.txt
+++ b/patches/fingerprints.txt
@@ -124,3 +124,18 @@
 # way to write that handler, deletes the token and the row starts failing on a
 # tree that is correct. The patch header says so at the call site too.
 0015 menubar keyboard resize|out/vs/code/browser/workbench/workbench.js|innerWidth===
+# 0016 gates on the comparison it introduces. Measured in the packaged pre-patch
+# workbench.js, `<this.centeredLayoutWidget.minimumWidth` occurs zero times while
+# the positive control `this.centeredLayoutWidget.minimumWidth` occurs once, so
+# the operator is what makes the token unique and the row cannot pass on the code
+# it replaces. Property names survive this bundle intact (the getter is emitted
+# with centeredLayoutWidget, layoutService and getMaximumEditorDimensions all
+# readable), so the token survives minification, and hoisting the read into a
+# local would delete it. The patch header says so at the call site too.
+0016 editor min width|out/vs/code/browser/workbench/workbench.js|<this.centeredLayoutWidget.minimumWidth
+# 0017 gates on the selector it introduces. Measured in the packaged pre-patch
+# workbench.js, `closest('.monaco-submenu')` occurs zero times while the class
+# name alone occurs three times, so the row cannot pass on the surrounding code
+# that creates the submenu. closest is a DOM method and the class is a string
+# literal, so neither is renamed.
+0017 menu pan ownership|out/vs/code/browser/workbench/workbench.js|closest('.monaco-submenu')

--- a/scripts/build-vscode-oss.sh
+++ b/scripts/build-vscode-oss.sh
@@ -685,7 +685,17 @@ cat >> "$WORKBENCH_CSS" << 'CSSEOF'
 .monaco-menu .monaco-action-bar.vertical .action-label { font-size: 14px !important; padding: 8px 24px 8px 12px !important; line-height: 28px !important; }
 .monaco-menu .submenu-indicator { font-size: 16px !important; }
 .monaco-menu .keybinding { font-size: 12px !important; }
-.monaco-menu .monaco-action-bar.vertical .action-label.separator { margin: 4px 8px !important; }
+.monaco-menu .monaco-action-bar.vertical .action-label.separator { margin: 4px 8px !important; min-height: 0 !important; padding: 0 !important; line-height: normal !important; }
+/* A separator is an .action-item whose label carries .separator, so the 44px
+   touch floor two rules above lands on the divider as well and renders a 1px
+   line as a blank band. Measured on an API 37 emulator, 411px portrait: each of
+   the File menu's seven separators was 71px and the menu was 1427px tall in an
+   810px viewport. Neutralising both halves puts them at 11px and the menu at
+   1007px with every real row still 44px. :has() is Chromium 105 and this build
+   floors at WebView 107; where it is missing the selector is dropped whole and
+   the divider stays as it was, which is the old behaviour rather than a broken
+   one. */
+.monaco-menu .monaco-action-bar.vertical .action-item:has(> .action-label.separator) { min-height: 0 !important; }
 CSSEOF
 grep -q "VSCodroid: Mobile-friendly" "$WORKBENCH_CSS" || { echo "  ERROR: append did not land" >&2; exit 1; }
 echo "  appended mobile menu overrides to workbench.css"

--- a/scripts/check-instrumented-inventory.py
+++ b/scripts/check-instrumented-inventory.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Hold androidTest/README.md to the suite it describes.
+
+    check-instrumented-inventory.py
+
+Nothing runs the instrumented suite. No runner this project has measured can
+(that README says why, with the error strings), so what CI does is compile it,
+and the only account of what the suite covers is prose in that file. A document
+that is the sole record of coverage, kept by hand, next to a directory nobody
+executes, is the exact shape that rots without anyone noticing.
+
+It did. The stated total read 22, then 37, against a suite that is neither, and
+three of its classes had no row in the table at all: two keyboard suites and the
+one covering the execution trampoline, which is the single claim no JVM test can
+settle. A reader working out whether to spend a minute on a device was being told
+the wrong size and the wrong contents.
+
+Two rules:
+
+  * the stated total matches the sources, counted the way the file itself says
+    it counts: `grep -cE '^\\s*@Test'` over the directory;
+  * every class carrying a `@Test` has a row in the "what is here" table, and
+    every row names a class that exists.
+
+The second is the one that actually decays. A count is one number and someone
+eventually re-runs the grep; a table gains rows only when whoever adds a suite
+remembers the table exists, and loses them only when someone notices a deleted
+class still listed. Neither happened.
+
+A file with no `@Test` in it is not a test class and is not expected in the
+table: `util/ServerReadyHelper.kt` is shared setup.
+"""
+
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+SUITE = ROOT / "android/app/src/androidTest/kotlin"
+README = ROOT / "android/app/src/androidTest/README.md"
+
+TEST = re.compile(r"^\s*@Test", re.M)
+# "**At HEAD there are 50 tests across eleven classes.**"
+STATED = re.compile(r"there are (\S+) tests across (\S+) classes", re.I)
+# A table row naming a class: `| `ServerHealthTest` | ... |`. The runner tables
+# higher up the file name runner images in the same cell shape, so the row is
+# recognised by its subject existing as a class rather than by position: an
+# entry that names no test class is reported, not silently skipped, which is
+# what would happen if this filtered on a heading.
+ROW = re.compile(r"^\|\s*`(\w+)`\s*\|", re.M)
+
+# Prose here writes small numbers as words and large ones as digits, and both
+# spellings appear in the sentence this parses. Refusing one of them would push
+# the file into an idiom it does not use anywhere else.
+WORDS = {w: i for i, w in enumerate(
+    "zero one two three four five six seven eight nine ten eleven twelve "
+    "thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty".split())}
+
+
+def number(token):
+    """`"50"` or `"eleven"` as an int, or None for anything else."""
+    token = token.strip(".*_ ").lower()
+    return int(token) if token.isdigit() else WORDS.get(token)
+
+
+def main() -> int:
+    if not SUITE.is_dir() or not README.is_file():
+        print(f"::error::{SUITE} or {README} is missing; this check would "
+              f"otherwise compare nothing")
+        return 1
+
+    counts = {}
+    for path in sorted(SUITE.rglob("*.kt")):
+        found = len(TEST.findall(path.read_text(encoding="utf-8")))
+        if found:
+            counts[path.stem] = found
+
+    # The left-hand side of both rules. An empty one would make each of them
+    # vacuously true, and "all classes documented" prints the same whether the
+    # table is complete or the glob stopped matching.
+    if not counts:
+        print(f"::error::no @Test found under {SUITE}; either the suite is gone "
+              f"or the pattern this file and the README both count with has "
+              f"stopped matching")
+        return 1
+
+    text = README.read_text(encoding="utf-8")
+    failed = False
+
+    stated = STATED.search(text)
+    if not stated:
+        print(f"::error::{README.name} no longer states a total in the form "
+              f"'there are N tests across M classes'; the sentence this check "
+              f"reads was reworded, so nothing holds the figure to the suite")
+        return 1
+
+    said_tests, said_classes = number(stated.group(1)), number(stated.group(2))
+    real_tests, real_classes = sum(counts.values()), len(counts)
+    if (said_tests, said_classes) != (real_tests, real_classes):
+        print(f"::error file={README.relative_to(ROOT)}::states "
+              f"{stated.group(1)} tests across {stated.group(2)} classes; the "
+              f"sources hold {real_tests} across {real_classes}")
+        failed = True
+    else:
+        print(f"  ok     the stated total is the suite's: {real_tests} tests "
+              f"across {real_classes} classes")
+
+    listed = set(ROW.findall(text))
+    undocumented = sorted(set(counts) - listed)
+    if undocumented:
+        print(f"::error file={README.relative_to(ROOT)}::{len(undocumented)} "
+              f"test class(es) have no row in the table, so the only account of "
+              f"what this suite covers omits them:")
+        for name in undocumented:
+            print(f"::error::  {name} ({counts[name]} tests)")
+        failed = True
+
+    # Only rows whose subject looks like a test class of this suite: the file
+    # legitimately names other classes in prose rows, and the runner tables use
+    # the same cell shape. A row for a class that has been deleted is the
+    # failure worth catching here.
+    ghosts = sorted(n for n in listed - set(counts)
+                    if n.endswith("Test") or n.endswith("InstrumentedTest"))
+    if ghosts:
+        print(f"::error file={README.relative_to(ROOT)}::{len(ghosts)} row(s) "
+              f"name a class this suite no longer has: {', '.join(ghosts)}")
+        failed = True
+
+    if not undocumented and not ghosts:
+        print(f"  ok     all {real_classes} test classes have a row, and no row "
+              f"names one that is gone")
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-workflow-steps.py
+++ b/scripts/check-workflow-steps.py
@@ -16,7 +16,7 @@ because that workflow is `workflow_dispatch` only and runs perhaps once per VS
 Code bump. The failure would have arrived a month later, on the one job whose
 output every app build depends on.
 
-Three assertions:
+Four assertions:
 
   * at least one workflow, carrying at least one step, was actually read. A
     checker that finds nothing reports nothing, and CI reads the exit code
@@ -27,7 +27,9 @@ Three assertions:
   * every `uses` reference is pinned to a full 40-character commit SHA. A
     floating tag is resolved at run time by whoever controls it, and these
     workflows publish the release assets, including the digest manifest that
-    non-Play toolchain installs verify against.
+    non-Play toolchain installs verify against;
+  * a workflow that can be started by hand AND by something else must not hand
+    the hand-started run a write-scoped token. See below.
 
 Both extensions are read. GitHub Actions runs `.yml` and `.yaml` alike, and a
 checker that knows only one of them would go on printing a healthy count while
@@ -35,7 +37,49 @@ the file it could not see carried exactly the defect this exists to catch.
 
 Deliberately not a general workflow linter. `actionlint` is that, and it is a
 Go binary this repository would have to fetch, pin and verify to run one check.
-These two questions are the ones that have actually gone wrong here.
+These questions are the ones that have actually gone wrong here.
+
+## Why the fourth one
+
+`release.yml` builds and signs, and then publishes: it creates the release and
+attaches the toolchain ZIPs and the `toolchains.sha256` that every non-Play
+install verifies against, under `releases/latest`. That pointer is read on every
+sideloaded install, including by devices already carrying a toolchain, so a
+release published off an arbitrary branch does not merely appear in a list. It
+moves what those devices resolve.
+
+That workflow now also takes `workflow_dispatch`, so the signed build can be
+exercised without publishing one -- and the only thing separating the two is a
+job-level `if:` on one job. Deleting that line is a one-character-looking edit
+whose consequence is invisible until a dispatched run has published.
+
+So: in a workflow declaring `workflow_dispatch` alongside at least one other
+trigger, a job whose token can write to this repository must be gated on a
+specific `github.event_name`, and that gate must not name `workflow_dispatch`
+at all. An allowlist, in other words, and `!= 'workflow_dispatch'` is refused
+even though it is correct as written: a denylist admits the next trigger added
+to the workflow without anyone deciding to, and this is the line whose quiet
+loosening the rule exists to prevent.
+
+The subject is the token scope rather than the step, because a rule that
+recognised publishing by naming `softprops/action-gh-release`, or by grepping
+for `gh release`, stops matching the day the same thing is written another way,
+and a rule that stops matching prints exactly what a clean tree prints. Nothing
+can create a release or attach an asset to one without `contents: write`.
+
+`contents` and not any write: `pages.yml` holds `pages: write` and deploys the
+documentation site from a hand-started run on purpose, which is a different
+question and not this one.
+
+A workflow whose ONLY trigger is `workflow_dispatch` is left alone, and that is
+the point of the "alongside" clause rather than an exemption:
+`build-vscode-oss.yml` is manual and publishing the server tarball is what it is
+for. Gating it on an event it can never see would fail every run.
+
+Gating on `github.event_name`, not on `github.ref`: a workflow_dispatch can be
+aimed at a tag ref, so a ref test alone is true for a dispatched run and would
+let one publish. A ref test beside the event test is fine and release.yml
+carries one; a ref test instead of it is the mistake this rule refuses.
 """
 
 import pathlib
@@ -77,16 +121,114 @@ def steps_of(doc):
             yield job_name, i, step
 
 
+def triggers_of(doc):
+    """The trigger names a workflow declares.
+
+    `on` is the one key that cannot be read by its name here. YAML 1.1 resolves
+    a bare `on` to the boolean True, which is what `yaml.safe_load` returns and
+    what GitHub's own schema tolerates, so `doc.get("on")` finds nothing on
+    every workflow in this tree. Both spellings are read rather than one, since
+    a quoted `"on":` in a future file would come back under the string.
+    """
+    raw = doc.get("on", doc.get(True))
+    if isinstance(raw, dict):
+        return set(raw)
+    if isinstance(raw, list):
+        return set(raw)
+    return {str(raw)} if raw else set()
+
+
+def writes_contents(doc, job) -> bool:
+    """Whether this job's GITHUB_TOKEN can write to the repository.
+
+    Job-level `permissions` replaces the workflow-level block outright rather
+    than merging with it, so the job's own is read first and the workflow's only
+    when the job declares none.
+
+    Neither declaring one is reported as write-capable, and that is the useful
+    reading rather than the strict one: with no block anywhere the scope is
+    whatever the repository's default workflow permissions happen to be, which
+    is a setting outside the file and outside review. Every workflow here
+    declares one, so this costs nothing today and starts acting the moment one
+    stops.
+
+    `contents` specifically. A job holding `pages: write` and nothing else can
+    deploy a site and cannot touch a release, and pages.yml deploys the docs
+    from a hand-started run on purpose.
+    """
+    perms = job.get("permissions", doc.get("permissions"))
+    if perms is None:
+        return True
+    if isinstance(perms, str):          # `permissions: write-all` / `read-all`
+        return perms != "read-all"
+    return perms.get("contents") == "write"
+
+
+def ungated_writers(path, doc):
+    """`(complaints, write-capable jobs examined)` for one workflow.
+
+    Jobs in `doc` that could write to the repository from a manual run.
+
+    Only asked of a workflow that takes `workflow_dispatch` together with some
+    other trigger. With that as its only trigger, writing is what the workflow
+    is for: `build-vscode-oss.yml` is manual and publishing the server tarball
+    is the whole of its job.
+
+    The question is asked of the token scope rather than of the steps, and that
+    is deliberate. A rule that recognised publishing by naming the action, or by
+    grepping for `gh release`, goes quiet the day the mechanism is written a
+    different way, and quiet is indistinguishable from clean. Nothing can create
+    a release or attach an asset without `contents: write`, so the capability is
+    the thing to look at.
+
+    It does not cover a step reaching for a personal access token out of a
+    secret, which needs no declared permission at all. Nothing here does that,
+    and no structural check of this shape could see it.
+    """
+    triggers = triggers_of(doc)
+    if "workflow_dispatch" not in triggers or len(triggers) < 2:
+        return [], 0
+
+    others = sorted(triggers - {"workflow_dispatch"})
+    bad, writers = [], 0
+    for job_name, job in (doc.get("jobs") or {}).items():
+        if not writes_contents(doc, job):
+            continue
+        writers += 1
+        gate = str(job.get("if") or "")
+        # The event has to be named, and workflow_dispatch must not appear at
+        # all -- an allowlist (`== 'push'`), never a denylist
+        # (`!= 'workflow_dispatch'`). Both read as correct today and they part
+        # company the moment a third trigger is added above: the allowlist keeps
+        # refusing everything it does not name, while the denylist admits the
+        # new one silently, which is the shape of edit this rule exists for.
+        if "github.event_name" not in gate or "workflow_dispatch" in gate:
+            bad.append(
+                f"{path.name}: job {job_name} can write to this repository "
+                f"(contents: write), and the workflow can be started by hand "
+                f"({', '.join(others)} and workflow_dispatch). Its job-level "
+                f"`if:` is {gate!r}, which does not hold a dispatched run back. "
+                f"Gate it on github.event_name, or drop the write scope; a "
+                f"github.ref test cannot stand in, because a dispatch can be "
+                f"aimed at a tag ref"
+            )
+    return bad, writers
+
+
 def main() -> int:
     failures = []
     checked_files = 0
     checked_steps = 0
+    gated_writers = 0
 
     paths = sorted(p for p in WORKFLOWS.iterdir()
                    if p.suffix in (".yml", ".yaml") and p.is_file())
     for path in paths:
         checked_files += 1
         doc = yaml.safe_load(path.read_text())
+        bad, writers = ungated_writers(path, doc)
+        failures.extend(bad)
+        gated_writers += writers - len(bad)
         for job, i, step in steps_of(doc):
             checked_steps += 1
             where = f"{path.name}: job {job}, step {i}"
@@ -127,6 +269,11 @@ def main() -> int:
     print(f"  ok     all {checked_steps} steps in {checked_files} workflows "
           f"have exactly one of uses/run")
     print(f"  ok     every uses reference is pinned to a full commit SHA")
+    # Zero is a legitimate answer and reads as one: it says no workflow that can
+    # be started by hand also holds a write-scoped job, which is the state this
+    # rule wants. It is not the empty-glob case the assertion above covers.
+    print(f"  ok     {gated_writers} write-scoped job(s) in a workflow that can "
+          f"also be started by hand, each gated on github.event_name")
     return 0
 
 


### PR DESCRIPTION
Three reported defects, all reproduced and measured on device, plus the
build-side items they exposed. Closes #366, #370 and #310.

## Side bar cannot be resized in portrait

The editor part's minimum width is the smaller of its own 220px and whatever
the container has left once every other visible part sits at its own minimum.
That second term is by construction "the container minus the side bar's
minimum", so the side bar's reachable maximum came out equal to its minimum and
the split view rendered the sash disabled.

Measured on a 411px portrait viewport: activity bar 48, side bar 170, editor
193, all three vertical sashes carrying `disabled`, and a 122px drag moving the
side bar by 0. Sweeping the viewport put the boundary at 439px, so it was every
phone in portrait.

`patches/0016` makes the editor ask for half of what is left rather than all of
it when the container cannot afford its own minimum. Halving rather than
clamping to a fixed floor, because a floor stops reducing anything once the
leftover falls below it, which is the narrow end where the pinning is worst.
Wider viewports are untouched: there the editor's own minimum is the smaller of
the two and is returned exactly as before.

Separately, `workbench.sash.size` is registered upstream as `isIOS ? 20 : 4` and
Android is in neither branch, so every divider was a 4px target for a finger. 20
is the maximum the setting registers and the value upstream already chose for
the other touch platform; it is now written to the shipped defaults and inserted
into an existing `settings.json` that has no opinion of its own.

## File menu closes instead of scrolling

A submenu is appended inside the item that opens it, so it is a DOM descendant
of the parent menu. Gesture dispatches a pan to every registered target that
contains the touch's initial target, separately, so the `EventHelper.stop` in
the submenu's own handler cannot prevent the parent's. The parent then scrolls
from a finger that was inside the submenu, and a parent that scrolled dismisses
its submenu, because the item it is anchored to has moved.

`patches/0017` ignores a pan that started inside a submenu. The answer is
remembered from the last event that carried an initial target rather than
recomputed per event: the momentum events Gesture emits after the finger lifts
carry none, and deciding per event was measured leaking three of them, which
scrolled the parent 2.3px and closed the submenu anyway. A pan that started in
the parent still scrolls it and still dismisses the submenu.

Patch 0014 does not cover this. That one gates the dismissal on the parent
having really scrolled; here the parent genuinely scrolls, so the dismissal is
correct by its own rules.

## Menu separators drawn as blank bands

The 44px touch floor this project adds applies to every `.action-item`, and a
separator is one, so a 1px divider was rendered as a 71px band. Seven of them
put 497px of nothing into a 1427px File menu, which is most of why it ran off
the screen at all. The floor and the label padding are now both lifted for
separators, in the injected CSS and in the block appended to `workbench.css`,
because either one alone still holds the row open.

Measured, 411px portrait: separators 71px to 11px, the File menu 1427px to
1007px, every real row still 44px.

## npm install fails in the default workspace

The default workspace was `getExternalFilesDir(null)/projects`, chosen so a file
manager could reach it. That reachability is gone: Android 11 closed
`Android/data` and minSdk here is 33. What did not go away is the filesystem.
Shared storage is served through FUSE, which implements no `symlink(2)`, so npm
died with EPERM on the first `node_modules/.bin` entry, naming a path that says
nothing about where the folder lives.

New installs get internal storage. An install that already has a projects
directory on shared storage keeps it, because `.bashrc` bakes `PROJECTS_DIR` in
once and nothing rewrites it, and moving a user's files behind their back is not
something to do at splash. `npm` now prints one line of cause on a failure in a
directory that refuses a link, measured rather than matched by path, so it says
nothing where links work.

## Build and CI

- `release.yml` takes `workflow_dispatch`, so the signed-build half can be
  exercised without publishing. It cannot publish: the release job is gated on
  `github.event_name == 'push'`, and the gate is on the trigger rather than the
  ref because a dispatch can be aimed at a tag.
- The Gradle distribution is pinned to `distributionSha256Sum`, verified against
  Gradle's own publication, and `lint.yml` refuses a tree without one. It was
  the only thing entering the build with nothing checking it.
- The instrumented tests are compiled in `release.yml` too, so a tag cut from a
  branch that reached neither of `build.yml`'s triggers cannot ship a suite that
  does not build. `scripts/check-instrumented-inventory.py` holds
  `androidTest/README.md` to the sources; its count had been wrong twice.
- An opt-in unit-test coverage report, using the Android plugin's own JaCoCo
  wiring rather than a new plugin. Nothing gates on the figure and the suite CI
  runs stays uninstrumented.

## Verification

- 2144 JVM tests, 0 failures. Lint clean. 20 python gates and 9 JavaScript
  self-checks exit 0.
- Code - OSS rebuilt from a wiped work volume: 66 verify checks, no failures,
  including both new patches reaching the packaged bundle. The server release
  is republished, so `fetch-vscode-oss.sh` resolves the tree these patches
  produce.
- All four fixes measured on API 33 and API 37 emulators, on the built APK:
  side bar 170 to 260 on a drag with the sash no longer disabled, separators
  11px with rows still 44px, a pan inside the File submenu scrolling it to 199
  with the parent left at 0, sashes 20px wide, and `node_modules/.bin/cli`
  created in the new workspace where the old one answers "Permission denied".
