### PR TITLE
docs: separate a missing Android build from a missing compiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A build that packages the app now fails loudly if the checks guarding its bundled tree have come unattached, instead of going quiet and shipping an unchecked tree.
 - Two accessibility guards stopped passing on code that is commented out, and one no longer loses its scope to a brace inside a comment.
 - The user guide no longer promises that certificate errors should not happen. It says which roots the bundle carries and that npm does not use it.
+- The user guide separates a package whose prebuilt binaries have no Android build from one that needs a compiler. The two fail differently and only the second has an alternative.
 - The picker's checked state and the Toolchains back-arrow label are now pinned by tests. Both are invisible to a sighted reviewer, so either could be deleted without a symptom.
 - Editing a layout or a string no longer leaves the unit suite up to date. Two suites read those files, and both were skipped on exactly the edits they exist to catch.
 - A test no longer states that AGP builds no release unit test task. It does build one, and it has run; what is true is that no workflow invokes it.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -611,6 +611,26 @@ The status bar shows a phantom process count. This tells you how many background
 
 Packages that require C/C++ compilation (node-gyp) fail on VSCodroid because there is no C compiler on the device. This affects packages like `better-sqlite3`, `bcrypt`, `sharp`, `canvas`, and `node-sass`. Pure JavaScript or WASM alternatives exist for most of them (see the [Web Development](#package-compatibility) section).
 
+### Packages With Prebuilt Binaries
+
+Some packages compile nothing. They download a ready-made binary chosen by
+platform name, from a fixed list their own installer carries, and Android is not
+on those lists. The install then stops with a message naming the platform it did
+not recognise, such as `Unsupported platform: android arm64 LE`. `workerd`, which
+Cloudflare Workers projects pull in through Wrangler, is one of these.
+
+Nothing on the device changes that. The Android build is not published, and
+taking the Linux one instead would fail later rather than sooner: it is built
+against a different C library, and an app may not execute a file from its own
+data directory.
+
+`npm install --ignore-scripts` installs the rest of the tree, so everything that
+does not need that particular binary works. What needs it does not run.
+
+This is not every package with a native part. Rollup and esbuild publish Android
+builds and install normally, which is why VSCodroid reports the platform it
+actually is rather than pretending to be Linux.
+
 ### Toolchains Must Be Started by Name
 
 Android refuses to execute any file inside an app's data directory, which is where
@@ -841,6 +861,7 @@ If `npm install` fails with errors:
 
 - **EACCES / permission errors** -- make sure you are working inside `~/projects/` or your home directory, not in a system path.
 - **node-gyp / compilation errors** -- the package requires native compilation. Use a pure JS alternative (see [Known Limitations](#native-npm-packages)).
+- **Unsupported platform errors** come from a package whose prebuilt binaries have no Android build, so there is nothing to install (see [Known Limitations](#packages-with-prebuilt-binaries)).
 - **Network timeout** -- check your internet connection. npm uses `--prefer-offline` by default, so cached packages install without network.
 
 ### Git Push/Pull Fails


### PR DESCRIPTION
The guide covered only packages that fail for want of a compiler. A package whose installer picks a prebuilt binary by platform name fails differently: it names a platform it does not recognise, and "use a pure JS alternative" is not the answer.

Reported in #375, where `npm install` stopped at `workerd`, whose installer carries a fixed list of platform keys with no Android entry. Cloudflare publishes no Android build, so nothing on the device changes it.

- A Known Limitations section for it, with the workaround that installs the rest of the tree.
- A bullet under npm Install Fails pointing at it, beside the node-gyp one.
- It also says Rollup and esbuild do publish Android builds and install normally, so the section is not read as covering every native package. Verified against both packages on the registry.

Docs only. No code paths touched.
