### PR TITLE
fix: keep Escape from becoming a back press

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Pressing Esc on a hardware keyboard no longer sends the app to the background. Some keyboard layouts turn an Escape the page leaves unhandled into a Back press, so leaving vi's insert mode in a terminal minimised the editor mid-keystroke.
 - Edits made in a workspace opened from a device folder now reach the device. Nothing was syncing them back, so they stayed in the app's private copy with nothing on screen to say so.
 - A workspace is reopened on the next launch and survives an editor crash. Both dropped you into the default folder, and opening a workspace file looked like it had loaded an empty project.
 - Closing the folder now survives an editor crash. It reopened the workspace you had just closed.

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -21,6 +21,7 @@ import android.os.Looper
 import android.os.SystemClock
 import android.provider.DocumentsContract
 import android.text.util.Linkify
+import android.view.KeyEvent
 import android.view.View
 import android.webkit.RenderProcessGoneDetail
 import android.webkit.WebResourceRequest
@@ -2010,6 +2011,47 @@ class MainActivity : AppCompatActivity() {
                 moveTaskToBack(true)
             }
         })
+    }
+
+    /**
+     * Escape is never reported unhandled, so nothing can turn it into a back press.
+     *
+     * A key the whole view tree declines is offered to the PRODUCING KEYBOARD's
+     * character map for a fallback action, not to `Generic.kcm`, and some of those
+     * maps still carry `ESCAPE base: fallback BACK`. AOSP ships one:
+     * `Vendor_18d1_Product_5018.kcm`, headed "Key character map for Google Pixel C
+     * Keyboard", which is present on a stock API 33 image where `Generic.kcm` and
+     * `Virtual.kcm` both read `base: none`. The BACK synthesised from it carries
+     * `FLAG_FALLBACK`, which nothing above the input pipeline reads, so it reaches
+     * [setupBackNavigation]'s callback as an ordinary back press and minimises the
+     * app in the middle of a keystroke. Reported as issue #385 by a user pressing
+     * Esc to leave vi's insert mode.
+     *
+     * The page cannot prevent this on its own. xterm cancels the Escape keydown
+     * and writes 0x1b, but the keyup is not cancelled on the same path, and an
+     * unconsumed keyup is enough: it comes back through
+     * `WebViewClient.onUnhandledKeyEvent`, whose platform default re-injects it,
+     * and re-injection is what asks the character map for a fallback.
+     *
+     * `super` runs first and its answer is kept, so the WebView receives the key
+     * exactly as dispatched and the workbench keeps every binding it has for
+     * Escape. Only the verdict reported back to the input pipeline widens. Every
+     * other key, `KEYCODE_BACK` included, passes through untouched, so the back
+     * gesture, the hardware back key and predictive back are unaffected.
+     *
+     * What this gives up deliberately is the Alt and Ctrl fallbacks on the same
+     * key, HOME and MENU. In a terminal Alt+Esc is `ESC ESC`, a real keystroke,
+     * and answering it by sending the user to the home screen is the same defect
+     * wearing a modifier.
+     *
+     * ⚠️ Not reproducible with `adb shell input keyevent 111`, and neither is the
+     * fix: an injected event carries `Virtual.kcm`, whose ESCAPE has no fallback,
+     * and the emulator's own keyboard resolves to `qwerty2.kcm`, which declares no
+     * ESCAPE at all. It takes a real HID keyboard whose map has the line.
+     */
+    override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+        val handled = super.dispatchKeyEvent(event)
+        return handled || event.keyCode == KeyEvent.KEYCODE_ESCAPE
     }
 
     private fun requestNotificationPermission() {

--- a/android/app/src/test/kotlin/com/vscodroid/keyboard/HardwareKeyboardTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/keyboard/HardwareKeyboardTest.kt
@@ -1,5 +1,6 @@
 package com.vscodroid.keyboard
 
+import com.vscodroid.SourceScan
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -11,9 +12,13 @@ import javax.xml.parsers.DocumentBuilderFactory
  * The two properties a physical keyboard's support rests on.
  *
  * Neither one is a feature anybody wrote, and that is the problem. Keys work
- * because nothing in this app touches a key event: the system dispatches it,
- * the WebView receives it unchanged, and the workbench binds it. The window
- * survives a keyboard being plugged in because the manifest claims the keyboard
+ * because nothing in this app takes a key event away from the page: the system
+ * dispatches it, the WebView receives it unchanged, and the workbench binds it.
+ * Exactly one override stands in that path, `MainActivity.dispatchKeyEvent`,
+ * and it delegates to `super` before widening the verdict on Escape alone, so
+ * the page still sees every key; the first case below pins both halves of that
+ * and refuses any other override anywhere in the tree. The window survives a
+ * keyboard being plugged in because the manifest claims the keyboard
  * configuration qualifiers, so Android hands the activity a configuration
  * change instead of destroying it and building a new one.
  *
@@ -103,8 +108,48 @@ class HardwareKeyboardTest {
             "shouldOverrideKeyEvent",
         )
 
+        // The one override this app has, pinned by path and by body rather than
+        // dropped from the list above: dropping the name would stop guarding it
+        // in every other file, which is most of what this case is for.
+        //
+        // It earns the exception by delegating. A key the whole view tree
+        // declines is offered to the producing keyboard's own character map for
+        // a fallback action, and some of those maps still read
+        // `ESCAPE base: fallback BACK`, which arrives at the back callback as an
+        // ordinary press and minimises the app mid-keystroke (issue #385). The
+        // override answers that by keeping `super`'s verdict and widening it for
+        // Escape alone, so the page loses no key.
+        val guardedFile = "src/main/kotlin/com/vscodroid/MainActivity.kt"
+        val allowed = interceptors.filter {
+            it.startsWith("$guardedFile:") && it.contains("dispatchKeyEvent")
+        }
+
         assertEquals(
-            emptyList<String>(), interceptors,
+            1, allowed.size,
+            "MainActivity.dispatchKeyEvent is gone. It is the only thing stopping a " +
+                "keyboard whose character map carries `ESCAPE base: fallback BACK` from " +
+                "minimising the app when Esc is pressed, and no page-side fix replaces " +
+                "it: the fallback is synthesised precisely from the key the page did " +
+                "not consume. Overrides found: $interceptors",
+        )
+
+        val dispatch = SourceScan.withoutComments(
+            SourceScan.body(SourceScan.read(guardedFile), "override fun dispatchKeyEvent("),
+        )
+
+        assertTrue(dispatch.contains("super.dispatchKeyEvent(event)")) {
+            "MainActivity.dispatchKeyEvent no longer delegates, so it swallows the key " +
+                "rather than only widening the verdict on it, and the WebView stops " +
+                "seeing Escape at all"
+        }
+        assertTrue(dispatch.contains("KeyEvent.KEYCODE_ESCAPE")) {
+            "MainActivity.dispatchKeyEvent no longer singles out Escape, so it reports " +
+                "keys handled that the workbench never bound, and the fallbacks those " +
+                "keys rely on stop firing"
+        }
+
+        assertEquals(
+            emptyList<String>(), interceptors - allowed.toSet(),
             "Hardware keyboard support here IS the absence of these overrides. Every " +
                 "keystroke reaches the WebView exactly as the system dispatched it, " +
                 "and the workbench binds it; an override is a chance to swallow one " +

--- a/docs/DEVICE_TEST_CHECKLIST.md
+++ b/docs/DEVICE_TEST_CHECKLIST.md
@@ -55,6 +55,7 @@
 | KB-15 | Ctrl+Enter from the key row | Put the caret in the MIDDLE of a line, tap Ctrl on the key row, then press Enter on the soft keyboard | A new line opens below and the caret moves to it, leaving the line under the caret unsplit (Insert Line Below). A split line means the latch was spent without being applied: the soft keyboard reports Enter as an edit rather than as a key, so this is a different path from every other row key | | |
 | KB-17 | Latched Ctrl and a composed word on the EditContext path | On a WebView 121 or newer device with Gboard suggestions on (KB-11's check says which path), latch Ctrl on the row, type a word, then space | The word is inserted plainly and the row's Ctrl clears as the word starts; the space is inserted and no suggest widget opens. Latch Ctrl and type `s` with a non-composing commit (suggestions off, or Samsung keyboard) as the control: the file still saves (KB-7) | | |
 | KB-18 | Latched modifier and a frame | Latch Ctrl on the row, tap into a Simple Browser page or an extension webview and type, then tap back into the editor and type `a` | The row's Ctrl clears within a moment of focus entering the frame, and `a` is inserted rather than run as a chord | | |
+| KB-19 | Escape on a hardware keyboard | Connect a BT/USB keyboard, open a terminal, start `vi`, press `i` for insert mode, then press Esc | vi leaves INSERT and the app stays in the foreground. Only hardware answers this row, and unusually it is the key character map rather than the dispatch that has to be real: an injected Escape carries `Virtual.kcm` and the emulator's own keyboard resolves to `qwerty2.kcm`, and neither declares the `ESCAPE base: fallback BACK` that turns the key into a back press. Record the keyboard model, since only some maps carry it | | |
 | KB-16 | Narrow phone paging | On a device or emulator whose portrait width is 360dp or less, bring the keyboard up and swipe through every page. `adb shell wm size` and `adb shell wm density` give the width in dp: pixels times 160, divided by density | There are more pages than the five a 411dp phone shows: six at 360dp, seven at 320dp. Every key still fills a comfortable target, no label is clipped, and the keys appear in the same order, only broken across more pages. The dots say how many there are | | |
 
 ## 4. Screen & Orientation
@@ -230,7 +231,7 @@ first launch of a build that has this line, so the row to run instead is TC-8.
 |----------|-------|------|------|------|
 | Device Matrix | 4 | | | |
 | Android Versions | 4 | | | |
-| Keyboard Input | 18 | | | |
+| Keyboard Input | 19 | | | |
 | Screen & Orientation | 6 | | | |
 | Editor Operations | 12 | | | |
 | Extensions | 6 | | | |
@@ -240,7 +241,7 @@ first launch of a build that has this line, so the row to run instead is TC-8.
 | Toolchains | 7 | | | |
 | Terminal & Tools | 11 | | | |
 | SAF & Files | 11 | | | |
-| **Total** | **101** | | | |
+| **Total** | **102** | | | |
 
 **Overall Result**: [ ] PASS / [ ] FAIL
 


### PR DESCRIPTION
Fixes #385

Pressing Esc on a hardware keyboard sent the app to the background instead of reaching the terminal, so vi could not be taken out of insert mode.

An Escape the page leaves unhandled is offered to the producing keyboard's own key character map for a fallback action, and some of those maps still read `ESCAPE base: fallback BACK`. AOSP ships one, `Vendor_18d1_Product_5018.kcm`, present on a stock API 33 image where `Generic.kcm` and `Virtual.kcm` both read `base: none`. The synthesised press carries `FLAG_FALLBACK`, which nothing above the input pipeline reads, so it arrives at the back callback as an ordinary press. The page cannot prevent it on its own: xterm cancels the Escape keydown but not the keyup, and an unconsumed keyup is enough, since it returns through `WebViewClient.onUnhandledKeyEvent`, whose platform default re-injects it, and re-injection is what asks the map for a fallback.

## What changed

- `MainActivity.dispatchKeyEvent` answers Escape as handled after passing it to the page. `super` runs first and its verdict is kept, so the WebView receives the key exactly as dispatched and only the answer reported back to the input pipeline widens.
- `HardwareKeyboardTest` keeps its repo wide ban on key overrides and pins this single exception rather than dropping the name from the list: the override must exist in `MainActivity`, delegate to `super`, and name `KEYCODE_ESCAPE`. Its class KDoc claimed nothing in the app touches a key event, which is no longer true, and is corrected in the same change.
- Checklist row KB-19, for the half no automated test can reach.

## Risk

`KEYCODE_BACK` is untouched, so the back gesture, the hardware back key and predictive back behave as before. What this gives up deliberately is the Alt and Ctrl fallbacks on the same key, HOME and MENU. In a terminal Alt+Esc is `ESC ESC`, a real keystroke, and answering it by sending the user to the home screen is the same defect wearing a modifier.

## Verification

- Full JVM unit suite green. Both mutations go red: removing the `super` delegation fails on the delegation assertion, renaming the override away fails on the presence assertion.
- On an API 33 emulator with a patched build, screenshots taken after each step: Escape still reaches the pty (`^[` under `cat -v`) with the app in the foreground, and a back press still sends the app to the background.
- The fix itself is not exercised there and cannot be. An injected Escape carries `Virtual.kcm`, whose `ESCAPE` has no fallback, and the emulator's own keyboard resolves to `qwerty2.kcm`, which declares no `ESCAPE` at all. Confirming the symptom is gone needs a real HID keyboard whose map carries the line, which is what KB-19 records.
