### PR TITLE
fix: harden device folders, setup, toolchains, the bridge and the build

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -122,9 +122,10 @@ jobs:
       - name: Check every workflow step is runnable and pinned
         run: python3 scripts/check-workflow-steps.py
 
-      # Three gates whose refusal has no file in the tree to fire on: every
+      # Four gates whose refusal has no file in the tree to fire on: every
       # release gate is an allowlist, every bundled executable names Android's
-      # loader, and every server tree carries the Copilot CLI licence. A
+      # loader, every server tree carries the Copilot CLI licence, and every
+      # patch in patches/ carries a number the manifest can key it by. A
       # refusal that has quietly stopped firing prints exactly what a clean
       # tree prints, so each one is handed the input it exists to refuse, and
       # a control it must accept, on every run.
@@ -133,6 +134,7 @@ jobs:
           python3 scripts/check-workflow-steps.py --self-test
           python3 scripts/verify-android-elf.py --self-test
           python3 scripts/verify-server-tree.py --self-test
+          python3 scripts/check-patch-fingerprints.py --self-test
 
       # The same question asked of the build tool itself, which the step above
       # cannot reach: `uses:` pinning covers the actions, and the wrapper

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - An install that copies a toolchain and then cannot record it no longer leaves the copy behind. Roughly 155 MB stayed with nothing able to name or remove it, on the full disk that caused the failure.
 - A heap ceiling set in settings is read past strings and comments. A glob such as `**/*.log` in an earlier value swallowed the setting, and one commented out could be applied instead.
 - A sign-in waiting for its callback is no longer dropped by a single address naming many requests. The record filled and evicted the entry the sign-in in flight was waiting for, and it hung with no message.
+- First-run setup writes its unpack to the medium before recording the run as finished. Losing power in that window left the app marked set up with the tail of the unpack missing, and nothing looked again.
+- Leaving the editor while a device folder is opening no longer leaves a file watcher running on the folder you closed. It kept writing the mirror back to the device for the rest of the session, and nothing could stop it.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- A file changed on the device is no longer replaced by the editor's copy when the sync record cannot account for it. The device version is set aside beside it first, and the write is held back if it cannot be read.
+- Installing a toolchain again after one failed part-way now asks only for the space the copy needs. The check charged for bytes the new copy was about to write over, so a device already holding most of the tree was refused every time.
+- The badge that says a modifier is still held is readable against the row it sits on. It was drawn in the accent blue, which this project's own contrast rule counts as too faint for text that size.
+- The bug report no longer says credentials were removed. It names which shapes are replaced and asks you to check, because a secret that arrives as an ordinary word cannot be told from one.
+
+### Changed
+
+- A patch file whose name the manifest cannot key now fails the build. It was applied to the server tree and then left out of every check that tracks patches.
+
 ## [1.2.0] - 2026-08-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Installing a toolchain again after one failed part-way now asks only for the space the copy needs. The check charged for bytes the new copy was about to write over, so a device already holding most of the tree was refused every time.
 - The badge that says a modifier is still held is readable against the row it sits on. It was drawn in the accent blue, which this project's own contrast rule counts as too faint for text that size.
 - The bug report no longer says credentials were removed. It names which shapes are replaced and asks you to check, because a secret that arrives as an ordinary word cannot be told from one.
