### PR TITLE
test(setup): assert the asset length the resume skip trusts

### DIFF
--- a/android/app/src/androidTest/kotlin/com/vscodroid/setup/ExtractionOnDeviceTest.kt
+++ b/android/app/src/androidTest/kotlin/com/vscodroid/setup/ExtractionOnDeviceTest.kt
@@ -125,6 +125,25 @@ class ExtractionOnDeviceTest {
         } catch (expected: IOException) {
             // what extractAssetFile catches
         }
+
+        // available() on a freshly opened asset is its UNCOMPRESSED length, and
+        // that is the premise the resume path rests on: extractAssetFile skips a
+        // destination whose length already equals this number. Nothing in the
+        // APK is stored uncompressed (there is no noCompress rule), so a stream
+        // reporting the packed size instead would let a retry pass over a file
+        // it had not finished writing. Asserted against the bytes rather than
+        // against a constant, so it stays true whatever the asset is.
+        assets.open("extensions/$own/package.json").use { stream ->
+            val reported = stream.available().toLong()
+            val actual = stream.readBytes().size.toLong()
+            assertEquals(
+                "available() is not the uncompressed length, so the resume skip " +
+                    "in extractAssetFile would compare against the wrong number",
+                actual,
+                reported,
+            )
+            assertTrue("the asset used for this contract is empty", actual > 0)
+        }
     }
 
     /**

--- a/android/app/src/main/kotlin/com/vscodroid/bridge/AndroidBridge.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/bridge/AndroidBridge.kt
@@ -580,16 +580,19 @@ class AndroidBridge(
             //
             // `vscodroid://callback` is this app's own sign-in relay. Its VIEW
             // filter is exported and BROWSABLE, so handing one to `startActivity`
-            // delivers it straight back into `MainActivity.onNewIntent` -- and the
-            // arming below runs before the scheme is looked at, so the same call
-            // both opened the ten-minute window for the ids in the URL and posted
-            // the callback that window exists to judge. `AuthTabWindow`'s stated
-            // property is that an outside caller cannot supply a sign-in this app
-            // started; a caller that can reach this method could supply exactly
-            // that, and through the relay that is anything sharing the workbench's
-            // origin. Even with the arming moved, the launch alone lets such a
-            // caller deliver a payload of its own for an id a REAL sign-in has in
-            // flight, which is the half not arming would leave open.
+            // delivers it straight back into `MainActivity.onNewIntent`. While this
+            // test sat BELOW the arming, one call both opened the ten-minute window
+            // for the ids in the URL and posted the callback that window exists to
+            // judge. The order is now the other way round, and what follows is why
+            // the refusal is kept rather than only the reordering.
+            //
+            // `AuthTabWindow`'s stated property is that an outside caller cannot
+            // supply a sign-in this app started; a caller that can reach this
+            // method could supply exactly that, and through the relay that is
+            // anything sharing the workbench's origin. Even with the arming
+            // moved, the launch alone lets such a caller deliver a payload of its
+            // own for an id a REAL sign-in has in flight, which is the half not
+            // arming would leave open.
             //
             // Nothing legitimate is lost. A sign-in returns by the browser firing
             // this filter, never by the editor asking Android to open its own

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -22,9 +22,13 @@
     stays inside the app sandbox; copying it to a cloud is what breaks that trade.
   - `server`, `usr`, the toolchains: hundreds of megabytes, and first-run setup
     extracts them again from the APK anyway.
-  - `external`: the projects directory. A source tree with `node_modules` in it
-    would exceed any backup quota on its own, and this is the one thing users
-    already keep in git.
+  - `projects`, and `external` for an install that still has one there: the
+    workspace. A source tree with `node_modules` in it would exceed any backup
+    quota on its own, and this is the one thing users already keep in git. Both
+    spellings are named because the default moved to internal storage, which has
+    no `symlink(2)` problem, while an install that already had one on shared
+    storage keeps it; the allowlist covers each without naming it, and this line
+    is here so the next reader knows both exist.
   - `saf-mirrors`: local copies of folders the user picked through SAF. The
     originals are the documents; these are rebuilt on reopening.
   - `sharedpref`: load-bearing, and the least obvious entry on this list.


### PR DESCRIPTION
`extractAssetFile` skips a destination whose length already equals
`stream.available()`, so the resume path rests entirely on that call answering the
asset's uncompressed size. Nothing in the APK is stored uncompressed and nothing
asserted the premise; a stream reporting the packed size would let a retry pass
over a file it had not finished writing.

`ExtractionOnDeviceTest` is where the other AssetManager contracts are held to the
real platform, so it holds this one too, compared against the bytes rather than a
constant. Measured on API 33 and API 37: `available()` is the uncompressed length
on both.

Two comments corrected in the same pass:

- The backup rules described the workspace as living under the `external` domain.
  That stopped being the whole answer when the default moved to internal storage.
  Both spellings are now named; the allowlist already covered each, so the
  behaviour is unchanged.
- `openExternalUrl` still said the arming ran before the scheme test. That is what
  it did before the refusal was added, not what it does now.

## Verification

2144 JVM tests, lint clean, the instrumented suite compiles, and the new case runs
green on both emulators.