### PR TITLE
feat: stop bundling Material Icon Theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The testing document gives the command that measures the suite instead of a figure that goes stale the next time a test is added.
 - Packaging refuses a release whose bundled extension tree failed to build, which previously deleted the extension and reported success.
 - Kill Idle Servers is removed, along with the automatic kill under memory pressure and at 24 processes: a killed language server is restarted by its extension within a second, so no slot was ever freed.
+- Material Icon Theme is no longer bundled. It was 5.9 MB that nothing enabled: no default setting selected it, so it shipped inactive unless the user picked it. Install it from the Extensions view to keep using it.
 - The process tree marks language servers idle after five minutes without CPU and says that disabling the owning extension is what frees a slot.
 - The toolchain picker's Skip is a 48dp button, so a screen reader announces it as a control.
 - The "Starting server..." placeholder and the repeated-crash explanation are string resources, so translations reach them.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -174,7 +174,6 @@ Downloaded from Open VSX at build time (`scripts/download-extensions.sh`):
 
 | Extension | ID | License |
 |-----------|----|---------|
-| Material Icon Theme | PKief.material-icon-theme | MIT |
 | Prettier | esbenp.prettier-vscode | MIT |
 | Python | ms-python.python | MIT |
 | ESLint | dbaeumer.vscode-eslint | MIT |

--- a/docs/05-API_SPEC.md
+++ b/docs/05-API_SPEC.md
@@ -1042,7 +1042,6 @@ on first run:
 flowchart TD
   ROOT["assets/extensions/"] --> T["5 from Open VSX, fetched at build time"]
   ROOT --> O["4 first-party, source in git"]
-  T --> T1["PKief.material-icon-theme"]
   T --> T2["esbenp.prettier-vscode"]
   T --> T3["ms-python.python"]
   T --> T4["dbaeumer.vscode-eslint"]

--- a/docs/12-IMPLEMENTATION_PLAN.md
+++ b/docs/12-IMPLEMENTATION_PLAN.md
@@ -1540,7 +1540,6 @@ android/app/src/main/kotlin/com/vscodroid/
 ```
 android/app/src/main/assets/
 └── extensions/
-    ├── pkief.material-icon-theme/
     ├── esbenp.prettier-vscode/
     ├── dbaeumer.vscode-eslint/
     ├── ms-python.python/

--- a/docs/DEVICE_TEST_CHECKLIST.md
+++ b/docs/DEVICE_TEST_CHECKLIST.md
@@ -93,7 +93,7 @@
 | EX-2 | Install extension | Install any extension from search | Downloads, installs, shows in sidebar | | |
 | EX-3 | Extension webview | Open Claude Code or theme picker | Webview renders, interactive | | |
 | EX-4 | Persist across restart | Install extension, kill + relaunch app | Extension still installed and active | | |
-| EX-5 | Bundled extensions | Check Extensions sidebar after first run | Process Monitor + themes visible | | |
+| EX-5 | Bundled extensions | Check Extensions sidebar after first run | Process Monitor, SAF bridge, Serve on Network, Welcome, Python, ESLint, Prettier and Tailwind visible; no icon theme is bundled, so file icons are VS Code's own until the user installs one | | |
 | EX-6 | Uninstall extension | Uninstall a previously installed extension | Removed cleanly, no errors | | |
 
 ## 7. Background / Foreground

--- a/scripts/download-extensions.sh
+++ b/scripts/download-extensions.sh
@@ -81,7 +81,6 @@ apply_tree_rewrites() {
 # moving afterwards. Bump the version and the digest together; the published
 # value is still fetched below and a disagreement fails the build.
 EXTENSIONS=(
-    "PKief.material-icon-theme@5.37.0#ade9adefe3909cea92aed52850ddd00975d1dc1b62fe558831f6fb8b88f7c3ce"
     "esbenp.prettier-vscode@12.4.0#fb730ea4306d09cdc0a3aaa9e9baae28058cc97a4fbfce8b056b377a0639a9fe"
     "ms-python.python@2026.4.0#232aeafb01f069824fdd92d3e628c1c442bbcfa1d3cc945ff97076340bb2b4a6"
     "dbaeumer.vscode-eslint@3.0.34#ca5334d46f6a39079e751ef4601bfc9f86bc3a46483e87291ec609239d161308"


### PR DESCRIPTION
Material Icon Theme was 5.9 MB of the asset tree that nothing turned on.

No default setting selects it. There is no `workbench.iconTheme` anywhere in
the Kotlin, in `server.js`, or in the settings first-run writes, so it shipped
inactive on every install and cost its size whether or not the user wanted it.
Measured on an API 33 emulator: a user who wanted a newer build installed one
from Open VSX and the device then carried both, the bundled `5.37.0` sitting
unused beside the `5.38.1` that was actually in use.

## What changed

- Dropped from the `EXTENSIONS` list `scripts/download-extensions.sh` fetches.
- Dropped from the notices table in `NOTICE.md`, and from the two documents that
  listed it (`docs/05-API_SPEC.md`, `docs/12-IMPLEMENTATION_PLAN.md`).
- `docs/DEVICE_TEST_CHECKLIST.md` EX-5 now names the extensions that do ship and
  says file icons are the editor's own until the user installs a theme.

## Impact

File icons fall back to the editor's built-in theme, which is what an install
without an icon theme has always shown. Anyone who wants it installs it from the
Extensions view; nothing carries over from the bundle, because nothing selected
it in the first place.

The trees themselves are fetched at build time and gitignored, so the diff is
the list and the documents; the next build simply fetches one fewer.

## Verification

- `check-bundled-extensions.py`: green, and it derives the count from the list
  rather than from a walk, so it reports four bundled extensions now.
- 2225 JVM tests, 0 failures. `check-plain-punctuation`, `check-checklist-totals`,
  `check-document-dates`, `check-instrumented-inventory`, `check-build-steps` and
  `check-workflow-steps` all exit 0.