+- Deleting a file in the editor now removes it from the device folder even when that copy had never been opened. It was kept, and the notice said the only copy was inside the app, which is the reverse of what happened.
+- An install that copies a toolchain and then cannot record it no longer leaves the copy behind. Roughly 155 MB stayed with nothing able to name or remove it, on the full disk that caused the failure.
+- A heap ceiling set in settings is read past strings and comments. A glob such as `**/*.log` in an earlier value swallowed the setting, and one commented out could be applied instead.
+- A sign-in waiting for its callback is no longer dropped by a single address naming many requests. The record filled and evicted the entry the sign-in in flight was waiting for, and it hung with no message.
 
 ### Changed
 

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -3975,12 +3975,14 @@ internal sealed interface BindDecision {
  */
 internal fun isWorkbenchUrl(url: String?, port: Int): Boolean {
     if (url == null || port <= 0) return false
-    // Named so they collide with nothing else in this file. `TokenTaint`, which
-    // guards this file against logging the connection token, follows taint by
-    // identifier name across the whole file: binding the parsed URL to `uri` or
-    // its host to `host` would mark two unrelated locals as token-bearing and
-    // report four honest log statements as leaks. The conservatism is the point,
-    // so the alias is what has to go.
+    // Named so they collide with nothing else in this file. `LogTaint`, which
+    // guards this file against logging the connection token or a device folder's
+    // tree URI, follows taint by identifier name across the whole file: binding
+    // the parsed URL to `uri` or its host to `host` would mark two unrelated
+    // locals as sensitive and report honest log statements as leaks. A `Uri`
+    // written as a type is a seed there too, so `val uri: Uri` is the same
+    // mistake spelled differently. The conservatism is the point, so the alias
+    // is what has to go.
     val parsed = runCatching { java.net.URI(url) }.getOrNull() ?: return false
     val hostName = parsed.host ?: return false
     return (hostName == "127.0.0.1" || hostName == "localhost") && parsed.port == port

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -905,8 +905,19 @@ class MainActivity : AppCompatActivity() {
         // Activity: reading `safManager` or `tag` from inside the lambda would
         // capture `this`, and with it the view tree, until the thread returns.
         //
+        // The shutdown rather than the stop, and that is what makes the detachment
+        // safe. The three calls in openSafFolder and restoreWatcherAfterFailure are
+        // serialised against each other by deviceFolderOpens; this one is outside it
+        // on purpose, so it can land in the middle of a start already running on
+        // Dispatchers.IO -- inside its own two-second drain, or inside the mirror
+        // walk -- and neither the mutex nor cancelling the scope can stop that start
+        // finishing afterwards. The shutdown is what the engine has to say "and
+        // nothing starts this again" with: the ordinary stop would be overtaken and
+        // leave observers and a write-back thread on an engine the replacement
+        // Activity, which builds its own manager, cannot reach.
+        //
         // Only half of what that costs was ever here, and the half that was is the
-        // smaller one: this thread ends when stopWatching does, about two seconds.
+        // smaller one: this thread ends when the shutdown does, about two seconds.
         // The manager it names is what outlives the Activity, because the engine
         // leaves the write-back worker running when the drain outruns that wait,
         // which is why the manager is built on the application context and why the
@@ -917,7 +928,7 @@ class MainActivity : AppCompatActivity() {
         if (stopping != null) {
             thread(name = "saf-watch-stop", isDaemon = true) {
                 try {
-                    stopping.stopFileWatcher()
+                    stopping.shutdownFileWatcher()
                 } catch (e: Exception) {
                     Logger.w(logTag, "Stopping the device folder watcher failed: ${e.message}")
                 }
@@ -1243,6 +1254,13 @@ class MainActivity : AppCompatActivity() {
                 // the user's own edits and pushes them onto the user's documents
                 // which is the exact damage the stop before the sync exists to
                 // prevent.
+                //
+                // `SafSyncEngine.shutdown()`, which is what `onDestroy` calls, now
+                // refuses that restart at the engine, so this is no longer the only
+                // thing standing between a cancelled scope and an unstoppable
+                // watcher. It stays because the rest of the handler is still wrong
+                // for a cancellation: a toast and a "sync failed" dialog for an
+                // Activity that is simply going away.
                 //
                 // Guarded because the window may already be gone: dismissing a
                 // dialog whose Activity has been destroyed throws, and an

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -658,17 +658,20 @@ class MainActivity : AppCompatActivity() {
             }
         }
 
-        // A directory deleted in the editor that stayed on the device, because it
-        // holds documents the sync never copied in and deleting it would have taken
-        // them. Its own wording again: the mirror copy is gone, so "the only copy is
-        // inside VSCodroid" would be exactly backwards.
-        safManager.onDirectoryKeptOnDevice { dir ->
+        // Something deleted in the editor that stayed on the device, because deleting
+        // it would have taken content the sync never copied in. Its own wording again:
+        // the mirror copy is gone, so "the only copy is inside VSCodroid" would be
+        // exactly backwards. Two sentences rather than one, because a directory was
+        // kept for what is inside it and a document was kept for what it is, and the
+        // engine has to say which: the entry is already unlinked by the time the event
+        // arrives, so nothing here can ask the disk.
+        safManager.onKeptOnDevice { kept, isDirectory ->
+            val message = appContext.getString(
+                if (isDirectory) R.string.saf_directory_kept else R.string.saf_document_kept,
+                kept.name,
+            )
             toMainThread.post {
-                Toast.makeText(
-                    appContext,
-                    appContext.getString(R.string.saf_directory_kept, dir.name),
-                    Toast.LENGTH_LONG,
-                ).show()
+                Toast.makeText(appContext, message, Toast.LENGTH_LONG).show()
             }
         }
 

--- a/android/app/src/main/kotlin/com/vscodroid/bridge/AndroidBridge.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/bridge/AndroidBridge.kt
@@ -116,8 +116,38 @@ private const val MAX_TRACKED_SIGN_INS = 32
  */
 private val AUTH_REQUEST_ID = Regex("""vscode-reqid(?:=|%(?:25)*3[Dd])(\d+)""")
 
+/**
+ * How many request ids one address may record.
+ *
+ * A bound, not a policy, and it is the record above that needs it. `launches`
+ * keeps the most recent [MAX_TRACKED_SIGN_INS] launches and evicts the eldest to
+ * stay there, while a URL can name as many ids as whoever wrote it cares to
+ * type, and both callers of this function record every id they are handed. So a
+ * single address carrying that many ids pushed out the sign-in the user had open
+ * in the browser at that moment, before any browser was even launched. Its
+ * callback then arrives for an id nothing recorded and is dropped in the log with
+ * no message at all, which leaves the extension waiting for ever on a value
+ * nothing will write.
+ *
+ * Eight rather than one because nobody has surveyed real authorisation addresses
+ * beyond the shapes in `AuthRequestIdTest`, and every one of those names exactly
+ * one request. The figure is generous on purpose: the cost of it being too low
+ * is a sign-in that cannot complete, and the cost of it being too high is only
+ * that fewer such addresses are needed to reach the same eviction.
+ *
+ * Taken off the lazy sequence rather than the finished list, so the scan stops
+ * once it has enough. The whole match runs on the thread the calling page is
+ * blocked on, and the address is that page's to choose.
+ *
+ * It does not close the eviction on its own, and should not be read as doing so.
+ * Enough separate launches still fill the record; what this removes is the
+ * variant that needs one call, no browser and nothing on screen.
+ */
+private const val MAX_AUTH_REQUEST_IDS = 8
+
 internal fun authRequestIdsIn(url: String): List<String> =
-    AUTH_REQUEST_ID.findAll(url).map { it.groupValues[1] }.distinct().toList()
+    AUTH_REQUEST_ID.findAll(url).map { it.groupValues[1] }
+        .distinct().take(MAX_AUTH_REQUEST_IDS).toList()
 
 /**
  * Why [AndroidBridge.openExternalUrl] did not open anything.

--- a/android/app/src/main/kotlin/com/vscodroid/keyboard/ExtraKeyRow.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/keyboard/ExtraKeyRow.kt
@@ -85,7 +85,7 @@ class ExtraKeyRow @JvmOverloads constructor(
      */
     private val modifierBadge = TextView(context).apply {
         setTextSize(TypedValue.COMPLEX_UNIT_SP, 11f)
-        setTextColor(context.getColor(R.color.colorExtraKeyActive))
+        setTextColor(context.getColor(R.color.colorPrimaryText))
         // Off, so the height this reports is its line height and nothing else.
         // The container below reserves exactly that, and a font-padding band
         // that varies by typeface would make the reservation wrong.

--- a/android/app/src/main/kotlin/com/vscodroid/service/ProcessManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/service/ProcessManager.kt
@@ -2315,8 +2315,19 @@ internal fun heapOverrideRaisesCeiling(
  * setting they believed was off had been suspended. The span is removed rather
  * than parsed around, because the reader wants nothing from inside it, and it is
  * removed non-greedily so a second comment further down does not swallow the
- * live key between the two. A comment opener sitting inside a string value is
- * read as starting one, which is a miss in the safe direction.
+ * live key between the two.
+ *
+ * Removing a comment means recognising one, and a delimiter is only a delimiter
+ * outside a string. That is not a hypothetical here: the default document this
+ * app writes plants three openers itself, inside the `<node_internals>` globs of
+ * its `launch` block, and no closer at all. `launch` is the last property and the
+ * workbench appends new keys after the last one, so a user's ceiling lands after
+ * all three openers, and the first exclude glob they add on the same settings tab
+ * supplies the closer. Everything between, the ceiling included, then read as one
+ * comment: the start summary said "derived from device RAM" while the settings
+ * editor went on showing the number, and for a value the user had LOWERED the
+ * fallback is the larger of the two. So [STRING_OR_COMMENT] walks strings and
+ * comments together in one left-to-right pass and keeps the strings.
  *
  * A regex over the text rather than a parse, for the reason
  * `FirstRunSetup.refreshManagedPaths` documents at length: parsing the document to
@@ -2330,14 +2341,25 @@ internal fun heapOverrideRaisesCeiling(
  * to the derived value is the safe reading of one.
  */
 internal fun heapOverrideFromSettings(content: String): Int? =
-    HEAP_SETTING_PATTERN.find(BLOCK_COMMENT.replace(content, ""))
-        ?.groupValues?.get(1)?.toIntOrNull()
+    HEAP_SETTING_PATTERN.find(
+        STRING_OR_COMMENT.replace(content) { if (it.value.startsWith("\"")) it.value else "" }
+    )?.groupValues?.get(1)?.toIntOrNull()
 
 private val HEAP_SETTING_PATTERN =
     Regex("""(?m)^\s*"${Regex.escape(HEAP_SETTING_KEY)}"\s*:\s*(\d+)""")
 
-/** A `/* ... */` span, shortest match, newlines included. */
-private val BLOCK_COMMENT = Regex("""/\*[\s\S]*?\*/""")
+/**
+ * A JSON string, a `//` comment, or a block comment, whichever starts first.
+ *
+ * Three arms and each one earns its place. The string arm leads so a delimiter
+ * inside a value is text, which is the whole point. The `//` arm is not
+ * decoration: a line comment is prose, an unbalanced quote in prose is ordinary,
+ * and without an arm of its own that quote opens a "string" that runs to the next
+ * quote in the file, takes the block opener after it inside, and hands a
+ * commented-out ceiling straight back to the anchor. The block arm is
+ * shortest-match, for the reason the reader's own documentation gives.
+ */
+private val STRING_OR_COMMENT = Regex(""""(?:\\.|[^"\\])*"|//[^\n]*|/\*[\s\S]*?\*/""")
 
 /**
  * Whether a user-chosen ceiling has spent its budget and must be ignored.

--- a/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
@@ -20,6 +20,7 @@ import java.security.KeyStore
 import java.security.MessageDigest
 import java.security.cert.Certificate
 import java.util.Base64
+import java.util.concurrent.TimeUnit
 import androidx.core.content.edit
 import android.annotation.SuppressLint
 
@@ -599,6 +600,19 @@ class FirstRunSetup(
             createDefaultSettings()
 
             reportProgress("Done!", 100)
+
+            // Before the flag, never after, and the order is the entire point.
+            // markSetupComplete() commits, and a commit fsyncs, so without this
+            // the record certifying an 875 MiB unpack is on the medium while the
+            // unpack itself is still page cache. A power cut there leaves
+            // isFirstRun() false over a tree with holes in it, and nothing on
+            // device checks that tree again: no repair path reads content, and
+            // only Clear Data or an app update re-extracts. See
+            // [flushWritesToMedia] for what this does not buy.
+            //
+            // The user sees this as a pause on "Done!", on Dispatchers.IO,
+            // behind a progress bar already at 100%.
+            flushWritesToMedia()
 
             markSetupComplete()
 
@@ -4563,6 +4577,93 @@ internal fun writeAtomically(
         releaseWriteLock(path, lock)
     }
 }
+
+/**
+ * Waits for what has been written so far to reach the storage medium.
+ *
+ * A barrier, not an atomicity guarantee, and that distinction is the whole of
+ * what this is for. [writeAtomically] already gives each file all-or-nothing
+ * CONTENT through a rename, and that much survives process death: once
+ * `write(2)` and `rename(2)` have returned the kernel owns the bytes, so a force
+ * stop, a low-memory kill or a phantom-process kill cannot take them back. What
+ * none of it survives is power loss or a panic, where the dirty pages die
+ * unwritten.
+ *
+ * That only matters because the completion flag is not symmetric with the
+ * payload it certifies. `SharedPreferences.commit()` writes the XML and then
+ * fsyncs it, `SharedPreferencesImpl.writeToFile` calling `FileUtils.sync`, which
+ * is `getFD().sync()`, so the record saying setup finished is on the medium
+ * while the several hundred MiB it vouches for may be nothing but page cache.
+ * Calling this first orders the run's writes ahead of the flag.
+ *
+ * What it does NOT buy, so that nobody reads it for more than it is:
+ *
+ * - It does not make any single file atomic. That is [writeAtomically]'s rename,
+ *   and it is unchanged.
+ * - It does not make the flush and the flag one event. Power loss DURING this
+ *   call leaves exactly the old ordering, over a window the length of the sync
+ *   rather than the length of the run. It narrows; it does not close.
+ * - It does nothing for a crash in the middle of extraction. The attempt marker
+ *   is committed before the first byte, so a retry still resumes over files this
+ *   never saw.
+ *
+ * `android.system.Os` has no `sync(2)`. Its only three entry points of that
+ * family are `fsync`, `fdatasync` and `msync`, checked against `android.jar` at
+ * compileSdk 37 and against the android-33 sources at minSdk, so a
+ * whole-filesystem barrier has to come from toybox, which has provided
+ * `/system/bin/sync` since Android 6. The in-process alternative is an `fsync`
+ * inside [writeAtomically], which is the same barrier spread over roughly 23,000
+ * extracted files at one journal commit each: minutes added to every cold
+ * install, to close a window measured in seconds.
+ *
+ * Best effort by design. A device that will not run it loses the barrier and
+ * nothing else, leaving the caller exactly where it stood before this existed,
+ * so every failure is logged and none is thrown. The wait is bounded because
+ * `sync(2)` blocks on the whole system's dirty set and not merely on ours, and
+ * no stream is piped: with both outputs discarded the child cannot fill a buffer
+ * nobody is draining and so cannot defeat that bound.
+ */
+internal fun flushWritesToMedia() {
+    val started = System.currentTimeMillis()
+    try {
+        // /dev/null rather than Redirect.DISCARD, which android.jar declares but
+        // the compile bootclasspath does not, so it fails to resolve here.
+        val devNull = File("/dev/null")
+        val sync = ProcessBuilder("/system/bin/sync")
+            .redirectInput(devNull)
+            .redirectOutput(devNull)
+            .redirectError(devNull)
+            .start()
+        if (!sync.waitFor(SYNC_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+            sync.destroyForcibly()
+            Logger.w(SYNC_TAG, "sync did not return within ${SYNC_TIMEOUT_SECONDS}s; continuing unflushed")
+            return
+        }
+        // Logged either way, and the exit status is why. A device whose policy
+        // refuses the exec, or whose image has no toybox, otherwise loses the
+        // barrier in silence and reads from the outside exactly like one that
+        // flushed.
+        val elapsed = System.currentTimeMillis() - started
+        if (sync.exitValue() == 0) {
+            Logger.i(SYNC_TAG, "Flushed writes to media in ${elapsed}ms")
+        } else {
+            Logger.w(SYNC_TAG, "sync exited ${sync.exitValue()} after ${elapsed}ms; continuing unflushed")
+        }
+    } catch (e: Exception) {
+        Logger.w(SYNC_TAG, "Could not flush writes to media: ${e.message}")
+    }
+}
+
+/** Its own tag, not either caller's: two classes share the one function. */
+private const val SYNC_TAG = "FlushWrites"
+
+/**
+ * Long enough that a real flush of a cold install's tail is never cut short, and
+ * short enough that a stuck one cannot park setup for ever. `sync(2)` waits on
+ * every dirty page on the device, including other apps', so the figure is a
+ * ceiling on someone else's I/O as much as on ours.
+ */
+private const val SYNC_TIMEOUT_SECONDS = 30L
 
 /**
  * PEM-encodes one certificate, in the shape the concatenated bundle is made of.

--- a/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
@@ -384,10 +384,12 @@ class FirstRunSetup(
                     // states: measured is a fact, a subtracted estimate is only
                     // as good as what it can see. The estimate this replaces
                     // came from `toolchains.json`, which knows the installs that
-                    // FINISHED. A copy that died before its record was written
-                    // leaves about 155 MB in `usr/` that nothing names
-                    // (ToolchainManager says so at the line where it happens),
-                    // and `npm install -g` and pip never had a record at all, so
+                    // FINISHED. `ToolchainManager` takes its install root back
+                    // on both failures it can see, but a process killed mid-copy
+                    // reaches neither and leaves up to 155 MB in `usr/` that
+                    // nothing names, the part written into the shared `usr/bin`
+                    // and `usr/lib` is never reclaimed on any exit, and
+                    // `npm install -g` and pip never had a record at all, so
                     // every one of those bytes was credited as a byte the next
                     // unpack writes over. The cap hid it while the bundled part
                     // of `usr/` was complete and stopped hiding it exactly where

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
@@ -1371,19 +1371,23 @@ class ToolchainManager(private val context: Context) {
             // first-run queue moves on, and the card reads "Install" again after
             // the next launch with nothing said.
             if (!writeState(state)) {
-                // ⚠️ The tree copied into `usr/` above is left where it is, and
-                // nothing removes it later. Uninstall works off this manifest, so a
-                // manifest that was never written leaves the files with no record
-                // naming them: roughly the unpacked size, about 155 MB for the Java 17
-                // this ships, that only clearing app data reclaims.
+                // Same reclaim as the copy failure above, because this is the same
+                // event a step later: the record naming the ~155 MB just copied does
+                // not exist, so nothing else can ever find those files. Uninstall
+                // works off this manifest, no card offers a Remove for a toolchain
+                // getInstalledToolchains() cannot name, and the repair pass only
+                // visits records that exist -- clearing app data was the way back.
+                // On the failure this is about, a full disk, they are exactly the
+                // bytes the retry the user is being asked to make needs.
                 //
-                // Not repaired here on purpose. The copy shares `usr/` with the base
-                // install and with other toolchains, so removing it means the
-                // uninstall path's own library bookkeeping rather than a
-                // deleteRecursively, and getting that wrong takes out a library the
-                // app itself loads. Pre-existing, but worth naming now that
-                // [reconcileDeliveredPacks] can reach this line at launch with no
-                // screen watching.
+                // Safe over a reinstall: writeState false means the file still holds
+                // the previous record, so [reclaimPartialCopy] re-reads it, still
+                // sees the toolchain named, and keeps the working copy's files. The
+                // `usr/bin` and `usr/lib` residue stays, for the reason that function
+                // documents: sorting it belongs to the uninstall's library
+                // bookkeeping, which needs the manifest this failure means we could
+                // not write.
+                reclaimPartialCopy(name, manifest)
                 fail(packName, ToolchainFailure.STORAGE)
                 // Play's copy is KEPT, which is the whole of the return value
                 // above. The user is told to free space and try again, and the
@@ -1439,15 +1443,16 @@ class ToolchainManager(private val context: Context) {
     }
 
     /**
-     * Deletes the tree a copy that threw partway had already written, when
+     * Deletes the tree an install that did not finish had already written, when
      * nothing else lays claim to it.
      *
-     * The install record is written last, so a copy that fails leaves up to the
-     * whole unpacked size -- about 155 MB for the Java 17 that ships today --
-     * under no manifest at all: [getInstalledToolchains] does not name it, the
-     * Toolchains screen offers no Remove for it, [uninstallLocked] has no record
-     * to work from, and the repair pass only visits records that exist. Clearing
-     * app data was the only way back.
+     * The install record is written last, so both ways an install can end after
+     * the copy has started -- the copy throwing, and the record write failing --
+     * leave up to the whole unpacked size, about 155 MB for the Java 17 that
+     * ships today, under no manifest at all: [getInstalledToolchains] does not
+     * name it, the Toolchains screen offers no Remove for it, [uninstallLocked]
+     * has no record to work from, and the repair pass only visits records that
+     * exist. Clearing app data was the only way back.
      *
      * The install root only. The same copy also writes into `usr/bin` and
      * `usr/lib`, which are shared with the base install and with other

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
@@ -14,6 +14,7 @@ import com.google.android.play.core.assetpacks.model.AssetPackErrorCode
 import com.google.android.play.core.assetpacks.model.AssetPackStatus
 import com.vscodroid.util.Environment
 import com.vscodroid.util.Logger
+import com.vscodroid.util.StorageManager
 import com.vscodroid.webview.redactToken
 import org.json.JSONArray
 import org.json.JSONObject
@@ -893,7 +894,13 @@ class ToolchainManager(private val context: Context) {
                     "a full device will fail during the copy instead of before it",
             )
         } else {
-            val required = packInstallBytes(unpacked)
+            val credit = existingTreeCredit(
+                deliveredInstallRoot(assetsDir, packName),
+                context.filesDir,
+                unpacked,
+                StorageManager::dirSize,
+            )
+            val required = (packInstallBytes(unpacked) - credit).coerceAtLeast(SPACE_BUFFER)
             val available = StatFs(context.filesDir.absolutePath).availableBytes
             if (available < required) {
                 Logger.e(
@@ -1188,6 +1195,28 @@ class ToolchainManager(private val context: Context) {
             // of the process.
             installsInFlight.remove(packName)
         }
+    }
+
+    /**
+     * The delivered manifest's install root under `filesDir`, best-effort.
+     *
+     * Best-effort and null on anything unexpected, because the authoritative
+     * parse stays where it is, in [installFromDirectoryHoldingPack]: a malformed
+     * manifest must still report CORRUPT from there rather than change the space
+     * gate's answer here.
+     */
+    private fun deliveredInstallRoot(assetsDir: File, packName: String): File? = try {
+        val manifestFile = File(assetsDir, "$packName.json")
+        if (!manifestFile.exists()) {
+            null
+        } else {
+            JSONObject(manifestFile.readText()).optString("installRoot", "")
+                .takeIf { it.isNotEmpty() }
+                ?.let { File(context.filesDir, it) }
+        }
+    } catch (e: Exception) {
+        Logger.w(tag, "Could not read the install root from $packName's manifest", e)
+        null
     }
 
     /**
@@ -3303,6 +3332,35 @@ internal fun packUnpackedBytes(packName: String): Long? =
  */
 internal fun packInstallBytes(unpackedBytes: Long): Long =
     unpackedBytes + SPACE_BUFFER
+
+/**
+ * Bytes already on disk under an install root that the copy will write over.
+ *
+ * `copyTo(overwrite = true)` deletes the destination before opening the output
+ * stream, so an overwrite of an identical tree allocates nothing net. Clamped at
+ * [recordedBytes] because a directory can hold more than the pack will write
+ * back, and a credit for those bytes is space the copy never returns.
+ */
+internal fun existingTreeCredit(
+    root: File?,
+    within: File,
+    recordedBytes: Long,
+    measure: (File) -> Long,
+): Long {
+    if (root == null) return 0
+    // A root that resolves outside [within] credits nothing. `..` escapes
+    // File(base, relative) while an absolute string is re-nested under it, so this
+    // rejects the one form that reaches outside. The manifest comes from a signed
+    // pack rather than an attacker, and uninstallLocked and reclaimPartialCopy
+    // already build the same File and delete through it, so this is not a last line
+    // of defence. It is that a credit is the first DECISION taken on that string:
+    // measuring the whole app data directory would clamp to the pack's own size and
+    // leave the gate asking for nothing but the buffer.
+    val base = runCatching { within.canonicalFile }.getOrNull() ?: return 0
+    val resolved = runCatching { root.canonicalFile }.getOrNull() ?: return 0
+    if (!generateSequence(resolved) { it.parentFile }.any { it == base }) return 0
+    return minOf(recordedBytes, measure(resolved)).coerceAtLeast(0)
+}
 
 /**
  * Copies a tree, refusing rather than shrugging when a directory cannot be read.

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
@@ -1343,6 +1343,18 @@ class ToolchainManager(private val context: Context) {
         // Only this tail is held, not the copy above it. The copy moves up to
         // 160 MB and holds nothing anyone else needs; the record is four lines
         // and is what everything else reads.
+        //
+        // Flushed before the record, for the reason [flushWritesToMedia] gives:
+        // the record is the only thing that says these binaries exist, and
+        // repairInstalledToolchainsSync re-checks the tree with isDirectory,
+        // never its contents. A power cut with the record on the medium and the
+        // copy still in page cache leaves a toolchain listed as installed whose
+        // binaries are holes, and nothing later looks. Outside the lock, not
+        // inside: the copy it flushes is already finished here, and a sync waits
+        // on the whole device's dirty set, which is not something to hold a lock
+        // across.
+        flushWritesToMedia()
+
         synchronized(stateLock) {
             val state = readState()
             // Remove any existing entry for this toolchain

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafStorageManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafStorageManager.kt
@@ -119,7 +119,9 @@ class SafStorageManager(context: Context) {
     ): Boolean = shouldAnnounce(now, last) && stamp.compareAndSet(last, now)
 
     /**
-     * Told when a directory deleted in the editor was kept on the device.
+     * Told when something deleted in the editor was kept on the device: the flag says
+     * whether it was a directory holding documents that never reached the editor, or
+     * one such document itself.
      *
      * Forwarded for the reason the others are. Throttled like [onWriteBackFailed] and
      * unlike the two below, because one deletion is not one directory: `rm -r` reports
@@ -128,12 +130,17 @@ class SafStorageManager(context: Context) {
      * notices back to back. On a stamp of its own rather than [lastFailureAnnouncedAt],
      * so the burst cannot swallow a write-back failure landing inside the same
      * interval, nor be swallowed by one.
+     *
+     * Both cases share that stamp, which is a deliberate simplification with a known
+     * ceiling: an `rm -r` whose ancestors are all kept can swallow a kept file landing
+     * inside the same interval. A stamp apiece would close it, at the price of a fifth
+     * seam for a sentence one word different from this one.
      */
-    fun onDirectoryKeptOnDevice(announce: (File) -> Unit) {
-        syncEngine.onDirectoryKeptOnDevice = { dir ->
+    fun onKeptOnDevice(announce: (File, Boolean) -> Unit) {
+        syncEngine.onKeptOnDevice = { file, isDirectory ->
             val last = lastKeptAnnouncedAt.get()
             if (claimAnnouncement(SystemClock.elapsedRealtime(), last, lastKeptAnnouncedAt)) {
-                announce(dir)
+                announce(file, isDirectory)
             }
         }
     }

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafStorageManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafStorageManager.kt
@@ -905,6 +905,20 @@ class SafStorageManager(context: Context) {
         syncEngine.stopWatching()
     }
 
+    /**
+     * Stops the active file watcher and refuses every later start on this engine. Call
+     * this on destroy; [stopFileWatcher] is the one for a folder switch.
+     *
+     * The difference is whether anything is allowed to follow. This manager belongs to
+     * one Activity and the next one builds its own, so after a teardown no caller can
+     * reach this engine to stop it a second time; a start that was already inside it
+     * when the teardown ran would leave observers and a write-back thread that outlive
+     * the process's ability to end them.
+     */
+    fun shutdownFileWatcher() {
+        syncEngine.shutdown()
+    }
+
     // -- Mirror Directory --
 
     /**

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
@@ -511,16 +511,30 @@ class SafSyncEngine(private val context: Context) {
                         // guard for the symmetric case already exists
                         // ([setAsideDivergedMirror]); this is the same guard facing
                         // the other way, and the one provider read it costs is paid
-                        // only where the record shows the device moved. A copy that
-                        // fails leaves both sides as they are: the mirror keeps its
-                        // edit, unvouched, and the next open tries again.
+                        // wherever the record cannot vouch for the path: where it
+                        // shows the device moved, and where it says nothing at all.
+                        // Silence is the arm below's own leavings, so a file written
+                        // back once pays that read on every open after it, and a
+                        // second mirror edit before the next open fetches this app's
+                        // own older bytes, which differ, and keeps them beside the
+                        // file. That is the known false positive [setAsideDivergedMirror]
+                        // already names for the three other producers of silence.
+                        //
+                        // A copy that fails leaves both sides as they are: the mirror
+                        // keeps its edit, unvouched, and the next open tries again. The
+                        // fetch failing is therefore a deferral, not a loss, but it is a
+                        // deferral of the user's own save and nothing but this log says
+                        // so, which for a persistent cause is indistinguishable from the
+                        // save never happening.
                         val deviceChanged =
                             previouslyRecorded?.let { deviceChangedSinceRecord(it, doc) } == true
                         if (deviceChanged && !setAsideDeviceCopy(doc, localPath)) {
                             Logger.w(
                                 tag,
-                                "Not writing ${doc.relativePath} back: its device copy " +
-                                    "changed since the last sync and could not be set aside",
+                                "Not writing ${doc.relativePath} back: the record cannot " +
+                                    "vouch for its device copy and that copy could not be " +
+                                    "read to set aside, so the mirror keeps the edit and " +
+                                    "the next open tries again",
                             )
                         } else {
                             if (deviceChanged) setAside++
@@ -739,18 +753,39 @@ class SafSyncEngine(private val context: Context) {
      * exactly, which `filesDir` never is; it would cost a spare `.device-` copy per
      * reopen, not a byte.
      *
-     * A record that does not name the path answers false, and that is the pre-existing
-     * behaviour rather than a claim of safety. The record is silent about a path this
-     * app wrote back and never re-read, which is what the caller's own branch leaves
-     * behind, and about a document the device gained under a name the mirror also
-     * gained; nothing on disk tells those two apart, and only the second is a stranger's
-     * bytes. The unusable record, absent or in a format this build cannot read, answers
-     * false for the reason [setAsideDivergedMirror] gives: its silence says nothing.
+     * A record that parses but does not name the path answers **true**, and so does a
+     * line whose time field will not parse. Silence here is not evidence that the device
+     * document is ours: the record is silent about a path this app wrote back and never
+     * re-read, which is exactly what the caller's own write-back branch leaves behind,
+     * and about a document the device gained under a name the mirror also gained.
+     * Nothing on disk tells those apart, and one of them is a stranger's bytes. Answering
+     * false meant the write-back arm disarmed the guard for every later pass over the
+     * same path, so the second foreign edit was destroyed by a `"wt"` open with no copy
+     * kept anywhere.
+     *
+     * True is not free, and the three costs are worth stating because the arm below
+     * manufactures the silence that triggers them. One provider read per affected path
+     * per open, forever, since nothing here re-records the path. A `.device-` copy kept
+     * whenever the bytes differ, which includes the case where the device holds this
+     * app's own earlier push and the mirror has been edited again since: that copy is a
+     * stale duplicate of the user's own file, and it is the same known false positive
+     * [setAsideDivergedMirror] already names for the other three producers of silence.
+     * And a fetch that fails withholds the write-back, which defers the user's save
+     * rather than losing it. False costs the user someone else's edit outright, which is
+     * why true is still the right answer.
+     *
+     * This writes nothing to the record, deliberately. Every fix that adds a line here
+     * is the one [reconcileDeletions] and `SafReconcileDeletionsTest` exist to refuse.
+     *
+     * The unusable record, absent or in a format this build cannot read, still answers
+     * false, at the call site rather than here, for the reason [setAsideDivergedMirror]
+     * gives: its silence says nothing, and a mirror that was never vouched for at all is
+     * not the same claim as one vouched for and then written past.
      */
     private fun deviceChangedSinceRecord(recorded: Set<String>, doc: DocumentInfo): Boolean {
         val prefix = escapeRecordPath(doc.relativePath) + '\t'
-        val line = recorded.firstOrNull { it.startsWith(prefix) } ?: return false
-        val recordedModified = line.split('\t').getOrNull(1)?.toLongOrNull() ?: return false
+        val line = recorded.firstOrNull { it.startsWith(prefix) } ?: return true
+        val recordedModified = line.split('\t').getOrNull(1)?.toLongOrNull() ?: return true
         return recordedModified != doc.lastModified
     }
 

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
@@ -1930,15 +1930,21 @@ class SafSyncEngine(private val context: Context) {
     internal var onUploadIncomplete: (File, Int, Boolean) -> Unit = { _, _, _ -> }
 
     /**
-     * Told when a directory deleted in the editor was left standing on the device,
-     * because it still holds documents this sync never copied in.
+     * Told when something deleted in the editor was left standing on the device,
+     * because it holds content this sync never copied in: a directory holding such a
+     * document, or the document itself.
      *
      * Its own seam for the reason [onDocumentsNotCopied] has one: [onWriteBackFailed]
      * says the app holds the only copy, and here the opposite is true. The mirror copy
      * is gone, the device holds the only one, and a notice worded the other way would
      * send the user looking inside the app for files that are safe where they are.
+     *
+     * The flag is what the sentence turns on and it cannot be recovered downstream:
+     * the entry is already unlinked when the event arrives, so nothing left on disk
+     * can be asked whether it was a directory. "It holds files that never reached the
+     * editor" is the right sentence for one case and false for the other.
      */
-    internal var onDirectoryKeptOnDevice: (File) -> Unit = {}
+    internal var onKeptOnDevice: (file: File, isDirectory: Boolean) -> Unit = { _, _ -> }
 
     /**
      * How much room is left where the mirror lives.
@@ -1970,8 +1976,8 @@ class SafSyncEngine(private val context: Context) {
      * The notice is [onWriteBackFailed]'s and it fits: the file did not reach the device
      * folder, and the copy inside the app is the only one of it that exists. What the
      * device holds under that name is a different document, which is why this refuses.
-     * The directory guard does not come through here, because for it the opposite is
-     * true; see [keepUnreadDirectory].
+     * A refused delete does not come through here, because for it the opposite is
+     * true; see [keepUnread].
      */
     private fun refuseUnreadDocument(localFile: File, describedAs: String) {
         Logger.w(
@@ -1997,21 +2003,25 @@ class SafSyncEngine(private val context: Context) {
     }
 
     /**
-     * Declines to delete the device directory at [relativePath], because it holds
-     * documents this sync never read, and says so.
+     * Declines to delete what the device holds at [relativePath], because it is, or it
+     * holds, a document this sync never read, and says so.
      *
      * Not through [refuseUnreadDocument]: that one announces on [onWriteBackFailed],
      * whose wording says the app holds the only copy, and here the app holds none.
-     * Not through [refusalsAnnounced] either: a directory is deleted once per deletion,
-     * and a user who recreates it and deletes it again is owed the notice again.
+     * Not through [refusalsAnnounced] either, and that is the second half of the same
+     * point: something is deleted once per deletion, and a user who recreates it and
+     * deletes it again is owed the notice again. Spending that budget here also costs
+     * the notice its owner needs, since the next save of a recreated name is refused
+     * as a write and is the one occasion on which "the only copy is inside VSCodroid"
+     * is both true and urgent.
      */
-    private fun keepUnreadDirectory(localFile: File, relativePath: String) {
+    private fun keepUnread(localFile: File, relativePath: String, isDirectory: Boolean) {
         Logger.w(
             tag,
-            "Not deleting $relativePath from the device: it holds documents this sync " +
+            "Not deleting $relativePath from the device: it holds content this sync " +
                 "never read",
         )
-        onDirectoryKeptOnDevice(localFile)
+        onKeptOnDevice(localFile, isDirectory)
     }
 
     private fun uploadJournal(): File = File(context.filesDir, UPLOADS_IN_FLIGHT_FILE)
@@ -2922,9 +2932,19 @@ class SafSyncEngine(private val context: Context) {
 
         if (!shouldWriteBack(relativePath, isDirectory)) return
 
-        // Placed here rather than in the four write-back branches: this covers
-        // CREATE, MODIFY, DELETE and both halves of a move in one statement, and
-        // stops the job being queued at all.
+        // Placed here rather than in the write-back branches: this covers CREATE,
+        // MODIFY and the arriving half of a move in one statement, and stops the job
+        // being queued at all.
+        //
+        // A delete is excluded and handled below instead, and the exclusion is the
+        // whole of why the type is read here at all. Both refusals are correct and
+        // they are correct for opposite reasons: a refused write leaves the edit
+        // inside the app, a refused delete leaves the document on the device and
+        // nowhere else. Answering for a delete here said the first sentence about
+        // the second situation, sending the user into the app after a file the app
+        // had never held, and spent that path's one refusal notice on it, so the
+        // save that came afterwards, the one that really did stay inside the app,
+        // was silent for the rest of the session.
         //
         // The provider is asked rather than trusted from the set alone, because
         // the set is a memory of what this sync could not read and the document
@@ -2936,7 +2956,8 @@ class SafSyncEngine(private val context: Context) {
         // outer one is not a duplicate: it is what keeps [providerHoldsDocument] off
         // the common path. [createOneInSaf] needs no such guard, because there the
         // provider's answer is already in hand.
-        if (localFile.absolutePath in unfetched &&
+        if (type != SyncType.DELETE &&
+            localFile.absolutePath in unfetched &&
             writeWouldReplaceUnreadDocument(
                 localFile.absolutePath,
                 providerHoldsDocument(safTreeUri, relativePath),
@@ -2992,13 +3013,22 @@ class SafSyncEngine(private val context: Context) {
             return
         }
 
-        // An outright delete of a directory, which on a directory document is
-        // `deleteDocument` taking everything beneath it on the device. The mirror is
-        // not all of it: a child skipped for size, or one whose copy failed, was never
-        // in the mirror, so the editor showed the directory without it, the user
-        // deleted what they could see, and the device lost a 60 MB archive nothing on
-        // screen had mentioned. The guard above cannot see this one: it tests the
-        // directory's own path, and [unfetched] holds files only.
+        // A delete the device holds the only copy of, at either level.
+        //
+        // On a directory document `deleteDocument` takes everything beneath it on the
+        // device, and the mirror is not all of it: a child skipped for size, or one
+        // whose copy failed, was never in the mirror, so the editor showed the
+        // directory without it, the user deleted what they could see, and the device
+        // lost a 60 MB archive nothing on screen had mentioned. A file arrives here for
+        // the same reason one step down: what the user deleted in the editor was a
+        // mirror entry that was never the document, and the document on the device is
+        // the only copy of itself.
+        //
+        // Matched by prefix for a directory, since a directory holds what is under it
+        // and [unfetched] holds files only, and by exact path for a file, since its own
+        // path is the only one that names it. The separator is appended so `docs` does
+        // not answer for `docs2`, and any depth below counts; on the file side
+        // exactness is what stops an unread `notes.md.bak` from keeping `notes.md`.
         //
         // Below the MOVED_FROM hold rather than above it, deliberately. A directory
         // with unread children is renamed by the same event pair as any other, and
@@ -3006,24 +3036,27 @@ class SafSyncEngine(private val context: Context) {
         // path that carries those children to the new name. Refusing the MOVED_FROM
         // would have left the pair unclaimed: the new name created from the mirror
         // without them, the old one standing on the device with them. Only an
-        // outright DELETE therefore reaches here as a directory.
+        // outright DELETE therefore reaches here as a directory. A file has no pair to
+        // protect, so both halves of its delete, the unlink and the move away, reach
+        // this and are kept the same way.
         //
-        // The provider is asked for the reason the file guard asks it: the set is a
-        // memory, and the directory may have been deleted on the device since, in
+        // The provider is asked for the reason the write guard asks it: the set is a
+        // memory, and the document may have been deleted on the device since, in
         // which case there is nothing left to keep. Only a provider that positively
-        // answers "gone" lets the delete through. The file guard folds a failed
+        // answers "gone" lets the delete through. The write guard folds a failed
         // lookup into "not held", and there that costs a duplicate name; here it would
-        // cost `deleteDocument` on a subtree the set says holds an unread document, so
-        // a provider that cannot answer keeps. The separator is appended so
-        // `docs` does not answer for `docs2`, and any depth below counts. One scan of
-        // a set that is normally empty, on the observer thread; the binder walk is
-        // paid only on a match.
-        if (type == SyncType.DELETE && isDirectory) {
-            val below = localFile.absolutePath + File.separator
-            if (unfetched.any { it.startsWith(below) } &&
-                providerHoldsDirectory(safTreeUri, relativePath) != false
-            ) {
-                keepUnreadDirectory(localFile, relativePath)
+        // cost `deleteDocument` on the one copy the set says nothing else has, so
+        // a provider that cannot answer keeps. One scan of a set that is normally
+        // empty, on the observer thread; the binder walk is paid only on a match.
+        if (type == SyncType.DELETE) {
+            val holdsUnread = if (isDirectory) {
+                val below = localFile.absolutePath + File.separator
+                unfetched.any { it.startsWith(below) }
+            } else {
+                localFile.absolutePath in unfetched
+            }
+            if (holdsUnread && providerHolds(safTreeUri, relativePath) != false) {
+                keepUnread(localFile, relativePath, isDirectory)
                 return
             }
         }
@@ -3178,18 +3211,20 @@ class SafSyncEngine(private val context: Context) {
      * device *not* holding a name has to ask the device.
      */
     /**
-     * Whether the device still holds a directory at [relativePath]: true, false, or null
-     * when the provider could not be asked.
+     * Whether the device still holds anything at [relativePath]: true, false, or null
+     * when the provider could not be asked. Type-agnostic, because it walks display
+     * names, which is what the delete guard needs: it asks the same question of a
+     * directory and of the document inside one.
      *
      * [providerHoldsDocument] folds a query that threw, or a cursor the provider would
      * not give, into "not held", which suits its caller: the cost of being wrong there
-     * is a duplicate name. The directory guard in [handleMirrorEvent] cannot take that
+     * is a duplicate name. The delete guard in [handleMirrorEvent] cannot take that
      * answer, because for it "not held" means the delete goes through, and the delete
-     * is `deleteDocument` on a subtree the sync knows it never fully read. So this walk
+     * is `deleteDocument` on content the sync knows it never read. So this walk
      * reports the three cases apart, and the guard treats only a positive "gone" as
      * permission.
      */
-    private fun providerHoldsDirectory(treeUri: Uri, relativePath: String): Boolean? {
+    private fun providerHolds(treeUri: Uri, relativePath: String): Boolean? {
         var currentDocId = DocumentsContract.getTreeDocumentId(treeUri)
         for (segment in relativePath.split("/")) {
             val childrenUri = DocumentsContract.buildChildDocumentsUriUsingTree(treeUri, currentDocId)

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
@@ -63,6 +63,36 @@ class SafSyncEngine(private val context: Context) {
     @Volatile private var isWatching = false
 
     /**
+     * Held across a whole [startWatching], [stopWatching] or [shutdown].
+     *
+     * The three decide between them whether this engine is live, and each of them takes
+     * several steps to say so: [startWatching] publishes a session, sets [isWatching] and
+     * then registers up to [MAX_WATCHED_DIRECTORIES] watches, and it opens by calling
+     * [stopWatching], which blocks up to [DRAIN_GRACE_MS] joining the previous drain.
+     * Run against each other those interleave, and the outcome is decided by whichever
+     * of the two [isWatching] writes lands last: a stop finishing inside a start's inner
+     * drain leaves observers registered, a worker polling and [isWatching] true, on an
+     * engine whose owner is gone. The Activity serialises its own three calls, but the
+     * one in `onDestroy` runs on a detached thread deliberately outside that mutex, so
+     * the serialisation has to be here, where every caller passes.
+     *
+     * Reentrant, which [startWatching] relies on: it calls [stopWatching] while holding
+     * this, and Java monitors admit the thread that already owns them.
+     */
+    private val lifecycleLock = Any()
+
+    /**
+     * Whether [shutdown] has been called, after which no start is honoured again.
+     *
+     * Ordering the calls is not enough on its own. The Activity's teardown is the last
+     * word about an engine nothing can reach afterwards -- the replacement Activity
+     * builds its own [SafSyncEngine], so its stop cannot reach this one -- and a start
+     * that arrives after it belongs to a coroutine of the Activity that has gone. It is
+     * refused rather than run late, because there is no one left to stop what it starts.
+     */
+    @Volatile private var shutDown = false
+
+    /**
      * One observer per watched directory, keyed by that directory.
      *
      * Holding them here is not only bookkeeping: [FileObserver]'s shared ObserverThread
@@ -1352,28 +1382,41 @@ class SafSyncEngine(private val context: Context) {
     /**
      * Starts watching the mirror directory for changes and syncing them back to SAF.
      * Must be called after [initialSync] completes.
+     *
+     * A no-op once [shutdown] has run; see [shutDown] for why that is a refusal rather
+     * than a start that happens to be late.
      */
     fun startWatching(mirrorDir: File, safUri: Uri) {
-        stopWatching()
+        synchronized(lifecycleLock) {
+            if (shutDown) {
+                Logger.i(
+                    tag,
+                    "Not watching ${mirrorDir.name}: this engine's owner is gone and " +
+                        "nothing could stop the watcher again",
+                )
+                return
+            }
+            stopWatching()
 
-        // Published before any observer exists, because an observer fires into whatever
-        // session is current and this is the one its jobs belong to.
-        val opening = WatchSession()
-        session = opening
-        isWatching = true
-        watchTree(mirrorDir, mirrorDir, safUri)
+            // Published before any observer exists, because an observer fires into whatever
+            // session is current and this is the one its jobs belong to.
+            val opening = WatchSession()
+            session = opening
+            isWatching = true
+            watchTree(mirrorDir, mirrorDir, safUri)
 
-        // Background thread to process this session's write-back queue. Handed over
-        // before it starts, so a stop arriving at once cannot find a null worker for a
-        // thread that is already running.
-        val worker = thread(start = false, name = "saf-writeback", isDaemon = true) {
-            runWriteBackLoop(opening) { opening.running }
+            // Background thread to process this session's write-back queue. Handed over
+            // before it starts, so a stop arriving at once cannot find a null worker for a
+            // thread that is already running.
+            val worker = thread(start = false, name = "saf-writeback", isDaemon = true) {
+                runWriteBackLoop(opening) { opening.running }
+            }
+            opening.worker = worker
+            worker.start()
+
+            val watched = synchronized(watchersLock) { watchers.size }
+            Logger.i(tag, "File watcher started for ${mirrorDir.absolutePath} ($watched directories)")
         }
-        opening.worker = worker
-        worker.start()
-
-        val watched = synchronized(watchersLock) { watchers.size }
-        Logger.i(tag, "File watcher started for ${mirrorDir.absolutePath} ($watched directories)")
     }
 
     /**
@@ -1432,63 +1475,83 @@ class SafSyncEngine(private val context: Context) {
      * Stops the file watcher and drains the write-back queue.
      */
     fun stopWatching() {
-        isWatching = false
-        synchronized(watchersLock) {
-            watchers.values.forEach { it.stopWatching() }
-            watchers.clear()
-        }
-        // The folder being closed keeps the queue its jobs are in, and the folder opened
-        // next gets an empty one, whether or not the drain below finishes in time.
-        val closing = session
-        session = WatchSession()
-        closing.running = false
-
-        // Wake the thread out of its sleep, then wait for it to drain remaining writes.
-        // An idle queue drains in microseconds, so this costs only what there is to lose.
-        val worker = closing.worker
-        closing.worker = null
-        worker?.interrupt()
-        try { worker?.join(DRAIN_GRACE_MS) } catch (_: InterruptedException) {}
-
-        if (worker != null && worker.isAlive) {
-            // Still draining. Emptying the queue from here would throw away exactly the
-            // writes the drain exists to save, and would do it in the case where there
-            // are the most of them: a burst of saves, or one slow provider. The thread
-            // owns this session's queue until it finishes, and nothing else can reach
-            // it: the queue went with the session, so the folder opened next offers its
-            // jobs somewhere this drain never polls. Addressing was never the question.
-            // Two threads polling one queue was: each write opens its document with
-            // "wt", which truncates at open, so the two interleave inside one document.
-            Logger.w(tag, "Write-back still draining after ${DRAIN_GRACE_MS}ms; leaving it to finish")
-        } else {
-            // Anything still here arrived after the drain took its last look, which is
-            // the one window an event observed while the folder was open can still fall
-            // into. Counted rather than dropped in silence: the mirror keeps the file and
-            // the record cannot vouch for it, so nothing is destroyed, but the save is
-            // not on the device and only reopening the folder puts it there. A user
-            // asking why needs this line to exist in a bug report.
-            val dropped = closing.queue.size
-            closing.queue.clear()
-            closing.abandoned = true
-            if (dropped > 0) {
-                Logger.w(tag, "$dropped write-back(s) arrived after the drain ended")
+        synchronized(lifecycleLock) {
+            isWatching = false
+            synchronized(watchersLock) {
+                watchers.values.forEach { it.stopWatching() }
+                watchers.clear()
             }
+            // The folder being closed keeps the queue its jobs are in, and the folder opened
+            // next gets an empty one, whether or not the drain below finishes in time.
+            val closing = session
+            session = WatchSession()
+            closing.running = false
+
+            // Wake the thread out of its sleep, then wait for it to drain remaining writes.
+            // An idle queue drains in microseconds, so this costs only what there is to lose.
+            val worker = closing.worker
+            closing.worker = null
+            worker?.interrupt()
+            try { worker?.join(DRAIN_GRACE_MS) } catch (_: InterruptedException) {}
+
+            if (worker != null && worker.isAlive) {
+                // Still draining. Emptying the queue from here would throw away exactly the
+                // writes the drain exists to save, and would do it in the case where there
+                // are the most of them: a burst of saves, or one slow provider. The thread
+                // owns this session's queue until it finishes, and nothing else can reach
+                // it: the queue went with the session, so the folder opened next offers its
+                // jobs somewhere this drain never polls. Addressing was never the question.
+                // Two threads polling one queue was: each write opens its document with
+                // "wt", which truncates at open, so the two interleave inside one document.
+                Logger.w(tag, "Write-back still draining after ${DRAIN_GRACE_MS}ms; leaving it to finish")
+            } else {
+                // Anything still here arrived after the drain took its last look, which is
+                // the one window an event observed while the folder was open can still fall
+                // into. Counted rather than dropped in silence: the mirror keeps the file and
+                // the record cannot vouch for it, so nothing is destroyed, but the save is
+                // not on the device and only reopening the folder puts it there. A user
+                // asking why needs this line to exist in a bug report.
+                val dropped = closing.queue.size
+                closing.queue.clear()
+                closing.abandoned = true
+                if (dropped > 0) {
+                    Logger.w(tag, "$dropped write-back(s) arrived after the drain ended")
+                }
+            }
+            // docIdCache is deliberately not cleared here. A drain that outlived the wait
+            // still needs the mappings of the folder it is finishing, and [initialSync]
+            // clears the cache itself before anything reads it for the next one.
+            //
+            // The half-renames are cleared, and the difference is that nothing consumes them
+            // after this point: a MOVED_TO of the next folder must not be able to claim a
+            // directory that left the previous one, which would rename a document in a folder
+            // the user has closed.
+            //
+            // Which is the same instant their upload records stop being able to move: a claim
+            // is the only thing that carries a line to the directory's new path. Retired here
+            // rather than left standing, because after this nothing can; see
+            // [consumeStaleUploadsUnder].
+            dropVanished { true }
+            Logger.i(tag, "File watcher stopped")
         }
-        // docIdCache is deliberately not cleared here. A drain that outlived the wait
-        // still needs the mappings of the folder it is finishing, and [initialSync]
-        // clears the cache itself before anything reads it for the next one.
-        //
-        // The half-renames are cleared, and the difference is that nothing consumes them
-        // after this point: a MOVED_TO of the next folder must not be able to claim a
-        // directory that left the previous one, which would rename a document in a folder
-        // the user has closed.
-        //
-        // Which is the same instant their upload records stop being able to move: a claim
-        // is the only thing that carries a line to the directory's new path. Retired here
-        // rather than left standing, because after this nothing can; see
-        // [consumeStaleUploadsUnder].
-        dropVanished { true }
-        Logger.i(tag, "File watcher stopped")
+    }
+
+    /**
+     * Stops the watcher for good: the same teardown as [stopWatching], plus the promise
+     * that no later [startWatching] will undo it.
+     *
+     * For the owner that is going away rather than switching folders. The two differ
+     * only in what may follow: a folder switch stops one watcher and starts the next on
+     * the same engine, while a teardown has no next. A start still on its way when this
+     * runs -- the one in a coroutine of the Activity being destroyed, which is not
+     * cancellable once it is inside the engine -- would otherwise finish afterwards and
+     * leave observers and a drain running on an engine no one holds any more.
+     */
+    fun shutdown() {
+        synchronized(lifecycleLock) {
+            shutDown = true
+            stopWatching()
+        }
     }
 
     // -- Internal: Watch Registration --

--- a/android/app/src/main/kotlin/com/vscodroid/util/CrashReporter.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/util/CrashReporter.kt
@@ -191,7 +191,15 @@ object CrashReporter {
         // The line telling the user what they are about to paste. This section
         // is not the app talking: it carries whatever the editor server and the
         // extension host printed, which is why [redactSecrets] runs over it.
-        sb.appendLine("(server and extension-host output, credentials removed)")
+        // "credentials removed" is what this said, and it is a promise the
+        // scrubber cannot keep: [ServerLog.redactSecrets] matches known shapes,
+        // and a bare secret is structurally indistinguishable from any other
+        // word, which is why widening the patterns is not the fix for the
+        // sentence. Say what is true and leave the user a reason to look.
+        sb.appendLine(
+            "(server and extension-host output; known credential shapes replaced, " +
+                "check before sharing)"
+        )
         val tail = ServerLog(File(Environment.getLogsDir(context), "server.log")).tail(200)
         if (tail.isEmpty()) {
             sb.appendLine("(no server output recorded)")

--- a/android/app/src/main/kotlin/com/vscodroid/webview/VSCodroidWebViewClient.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/webview/VSCodroidWebViewClient.kt
@@ -1335,11 +1335,21 @@ class VSCodroidWebViewClient(
                 // difference is easy to overstate. An `.html` file under a
                 // published root, loaded as a document from this authority, runs
                 // its script at an origin ending `.vscode-cdn.net`, and
-                // [isOurOrigin] refusing that authority stops it only from
-                // *asking*: a `fetch` carries an `Origin` and is turned away here.
-                // A navigation carries none, so the same document can frame
-                // another path on the identical origin, be served it by the branch
-                // below, and read it out of `contentDocument` same-origin. That a
+                // [isOurOrigin] refusing that authority turns away the requests
+                // that reach this gate at all: a CORS-mode request carries an
+                // `Origin`, so such a document cannot ask a *different* one of our
+                // origins for anything.
+                //
+                // It does not turn away the sibling it shares an origin with, and
+                // the earlier wording here said it did. A same-origin `fetch`
+                // sends no `Origin` header, so it never reaches this branch; it
+                // falls to the `Referer` rule below, which accepts the resource
+                // authority deliberately, since a stylesheet already served from
+                // there is what asks for its own `url(...)` subresources. Every
+                // published root answers on one authority, so "another file under
+                // another root" is that same origin. A navigation carries no
+                // origin either, so the same document can also frame another path
+                // and read it out of `contentDocument`. That a
                 // frame's own navigation reaches this callback is not a guess:
                 // `pre/index.html` is exactly that, an iframe document the CDN arm
                 // above answers. What it reaches is whatever [MIME_TYPES] renders
@@ -1741,10 +1751,13 @@ class VSCodroidWebViewClient(
          * there: webview documents come from the `{{uuid}}.vscode-cdn.net` template,
          * and the resource authority only ever answers subresources.
          *
-         * It closes the asking rather than the reading, and the caller's comment
-         * records the difference: a navigation reaches this app carrying no
-         * origin at all, so a document served here can still frame another path
-         * on its own origin and read that one back.
+         * It closes the asking that reaches this predicate, which is the asking
+         * that carries an `Origin`: a CORS-mode request to a different one of our
+         * origins. The caller's comment records what it does not close, and it is
+         * wider than framing. A same-origin `fetch` sends no `Origin`, so it is
+         * judged by [isOurReferer], which accepts this authority on purpose; and a
+         * navigation carries none either, so a document served here can frame
+         * another path on its own origin and read that one back.
          */
         internal fun isOurOrigin(origin: String, port: Int): Boolean =
             isWorkbenchOrigin(origin, port) ||

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -232,6 +232,12 @@
          inside VSCodroid" would be backwards here. -->
     <string name="saf_directory_kept">%1$s was kept in the device folder: it holds files that were never copied into the editor. Delete it there if you no longer need them.</string>
 
+    <!-- The same refusal one level down: a single document that never reached the
+         editor, deleted in the editor anyway. Worded apart from saf_directory_kept
+         because that one says the thing holds files, which is false of a file, and
+         apart from saf_write_back_failed because the app holds nothing here at all. -->
+    <string name="saf_document_kept">%1$s was kept in the device folder: the editor never had a copy of it. Delete it there if you no longer need it.</string>
+
     <!-- Removing the local copy of a device folder, from the storage screen. The
          mirror named by a hash the screen holds no longer exists: the user picked it
          from a list this app built a moment earlier, so this means the folder was

--- a/android/app/src/test/kotlin/com/vscodroid/ActivityRetentionTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/ActivityRetentionTest.kt
@@ -64,7 +64,7 @@ class ActivityRetentionTest {
         "safManager.onWriteBackFailed {",
         "safManager.onUploadIncomplete {",
         "safManager.onDocumentsNotCopied {",
-        "safManager.onDirectoryKeptOnDevice {",
+        "safManager.onKeptOnDevice {",
     )
 
     @Test

--- a/android/app/src/test/kotlin/com/vscodroid/ActivityTeardownTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/ActivityTeardownTest.kt
@@ -132,7 +132,8 @@ class ActivityTeardownTest {
         // confined.
         val lines = code(source)
         val calls = lines.withIndex().filter { (_, line) ->
-            line.contains(".startFileWatcher(") || line.contains(".stopFileWatcher(")
+            line.contains(".startFileWatcher(") || line.contains(".stopFileWatcher(") ||
+                line.contains(".shutdownFileWatcher(")
         }
 
         assertEquals(
@@ -160,6 +161,39 @@ class ActivityTeardownTest {
                 "screen. The stop blocks for up to two seconds behind a write-back drain " +
                 "the interrupt cannot cut short, with the sync dialog frozen; the start " +
                 "walks the mirror and registers up to 2048 kernel watches.",
+        )
+    }
+
+    @Test
+    fun `the teardown ends the device folder watcher for good rather than until the next start`() {
+        // The three calls in openSafFolder and restoreWatcherAfterFailure are
+        // serialised against each other by `deviceFolderOpens`; the one here is
+        // outside that mutex on purpose, on a detached thread, so it can run in
+        // the middle of a start that is already inside the engine on
+        // Dispatchers.IO. That start is not cancellable from here and finishes
+        // afterwards, leaving observers and the `saf-writeback` thread on an
+        // engine the replacement Activity cannot reach: it builds its own
+        // manager. Only the shutdown refuses that start; the ordinary stop is
+        // simply overtaken by it.
+        val destroy = code(body("override fun onDestroy()"))
+
+        assertTrue(destroy.any { it.contains(".shutdownFileWatcher()") }) {
+            "onDestroy no longer shuts the device folder watcher down. A plain stop is " +
+                "overtaken by a start already running on Dispatchers.IO, which then " +
+                "leaves a watcher and a write-back thread nothing can ever stop again."
+        }
+
+        // The folder switch must keep the restartable stop: the next folder's
+        // watcher starts on this same engine, and a shutdown there would leave the
+        // user editing a folder nothing writes back.
+        val switching = code(body("private fun openSafFolder(uri: Uri, navigate: Boolean)")) +
+            code(body("private suspend fun restoreWatcherAfterFailure("))
+
+        assertEquals(
+            emptyList<String>(),
+            switching.filter { it.contains(".shutdownFileWatcher(") }.map { it.trim() },
+            "a folder switch shut the engine down instead of stopping it, so the folder " +
+                "opened next is never watched and its saves never reach the device",
         )
     }
 }

--- a/android/app/src/test/kotlin/com/vscodroid/ExtensionCallbackTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/ExtensionCallbackTest.kt
@@ -195,6 +195,39 @@ class AuthTabWindowTest {
     }
 
     @Test
+    fun `a sign-in in flight survives an address naming a crowd of requests`() {
+        // The bound above is what makes this reachable: the record holds the most
+        // recent few launches, so anything able to record launches at will can
+        // push the sign-in the user has open in the browser out of it, and the
+        // callback then arrives for an id nothing recorded and is dropped in the
+        // log with nothing said. One address is enough, because a single one can
+        // name as many request ids as its author cares to type, and both arming
+        // sites read every id an address carries.
+        //
+        // The count is the record's own capacity: with the victim recorded first,
+        // that many further ids evict exactly it. Written so it holds whatever
+        // else this JVM has left in the record: an eviction takes the eldest, so
+        // ids arriving after the sign-in can only push out what arrived before
+        // it.
+        val crowd = (1..32).map { "9300$it" }
+        val address = crowd.joinToString("&") { "vscode-reqid=$it" }
+        try {
+            AuthTabWindow.arm(listOf("900001"), 1_000L)
+
+            AuthTabWindow.arm(authRequestIdsIn(address), 2_000L)
+
+            assertEquals(
+                1_000L, AuthTabWindow.armedAt("900001"),
+                "one address pushed the sign-in actually in flight out of the record. Its " +
+                    "callback comes back to an id nothing launched, is dropped without a " +
+                    "message, and the extension waits for ever on a value nothing will write.",
+            )
+        } finally {
+            AuthTabWindow.disarm(crowd)
+        }
+    }
+
+    @Test
     fun `the record does not grow for the life of the process`() {
         // Entries outlive their own window on purpose, so that a late callback can
         // be told apart from an invented one. Without a bound that is a leak in a
@@ -283,6 +316,21 @@ class AuthRequestIdTest {
         )) {
             assertEquals(emptyList<String>(), authRequestIdsIn(link), "armed by: $link")
         }
+    }
+
+    @Test
+    fun `an address naming more requests than a sign-in ever does is read only so far`() {
+        // Nothing bounded this, and the record the ids go into holds the most
+        // recent few, so one address naming enough of them evicted the sign-in
+        // the user had in flight. Every real shape above names one.
+        //
+        // The ids kept are the first ones the address carries, not the last: an
+        // authorisation address puts the callback it will return to near the
+        // front, and a cap applied to the other end would drop exactly that one
+        // for any address padded after it.
+        val ids = authRequestIdsIn((1..40).joinToString("&") { "vscode-reqid=$it" })
+
+        assertEquals(listOf("1", "2", "3", "4", "5", "6", "7", "8"), ids)
     }
 
     @Test

--- a/android/app/src/test/kotlin/com/vscodroid/ExtensionCallbackTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/ExtensionCallbackTest.kt
@@ -902,16 +902,21 @@ class WorkbenchUrlTest {
  * leak, `"at $url"` fails it, and `"at " + url` walks straight through while the
  * token goes to a release build's logcat, readable by anything holding READ_LOGS.
  *
- * So [TokenTaint] reads the file the way taint reads it. A `val`/`var`
+ * So [LogTaint] reads the file the way taint reads it. A `val`/`var`
  * declaration seeded from `workbenchUrl(...)`, `getConnectionToken()` or a
  * WebView's `url` is tainted; anything declared from a tainted name is tainted
  * too; and a `Logger` statement is an offender when a tainted name survives
- * removing every `redactToken(...)` from it. Statements are read whole, across
- * the lines a formatter wraps them onto, and string prose is dropped so the word
+ * removing everything that treats it. Statements are read whole, across the
+ * lines a formatter wraps them onto, and string prose is dropped so the word
  * "token" in a message is not mistaken for the variable. Interpolation,
  * concatenation and an intermediate local all read the same to it. The reader is
  * driven against fixed snippets in the cases below, so it is measured in both
  * directions rather than trusted in either.
+ *
+ * That reader is shared with `SafFolderLogCallSiteTest`, which seeds it with
+ * `Uri`-typed declarations for the other value in this file worth keeping out of
+ * logcat. A device folder printed here therefore fails the case below as well,
+ * and that file is where the remedy for one of those is written down.
  *
  * What still passes. The first of these is pinned as a case below, so the claim
  * is measured rather than promised, and the rest are the same shape as it:
@@ -921,15 +926,17 @@ class WorkbenchUrlTest {
  *    after it was declared;
  *  - a declaration split across lines, with `val x =` on one and the value on the
  *    next;
- *  - a token arriving by a route none of the three seeds name;
+ *  - a token arriving by a route none of the seeds name;
  *  - a value handed to a helper that logs it somewhere else. The reverse of that
- *    one is a false accusation rather than a miss: only `redactToken(...)` counts
- *    as sanitising, so any other wrapper is reported and has to be argued with;
+ *    one is a false accusation rather than a miss: `redactToken(...)` and the
+ *    two reductions are the whole list of what counts as treating a value, so
+ *    any other wrapper is reported and has to be argued with;
  *  - names are tracked across the whole file rather than per scope, so an
- *    unrelated local called `url` or `token` is held to the same rule. Every
- *    binding of either name in this file today holds the same tokened URL or the
- *    bridge's session token, so here that is the answer wanted; elsewhere it
- *    would be a nuisance.
+ *    unrelated local called `url`, `token` or `uri` is held to the same rule.
+ *    Every binding of those names in this file today holds the same tokened URL,
+ *    the bridge's session token or a device folder, so here that is the answer
+ *    wanted; elsewhere it would be a nuisance. `isWorkbenchUrl` names its locals
+ *    `parsed` and `hostName` for exactly this reason, and says so.
  *
  * Source reading, and the weaker layer for the usual reason: the statement is
  * inside an Activity method, and a plain JVM test can build no Activity. The
@@ -951,13 +958,15 @@ class NavigationTokenLoggingTest {
 
     @Test
     fun `no log statement prints a token-bearing value unredacted`() {
-        val offenders = TokenTaint.leaks(source()).map { "MainActivity.kt:$it" }
+        val offenders = LogTaint.leaks(source()).map { "MainActivity.kt:$it" }
 
         assertEquals(
             emptyList<String>(), offenders,
-            "the URL the WebView loads carries the connection token, and only " +
-                "Logger.d is gated on a debuggable build, so this reaches a release " +
-                "build's logcat. Print it through redactToken().",
+            "the URL the WebView loads carries the connection token, only Logger.d is " +
+                "gated on a debuggable build, so this reaches a release build's " +
+                "logcat. Print it through redactToken(). LogTaint follows a device " +
+                "folder's tree URI as well, and `SafFolderLogCallSiteTest` says what " +
+                "to do about one of those: name it by its mirror.",
         )
     }
 
@@ -968,13 +977,13 @@ class NavigationTokenLoggingTest {
         // `val safe = redactToken(url)` that nothing logs, which is exactly the
         // company a raw log statement keeps. Deleting the log statement, renaming
         // the local, or logging the URL by some other route all leave this empty.
-        val redacted = TokenTaint.redactedLogs(source())
+        val redacted = LogTaint.redactedLogs(source())
 
         assertTrue(
             redacted.isNotEmpty(),
             "no log statement in MainActivity prints a token-bearing value through " +
                 "redactToken. Either the navigation log went, or it stopped going " +
-                "through the redactor, or the seeds in TokenTaint no longer recognise " +
+                "through the redactor, or the seeds in LogTaint no longer recognise " +
                 "where the token enters the file, and in every one of those cases the " +
                 "test above is passing by looking at nothing",
         )
@@ -985,7 +994,7 @@ class NavigationTokenLoggingTest {
         // The affordance, not the symptom. Two expressions for the same URL is
         // what made the redaction a matter of discipline; one cannot drift from
         // itself. Read off the raw lines: the literal host is string prose, which
-        // is the one thing TokenTaint's reader throws away.
+        // is the one thing LogTaint's reader throws away.
         val builders = source().withIndex()
             .filterNot { (_, l) ->
                 val t = l.trimStart()
@@ -1003,7 +1012,7 @@ class NavigationTokenLoggingTest {
 
     // --- The reader itself, driven against fixed snippets. ------------------
     //
-    // Everything above points TokenTaint at one file, where the only measurable
+    // Everything above points LogTaint at one file, where the only measurable
     // outcome is "found nothing". A reader that always finds nothing passes all
     // of it. These give it sources whose answer is known.
 
@@ -1025,9 +1034,9 @@ class NavigationTokenLoggingTest {
     fun `the code as it stands reads clean`() {
         val clean = navigateSource(redactedLog)
 
-        assertEquals(emptyList<String>(), TokenTaint.leaks(clean))
+        assertEquals(emptyList<String>(), LogTaint.leaks(clean))
         assertTrue(
-            TokenTaint.redactedLogs(clean).isNotEmpty(),
+            LogTaint.redactedLogs(clean).isNotEmpty(),
             "the reader did not recognise the redacted log statement it is built around",
         )
     }
@@ -1052,7 +1061,7 @@ class NavigationTokenLoggingTest {
 
         assertLeaks(defeat)
         assertEquals(
-            emptyList<String>(), TokenTaint.redactedLogs(defeat),
+            emptyList<String>(), LogTaint.redactedLogs(defeat),
             "a `val safeUrl = redactToken(url)` that nothing logs must not answer for " +
                 "the log statement; that is how a control gets satisfied by a line it " +
                 "has nothing to do with",
@@ -1090,9 +1099,9 @@ class NavigationTokenLoggingTest {
         )
 
         assertLeaks(wrappedRaw)
-        assertEquals(emptyList<String>(), TokenTaint.leaks(wrappedRedacted))
+        assertEquals(emptyList<String>(), LogTaint.leaks(wrappedRedacted))
         assertTrue(
-            TokenTaint.redactedLogs(wrappedRedacted).isNotEmpty(),
+            LogTaint.redactedLogs(wrappedRedacted).isNotEmpty(),
             "a redacted log statement stopped counting as one once it was wrapped",
         )
     }
@@ -1109,7 +1118,7 @@ class NavigationTokenLoggingTest {
             redactedLog,
         )
 
-        assertEquals(emptyList<String>(), TokenTaint.leaks(prose))
+        assertEquals(emptyList<String>(), LogTaint.leaks(prose))
     }
 
     @Test
@@ -1130,207 +1139,20 @@ class NavigationTokenLoggingTest {
             """        Logger.w(tag, message.toString())""",
         )
 
-        assertEquals(emptyList<String>(), TokenTaint.leaks(laundered))
+        assertEquals(emptyList<String>(), LogTaint.leaks(laundered))
         assertTrue(
-            TokenTaint.redactedLogs(laundered).isNotEmpty(),
+            LogTaint.redactedLogs(laundered).isNotEmpty(),
             "the control has to be satisfied here, or this case is not the gap it claims",
         )
     }
 
     private fun assertLeaks(source: List<String>) {
         assertTrue(
-            TokenTaint.leaks(source).isNotEmpty(),
+            LogTaint.leaks(source).isNotEmpty(),
             "a token-bearing value reaches Logger here and the reader did not see it:\n" +
                 source.joinToString("\n"),
         )
     }
-}
-
-/**
- * Which `Logger` statements in a Kotlin source hand on a value carrying the
- * connection token.
- *
- * Kept apart from the test that uses it because it is the part with behaviour of
- * its own: the cases in [NavigationTokenLoggingTest] drive it against sources
- * whose answer is known, which is only possible while it takes lines rather than
- * a filename.
- *
- * Three passes over the text, none of them a Kotlin parser and none pretending to
- * be. [codeView] drops string prose while keeping what a `$` interpolation names,
- * so a message can talk about a token without being one. [statements] gathers a
- * `Logger` call across however many lines it was wrapped onto, by counting
- * parentheses on that same prose-free view, which is what keeps a `" ("` in a
- * message from unbalancing the count. [taintedNames] walks declarations to a
- * fixpoint from the three places the token enters.
- *
- * Its blind spots are the docstring on [NavigationTokenLoggingTest], and one more
- * that belongs to the text scanning rather than to the design: a double quote
- * written inside an interpolation inside a string, `trim('"')` is one, and
- * MainActivity has it, ends the literal early, because handling it properly
- * means recursing into interpolations. The damage is bounded to that one
- * statement, and it cannot hide an interpolated name: [leaks] asks twice, once of
- * the prose-free view and once of the raw text, and only the first is affected.
- */
-private object TokenTaint {
-
-    /** Where a value carrying the connection token enters a file. */
-    private val SOURCES = listOf(
-        Regex("""\bworkbenchUrl\("""),
-        Regex("""\bgetConnectionToken\("""),
-        Regex("""\b(?:wv|webView)\??\.url\b"""),
-    )
-
-    private val DECLARATION = Regex("""\b(?:val|var)\s+([A-Za-z_]\w*)\s*(?::[^=]*?)?=(.*)""")
-    private val INTERPOLATION = Regex("""\$\{[^}]*}|\$[A-Za-z_]\w*""")
-    private val IDENTIFIER = Regex("""[A-Za-z_]\w*""")
-
-    /** Statements printing a tainted value with nothing hiding it. */
-    fun leaks(source: List<String>): List<String> {
-        val tainted = taintedNames(source)
-        return statements(source).filter { st ->
-            val code = stripRedacted(st.code)
-            val raw = stripRedacted(st.raw)
-            tainted.any { mentions(code, it) } ||
-                INTERPOLATION.findAll(raw).any { hole ->
-                    IDENTIFIER.findAll(hole.value).any { it.value in tainted }
-                }
-        }.map { "${it.line}: ${it.raw}" }
-    }
-
-    /** Statements printing a tainted value through the redactor. */
-    fun redactedLogs(source: List<String>): List<String> {
-        val tainted = taintedNames(source)
-        return statements(source).filter { st ->
-            redactedArguments(st.raw).any { arg -> tainted.any { mentions(arg, it) } }
-        }.map { "${it.line}: ${it.raw}" }
-    }
-
-    private class Statement(val line: Int, val raw: String, val code: String)
-
-    private fun isComment(line: String): Boolean {
-        val t = line.trimStart()
-        return t.startsWith("//") || t.startsWith("*") || t.startsWith("/*")
-    }
-
-    private fun mentions(text: String, name: String): Boolean =
-        Regex("""\b${Regex.escape(name)}\b""").containsMatchIn(text)
-
-    /**
-     * The line with its string prose removed and its interpolations kept.
-     *
-     * An identifier inside a literal can only be referred to through `$`, so what
-     * is left after this is every position where a name means a value.
-     */
-    private fun codeView(line: String): String {
-        val out = StringBuilder()
-        var i = 0
-        while (i < line.length) {
-            when {
-                line.startsWith("\"\"\"", i) -> {
-                    val end = line.indexOf("\"\"\"", i + 3)
-                    val inner = if (end < 0) line.substring(i + 3) else line.substring(i + 3, end)
-                    out.append(' ').append(interpolations(inner)).append(' ')
-                    i = if (end < 0) line.length else end + 3
-                }
-                line[i] == '"' -> {
-                    var j = i + 1
-                    while (j < line.length && !(line[j] == '"' && line[j - 1] != '\\')) j++
-                    val inner = line.substring(i + 1, j.coerceAtMost(line.length))
-                    out.append(' ').append(interpolations(inner)).append(' ')
-                    i = j + 1
-                }
-                else -> out.append(line[i++])
-            }
-        }
-        return out.toString()
-    }
-
-    private fun interpolations(inner: String): String =
-        INTERPOLATION.findAll(inner).joinToString(" ") { it.value }
-
-    /** Every `Logger` call, gathered across the lines it was wrapped onto. */
-    private fun statements(source: List<String>): List<Statement> {
-        val code = source.map { if (isComment(it)) "" else codeView(it) }
-        val out = mutableListOf<Statement>()
-        var i = 0
-        while (i < source.size) {
-            if (!code[i].contains("Logger.")) {
-                i++
-                continue
-            }
-            val raw = StringBuilder()
-            val whole = StringBuilder()
-            var depth = 0
-            var j = i
-            while (j < source.size && j - i < 12) {
-                raw.append(if (isComment(source[j])) "" else source[j].trim()).append(' ')
-                whole.append(code[j]).append(' ')
-                depth += code[j].count { it == '(' } - code[j].count { it == ')' }
-                if (depth <= 0) break
-                j++
-            }
-            out += Statement(i + 1, raw.toString().trim(), whole.toString())
-            i = j + 1
-        }
-        return out
-    }
-
-    /** Names holding a value that came, however indirectly, from a [SOURCES] hit. */
-    private fun taintedNames(source: List<String>): Set<String> {
-        val code = source.filterNot(::isComment).map(::codeView)
-        val names = linkedSetOf<String>()
-        // Declarations are walked to a fixpoint rather than once in file order, so
-        // that a chain assigned in the other order is still followed.
-        repeat(3) {
-            for (line in code) {
-                for (m in DECLARATION.findAll(line)) {
-                    val name = m.groupValues[1]
-                    val initialiser = m.groupValues[2]
-                    val seeded = SOURCES.any { it.containsMatchIn(initialiser) }
-                    val derived = names.toList()
-                        .any { mentions(stripRedacted(initialiser), it) }
-                    if (seeded || derived) names += name
-                }
-            }
-        }
-        return names
-    }
-
-    /** The spans of every `redactToken(...)` call, argument list included. */
-    private fun redactSpans(text: String): List<IntRange> {
-        val spans = mutableListOf<IntRange>()
-        var from = 0
-        while (true) {
-            val at = text.indexOf("redactToken(", from)
-            if (at < 0) return spans
-            var depth = 0
-            var i = at + "redactToken".length
-            var end = -1
-            while (i < text.length) {
-                if (text[i] == '(') depth++
-                else if (text[i] == ')' && --depth == 0) {
-                    end = i
-                    break
-                }
-                i++
-            }
-            if (end < 0) {
-                spans += at..text.lastIndex
-                return spans
-            }
-            spans += at..end
-            from = end + 1
-        }
-    }
-
-    private fun stripRedacted(text: String): String {
-        var out = text
-        for (span in redactSpans(text).reversed()) out = out.removeRange(span)
-        return out
-    }
-
-    private fun redactedArguments(text: String): List<String> =
-        redactSpans(text).map { text.substring(it).substringAfter('(').removeSuffix(")") }
 }
 
 /**

--- a/android/app/src/test/kotlin/com/vscodroid/LogTaint.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/LogTaint.kt
@@ -1,0 +1,244 @@
+package com.vscodroid
+
+/**
+ * Which `Logger` statements in a Kotlin source hand on a value the user would not
+ * want in logcat: the URL carrying the connection token, or a device folder's
+ * tree URI.
+ *
+ * Kept apart from the tests that use it because it is the part with behaviour of
+ * its own: the cases in [NavigationTokenLoggingTest] and
+ * `SafFolderLogCallSiteTest` drive it against sources whose answer is known,
+ * which is only possible while it takes lines rather than a filename.
+ *
+ * Three passes over the text, none of them a Kotlin parser and none pretending to
+ * be. [codeView] drops string prose while keeping what a `$` interpolation names,
+ * so a message can talk about a token without being one. [statements] gathers a
+ * `Logger` call across however many lines it was wrapped onto, by counting
+ * parentheses on that same prose-free view, which is what keeps a `" ("` in a
+ * message from unbalancing the count. [taintedNames] walks declarations to a
+ * fixpoint from the places a sensitive value enters: a [SOURCES] call, and any
+ * name a signature or a property declares as a [URI_NAME].
+ *
+ * Both seeds are here rather than one per guard on purpose. A guard written from
+ * the one spelling that had just been fixed catches that spelling and nothing
+ * else; the point of a reader is that interpolation, concatenation, an
+ * intermediate local and a wrapped call all read the same to it, and that adding
+ * a source closes every method in the file at once rather than one at a time.
+ *
+ * Its blind spots are the docstring on [NavigationTokenLoggingTest], and one more
+ * that belongs to the text scanning rather than to the design: a double quote
+ * written inside an interpolation inside a string, `trim('"')` is one, and
+ * MainActivity has it, ends the literal early, because handling it properly
+ * means recursing into interpolations. The damage is bounded to that one
+ * statement, and it cannot hide an interpolated name: [leaks] asks twice, once of
+ * the prose-free view and once of the raw text, and only the first is affected.
+ */
+internal object LogTaint {
+
+    /** Where a value carrying the connection token enters a file. */
+    private val SOURCES = listOf(
+        Regex("""\bworkbenchUrl\("""),
+        Regex("""\bgetConnectionToken\("""),
+        Regex("""\b(?:wv|webView)\??\.url\b"""),
+    )
+
+    /**
+     * A name a declaration gives the type `Uri`: a parameter, a property, a local.
+     *
+     * A SAF tree URI is the user's own directory spelled out
+     * (`.../tree/primary%3ADocuments%2F<folder>`), so it is a source in its own
+     * right and needs no call to arrive: `openSafFolder(uri: Uri, …)` is handed
+     * one. A declaration is the only place a type is written down, which is why
+     * this is a seed rather than something [SOURCES] could express.
+     *
+     * Missed by it: a `Uri` reaching a name through a type argument, as
+     * `previous: Pair<File, Uri>?` does, and one arriving with no type written at
+     * all. Both are the [taintedNames] ceiling, not a new one.
+     */
+    private val URI_NAME = Regex("""\b([A-Za-z_]\w*)\s*:\s*Uri\b""")
+
+    /**
+     * Calls that take the secret out of a value and leave the rest printable.
+     *
+     * `redactToken` replaces the `tkn=` parameter and nothing else, which is the
+     * whole treatment a tokened URL needs.
+     */
+    private val REDACTION = listOf("redactToken")
+
+    /**
+     * Calls that print no part of the value at all, only a name for the thing it
+     * points at.
+     *
+     * `getMirrorDir(uri).name` is the six-byte digest a device folder's mirror is
+     * called after; `urlLogLabel` is an address cut down to a scheme and a host.
+     * The distinction from [REDACTION] is load-bearing and `PageSuppliedLogging`
+     * states it too: a tree URI carries no `tkn=`, so wrapping one in
+     * `redactToken` satisfies a search for the call and changes nothing about
+     * what ships. Only [leaks] accepts these. [redactedLogs] must not, or the
+     * control it answers stops distinguishing a redacted log statement from a
+     * folder named by its digest.
+     */
+    private val REDUCTION = listOf("urlLogLabel", "getMirrorDir")
+
+    private val DECLARATION = Regex("""\b(?:val|var)\s+([A-Za-z_]\w*)\s*(?::[^=]*?)?=(.*)""")
+    private val INTERPOLATION = Regex("""\$\{[^}]*}|\$[A-Za-z_]\w*""")
+    private val IDENTIFIER = Regex("""[A-Za-z_]\w*""")
+
+    /** Statements printing a tainted value with nothing hiding it. */
+    fun leaks(source: List<String>): List<String> {
+        val tainted = taintedNames(source)
+        return statements(source).filter { st ->
+            val code = stripTreated(st.code)
+            val raw = stripTreated(st.raw)
+            tainted.any { mentions(code, it) } ||
+                INTERPOLATION.findAll(raw).any { hole ->
+                    IDENTIFIER.findAll(hole.value).any { it.value in tainted }
+                }
+        }.map { "${it.line}: ${it.raw}" }
+    }
+
+    /** Statements printing a tainted value through the redactor. */
+    fun redactedLogs(source: List<String>): List<String> {
+        val tainted = taintedNames(source)
+        return statements(source).filter { st ->
+            redactedArguments(st.raw).any { arg -> tainted.any { mentions(arg, it) } }
+        }.map { "${it.line}: ${it.raw}" }
+    }
+
+    private class Statement(val line: Int, val raw: String, val code: String)
+
+    private fun isComment(line: String): Boolean {
+        val t = line.trimStart()
+        return t.startsWith("//") || t.startsWith("*") || t.startsWith("/*")
+    }
+
+    private fun mentions(text: String, name: String): Boolean =
+        Regex("""\b${Regex.escape(name)}\b""").containsMatchIn(text)
+
+    /**
+     * The line with its string prose removed and its interpolations kept.
+     *
+     * An identifier inside a literal can only be referred to through `$`, so what
+     * is left after this is every position where a name means a value.
+     */
+    private fun codeView(line: String): String {
+        val out = StringBuilder()
+        var i = 0
+        while (i < line.length) {
+            when {
+                line.startsWith("\"\"\"", i) -> {
+                    val end = line.indexOf("\"\"\"", i + 3)
+                    val inner = if (end < 0) line.substring(i + 3) else line.substring(i + 3, end)
+                    out.append(' ').append(interpolations(inner)).append(' ')
+                    i = if (end < 0) line.length else end + 3
+                }
+                line[i] == '"' -> {
+                    var j = i + 1
+                    while (j < line.length && !(line[j] == '"' && line[j - 1] != '\\')) j++
+                    val inner = line.substring(i + 1, j.coerceAtMost(line.length))
+                    out.append(' ').append(interpolations(inner)).append(' ')
+                    i = j + 1
+                }
+                else -> out.append(line[i++])
+            }
+        }
+        return out.toString()
+    }
+
+    private fun interpolations(inner: String): String =
+        INTERPOLATION.findAll(inner).joinToString(" ") { it.value }
+
+    /** Every `Logger` call, gathered across the lines it was wrapped onto. */
+    private fun statements(source: List<String>): List<Statement> {
+        val code = source.map { if (isComment(it)) "" else codeView(it) }
+        val out = mutableListOf<Statement>()
+        var i = 0
+        while (i < source.size) {
+            if (!code[i].contains("Logger.")) {
+                i++
+                continue
+            }
+            val raw = StringBuilder()
+            val whole = StringBuilder()
+            var depth = 0
+            var j = i
+            while (j < source.size && j - i < 12) {
+                raw.append(if (isComment(source[j])) "" else source[j].trim()).append(' ')
+                whole.append(code[j]).append(' ')
+                depth += code[j].count { it == '(' } - code[j].count { it == ')' }
+                if (depth <= 0) break
+                j++
+            }
+            out += Statement(i + 1, raw.toString().trim(), whole.toString())
+            i = j + 1
+        }
+        return out
+    }
+
+    /**
+     * Names holding a value that came, however indirectly, from a [SOURCES] hit or
+     * a [URI_NAME] declaration.
+     */
+    private fun taintedNames(source: List<String>): Set<String> {
+        val code = source.filterNot(::isComment).map(::codeView)
+        val names = linkedSetOf<String>()
+        for (line in code) {
+            for (m in URI_NAME.findAll(line)) names += m.groupValues[1]
+        }
+        // Declarations are walked to a fixpoint rather than once in file order, so
+        // that a chain assigned in the other order is still followed.
+        repeat(3) {
+            for (line in code) {
+                for (m in DECLARATION.findAll(line)) {
+                    val name = m.groupValues[1]
+                    val initialiser = m.groupValues[2]
+                    val seeded = SOURCES.any { it.containsMatchIn(initialiser) }
+                    val derived = names.toList()
+                        .any { mentions(stripTreated(initialiser), it) }
+                    if (seeded || derived) names += name
+                }
+            }
+        }
+        return names
+    }
+
+    /** The spans of every call to one of [calls], argument list included. */
+    private fun spansOf(text: String, calls: List<String>): List<IntRange> {
+        val spans = mutableListOf<IntRange>()
+        var from = 0
+        while (true) {
+            val call = calls
+                .map { it to text.indexOf("$it(", from) }
+                .filter { it.second >= 0 }
+                .minByOrNull { it.second } ?: return spans
+            val at = call.second
+            var depth = 0
+            var i = at + call.first.length
+            var end = -1
+            while (i < text.length) {
+                if (text[i] == '(') depth++
+                else if (text[i] == ')' && --depth == 0) {
+                    end = i
+                    break
+                }
+                i++
+            }
+            if (end < 0) {
+                spans += at..text.lastIndex
+                return spans
+            }
+            spans += at..end
+            from = end + 1
+        }
+    }
+
+    /** [text] with everything a reader may treat as handled taken out of it. */
+    private fun stripTreated(text: String): String {
+        var out = text
+        for (span in spansOf(text, REDACTION + REDUCTION).reversed()) out = out.removeRange(span)
+        return out
+    }
+
+    private fun redactedArguments(text: String): List<String> =
+        spansOf(text, REDACTION).map { text.substring(it).substringAfter('(').removeSuffix(")") }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/ServerReadinessCallSiteTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/ServerReadinessCallSiteTest.kt
@@ -39,6 +39,8 @@ class ServerReadinessCallSiteTest {
 
     private val mainActivity = File("src/main/kotlin/com/vscodroid/MainActivity.kt")
 
+    private val source = SourceScan.read("src/main/kotlin/com/vscodroid/MainActivity.kt")
+
     /** Source lines with comments dropped, since both methods are named in prose. */
     private fun codeLines(): List<IndexedValue<String>> =
         mainActivity.readLines().withIndex().filterNot { (_, line) ->
@@ -65,27 +67,74 @@ class ServerReadinessCallSiteTest {
         )
     }
 
+    // The two cases below replaced a single count with a floor of two. The floor
+    // was the control for the case above, and it stopped discriminating once a
+    // third `isServerReady()` reached this file: deleting either decision, or
+    // reverting one to the port-only check, still left two tokens for it to
+    // count, so it passed. A count cannot say WHICH decision it counted, and
+    // that is the whole question here. Each decision is now pinned where it
+    // lives, so absence fails by name rather than by arithmetic.
+    //
+    // `SourceScan.body` throws with a sentence when the declaration is gone,
+    // which is the self-blindness this class of test otherwise has: "found
+    // nothing" and "found what I wanted" look identical from the same distance.
+
     @Test
-    fun `both places that decide on the server ask it`() {
-        // A file with neither call would satisfy the test above. This is the
-        // control for it, not a second assertion about the same thing.
-        //
-        // A floor of two rather than of one, and the difference is a real hole
-        // that a threshold of `> 0` left open: there are two decisions here, the
-        // bind-time check and the resume-from-background guard, and reverting
-        // just one of them restores half the defect while leaving both tests
-        // green. Either one alone is enough to put a user in front of a dead
-        // port.
-        //
-        // A floor rather than an exact count, because a third site would be an
-        // ordinary thing to add and should not have to come here first.
-        check(mainActivity.isFile) { "MainActivity.kt not found" }
+    fun `the resume guard asks the readiness question and obeys it`() {
+        val body = SourceScan.withoutComments(
+            SourceScan.body(source, "private fun handleResumeFromBackground()"),
+        )
 
-        val readinessCalls = codeLines().count { (_, line) -> line.contains("isServerReady()") }
-
+        val decisions = Regex("""shouldActOnResume\(""").findAll(body).count()
+        assertEquals(
+            1, decisions,
+            "expected exactly one resume decision inside handleResumeFromBackground(), " +
+                "found $decisions. Two of them split the verdict this case pins, and " +
+                "zero means the guard is gone.",
+        )
         assertTrue(
-            readinessCalls >= 2,
-            "both decisions must ask the readiness question; found $readinessCalls call site(s)",
+            body.contains("shouldActOnResume(nodeService?.isServerReady()"),
+            "the resume decision must be handed the readiness answer. A port that is " +
+                "merely allocated, or a process that is merely alive, reloads the page " +
+                "into a socket nothing is listening on yet.",
+        )
+
+        // The call and the branch are separate mutations: keeping the call and
+        // dropping its `return` leaves this file's token counts untouched and was
+        // one of the mutations the old floor passed.
+        val decidedAt = body.indexOf("shouldActOnResume(")
+        val actedAt = body.indexOf("resumeAction(")
+        assertTrue(
+            actedAt > decidedAt,
+            "resumeAction( no longer follows the resume decision in this body, so the " +
+                "span this case reads for the verdict is not the one that guards it",
+        )
+        assertTrue(
+            body.substring(decidedAt, actedAt).contains("return"),
+            "the resume decision's verdict must be obeyed before resumeAction( is " +
+                "reached; nothing returns between them, so the guard is computed and " +
+                "discarded",
+        )
+    }
+
+    @Test
+    fun `the binding decision is handed the readiness answer`() {
+        val body = SourceScan.withoutComments(
+            SourceScan.body(source, "private fun setupServiceCallbacks()"),
+        )
+
+        val decisions = Regex("""bindDecision\(""").findAll(body).count()
+        assertEquals(
+            1, decisions,
+            "expected exactly one binding decision inside setupServiceCallbacks(), " +
+                "found $decisions",
+        )
+        assertTrue(
+            body.contains("ready = service.isServerReady()"),
+            "the binding decision must be told what the health probe found. Handed " +
+                "`getPort() > 0` instead it navigates the WebView at a port that is " +
+                "allocated but not yet bound, and onReceivedError only logs, so the " +
+                "connection-refused page stays.",
         )
     }
 }

--- a/android/app/src/test/kotlin/com/vscodroid/service/ProcessManagerTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/service/ProcessManagerTest.kt
@@ -3470,6 +3470,75 @@ class HeapOverrideReaderTest {
     }
 
     @Test
+    fun `a glob in a value does not swallow a live key`() {
+        // The document this app itself writes plants three comment openers, inside
+        // the `<node_internals>` globs of its default `launch` block, and no closer
+        // at all. `launch` is the last property and the workbench appends new keys
+        // after the last one, so the user's key lands after all three openers, and
+        // the first exclude glob they add on the same settings tab supplies the
+        // closer. Everything between, the key included, read as one comment and the
+        // user silently got the derived ceiling, which for a value they had lowered
+        // is the larger of the two numbers. A delimiter inside a string value is
+        // text, and the reader has to know the difference.
+        val doc = """
+            {
+                "launch": {
+                    "version": "0.2.0",
+                    "configurations": [
+                        {
+                            "name": "Attach to Node.js",
+                            "type": "node",
+                            "skipFiles": ["<node_internals>/**"]
+                        }
+                    ]
+                },
+                "vscodroid.server.heapCeilingMb": 1024,
+                "files.exclude": { "**/node_modules": true },
+            }
+        """.trimIndent()
+        assertEquals(1024, heapOverrideFromSettings(doc), "a glob was read as a comment")
+    }
+
+    @Test
+    fun `a stray quote in a line comment does not hide a block comment`() {
+        // The cost of knowing strings from delimiters, and the reason line comments
+        // are recognised too. A `//` comment is prose, so an unbalanced quote in one
+        // is ordinary; left to be read as opening a string it would run to the next
+        // quote in the file, carry the block opener after it inside, and hand the
+        // commented-out key straight back to the anchor. 8192 for the reason the
+        // cases above give.
+        val doc = """
+            {
+                // careful with "this
+                /*
+                "vscodroid.server.heapCeilingMb": 8192,
+                */
+                "extensions.verifySignature": false,
+            }
+        """.trimIndent()
+        assertNull(heapOverrideFromSettings(doc), "a key inside a block comment was honoured")
+    }
+
+    @Test
+    fun `a comment closed early by a glob is a known and accepted miss`() {
+        // The mirror of the case above, pinned here so nobody later reads this suite
+        // as claiming it is closed. It is not a misreading: a block comment ends at
+        // the first closer, quotes inside it notwithstanding, exactly as it does in
+        // C, so a comment carrying an exclude glob has already ended by the time the
+        // key is reached and the document is no longer valid JSONC. A real JSONC
+        // scanner reads it the same way. What keeps it harmless is what keeps every
+        // misreading here harmless: [heapCeilingMb] clamps whatever comes out, and a
+        // value that keeps killing the server spends its budget and is dropped.
+        val doc = """
+            {
+                /* ignore "**/build" for now */
+                "vscodroid.server.heapCeilingMb": 1536,
+            }
+        """.trimIndent()
+        assertEquals(1536, heapOverrideFromSettings(doc))
+    }
+
+    @Test
     fun `a key that is only mentioned inside another value is not honoured`() {
         // The other half of the anchor: a key name appearing mid-line, here inside a
         // string somebody wrote, is not a setting either. On its own line, so the

--- a/android/app/src/test/kotlin/com/vscodroid/setup/PackReleaseOutcomeTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/PackReleaseOutcomeTest.kt
@@ -291,6 +291,88 @@ class PackReleaseOutcomeTest {
         verify(timeout = 10_000, exactly = 1) { packManager.removePack("toolchain_java") }
     }
 
+    /** A manager reporting into [sink], settling [latch] on a terminal status. */
+    private fun managerReporting(latch: CountDownLatch, sink: MutableList<Int>) =
+        ToolchainManager(context).apply {
+            onStateChange = { _, status, _, _ ->
+                sink.add(status)
+                if (status == AssetPackStatus.COMPLETED || status == AssetPackStatus.FAILED) {
+                    latch.countDown()
+                }
+            }
+        }
+
+    /** Exactly [bytes] free, so a gate's arithmetic decides the outcome. */
+    private fun room(bytes: Long) {
+        mockkConstructor(StatFs::class)
+        every { anyConstructed<StatFs>().availableBytes } returns bytes
+    }
+
+    /** Eight readable megabytes inside the delivered tree, so the credit is legible. */
+    private fun fattenDelivery(pack: String, name: String) {
+        val lib = File(filesDir, "delivered/$pack/usr/opt/$name/lib").apply { mkdirs() }
+        File(lib, "rt").writeBytes(ByteArray(8_000_000))
+    }
+
+    /** 8,000,007 bytes: the fattened file plus the "payload" [deliver] writes. */
+    private val orphanBytes = 8_000_007L
+
+    @Test
+    fun `an orphaned tree the copy writes over is credited to the space gate`() {
+        playHolds("toolchain_java")
+        deliver("toolchain_java", "java")
+        fattenDelivery("toolchain_java", "java")
+
+        plentyOfRoom()
+        blockTheRecordWrite()
+        val firstOut = Collections.synchronizedList(mutableListOf<Int>())
+        val first = CountDownLatch(1)
+        managerReporting(first, firstOut).reconcileDeliveredPacks()
+        assertTrue(first.await(10, TimeUnit.SECONDS), "the first pass never reported an outcome")
+        assertEquals(
+            listOf(AssetPackStatus.FAILED), firstOut,
+            "the first pass did not fail at the record write, so no orphan was made",
+        )
+        assertEquals(
+            orphanBytes,
+            com.vscodroid.util.StorageManager.dirSize(File(filesDir, "usr/opt/java")),
+            "the orphan is not the size this case's arithmetic assumes",
+        )
+
+        File(filesDir, "home/.vscodroid/toolchains.json.tmp~").deleteRecursively()
+
+        // Strictly between the credited demand (206,000,000 - 8,000,007) and the
+        // uncredited one (206,000,000).
+        room(200_000_000L)
+        val secondOut = Collections.synchronizedList(mutableListOf<Int>())
+        val second = CountDownLatch(1)
+        managerReporting(second, secondOut).reconcileDeliveredPacks()
+        assertTrue(second.await(10, TimeUnit.SECONDS), "the second pass never reported an outcome")
+        assertEquals(
+            listOf(AssetPackStatus.COMPLETED), secondOut,
+            "the gate charged for bytes the copy writes over",
+        )
+        verify(timeout = 10_000, exactly = 1) { packManager.removePack("toolchain_java") }
+    }
+
+    /** The control: the same tight figure with nothing on disk to credit must refuse. */
+    @Test
+    fun `the same room with no tree on disk is still refused`() {
+        playHolds("toolchain_java")
+        deliver("toolchain_java", "java")
+        fattenDelivery("toolchain_java", "java")
+
+        room(200_000_000L)
+        val out = Collections.synchronizedList(mutableListOf<Int>())
+        val settledHere = CountDownLatch(1)
+        managerReporting(settledHere, out).reconcileDeliveredPacks()
+        assertTrue(settledHere.await(10, TimeUnit.SECONDS), "the pass never reported an outcome")
+        assertEquals(
+            listOf(AssetPackStatus.FAILED), out,
+            "the gate passed with nothing on disk to credit, so it was weakened rather than corrected",
+        )
+    }
+
     /**
      * The outcome of the delete reaches a channel.
      *

--- a/android/app/src/test/kotlin/com/vscodroid/setup/PackReleaseOutcomeTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/PackReleaseOutcomeTest.kt
@@ -317,29 +317,32 @@ class PackReleaseOutcomeTest {
     /** 8,000,007 bytes: the fattened file plus the "payload" [deliver] writes. */
     private val orphanBytes = 8_000_007L
 
+    /**
+     * The orphan is placed on disk rather than made by a failing install, and the
+     * difference is the whole point of the case.
+     *
+     * A record write that fails now reclaims what it copied, so that exit no longer
+     * leaves one. Two sources still do, and neither has a code path that can clear
+     * them: a process killed partway through the copy, which nothing persists intent
+     * before, and a device already carrying an orphan from a build before the reclaim
+     * existed. For both, the tree is on disk and no record names it, which is exactly
+     * what is built here. Driving a failing install instead would measure the reclaim
+     * and call it the credit.
+     */
     @Test
     fun `an orphaned tree the copy writes over is credited to the space gate`() {
         playHolds("toolchain_java")
         deliver("toolchain_java", "java")
         fattenDelivery("toolchain_java", "java")
 
-        plentyOfRoom()
-        blockTheRecordWrite()
-        val firstOut = Collections.synchronizedList(mutableListOf<Int>())
-        val first = CountDownLatch(1)
-        managerReporting(first, firstOut).reconcileDeliveredPacks()
-        assertTrue(first.await(10, TimeUnit.SECONDS), "the first pass never reported an outcome")
-        assertEquals(
-            listOf(AssetPackStatus.FAILED), firstOut,
-            "the first pass did not fail at the record write, so no orphan was made",
-        )
+        val orphan = File(filesDir, "usr/opt/java/lib").apply { mkdirs() }
+        File(orphan, "rt").writeBytes(ByteArray(8_000_000))
+        File(File(filesDir, "usr/opt/java"), "payload").writeBytes(ByteArray(7))
         assertEquals(
             orphanBytes,
             com.vscodroid.util.StorageManager.dirSize(File(filesDir, "usr/opt/java")),
             "the orphan is not the size this case's arithmetic assumes",
         )
-
-        File(filesDir, "home/.vscodroid/toolchains.json.tmp~").deleteRecursively()
 
         // Strictly between the credited demand (206,000,000 - 8,000,007) and the
         // uncredited one (206,000,000).

--- a/android/app/src/test/kotlin/com/vscodroid/setup/SetupDurabilityBarrierTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/SetupDurabilityBarrierTest.kt
@@ -1,0 +1,92 @@
+package com.vscodroid.setup
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * The flush stands between the payload and the record that certifies it.
+ *
+ * READ WHAT THIS PINS, WHICH IS ORDERING AND NOT DURABILITY. A JVM test has no
+ * page cache to look at, cannot cut power, and cannot tell a file on the medium
+ * from a file sitting in a dirty page, so nothing here shows that anything was
+ * made durable, and no assertion below should be read as showing it. What it can
+ * show is the property the barrier's entire value rests on: that the flush is the
+ * last statement before the write that says the work is finished. Out of that
+ * order the flush is worse than absent, because the record is fsynced either way
+ * and goes on certifying bytes that may never have left memory.
+ *
+ * Two call sites, one shape. `markSetupComplete()` fsyncs through `commit()`, and
+ * `toolchains.json` is the only thing that names the ~155 MB a toolchain install
+ * copies, which no later pass reads the contents of.
+ *
+ * Source reading, with comments dropped first so that prose naming the calls
+ * cannot satisfy the scan.
+ *
+ * NEGATIVE CONTROL: move `flushWritesToMedia()` in `runSetupLocked` below
+ * `markSetupComplete()` and the first case names it; move it past
+ * `writeState(state)` in `installFromDirectoryHoldingPack` and the second does.
+ */
+class SetupDurabilityBarrierTest {
+
+    /** [path]'s Kotlin, comments dropped, relative to `android/app`. */
+    private fun codeOf(path: String): String {
+        val source = File(path)
+        check(source.isFile) {
+            "$path not found at ${source.absolutePath}; this test would otherwise pass " +
+                "by looking at nothing"
+        }
+        return source.readLines().filterNot {
+            val t = it.trimStart()
+            t.startsWith("//") || t.startsWith("*") || t.startsWith("/*")
+        }.joinToString("\n")
+    }
+
+    @Test
+    fun `first-run setup flushes immediately before it records completion`() {
+        val code = codeOf("src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt")
+
+        // The control on the scan: the declaration is excluded by the lookbehind,
+        // so a count other than one means this no longer reads the run it is about.
+        val calls = Regex("""(?<!fun )markSetupComplete\(\)""").findAll(code).count()
+        assertEquals(1, calls) {
+            "expected exactly one markSetupComplete() call outside its declaration, found $calls"
+        }
+
+        assertTrue(Regex("""flushWritesToMedia\(\)\s*markSetupComplete\(\)""").containsMatchIn(code)) {
+            "nothing flushes between the last write of the run and the commit that certifies " +
+                "it. markSetupComplete() commits, and a commit fsyncs, so in any other order " +
+                "the flag reaches the medium while the unpacked tree it vouches for is still " +
+                "page cache, and no later launch checks that tree's contents"
+        }
+    }
+
+    @Test
+    fun `a toolchain install flushes before the record naming its files`() {
+        val code = codeOf("src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt")
+
+        // Scoped to the one function, because writeState(state) is written from
+        // three places and only this one has a freshly copied tree behind it.
+        val start = code.indexOf("private fun installFromDirectoryHoldingPack")
+        assertTrue(start >= 0) {
+            "installFromDirectoryHoldingPack not found; the scan has lost the function it reads"
+        }
+        val end = Regex("""\n    private fun """).find(code, start + 1)?.range?.first ?: code.length
+        val body = code.substring(start, end)
+
+        val record = body.indexOf("writeState(state)")
+        assertTrue(record >= 0) {
+            "writeState(state) not found in installFromDirectoryHoldingPack; the scan has lost " +
+                "the write it orders against"
+        }
+        val flush = body.indexOf("flushWritesToMedia()")
+        assertTrue(flush in 0 until record) {
+            "the copy into usr/ is not flushed before toolchains.json records it (flush at " +
+                "$flush, record at $record). That record is the only thing that names those " +
+                "files, and the repair pass re-checks the tree with isDirectory alone, so a " +
+                "record that outlives the copy leaves a toolchain listed as installed over " +
+                "binaries that are holes"
+        }
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/setup/StoragePreflightTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/StoragePreflightTest.kt
@@ -625,10 +625,11 @@ class StoragePreflightTest {
      * `usr/` is credited for the entries the APK names and for nothing else.
      *
      * The estimate this replaces came out of `toolchains.json`, which records the
-     * installs that FINISHED. `ToolchainManager` says at the line where it
-     * happens that a copy which dies after the tree is written and before the
-     * record is leaves about 155 MB in `usr/` that nothing names, and
-     * `npm install -g` and pip never had a record at all. Every one of those
+     * installs that FINISHED. `ToolchainManager` takes its install root back on
+     * both failures it can see, but a process killed mid-copy reaches neither
+     * and leaves about 155 MB in `usr/` that nothing names, the part written
+     * into the shared `usr/bin` and `usr/lib` is never reclaimed on any exit,
+     * and `npm install -g` and pip never had a record at all. Every one of those
      * bytes was subtracted from nothing and credited as a byte the unpack writes
      * over. The cap kept that harmless while the bundled part of `usr/` was
      * complete, and stopped keeping it harmless exactly where the gate is worth

--- a/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainInstallSpaceTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainInstallSpaceTest.kt
@@ -89,6 +89,71 @@ class ToolchainInstallSpaceTest {
         }
     }
 
+    // -- the credit for a tree the copy writes over --
+
+    @TempDir
+    lateinit var filesDir: File
+
+    private fun rootUnder(name: String) = File(filesDir, name).apply { mkdirs() }
+
+    @Test
+    fun `a tree larger than the pack records is credited only what the pack writes back`() {
+        assertEquals(
+            156_000_000L,
+            existingTreeCredit(rootUnder("usr"), filesDir, 156_000_000L) { 900_000_000L },
+            "a swollen directory credited bytes the overwrite never returns",
+        )
+    }
+
+    @Test
+    fun `a smaller tree is credited what is measured`() {
+        assertEquals(
+            8_000_007L,
+            existingTreeCredit(rootUnder("usr"), filesDir, 156_000_000L) { 8_000_007L },
+        )
+    }
+
+    @Test
+    fun `no install root means no credit`() {
+        assertEquals(0L, existingTreeCredit(null, filesDir, 156_000_000L) { 900_000_000L })
+    }
+
+    /**
+     * The credit is the first decision built on the manifest's `installRoot`, and
+     * `File(base, "../..")` resolves outside the base it was joined to. Measuring
+     * there would return the whole app data directory, clamp to the pack's own
+     * size, and leave the gate asking for nothing but the buffer, which is the
+     * refusal switched off rather than relaxed.
+     */
+    @Test
+    fun `a root that resolves outside the base credits nothing`() {
+        val escaped = File(filesDir, "../..")
+        var measured = false
+        assertEquals(
+            0L,
+            existingTreeCredit(escaped, filesDir, 156_000_000L) { measured = true; 900_000_000L },
+        )
+        assertFalse(measured, "the escaped root was walked, which is the cost this refuses")
+    }
+
+    @Test
+    fun `the base itself is inside the base`() {
+        assertEquals(
+            8_000_007L,
+            existingTreeCredit(filesDir, filesDir, 156_000_000L) { 8_000_007L },
+            "a manifest naming the base directly is not an escape",
+        )
+    }
+
+    @Test
+    fun `the credited gate never falls below the buffer`() {
+        val credit = existingTreeCredit(rootUnder("usr"), filesDir, 156_000_000L) { 900_000_000L }
+        assertEquals(
+            SPACE_BUFFER,
+            (packInstallBytes(156_000_000L) - credit).coerceAtLeast(SPACE_BUFFER),
+        )
+    }
+
     // -- what the pre-flight is told a pack unpacks to --
 
     /**

--- a/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainInstallTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainInstallTest.kt
@@ -362,11 +362,7 @@ class ToolchainInstallTest {
     fun `an install whose record cannot be written reports FAILED rather than COMPLETED`() {
         val pack = File(filesDir, "pack-java").apply { mkdirs() }
         File(pack, "toolchain_java.json").writeText("""{"name":"java","installRoot":"usr/opt/java"}""")
-        // Non-empty, so the cleanup delete() cannot quietly reclaim it and let the
-        // write through, the point is that this write fails.
-        val blocker = File(filesDir, "home/.vscodroid/toolchains.json.tmp~")
-        assertTrue(blocker.mkdirs(), "could not stage the blocked temp path")
-        File(blocker, "occupied").writeText("x")
+        blockTheRecordWrite()
 
         installFromDirectory(manager(), "toolchain_java", pack)
 
@@ -377,6 +373,91 @@ class ToolchainInstallTest {
         assertFalse(
             File(filesDir, "home/.vscodroid/toolchains.json").exists(),
             "the harness did not block the write, so this test proves nothing",
+        )
+    }
+
+    /**
+     * Occupies the temporary path `writeAtomically` derives from `toolchains.json`,
+     * which is how the rest of this package arranges a record write that fails.
+     *
+     * Non-empty, so the cleanup `delete()` cannot quietly reclaim it and let the
+     * write through; the point is that this write fails.
+     */
+    private fun blockTheRecordWrite() {
+        val blocker = File(filesDir, "home/.vscodroid/toolchains.json.tmp~")
+        assertTrue(blocker.mkdirs(), "could not stage the blocked temp path")
+        File(blocker, "occupied").writeText("x")
+    }
+
+    /** A pack whose copy runs to the end, so the record write is what fails. */
+    private fun packThatCopiesCleanly(): File {
+        val pack = File(filesDir, "pack-java").apply { mkdirs() }
+        File(pack, "toolchain_java.json").writeText("""{"name":"java","installRoot":"usr/opt/java"}""")
+        File(pack, "usr/opt/java/bin").mkdirs()
+        File(pack, "usr/opt/java/bin/java").writeText("payload")
+        return pack
+    }
+
+    /**
+     * The copy is taken back when the record write is what fails, not only when
+     * the copy is.
+     *
+     * The two are the same event a step apart -- a disk that fills up during or at
+     * the end of a copy -- and they left opposite states behind. A copy that threw
+     * reclaimed its tree; a copy that finished and then could not be recorded kept
+     * every byte of it, under no manifest at all: nothing names it, no card offers
+     * to remove it, and the retry the user is told to make has to fit alongside it.
+     */
+    @Test
+    fun `an install whose record cannot be written takes back what it copied`() {
+        blockTheRecordWrite()
+
+        installFromDirectory(manager(), "toolchain_java", packThatCopiesCleanly())
+
+        assertEquals(
+            listOf(AssetPackStatus.FAILED), statuses(),
+            "the install did not fail at the record write, so this proves nothing",
+        )
+        assertEquals(
+            listOf(ToolchainFailure.STORAGE), synchronized(reasons) { reasons.toList() },
+            "an install that ran out of room was not reported as a storage problem",
+        )
+        assertFalse(
+            File(filesDir, "home/.vscodroid/toolchains.json").exists(),
+            "the harness did not block the write, so this test proves nothing",
+        )
+        assertFalse(
+            File(filesDir, "usr/opt/java").exists(),
+            "the copied tree is still there, and nothing names it: no card offers to " +
+                "remove it and no uninstall can find it",
+        )
+    }
+
+    /**
+     * The same direction as the failed reinstall above, at the other exit: a
+     * record write that fails leaves `toolchains.json` holding the previous
+     * record, so the files it names still belong to the install that succeeded.
+     */
+    @Test
+    fun `a failed reinstall keeps the installed tree when the record cannot be written`() {
+        File(filesDir, "home/.vscodroid/toolchains.json").writeText(
+            """[{"name":"java","installRoot":"usr/opt/java"}]"""
+        )
+        // Part of the working copy that the incoming pack does not carry, so its
+        // survival is the working copy's and not the failed copy's own output.
+        File(filesDir, "usr/opt/java/lib").mkdirs()
+        File(filesDir, "usr/opt/java/lib/rt").writeText("the install that succeeded")
+        blockTheRecordWrite()
+
+        installFromDirectory(manager(), "toolchain_java", packThatCopiesCleanly())
+
+        assertEquals(
+            listOf(AssetPackStatus.FAILED), statuses(),
+            "the install did not fail at the record write, so this proves nothing",
+        )
+        assertTrue(
+            File(filesDir, "usr/opt/java/lib/rt").exists(),
+            "the failed reinstall deleted the tree of the install that is still recorded",
         )
     }
 }

--- a/android/app/src/test/kotlin/com/vscodroid/storage/InitialSyncWiringTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/InitialSyncWiringTest.kt
@@ -618,4 +618,112 @@ class InitialSyncWiringTest {
 
         assertEquals(1_700_000_000_000, File(mirror, "stamped.txt").lastModified())
     }
+
+    /**
+     * The second consecutive pass through the write-back arm.
+     *
+     * Sync 2 pushes and records nothing, so sync 3 finds the record silent about the
+     * path, answers "the device did not change" and truncates it unread.
+     */
+    @Test
+    fun `a second write-back pass still sets a foreign device edit aside`() {
+        deviceFolderHolding("notes.txt", "from the device", 1_700_000_000_000)
+        sync()
+        val local = File(mirror, "notes.txt")
+
+        // Pass 1: the delivered write-back under a coarse stamp. Empties the record.
+        local.writeText("saved in the editor")
+        local.setLastModified(1_700_000_120_900)
+        deviceFolderHolding("notes.txt", "saved in the editor", 1_700_000_120_000)
+        sync()
+        val recordAfterPass1 =
+            File(mirror.path + SafSyncEngine.SYNCED_RECORD_SUFFIX).readLines()
+
+        // Pass 2: another app wrote the device document, still stamped below the
+        // mirror, and the editor saved again afterwards.
+        openedDocuments.clear()
+        writtenDocuments.clear()
+        deviceFolderHolding("notes.txt", "changed by another app", 1_700_000_120_500)
+        local.writeText("saved in the editor, again")
+        local.setLastModified(1_700_000_180_000)
+        sync()
+
+        val preserved =
+            File(mirror, "notes.txt${SafSyncEngine.DEVICE_COPY_SUFFIX}1700000120500")
+        assertEquals(listOf("notes.txt"), writtenDocuments, "the newer mirror copy still has to reach the device")
+        assertTrue(
+            preserved.isFile,
+            "the foreign device edit was overwritten with no copy anywhere; mirror now holds " +
+                mirror.list()?.sorted() + ", record after pass 1 was " + recordAfterPass1 +
+                ", opened during pass 2 was " + openedDocuments,
+        )
+        assertEquals("changed by another app", preserved.readText())
+    }
+
+    /**
+     * A record that parsed and does not name the path, meeting a foreign
+     * device edit under the write-back arm. Nothing to carry forward, so this is the
+     * case that separates "answer true on silence" from "carry the old line".
+     */
+    @Test
+    fun `a record silent about the path still sets a foreign device edit aside`() {
+        deviceFolderHolding("notes.txt", "from the device", 1_700_000_000_000)
+        sync()
+        val local = File(mirror, "notes.txt")
+
+        // The record parses and vouches for nothing: what a sync that kept every file
+        // it saw leaves behind, and what the write-back arm leaves behind too.
+        File(mirror.path + SafSyncEngine.SYNCED_RECORD_SUFFIX)
+            .writeText(SafSyncEngine.RECORD_HEADER)
+
+        openedDocuments.clear()
+        writtenDocuments.clear()
+        local.writeText("saved in the editor, again")
+        local.setLastModified(1_700_000_180_000)
+        deviceFolderHolding("notes.txt", "changed by another app", 1_700_000_120_500)
+        sync()
+
+        val preserved =
+            File(mirror, "notes.txt${SafSyncEngine.DEVICE_COPY_SUFFIX}1700000120500")
+        assertEquals(listOf("notes.txt"), writtenDocuments, "the newer mirror copy still has to reach the device")
+        assertTrue(
+            preserved.isFile,
+            "the foreign device edit was overwritten with no copy anywhere; mirror now holds " +
+                mirror.list()?.sorted() + ", opened was " + openedDocuments,
+        )
+        assertEquals("changed by another app", preserved.readText())
+    }
+
+    @Test
+    fun `a record line whose time will not parse still sets a foreign device edit aside`() {
+        deviceFolderHolding("notes.txt", "from the device", 1_700_000_000_000)
+        sync()
+        val local = File(mirror, "notes.txt")
+
+        // The third producer of silence, and the one the two cases above leave
+        // uncovered: a line that names the path but carries a time this build
+        // cannot read. A record written by a later format, or one truncated in
+        // the middle of a field, arrives here looking exactly like a vouched
+        // path. It vouches for nothing, and the arm that reads it has to say so.
+        File(mirror.path + SafSyncEngine.SYNCED_RECORD_SUFFIX)
+            .writeText(SafSyncEngine.RECORD_HEADER + "\nnotes.txt\tnot-a-number\t15\n")
+
+        openedDocuments.clear()
+        writtenDocuments.clear()
+        local.writeText("saved in the editor, again")
+        local.setLastModified(1_700_000_180_000)
+        deviceFolderHolding("notes.txt", "changed by another app", 1_700_000_120_500)
+        sync()
+
+        val preserved =
+            File(mirror, "notes.txt${SafSyncEngine.DEVICE_COPY_SUFFIX}1700000120500")
+        assertEquals(listOf("notes.txt"), writtenDocuments, "the newer mirror copy still has to reach the device")
+        assertTrue(
+            preserved.isFile,
+            "a line this build cannot read was treated as a vouched copy, and the foreign " +
+                "device edit was overwritten with no copy anywhere; mirror now holds " +
+                mirror.list()?.sorted() + ", opened was " + openedDocuments,
+        )
+        assertEquals("changed by another app", preserved.readText())
+    }
 }

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafUnfetchedDocumentTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafUnfetchedDocumentTest.kt
@@ -226,7 +226,11 @@ class SafUnfetchedDocumentTest {
     @Test
     fun `a directory holding a document the sync never read is kept on the device`() {
         val kept = mutableListOf<String>()
-        engine.onDirectoryKeptOnDevice = { kept.add(it.name) }
+        val asDirectory = mutableListOf<Boolean>()
+        engine.onKeptOnDevice = { file, isDirectory ->
+            kept.add(file.name)
+            asDirectory.add(isDirectory)
+        }
         deviceTree(docsHoldingUnread)
         runBlocking { engine.initialSync(treeUri, mirror) { _, _ -> } }
 
@@ -238,6 +242,14 @@ class SafUnfetchedDocumentTest {
             kept,
             "the directory was kept, or deleted, without the user being told which",
         )
+        // The flag picks the sentence, and nothing downstream can recover it: the
+        // entry is unlinked before the event arrives, so it cannot be stat'd.
+        assertEquals(
+            listOf(true),
+            asDirectory,
+            "the directory was announced with the wording for a single document, which " +
+                "says the editor never had a copy of a folder",
+        )
     }
 
     /**
@@ -248,7 +260,7 @@ class SafUnfetchedDocumentTest {
     @Test
     fun `a directory the sync read whole is deleted from the device`() {
         val kept = mutableListOf<String>()
-        engine.onDirectoryKeptOnDevice = { kept.add(it.name) }
+        engine.onKeptOnDevice = { file, _ -> kept.add(file.name) }
         deviceTree(
             mapOf(
                 "root" to listOf(Entry("docs", isDirectory = true)),
@@ -267,7 +279,7 @@ class SafUnfetchedDocumentTest {
     @Test
     fun `a directory is kept for a document the sync never read at any depth`() {
         val kept = mutableListOf<String>()
-        engine.onDirectoryKeptOnDevice = { kept.add(it.name) }
+        engine.onKeptOnDevice = { file, _ -> kept.add(file.name) }
         deviceTree(
             mapOf(
                 "root" to listOf(Entry("docs", isDirectory = true)),
@@ -291,7 +303,7 @@ class SafUnfetchedDocumentTest {
     @Test
     fun `a sibling whose name merely starts the same does not keep the directory`() {
         val kept = mutableListOf<String>()
-        engine.onDirectoryKeptOnDevice = { kept.add(it.name) }
+        engine.onKeptOnDevice = { file, _ -> kept.add(file.name) }
         deviceTree(
             mapOf(
                 "root" to listOf(
@@ -318,7 +330,7 @@ class SafUnfetchedDocumentTest {
     @Test
     fun `a directory the device no longer holds is not kept`() {
         val kept = mutableListOf<String>()
-        engine.onDirectoryKeptOnDevice = { kept.add(it.name) }
+        engine.onKeptOnDevice = { file, _ -> kept.add(file.name) }
         deviceTree(docsHoldingUnread)
         runBlocking { engine.initialSync(treeUri, mirror) { _, _ -> } }
 
@@ -345,7 +357,7 @@ class SafUnfetchedDocumentTest {
     @Test
     fun `renaming a directory that holds a document the sync never read still renames it`() {
         val kept = mutableListOf<String>()
-        engine.onDirectoryKeptOnDevice = { kept.add(it.name) }
+        engine.onKeptOnDevice = { file, _ -> kept.add(file.name) }
         deviceTree(docsHoldingUnread)
         runBlocking { engine.initialSync(treeUri, mirror) { _, _ -> } }
 
@@ -370,7 +382,7 @@ class SafUnfetchedDocumentTest {
     @Test
     fun `a renamed directory still keeps the document the sync never read`() {
         val kept = mutableListOf<String>()
-        engine.onDirectoryKeptOnDevice = { kept.add(it.name) }
+        engine.onKeptOnDevice = { file, _ -> kept.add(file.name) }
         deviceTree(docsHoldingUnread)
         runBlocking { engine.initialSync(treeUri, mirror) { _, _ -> } }
         engine.handleMirrorEvent(
@@ -399,7 +411,7 @@ class SafUnfetchedDocumentTest {
     @Test
     fun `a directory is kept when the provider cannot say whether it still holds it`() {
         val kept = mutableListOf<String>()
-        engine.onDirectoryKeptOnDevice = { kept.add(it.name) }
+        engine.onKeptOnDevice = { file, _ -> kept.add(file.name) }
         deviceTree(docsHoldingUnread)
         runBlocking { engine.initialSync(treeUri, mirror) { _, _ -> } }
         every { resolver.query(any(), any(), any(), any(), any()) } throws
@@ -409,6 +421,180 @@ class SafUnfetchedDocumentTest {
 
         verify(exactly = 0) { DocumentsContract.deleteDocument(any(), any()) }
         assertEquals(listOf("docs"), kept, "an unanswerable provider was read as \"gone\"")
+    }
+
+    /**
+     * The same question one level down, where the answer used to be the opposite of
+     * the truth. A document the sync could not read leaves the mirror without it and
+     * its path in the set; the user deletes the name they can see in the editor; and
+     * the delete has to be declined for the reason the directory above is declined,
+     * because `deleteDocument` here takes the only copy of the document.
+     *
+     * What was wrong was not the refusal but the sentence. The guard that refuses
+     * writes sat above the event type and answered for the delete as well, so the
+     * user was told the only copy was inside VSCodroid at the moment the app held
+     * none of it.
+     */
+    @Test
+    fun `a document the sync never read is kept on the device when the editor deletes it`() {
+        val kept = mutableListOf<String>()
+        val asDirectory = mutableListOf<Boolean>()
+        val lost = mutableListOf<String>()
+        engine.onKeptOnDevice = { file, isDirectory ->
+            kept.add(file.name)
+            asDirectory.add(isDirectory)
+        }
+        engine.onWriteBackFailed = { lost.add(it.name) }
+        deviceHolding("notes.md", size = 64, readable = false)
+        runBlocking { engine.initialSync(treeUri, mirror) { _, _ -> } }
+
+        deliver(FileObserver.DELETE, "notes.md")
+
+        verify(exactly = 0) { DocumentsContract.deleteDocument(any(), any()) }
+        assertEquals(
+            listOf("notes.md"),
+            kept,
+            "the device document was kept without the user being told where their file is",
+        )
+        assertEquals(
+            listOf(false),
+            asDirectory,
+            "a single document was announced in the wording for a directory, which tells " +
+                "the user their file holds files",
+        )
+        assertTrue(
+            lost.isEmpty(),
+            "a document that is only on the device was announced as one only the app " +
+                "holds, which sends the user looking in the wrong place: $lost",
+        )
+    }
+
+    /**
+     * The same rule the directory arm follows, and the reason this walk is the
+     * three-state one: a provider that cannot be asked has not said "gone". Answering
+     * "not held" for a failed lookup is right where the cost of being wrong is a
+     * duplicate name, and wrong here, where it is `deleteDocument` on the one copy of
+     * a document the editor never had.
+     */
+    @Test
+    fun `a document is kept when the provider cannot say whether it still holds it`() {
+        val kept = mutableListOf<String>()
+        engine.onKeptOnDevice = { file, _ -> kept.add(file.name) }
+        deviceHolding("notes.md", size = 64, readable = false)
+        runBlocking { engine.initialSync(treeUri, mirror) { _, _ -> } }
+        every { resolver.query(any(), any(), any(), any(), any()) } throws
+            IllegalStateException("the provider is gone")
+
+        deliver(FileObserver.DELETE, "notes.md")
+
+        verify(exactly = 0) { DocumentsContract.deleteDocument(any(), any()) }
+        assertEquals(listOf("notes.md"), kept, "an unanswerable provider was read as \"gone\"")
+    }
+
+    /**
+     * The control that keeps the two cases above honest. A document the sync did read
+     * is mirrored, so deleting it in the editor is a deletion of something the device
+     * and the app both have, and it goes through as it always did. A guard widened past
+     * the set fails here.
+     */
+    @Test
+    fun `a document the sync did read is deleted from the device`() {
+        val kept = mutableListOf<String>()
+        engine.onKeptOnDevice = { file, _ -> kept.add(file.name) }
+        deviceHolding("notes.md", size = 64)
+        runBlocking { engine.initialSync(treeUri, mirror) { _, _ -> } }
+
+        File(mirror, "notes.md").delete()
+        deliver(FileObserver.DELETE, "notes.md")
+
+        verify(exactly = 1) {
+            DocumentsContract.deleteDocument(any(), uris.getValue("doc:notes.md"))
+        }
+        assertTrue(kept.isEmpty(), "a delete that went through was announced as kept: $kept")
+    }
+
+    /**
+     * The other half of a delete, and the one the workbench is measured to send for a
+     * directory: the entry is renamed away rather than unlinked. Both arrive as one
+     * type here, so a guard reading the raw event instead of the type would let this
+     * one through and take the document with it.
+     */
+    @Test
+    fun `a document the sync never read is kept when it is moved away instead`() {
+        val kept = mutableListOf<String>()
+        val lost = mutableListOf<String>()
+        engine.onKeptOnDevice = { file, _ -> kept.add(file.name) }
+        engine.onWriteBackFailed = { lost.add(it.name) }
+        deviceHolding("notes.md", size = 64, readable = false)
+        runBlocking { engine.initialSync(treeUri, mirror) { _, _ -> } }
+
+        deliver(FileObserver.MOVED_FROM, "notes.md")
+
+        verify(exactly = 0) { DocumentsContract.deleteDocument(any(), any()) }
+        assertEquals(
+            listOf("notes.md"),
+            kept,
+            "a move away deleted the document the sync never read",
+        )
+        assertTrue(lost.isEmpty(), "the notice said the app holds the only copy: $lost")
+    }
+
+    /**
+     * `notes.md` is a prefix of `notes.md.bak` as a string and not as a path. The
+     * directory arm above matches by prefix because a directory holds what is under
+     * it; a file has to match its own path exactly, or deleting a document the sync
+     * read whole is refused because an unrelated backup beside it was skipped.
+     */
+    @Test
+    fun `a neighbour whose name merely starts the same does not keep the document`() {
+        val kept = mutableListOf<String>()
+        engine.onKeptOnDevice = { file, _ -> kept.add(file.name) }
+        deviceTree(
+            mapOf(
+                "root" to listOf(
+                    Entry("notes.md"),
+                    Entry("notes.md.bak", size = SafSyncEngine.MAX_FILE_SIZE + 1),
+                ),
+            )
+        )
+        runBlocking { engine.initialSync(treeUri, mirror) { _, _ -> } }
+
+        File(mirror, "notes.md").delete()
+        deliver(FileObserver.DELETE, "notes.md")
+
+        verify(exactly = 1) {
+            DocumentsContract.deleteDocument(any(), uris.getValue("doc:notes.md"))
+        }
+        assertTrue(kept.isEmpty(), "notes.md was kept for a document named notes.md.bak: $kept")
+    }
+
+    /**
+     * The refusal notice is a budget of one per path per folder open, and it belongs to
+     * the write refusal, whose sentence is only ever said once for a file the editor
+     * keeps saving. A delete spending it costs the save that comes after: the user
+     * recreates the name, saves it, the write is refused because the device still holds
+     * the document under it, and this time "the only copy is inside VSCodroid" is true
+     * and urgent. Nothing said it, until the folder was closed and opened again.
+     */
+    @Test
+    fun `a refused delete leaves the notice the next refused save needs`() {
+        val lost = mutableListOf<String>()
+        engine.onWriteBackFailed = { lost.add(it.name) }
+        deviceHolding("notes.md", size = 64, readable = false)
+        runBlocking { engine.initialSync(treeUri, mirror) { _, _ -> } }
+
+        deliver(FileObserver.DELETE, "notes.md")
+        assertTrue(lost.isEmpty(), "the delete announced a refusal of its own: $lost")
+
+        File(mirror, "notes.md").writeText("typed again, in the editor")
+        deliver(FileObserver.CREATE, "notes.md")
+
+        assertEquals(
+            listOf("notes.md"),
+            lost,
+            "the save that really did stay inside the app was silent, because the " +
+                "delete before it had already spent the one notice for that path",
+        )
     }
 
     /**

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafWatchLifecycleTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafWatchLifecycleTest.kt
@@ -1,0 +1,223 @@
+package com.vscodroid.storage
+
+import android.content.ContentResolver
+import android.content.Context
+import android.net.Uri
+import com.vscodroid.util.Logger
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotSame
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertTimeoutPreemptively
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.time.Duration
+
+/**
+ * When this engine may be started, and when it stops being startable at all.
+ *
+ * The Activity has four call sites and serialises three of them behind one mutex.
+ * The fourth is `onDestroy`, deliberately on a detached thread outside that mutex,
+ * because the stop it makes blocks for up to `DRAIN_GRACE_MS` and the teardown gains
+ * nothing by waiting. What that hands the engine is a call that can arrive in the
+ * middle of a start already running on `Dispatchers.IO`: inside the inner stop's own
+ * drain, or inside the mirror walk. Cancelling the scope does not reach it, because
+ * nothing in `startWatching` suspends.
+ *
+ * With the two methods sharing no monitor, whichever of them wrote `isWatching` last
+ * decided the outcome, and the start winning left observers registered, a
+ * `saf-writeback` thread polling and a live engine that no code path could reach
+ * again: the replacement Activity builds its own [SafStorageManager], and its stop
+ * goes to a different engine. So the lifecycle is serialised here, where all four
+ * calls pass, and a teardown says so in a way a late start cannot undo.
+ *
+ * The mirror these tests name does not exist, which is what keeps them on the JVM:
+ * `watchableDirectories` returns nothing for a path that is not a directory, so no
+ * [android.os.FileObserver] is built, and building one runs a static initializer that
+ * reaches native code. Everything decided here -- the refusal, the session hand-over,
+ * the worker -- is decided before any observer would exist.
+ */
+class SafWatchLifecycleTest {
+
+    @TempDir
+    lateinit var filesDir: File
+
+    @TempDir
+    lateinit var parent: File
+
+    private lateinit var engine: SafSyncEngine
+
+    /** A mirror path with no directory at it. See the class comment. */
+    private val mirror: File get() = File(parent, "folder-that-was-never-synced")
+
+    private val treeUri: Uri = mockk(relaxed = true)
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(Logger)
+        every { Logger.i(any(), any()) } just Runs
+        every { Logger.d(any(), any()) } just Runs
+        every { Logger.w(any(), any()) } just Runs
+        every { Logger.w(any(), any(), any()) } just Runs
+        every { Logger.e(any(), any()) } just Runs
+        every { Logger.e(any(), any(), any()) } just Runs
+
+        val resolver = mockk<ContentResolver>(relaxed = true)
+        val context = mockk<Context>(relaxed = true)
+        every { context.contentResolver } returns resolver
+        every { context.filesDir } returns filesDir
+        engine = SafSyncEngine(context)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        // However the assertions ended, no test may leave a write-back thread polling.
+        engine.shutdown()
+        unmockkAll()
+    }
+
+    @Test
+    fun `a start that outlived its owner is refused rather than run late`() {
+        engine.shutdown()
+        val closed = engine.session
+
+        engine.startWatching(mirror, treeUri)
+
+        assertSame(
+            closed, engine.session,
+            "a start after the shutdown installed a session on an engine whose owner is " +
+                "gone: nothing can stop what it starts, because the next Activity's " +
+                "manager holds a different engine",
+        )
+        assertNull(
+            engine.session.worker,
+            "a start after the shutdown left a saf-writeback thread polling for the rest " +
+                "of the process",
+        )
+    }
+
+    @Test
+    fun `the shutdown ends the drain the way a folder switch does`() {
+        // Control on the other half: refusing later starts is worth nothing if the
+        // watcher this call is closing keeps running.
+        engine.startWatching(mirror, treeUri)
+        val worker = engine.session.worker
+
+        engine.shutdown()
+
+        assertTrue(worker != null) { "setup failed: the start never began a write-back" }
+        assertFalse(worker!!.isAlive, "the shutdown left the drain polling")
+    }
+
+    @Test
+    fun `a folder switch still starts the next watcher from inside the stop it opens with`() {
+        // Two things at once, and both are load-bearing. The refusal must apply to a
+        // shutdown only, or every folder switch after the first leaves the folder on
+        // screen unwatched. And `startWatching` calls `stopWatching` while holding the
+        // lifecycle lock, so this deadlocks the moment that monitor stops being
+        // reentrant -- which is why the timeout is here rather than a plain call.
+        assertTimeoutPreemptively(Duration.ofSeconds(10)) {
+            engine.startWatching(mirror, treeUri)
+            val first = engine.session
+
+            engine.startWatching(mirror, treeUri)
+
+            assertNotSame(first, engine.session, "the next folder was handed the previous session")
+            assertFalse(
+                first.running,
+                "the previous folder's write-back was left running by the start that replaced it",
+            )
+            assertTrue(
+                engine.session.worker?.isAlive == true,
+                "the folder opened next has no drain, so its saves reach no device",
+            )
+        }
+    }
+}
+
+/**
+ * That the teardown path still reaches the terminal stop, and the two lifecycle
+ * methods still exclude each other.
+ *
+ * Source reading, for the reason `ServerReadinessCallSiteTest` gives: what regresses
+ * here is a call going to the wrong one of two near-identical methods, or a monitor
+ * being dropped, neither of which changes a value a JVM test can observe. The
+ * behaviour above pins what the engine does once the calls are wired this way; this
+ * pins the wiring.
+ */
+class SafWatchLifecycleWiringTest {
+
+    private val engineFile = File("src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt")
+    private val managerFile = File("src/main/kotlin/com/vscodroid/storage/SafStorageManager.kt")
+
+    /** The lines of a declaration's body, comments dropped, by brace matching. */
+    private fun body(file: File, declaration: String): List<String> {
+        check(file.isFile) {
+            "${file.absolutePath} not found; this test would otherwise pass by looking " +
+                "at nothing"
+        }
+        val source = file.readText()
+        val start = source.indexOf(declaration)
+        check(start >= 0) {
+            "`$declaration` is gone from ${file.name}, so this test is measuring nothing. " +
+                "If it moved or was renamed, point this at the new site rather than " +
+                "deleting it."
+        }
+        val open = source.indexOf('{', start)
+        var depth = 0
+        var i = open
+        while (i < source.length) {
+            if (source[i] == '{') depth += 1
+            if (source[i] == '}') {
+                depth -= 1
+                if (depth == 0) {
+                    return source.substring(open + 1, i).lines().map { it.trim() }.filterNot {
+                        it.isEmpty() || it.startsWith("//") || it.startsWith("*") ||
+                            it.startsWith("/*")
+                    }
+                }
+            }
+            i += 1
+        }
+        throw AssertionError("Could not find the end of `$declaration` in ${file.name}")
+    }
+
+    @Test
+    fun `the lifecycle methods hold one monitor for the whole of what they do`() {
+        for (declaration in listOf(
+            "fun startWatching(mirrorDir: File, safUri: Uri) {",
+            "fun stopWatching() {",
+            "fun shutdown() {",
+        )) {
+            val first = body(engineFile, declaration).first()
+            assertTrue(first == "synchronized(lifecycleLock) {") {
+                "`$declaration` no longer holds the lifecycle lock across its whole body " +
+                    "(it opens with `$first`). Each of these takes several steps to say " +
+                    "whether the engine is live, and run against each other the last " +
+                    "writer wins: a stop finishing inside a start's drain leaves a " +
+                    "watcher and a write-back thread on an engine whose owner is gone."
+            }
+        }
+    }
+
+    @Test
+    fun `the manager's shutdown reaches the engine's, not its ordinary stop`() {
+        val delegation = body(managerFile, "fun shutdownFileWatcher() {")
+
+        assertTrue(delegation.any { it.contains("syncEngine.shutdown()") }) {
+            "shutdownFileWatcher no longer shuts the engine down, so `onDestroy` makes a " +
+                "stop that a start already inside the engine simply overtakes. Found: " +
+                delegation
+        }
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/storage/WriteBackNoticeWiringTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/WriteBackNoticeWiringTest.kt
@@ -135,20 +135,32 @@ class WriteBackNoticeWiringTest {
         )
     }
 
+    /**
+     * One seam, two sentences. A directory is kept for what is inside it and a
+     * document is kept for what it is, so the second wording is named here as
+     * separately as the capped upload is above: the directory sentence says the thing
+     * holds files that never reached the editor, which of a single document is simply
+     * false, and a user told that goes looking inside a file.
+     */
     @Test
-    fun `MainActivity asks to be told when a deleted directory was kept on the device`() {
+    fun `MainActivity asks to be told when a delete was declined to save the device copy`() {
         assertTrue(activity.isFile, "MainActivity.kt is not where this test expects it")
         val source = activity.readText()
 
         assertTrue(
-            Regex("""(?m)^\s*safManager\.onDirectoryKeptOnDevice\s*\{""").containsMatchIn(source),
-            "nothing wires the notice for a directory kept on the device, so a delete " +
+            Regex("""(?m)^\s*safManager\.onKeptOnDevice\s*\{""").containsMatchIn(source),
+            "nothing wires the notice for what was kept on the device, so a delete " +
                 "that was declined to save an unread archive says nothing about it",
         )
         assertTrue(
             Regex("""(?m)^\s*[^/\n]*saf_directory_kept\b""").containsMatchIn(source),
             "the notice does not name the string that says the device, not the app, " +
                 "holds the files",
+        )
+        assertTrue(
+            Regex("""(?m)^\s*[^/\n]*saf_document_kept\b""").containsMatchIn(source),
+            "a single kept document is announced in the wording for a directory, which " +
+                "tells the user their file holds files",
         )
     }
 

--- a/android/app/src/test/kotlin/com/vscodroid/util/CrashReporterTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/util/CrashReporterTest.kt
@@ -447,6 +447,16 @@ class CrashReporterTest {
                 "the section does not say whose output it is, and the user is about " +
                     "to paste it somewhere public:\n$report",
             )
+            // The header may not promise more than the scrubber can do. It matches
+            // known shapes, and a bare secret reads like any other word, so a
+            // sentence saying credentials are gone tells the user to stop looking
+            // at exactly the moment they should look. Pinned because it was that
+            // sentence once, and a shorter line is a tempting edit.
+            assertFalse(
+                report.contains("credentials removed"),
+                "the header promises the credentials are gone, which the redaction " +
+                    "cannot guarantee for a shape it does not know:\n$report",
+            )
         }
 
         /**

--- a/android/app/src/test/kotlin/com/vscodroid/util/TextContrastTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/util/TextContrastTest.kt
@@ -106,6 +106,8 @@ class TextContrastTest {
     private val themesXml = File("src/main/res/values/themes.xml")
     private val pickerAdapter =
         File("src/main/kotlin/com/vscodroid/setup/ToolchainPickerAdapter.kt")
+    private val extraKeyRow =
+        File("src/main/kotlin/com/vscodroid/keyboard/ExtraKeyRow.kt")
 
     // -- The WCAG arithmetic --
 
@@ -576,6 +578,66 @@ class TextContrastTest {
             "ToolchainPickerAdapter no longer paints a selected card with " +
                 "colorCardSelected, so the second ground this class measures the card's " +
                 "text against is a colour nothing shows",
+        )
+    }
+
+    /**
+     * That the latch badge beside the page dots can be read on the ground it sits on.
+     *
+     * The one text on the extra key row whose colour is chosen in Kotlin and whose
+     * ground is chosen in the same file, so neither end is in a layout and the walk
+     * above cannot see either. Both ends are read out of the source rather than named
+     * here: naming `colorPrimaryText` would measure this test's memory of the fix, and
+     * the badge is at AA only because it sits on `colorSurface`, so a ground moved to a
+     * key's own `#2D2D2D` takes the same colour to 4.49:1 and has to redden this.
+     *
+     * The window is opened at the badge's declaration because the file sets a text
+     * colour nowhere else today and this must not start passing on some other view's
+     * colour if it ever does.
+     */
+    @Test
+    fun `the latch badge is readable on the ground the row paints under it`() {
+        assertTrue(
+            extraKeyRow.isFile,
+            "${extraKeyRow.path} is not at ${extraKeyRow.absolutePath}; this test would " +
+                "otherwise pass by reading nothing",
+        )
+        val source = extraKeyRow.readText()
+
+        val badgeStart = source.indexOf("modifierBadge = TextView(context).apply {")
+        assertTrue(
+            badgeStart >= 0,
+            "ExtraKeyRow no longer declares `modifierBadge = TextView(context).apply {`, " +
+                "so the window this measures the latch cue in was not found and the " +
+                "colour asserted below is some other view's",
+        )
+
+        // Anchored at the start of a line with a no-slash class, as the picker case
+        // above is: a commented-out call must not satisfy either end.
+        val colorRef = Regex("""(?m)^\s*[^/\n]*setTextColor\(context\.getColor\(R\.color\.(\w+)\)\)""")
+            .find(source, badgeStart)
+            ?.groupValues?.get(1)
+        checkNotNull(colorRef) {
+            "no setTextColor(context.getColor(R.color.…)) follows the modifierBadge " +
+                "declaration, so nothing was measured"
+        }
+
+        val groundRef = Regex("""(?m)^\s*[^/\n]*setBackgroundColor\(context\.getColor\(R\.color\.(\w+)\)\)""")
+            .find(source)
+            ?.groupValues?.get(1)
+        checkNotNull(groundRef) {
+            "ExtraKeyRow paints no background of its own any more, so the ground the " +
+                "badge is measured against is a guess"
+        }
+
+        val ratio = contrast(resolve("@color/$colorRef").first, flatten("@color/$groundRef"))
+        assertTrue(
+            ratio >= AA_NORMAL,
+            "the latch badge: @color/$colorRef on @color/$groundRef measures " +
+                "${ratio.two()}:1, and WCAG AA asks $AA_NORMAL:1 for text this size. " +
+                "It is 11sp, which this file's own rule counts as normal text, and it " +
+                "is the only report that a modifier is still held once the row has " +
+                "been swiped past the page the modifier keys are on",
         )
     }
 

--- a/android/app/src/test/kotlin/com/vscodroid/webview/ExternalUrlHandoffTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/ExternalUrlHandoffTest.kt
@@ -646,6 +646,50 @@ class ExternalUrlHandoffTest {
     }
 
     /**
+     * A navigation cannot flush the record of what this app has in flight.
+     *
+     * The record holds the most recent few launches, and an address may name as
+     * many request ids as its author cares to type, so one navigation carrying
+     * enough of them pushed out the sign-in the user had open in the browser.
+     * The callback then comes back for an id nothing recorded, is dropped in the
+     * log with no message, and the extension waits for ever.
+     *
+     * Here rather than only at the bridge, because the two exits read the ids
+     * through the same function and a bound written at one call site leaves the
+     * other unbounded. The main frame is our own page, but the address is not
+     * necessarily ours: `injectWindowOpenOverride` falls through to a plain
+     * navigation and the workbench's own opener assigns `location.href`, so
+     * whatever asked to open a URL chose this string.
+     *
+     * NEGATIVE CONTROL: bound the ids at `AndroidBridge.openExternalUrl` instead
+     * of inside `authRequestIdsIn` and this case goes red while the bridge's own
+     * stays green.
+     */
+    @Test
+    fun `a navigation naming a crowd of requests leaves the sign-in in flight armed`() {
+        val crowd = (1..32).map { "9400$it" }
+        try {
+            client.shouldOverrideUrlLoading(view, request("https", "github.com", -1, SIGN_IN))
+
+            client.shouldOverrideUrlLoading(
+                view,
+                request(
+                    "https", "example.com", -1,
+                    "https://example.com/?" + crowd.joinToString("&") { "vscode-reqid=$it" },
+                ),
+            )
+
+            assertTrue(
+                callbackWouldBeTaken(SIGN_IN_REQUEST_ID),
+                "one navigation pushed the sign-in actually in flight out of the record, so " +
+                    "its callback is refused and nothing tells the user why",
+            )
+        } finally {
+            AuthTabWindow.disarm(crowd)
+        }
+    }
+
+    /**
      * The other half, and the one that keeps this from being a widening: every
      * external link goes through here, and a link to documentation must not put
      * the callback relay within reach of an id nobody asked for.

--- a/android/app/src/test/kotlin/com/vscodroid/webview/ResourceInterceptionWiringTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/ResourceInterceptionWiringTest.kt
@@ -231,11 +231,13 @@ class ResourceInterceptionWiringTest {
      * webview documents come from the `{{uuid}}.vscode-cdn.net` template and the
      * resource authority only ever answers subresources.
      *
-     * The name says `fetch` because that is the whole of what this closes. The
-     * same document can still frame another path on its own origin and read that
-     * one back, since a navigation arrives here with no origin to refuse; the
-     * comment on the gate itself states that residual rather than leaving it to
-     * be discovered.
+     * What this closes is the asking that carries an `Origin`, which is a
+     * CORS-mode request to a different one of our origins. It does not close the
+     * same-origin case: a `fetch` for a sibling path sends no `Origin` at all and
+     * is judged by the `Referer` rule, which accepts this authority on purpose.
+     * Nor a navigation, which carries none either, so the document can frame
+     * another path and read it back. The comment on the gate states both
+     * residuals rather than leaving them to be discovered.
      */
     @Test
     fun `a document at the resource authority cannot fetch another resource`() {

--- a/android/app/src/test/kotlin/com/vscodroid/webview/SafFolderLogCallSiteTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/SafFolderLogCallSiteTest.kt
@@ -1,8 +1,10 @@
 package com.vscodroid.webview
 
+import com.vscodroid.LogTaint
+import com.vscodroid.SourceScan
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import java.io.File
 
 /**
  * That opening a device folder does not spell the user's directory into logcat.
@@ -20,100 +22,59 @@ import java.io.File
  * directly and never opens `MainActivity.kt`, so the caller one frame up was
  * outside the population it covers and went on printing the value in full.
  *
+ * Read through `LogTaint`, and that is the substance of this file rather than a
+ * detail of it. The first version of this guard searched the text of
+ * `openSafFolder` for `${'$'}uri`, which is the one spelling the leak had happened to
+ * be written in. A concatenation, a `uri.toString()`, an intermediate local, a
+ * statement the formatter wrapped and a rename of the parameter all walk past a
+ * search like that, and so does the same leak in any of the four other methods
+ * here that are handed a `Uri`. `LogTaint` follows the value instead: every name
+ * a declaration types as `Uri` is a source, taint runs through declarations to a
+ * fixpoint, statements are read whole, and the whole file is in scope, so this
+ * case is about device folders reaching the log rather than about one line.
+ *
  * Source reading, for the reason `DownloadListenerWiringTest` gives: there is no
  * seam. `openSafFolder` shows a dialog, takes a permission and launches a
- * coroutine, none of which a plain JVM test has. Comments are stripped first,
- * because the rule is discussed at length in prose beside the very line it
- * governs and a search over the raw text would be satisfied by the explanation.
+ * coroutine, none of which a plain JVM test has.
  *
  * What this deliberately does not certify: the `Logger.e` calls in the same body
- * pass a `SecurityException` whose own message can quote the URI the provider
- * refused. That is the same defect in a different channel and is not fixed here,
- * so nothing below reads as a clean bill for it.
+ * hand over a `SecurityException`, and nothing on this side can read the message
+ * inside one. That the throwables reaching them are already redacted is held by
+ * `SafFolderPathLoggingTest`, which drives the frames that raise them.
  */
 class SafFolderLogCallSiteTest {
 
-    private val source = File("src/main/kotlin/com/vscodroid/MainActivity.kt").readText()
+    private val source = SourceScan.read("src/main/kotlin/com/vscodroid/MainActivity.kt")
 
-    /** The body of a `private fun name(` declaration, to its closing brace. */
-    private fun body(name: String): String {
-        val start = source.indexOf("private fun $name(")
-        assertTrue(start >= 0) {
-            "$name is gone from MainActivity.kt, so this test is measuring nothing. " +
-                "If it moved or was renamed, point this at the new site rather than deleting it."
-        }
-        val open = source.indexOf('{', start)
-        var depth = 0
-        var i = open
-        while (i < source.length) {
-            if (source[i] == '{') depth += 1
-            if (source[i] == '}') {
-                depth -= 1
-                if (depth == 0) return source.substring(open, i + 1)
-            }
-            i += 1
-        }
-        throw AssertionError("Could not find the end of $name in MainActivity.kt")
+    private val opened by lazy {
+        SourceScan.withoutComments(SourceScan.body(source, "private fun openSafFolder("))
     }
-
-    /**
-     * Comments removed, so prose about the rule cannot satisfy a search for the
-     * rule. Both forms, because both disable code, and a block counts as a
-     * comment only where it opens a line.
-     */
-    private fun withoutComments(text: String): String {
-        var inBlock = false
-        return text.lines().joinToString("\n") { raw ->
-            var line = raw
-            if (inBlock) {
-                val close = line.indexOf("*/")
-                if (close < 0) return@joinToString ""
-                inBlock = false
-                line = line.substring(close + 2)
-            }
-            while (line.trimStart().startsWith("/*")) {
-                val open = line.indexOf("/*")
-                val close = line.indexOf("*/", open + 2)
-                if (close < 0) {
-                    inBlock = true
-                    return@joinToString line.substring(0, open)
-                }
-                line = line.substring(0, open) + line.substring(close + 2)
-            }
-            val marker = line.indexOf("//")
-            if (marker >= 0) line.substring(0, marker) else line
-        }
-    }
-
-    private val opened by lazy { withoutComments(body("openSafFolder")) }
 
     @Test
     fun `the body being checked was actually found`() {
         assertTrue(opened.isNotBlank() && opened.contains("persistPermission")) {
             "openSafFolder no longer looks like the function these cases were written " +
-                "against, so both of them are searching an empty string and would pass " +
-                "over anything. Point them at wherever a device folder is opened now."
+                "against, so the ones reading its body are searching an empty string " +
+                "and would pass over anything. Point them at wherever a device folder " +
+                "is opened now."
         }
     }
 
     @Test
-    fun `opening a device folder does not put its tree URI in the log`() {
-        val interpolated = Regex("""\$\{?uri\b""")
-        val leaks = opened.lines()
-            .filter { it.contains("Logger.") && interpolated.containsMatchIn(it) }
-
-        assertTrue(leaks.isEmpty()) {
+    fun `no log statement prints a device folder's tree URI`() {
+        assertEquals(
+            emptyList<String>(), LogTaint.leaks(source.lines()),
             "a SAF tree URI is the user's own directory written out, and these lines " +
                 "ship: Logger.i is not gated on a debuggable build. Name the folder by " +
-                "its mirror digest, which is what persistPermission one line below " +
-                "already does. Found:\n" + leaks.joinToString("\n") { "  ${it.trim()}" }
-        }
+                "its mirror digest, which is what the statement at the top of " +
+                "openSafFolder already does.",
+        )
     }
 
     @Test
     fun `the line still names the folder by its mirror`() {
         val named = opened.lines()
-            .any { it.contains("Logger.") && it.contains("getMirrorDir(uri).name") }
+            .any { it.contains("Logger.") && it.contains("getMirrorDir(") }
 
         assertTrue(named) {
             "nothing in openSafFolder says which folder is being opened, so a bug report " +
@@ -123,5 +84,76 @@ class SafFolderLogCallSiteTest {
                 opened.lines().filter { it.contains("Logger.") }
                     .joinToString("\n") { "  ${it.trim()}" }
         }
+    }
+
+    // --- The reader itself, driven against fixed snippets. ------------------
+    //
+    // The case above points LogTaint at one file, where the only measurable
+    // outcome is "found nothing", and a reader that always finds nothing passes
+    // it. `NavigationTokenLoggingTest` pins the behaviour the tokened URL needs;
+    // these pin the two parts a device folder needs and it does not.
+
+    /** A stand-in for `openSafFolder`, with the log statement swapped in. */
+    private fun openSource(vararg body: String): List<String> =
+        listOf("    private fun openSafFolder(uri: Uri, navigate: Boolean) {") +
+            body + listOf("    }")
+
+    @Test
+    fun `a URI handed in as a parameter is a source`() {
+        // The seed the tokened-URL cases never exercise: every one of them starts
+        // from a `val` initialiser, and a device folder never has one. Drop the
+        // parameter pass and this is the only case that notices.
+        assertTrue(
+            LogTaint.leaks(
+                openSource("""        Logger.i(tag, "Opening the device folder " + uri)"""),
+            ).isNotEmpty(),
+            "a Uri arrives as a parameter, not as a declaration, and the reader did " +
+                "not treat it as a source",
+        )
+    }
+
+    @Test
+    fun `naming the folder by its mirror answers for it, printing it does not`() {
+        // Both directions of the same call, because only one of them is a
+        // reduction. Widen the span this takes out and the leak sitting after it
+        // on the same line is swallowed with it, which is the failure this pins.
+        val reduced = openSource(
+            """        Logger.i(tag, "Opening ${'$'}{safManager.getMirrorDir(uri).name}")""",
+        )
+        val beside = openSource(
+            """        Logger.i(tag, "Opening ${'$'}{safManager.getMirrorDir(uri).name} " + uri)""",
+        )
+
+        assertEquals(emptyList<String>(), LogTaint.leaks(reduced))
+        assertTrue(
+            LogTaint.leaks(beside).isNotEmpty(),
+            "a folder named by its digest cannot answer for the tree URI printed " +
+                "beside it on the same line",
+        )
+        assertEquals(
+            emptyList<String>(), LogTaint.redactedLogs(reduced),
+            "naming a folder by its mirror is not redaction and must not answer the " +
+                "control that asks whether the tokened URL still reaches the log; " +
+                "letting it count there is how that control goes on passing after the " +
+                "statement it was written about has gone",
+        )
+    }
+
+    @Test
+    fun `a mirror named on a line of its own is not the folder that made it`() {
+        // The false accusation a reader that taints by proximity makes here, and
+        // the reason this file uses LogTaint rather than the scan in
+        // `PageSuppliedLoggingTest`: that one taints `mirrorDir` from the sync
+        // call and reddens the safe statement below. `File.name` under
+        // `saf-mirrors` IS the digest; a reader that cannot print it has nothing
+        // left to say and gets narrowed back by whoever it stops.
+        val safe = openSource(
+            """        val mirrorDir = withContext(Dispatchers.IO) {""",
+            """            safManager.syncToLocal(uri) { done, total -> }""",
+            """        }""",
+            """        Logger.i(tag, "Synced " + mirrorDir.name)""",
+        )
+
+        assertEquals(emptyList<String>(), LogTaint.leaks(safe))
     }
 }

--- a/android/app/src/test/kotlin/com/vscodroid/webview/WebviewOriginTrustTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/WebviewOriginTrustTest.kt
@@ -57,14 +57,16 @@ class WebviewOriginTrustTest {
      * root can be loaded as a document from
      * `https://file+.vscode-resource.vscode-cdn.net/<path>` and will run: a
      * published root is routinely a checked-out repository. While this answered
-     * true, that document could `fetch` every other file under every root back
-     * through the same arm.
+     * true, that document could reach a different one of our origins, the
+     * workbench or a webview, with a CORS-mode request.
      *
      * What it does not close, since the comment on the gate says so and this
-     * should not say otherwise: the same document can still frame another path
-     * on its own origin, which is a navigation and so carries no origin to
-     * refuse, and read it back same-origin. This shuts the asking, not the
-     * reading.
+     * should not say otherwise: this predicate is handed an `Origin`, and a
+     * same-origin `fetch` sends none, so a request for another file under
+     * another published root never arrives here. It is judged by the `Referer`
+     * rule, which accepts this authority on purpose. A navigation carries no
+     * origin either, so the document can also frame another path and read it
+     * back. This shuts one kind of asking, not the reading.
      */
     @Test
     fun `a document at the resource authority is not ours`() {

--- a/docs/05-API_SPEC.md
+++ b/docs/05-API_SPEC.md
@@ -597,6 +597,15 @@ exist for a request whose id left this app inside the address it opened;
 because the callback address usually travels as a parameter of the authorisation
 address. A documentation link carries none and arms nothing.
 
+At most the first eight of them, and that bound is on the record rather than on
+the address. The record keeps the most recent 32 launches and drops the eldest to
+stay there, so without a cap a single address naming 32 ids evicted the sign-in
+the user had open in the browser at that moment, whose callback then arrived for
+an id nothing had recorded and was dropped in the log with nothing said. Eight
+because every real authorisation address names exactly one. It bounds what one
+launch can do and not what many can: enough separate launches still fill the
+record.
+
 Neither message carries any part of the callback. The payload arrives through an
 exported filter, so quoting it would be a way to put chosen words in front of a
 user who trusts this app.

--- a/docs/06-SECURITY.md
+++ b/docs/06-SECURITY.md
@@ -174,13 +174,18 @@ to: patch 0005 disables the service worker upstream uses to scope each webview t
   workbench or a `*.vscode-cdn.net` document. An absent `Referer` is refused, because a page
   suppresses its own with one `<meta name="referrer">` and measured still read the workspace
   without it. CORS-mode loads (module scripts, fonts) carry an `Origin` and are judged above.
-- **The resource authority is not trusted to read another resource.** `isOurOrigin` accepts the
-  workbench and a webview document and excludes anything under `*.vscode-resource.vscode-cdn.net`.
-  Without that, an `.html` file under a published root (a checked-out repository, routinely) could
-  be loaded as a document from that authority and then `fetch` every other published file.
-  **Residual, and deliberate:** a navigation carries no `Origin` at all, so such a document can
-  still frame another path on the identical origin and read it back. Closing that needs a test for
-  what the request is for, and the only candidate header has not been measured on this WebView.
+- **The resource authority is not trusted to ask a different origin of ours.** `isOurOrigin`
+  accepts the workbench and a webview document and excludes anything under
+  `*.vscode-resource.vscode-cdn.net`. An `.html` file under a published root (a checked-out
+  repository, routinely) can be loaded as a document from that authority, and this stops it
+  reaching the workbench origin or a webview origin with a CORS-mode request.
+  **Residual, and wider than it used to say here:** the gate sees only requests carrying an
+  `Origin`. A same-origin `fetch` sends none, so a document at that authority asking for another
+  file under another published root is judged by the `Referer` rule instead, which accepts the
+  resource authority on purpose, because a stylesheet served from there is what asks for its own
+  `url(...)` subresources. A navigation carries no origin either, so the same document can frame
+  another path and read it back. Closing either needs a test for what the request is for, and the
+  only candidate header has not been measured on this WebView.
 - **A `*.vscode-cdn.net` request naming a foreign `parentOrigin` is refused.** The webview host page
   takes its parent's origin from its own query string, so a page that can compose a URL could
   otherwise host its script at an origin ending `.vscode-cdn.net`. Asset requests carry no

--- a/scripts/check-patch-fingerprints.py
+++ b/scripts/check-patch-fingerprints.py
@@ -159,6 +159,39 @@ def diff_body(patch_path):
     return None
 
 
+def patch_names(patches_dir):
+    """Every *.patch in the directory, or None if one of them cannot be keyed.
+
+    The enumeration lives here, once, because it used to live twice: as a list
+    in write_manifest and as an id-keyed dict in main, both filtering on
+    PATCH_ID with no else-branch. build-vscode-oss.sh applies `patches/*.patch`
+    unfiltered, so a file the pattern cannot key was compiled into the shipped
+    tree and then dropped by both sides of the check that exists to notice it.
+    Dropping it is what makes it silent: it appears in neither the manifest nor
+    the row loop, so the run prints only ok lines.
+    """
+    # Leading dots excluded to match the applier, not to be lenient. pathlib's glob
+    # matches a leading-dot name and bash's does not, so `patches/*.patch` in
+    # build-vscode-oss.sh never sees one. Without this, an AppleDouble sidecar
+    # (`._0001-...patch`, which extracting an archive or copying the tree over exFAT
+    # leaves behind) would be refused here as "applied and tracked by nothing" when
+    # the build does not apply it at all, and the refusal reaches every APK through
+    # the packaging gates.
+    paths = sorted(p for p in patches_dir.glob("*.patch") if not p.name.startswith("."))
+    stray = [p.name for p in paths if not PATCH_ID.match(p.name)]
+    if stray:
+        print(f"  FAIL   {stray} in {patches_dir} is applied by "
+              f"build-vscode-oss.sh and tracked by nothing; rename it "
+              f"NNNN-short-description.patch or move it out of patches/")
+        return None
+    if not paths:
+        # An empty left-hand side would make every comparison below vacuously
+        # true.
+        print(f"  FAIL   no patches found in {patches_dir}; the naming changed")
+        return None
+    return [p.name for p in paths]
+
+
 def patch_hashes(patches_dir, names):
     """{patch filename: sha256 of its diff}, or None if the set is not usable.
 
@@ -271,9 +304,8 @@ def check_manifest(tree, patches_dir, names):
 
 def write_manifest(tree, patches_dir):
     """Record in the tree which patch text produced it."""
-    names = [p.name for p in sorted(patches_dir.glob("*.patch")) if PATCH_ID.match(p.name)]
-    if not names:
-        print(f"  FAIL   no patches found in {patches_dir}; the naming changed")
+    names = patch_names(patches_dir)
+    if names is None:
         return 1
     hashes = patch_hashes(patches_dir, names)
     if hashes is None:
@@ -293,16 +325,10 @@ def main(tree, patches_dir):
     if rows is None:
         return 1
 
-    patches = {}
-    for path in sorted(patches_dir.glob("*.patch")):
-        m = PATCH_ID.match(path.name)
-        if m:
-            patches[m.group(1)] = path.name
-
-    # An empty left-hand side would make every comparison below vacuously true.
-    if not patches:
-        print(f"  FAIL   no patches found in {patches_dir}; the naming changed")
+    names = patch_names(patches_dir)
+    if names is None:
         return 1
+    patches = {PATCH_ID.match(name).group(1): name for name in names}
 
     check_manifest(tree, patches_dir, patches.values())
 
@@ -340,8 +366,82 @@ def main(tree, patches_dir):
     return 1 if failed else 0
 
 
+def self_test():
+    """Hand both entry points a directory holding a patch nobody can key.
+
+    Both, separately: restoring the PATCH_ID filter at either one alone leaves
+    the other's mutation alive, and a self-test exercising only main would
+    print green while write_manifest still wrote a manifest omitting a patch
+    the build had already compiled in.
+
+    The negative control is not optional. A refusal that has started firing on
+    everything reads exactly like a refusal that works, so each case is
+    followed by a conforming directory the same call has to accept.
+    """
+    import contextlib
+    import io
+    import shutil
+    import tempfile
+
+    global failed
+    strays = ("foo.patch", "009-foo.patch", "0009_foo.patch")
+    real = sorted(DEFAULT_PATCHES.glob("[0-9][0-9][0-9][0-9]-*.patch"))
+    if len(real) < 2:
+        print(f"  FAIL   self-test: {DEFAULT_PATCHES} holds no conforming patches "
+              f"to build a control from")
+        return 1
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tree = pathlib.Path(tmp) / "tree"
+        tree.mkdir()
+        for stray in strays + (None,):
+            src = pathlib.Path(tmp) / ("stray" if stray else "clean")
+            src.mkdir()
+            for p in real:
+                shutil.copy(p, src / p.name)
+            shutil.copy(DEFAULT_PATCHES / "fingerprints.txt", src / "fingerprints.txt")
+            if stray:
+                # Distinct content, not a copy of a real patch. A byte-identical
+                # copy shares its diff hash with the file it came from, so a
+                # refusal could be the collision detector rather than the naming
+                # rule, and the case would pass while measuring the wrong thing.
+                (src / stray).write_text(
+                    "diff --git a/self-test b/self-test\n"
+                    "--- a/self-test\n+++ b/self-test\n"
+                    "@@ -1 +1 @@\n-nothing\n+nothing at all\n"
+                )
+
+            for label, call in (("write_manifest", lambda: write_manifest(tree, src)),
+                                ("main", lambda: main(tree, src))):
+                out = io.StringIO()
+                failed = False
+                with contextlib.redirect_stdout(out):
+                    rc = call()
+                text = out.getvalue()
+                if stray:
+                    if rc == 0 or stray not in text:
+                        print(f"  FAIL   self-test: {label} accepted {stray}, "
+                              f"or never named it (rc={rc})")
+                        return 1
+                else:
+                    # The control only has to get PAST the naming rule. main()
+                    # still judges a real tree it was not given, so its rc is
+                    # not the signal; the absence of a naming refusal is.
+                    if "the naming changed" in text or "tracked by nothing" in text:
+                        print(f"  FAIL   self-test: {label} refused a directory "
+                              f"whose names all conform")
+                        return 1
+            shutil.rmtree(src)
+    failed = False
+    print("  ok     self-test: a patch outside NNNN- is refused by both entry "
+          "points, and a conforming directory is not")
+    return 0
+
+
 if __name__ == "__main__":
     argv = sys.argv[1:]
+    if argv == ["--self-test"]:
+        sys.exit(self_test())
     writing = bool(argv) and argv[0] == "--write-manifest"
     if writing:
         argv = argv[1:]


### PR DESCRIPTION
Four guards that did not refuse what they exist to refuse, and one space gate
that charged for bytes it was about to overwrite.

## Device folders

The write-back arm pushes a newer mirror copy over the device document and
records nothing, so the path leaves the sync record. On the next open the guard
that sets a foreign edit aside asked the record, was told nothing, and read that
silence as proof the document was still ours. It opened with `"wt"`, which
truncates at open, and an edit another app had made since was destroyed with no
copy kept anywhere.

A record that parses but does not name the path, and a line whose time field this
build cannot read, now both answer that the device may have changed. Nothing is
written to the record: every fix that adds a line there is the one
`reconcileDeletions` exists to refuse, and `SafReconcileDeletionsTest` fails on
all of them. An absent or foreign-format record still says nothing, at the call
site, unchanged.

It is not free, and the arm itself manufactures the silence that triggers it.
An affected path pays one provider read per open, since nothing re-records it.
Where the bytes differ a `.device-` copy is kept, and that includes the device
holding this app's own earlier push with the mirror edited again since, which is
the known false positive `setAsideDivergedMirror` already names for the three
other producers of silence. A fetch that fails withholds the write-back,
deferring the user's save to the next open rather than losing it. All three are
stated at the call site and in the KDoc rather than left for a reader to find.

## Toolchains

A copy that lands but fails to record leaves the tree in place, and the space
gate then charged for bytes that copy would overwrite: the retry asked for the
pack's full size on a device already holding most of it. The Play path re-drives
the install from the retained delivery on every launch, so the refusal repeated
indefinitely. `copyTo(overwrite = true)` deletes the destination before opening
the stream, so an overwrite allocates nothing net; the gate subtracts what is
already under the manifest's install root, clamped at what the pack records and
floored at the buffer.

A root that resolves outside `filesDir` credits nothing and is not walked. The
manifest arrives in a signed pack and the uninstall and reclaim paths already
build the same `File` and delete through it, so this is not a last line of
defence. It is that a credit is the first decision taken on that string, and
measuring the whole app data directory would clamp to the pack's own size and
leave the gate asking for the buffer alone.

## Key row

The badge beside the page dots is the report that a modifier is still held once
the row has moved off the page its key sits on. It was drawn in
`colorExtraKeyActive` on `colorSurface`, 3.40:1, against the 4.5:1 this project's
own rule asks of 11sp text. The pair was already banned as text when the badge
was written; the badge reached the tree through the one channel the contrast walk
cannot see, a colour set in Kotlin whose ground is set in the same file rather
than in a layout. The new case reads both ends out of the source instead of
naming them, so it still measures the badge if either moves.

## Build gate

`build-vscode-oss.sh` applies `patches/*.patch` unfiltered, but both sides of the
fingerprint check filtered on the `NNNN-` pattern with no else branch. A patch
named outside it was compiled into the shipped server and then dropped by the
manifest writer and the row loop alike, so the run printed only ok lines and
exited 0 while tracking one patch fewer than the build had applied. Both entry
points now enumerate through one helper that refuses a name it cannot key, and
`lint.yml` runs its self-test beside the other three.

Leading-dot names are excluded, to mirror the applier rather than to be strict:
pathlib's glob matches them and bash's does not, so an AppleDouble sidecar left
by extracting an archive would otherwise be refused as applied-and-untracked when
the build never applies it, and that refusal reaches every APK through the
packaging gates.

## Tests

The case guarding the readiness call sites counted `isServerReady()` tokens in
`MainActivity` and asked for two or more. A third token reached the file and the
count stopped discriminating. Each decision is now pinned inside the body it
lives in, so absence fails by name rather than by arithmetic, and the
keep-the-call-drop-the-verdict mutation is covered by asserting that the span
between the decision and `resumeAction(` returns. No production change: the sites
are correct today.

## Bug report

The server section was headed "credentials removed". The redaction it describes
matches known shapes: a bearer header, a URL query token, a one-line private key,
a quoted JSON credential. A secret that arrives as a bare word is
indistinguishable from any other word, which is why the scrubber is a pattern
list rather than a classifier, so the promise was one the code could not keep,
and the user is about to paste that text somewhere public. It now names which
shapes were replaced and asks them to check. The patterns are unchanged: no
measured session has produced a shape the six do not cover.

## Documentation

Five places stated that excluding the resource authority from `isOurOrigin`
turns away a `fetch` from a document served there. It does not, and the asymmetry
that makes it not do so is documented two functions away as deliberate:
`isOurOrigin` is handed an `Origin` header, a same-origin `fetch` sends none, and
the request is judged by `isOurReferer`, which accepts that authority on purpose
because a stylesheet served from it is what asks for its own `url(...)`
subresources. Every published root answers on one authority, so the file under
another root that the old wording promised was refused is the same origin as the
asker. What the exclusion does close is a CORS-mode request to a different one of
our origins. No behaviour changes.

## Device folders, second round

A delete the user made in the editor was not carried out on the device document when the
mirror copy had never been read, and the notice they got said the only copy was inside the
app, which for a delete is the reverse of what happened. The guard refusing to replace an
unread document sat above the switch on event type, so a delete took the write refusal's
arm. It now excludes deletes, and the delete arm asks the provider at both levels: a prefix
match for a directory as before, and an exact match for a file, which had no arm at all.

## Toolchains, second round

An install that copied the tree and then failed to write `toolchains.json` left roughly
155 MB with nothing naming it: uninstall works off that manifest, no card offers Remove for
a toolchain `getInstalledToolchains()` cannot name, and the repair pass only visits records
that exist. The failure this happens on is a full disk, which makes those bytes exactly the
ones the retry needs. The record-write exit now calls the reclaim its neighbour already
used, placed in the funnel both delivery channels converge on.

The space-credit case was reworked as a consequence: it used to build its orphan by driving
a failing install, and that exit no longer leaves one. It now places the tree on disk, which
is how the two remaining sources produce it, a process killed partway through the copy and a
device already carrying one.

## Settings

A heap ceiling set in `Machine/settings.json` was read through a stripper that removed
everything between the first `/*` and the next `*/` over flat text. Ordinary content carries
both sequences inside string values, so a live setting after a glob such as `**/*.log` was
swallowed, and a setting genuinely commented out could survive the same mismatch and be
applied. One pass now matches strings and comments in document order and keeps a string
verbatim.

## Bridge

The record of sign-ins waiting for a callback is keyed by request id, and every id in an
address being opened was armed, so one address carrying many filled it and the eviction
dropped the entry a sign-in in flight was waiting for. The cap sits in `authRequestIdsIn`,
the one function both arming sites route through; at the bridge call site instead, the
main-frame navigation route stays unbounded, which was measured.

## Logging

The guard against logging a device folder's tree URI matched one Kotlin spelling of the
value it names, so the same address reached a log line through a different local and the
guard stayed green. The matcher moved into a shared helper that seeds its tainted set from
any declaration typed `Uri`, closing six functions and one field in a single edit. Nothing
leaks today; the guard would simply not have stopped the next one.

## Setup durability

Setup records completion with a preference commit, which fsyncs, while the 875 MiB it just
wrote is still whatever the page cache holds. Power lost in that window leaves the flag
saying the run finished, the attempt key it clears gone, and the tail of the unpack not on
the medium; nothing looks again, because the flag is what decides whether to unpack.

A whole-filesystem flush now runs immediately before the flag, and before the record naming
a toolchain's freshly copied files. There is no `android.system.Os.sync` in the SDK, only
`fsync`, `fdatasync` and `msync` over a descriptor, so the barrier is `/system/bin/sync`
with a bounded wait and both outcomes logged: a device whose policy refuses the exec
otherwise loses the barrier in silence. Measured on an emulator at 129 ms with 100 MB dirty
and 220 ms with 300 MB, against an unpack that takes minutes. An fsync per extracted file
was rejected on cost across roughly 23,490 of them.

The KDoc states what it does not buy: no file becomes atomic, the flush and the flag are not
one event, and a crash mid-extraction is covered by the attempt key rather than by this. The
case pins the ordering the barrier rests on and says in its first line that it cannot pin
durability.

## Device folder watcher

`startWatching` and `stopWatching` shared no monitor, and `startWatching` begins by calling
`stopWatching`. Opening a device folder while the activity was being torn down could install
a watcher after the teardown had run: it kept writing the mirror back to the device for the
rest of the session and nothing held a reference that could stop it. Both are now serialised
on one monitor inside the engine, with a terminal flag that refuses a late start rather than
reordering it, and the activity's teardown routes through that terminal path.

## Verification

2266 JVM tests, 0 failures, 0 errors. Android lint clean and the baseline
unchanged at its 3 entries. 18 python gates, 4 gate self-tests, 9 JavaScript
self-checks and `device-test.sh --self-check` all exit 0.
`check-patch-fingerprints.py` passes against the packaged server tree.

Negative controls, each reverted on its own and each reddening only what it owns:

- `deviceChangedSinceRecord`: reverting the absent-line arm reddens two cases,
  reverting the unparseable-time arm reddens the third. The second arm had no
  case at all until this change; it was found by reverting the arms one at a time
  rather than together.
- `existingTreeCredit` forced to 0: exactly 4 cases red, each naming the credit.
  Disabling the containment check alone reddens only the escaped-root case.
- The badge colour reverted: the new contrast case fails quoting `3.40:1` and
  `4.5:1`, and no other case moves.
- The readiness pins: all four mutations that the old floor passed are now red,
  each by the assertion that owns it, namely deleting the resume guard, reverting
  the binding decision to a port-only check, keeping the resume call but dropping
  its `return`, and hiding a decoy call in a log line.
- The patch gate: an unkeyable name is refused with `rc=1` and named in the
  output; the previous gate answered `rc=0`, printed 35 ok lines and named the
  file zero times. A leading-dot sidecar is accepted, and bash's own glob is
  confirmed to see 17 of the 18 files present.

Three rival directions for the device-folder fix were implemented and rejected by
running them, so they are not tried again: recording on a landed write breaks
`SafReconcileDeletionsTest > a local edit that never reached the device survives
a reopen and then its removal`; carrying the previous record line forward passes
the first case and fails the second; forcing the guard on breaks two
`InitialSyncWiringTest` cases.

Device, API 33 emulator: a foreign process holding the configured port before
launch does not wedge the app. `PortFinder` moves to the next port and the
workbench loads; both ports stay LISTEN and the five node processes stay stable
through 120 s, with no `EADDRINUSE` in `server.log`. Screenshot captured and
viewed.

Two things deliberately not claimed:

- The key-row badge after the colour change was not photographed. The badge
  before it was, and measured at 2712 px of `#007ACC` in the dots row; the change
  rests on the contrast case and the suite alone.
- Whether a `.device-` copy reaches the device folder is not measured here. The
  JVM harness does not exercise the upload pass at all: a probe returned no
  created documents, and so did a control holding an ordinary stranded file, so
  the harness cannot answer it either way. `setAsideDeviceCopy`'s own KDoc says it
  does reach the device and treats that as intended, and this change makes it more
  frequent rather than newly possible.

The changelog carries four of these as user-facing fixes and the patch gate as a
build-time change, one line each.
