### PR TITLE
release: bump to 1.3.0 and close the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - An Escape the editor leaves unhandled is no longer handed back to Android. Some keyboard layouts answer it with a Back press, which sends the app to the background mid-keystroke.
+- Opening a workspace file no longer costs a filesystem check on every resource the editor loads, and a workspace file that is briefly absent while it is saved no longer cuts off every resource beside it.
+- The address of the page is no longer written to the system log on every load. It carried the full path of the folder you had open.
 - Edits made in a workspace opened from a device folder now reach the device. Nothing was syncing them back, so they stayed in the app's private copy with nothing on screen to say so.
 - A workspace is reopened on the next launch and survives an editor crash. Both dropped you into the default folder, and opening a workspace file looked like it had loaded an empty project.
 - A folder whose own name ends in `.code-workspace` opens as a folder. It was sent to the editor as a workspace, and an unreadable workspace opens an empty window, which every later launch reopened because the folder had already been remembered.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-09-04
+
 ### Added
 
 - A device folder holding one `.code-workspace` now opens as that workspace. Android's picker can only hand back a folder, so a workspace on device storage was reachable only by finding the file in the explorer and opening it from there.
@@ -14,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Pressing Esc on a hardware keyboard no longer sends the app to the background. Some keyboard layouts turn an Escape the page leaves unhandled into a Back press, so leaving vi's insert mode in a terminal minimised the editor mid-keystroke.
+- An Escape the editor leaves unhandled is no longer handed back to Android. Some keyboard layouts answer it with a Back press, which sends the app to the background mid-keystroke.
 - Edits made in a workspace opened from a device folder now reach the device. Nothing was syncing them back, so they stayed in the app's private copy with nothing on screen to say so.
 - A workspace is reopened on the next launch and survives an editor crash. Both dropped you into the default folder, and opening a workspace file looked like it had loaded an empty project.
 - A folder whose own name ends in `.code-workspace` opens as a folder. It was sent to the editor as a workspace, and an unreadable workspace opens an empty window, which every later launch reopened because the folder had already been remembered.
@@ -888,7 +890,8 @@ This release represents the cumulative work across milestones M0 through M5, bri
 - Health check polling for server readiness
 - Android intent handling for "Open with VSCodroid"
 
-[Unreleased]: https://github.com/rmyndharis/VSCodroid/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/rmyndharis/VSCodroid/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/rmyndharis/VSCodroid/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/rmyndharis/VSCodroid/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/rmyndharis/VSCodroid/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/rmyndharis/VSCodroid/compare/v0.2.9...v1.0.0

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -136,8 +136,8 @@ android {
         // browser simply times out.
         @Suppress("OldTargetApi")
         targetSdk = 36
-        versionCode = 13
-        versionName = "1.2.0"
+        versionCode = 14
+        versionName = "1.3.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -324,6 +324,32 @@ class MainActivity : AppCompatActivity() {
     private var openWorkspaceFolder: String? = null
 
     /**
+     * The same place, reduced to the directory the resource interceptor publishes.
+     *
+     * Volatile and written beside [openWorkspaceFolder] by the one writer, for the
+     * same reason: the reader is `shouldInterceptRequest`, which is not on the UI
+     * thread.
+     *
+     * A second field rather than a reduction at the point of use, and the field
+     * above says why in its own words: reducing needs a `stat`, because a
+     * `.code-workspace` is only a workspace when it is a FILE, and the interceptor
+     * runs once per resource request while the workbench issues hundreds during a
+     * cold load. Deriving here pays for it once per navigation.
+     *
+     * Correctness, not only cost. A `stat` on the request path answers for the
+     * filesystem at that instant, so a workspace file momentarily absent, during a
+     * save-replace or a mirror re-sync, would answer "not a file", the reduction
+     * would not happen, and the published root would become the workspace file
+     * itself. A root that is a single file matches only itself, so every resource
+     * beside it would be refused until something navigated again.
+     *
+     * Not folded into [openWorkspaceFolder]: `mirrorNameFor` reads that one and
+     * wants the path the user opened, not its parent.
+     */
+    @Volatile
+    private var openWorkspaceRoot: String? = null
+
+    /**
      * Where the last open workspace is remembered, resolved once.
      *
      * The same file `PortFinder` and `SplashActivity` use, under a key of its
@@ -2588,14 +2614,14 @@ class MainActivity : AppCompatActivity() {
         // than `self.get()?....` for that reason.
         val self = WeakReference(this)
         VSCodroidWebViewClient.setupServiceWorkerInterception(
-            port, roots, sensitive, { self.get()?.openWorkspaceFolder }
+            port, roots, sensitive, { self.get()?.openWorkspaceRoot }
         ) { self.get()?.nodeService?.getConnectionToken() }
 
         wv.webViewClient = VSCodroidWebViewClient(
             allowedPort = port,
             resourceRoots = roots,
             sensitiveLocations = sensitive,
-            openFolder = { openWorkspaceFolder },
+            openFolder = { openWorkspaceRoot },
             connectionToken = { nodeService?.getConnectionToken() },
             onCrash = { recreateWebView() },
             // A hand-off that no app accepted used to be indistinguishable from a
@@ -2749,6 +2775,11 @@ class MainActivity : AppCompatActivity() {
      */
     private fun rememberWorkspaceFolder(folderPath: String) {
         openWorkspaceFolder = folderPath
+        // The one `stat` this costs, and the only place it is paid. Above the
+        // early return, because the return only means the preference is already
+        // written; the fields still have to describe the folder being navigated
+        // to, and after a process restart they start out null.
+        openWorkspaceRoot = workspaceDirectoryInForce(folderPath)
         // Written only on a change: this runs on every main-frame load, and the
         // server redirects, so a folder switch alone reaches it twice.
         if (workspacePrefs.getString(KEY_LAST_FOLDER, null) == folderPath) return

--- a/android/app/src/main/kotlin/com/vscodroid/webview/VSCodroidWebViewClient.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/webview/VSCodroidWebViewClient.kt
@@ -198,21 +198,22 @@ private var lastRefusedWorkspace: String? = null
  * See [lastRefusedWorkspace].
  */
 internal fun resourceRootsInForce(
-    published: List<String>, sensitive: List<String>, workspaceOrFolder: String?,
-    // Handed on to [workspaceDirectoryInForce], which reduces a workspace to the
-    // directory holding it only when it really is a file. Passed rather than
-    // called for the reason every predicate in this pair of files is: these paths
-    // do not exist on a JVM test machine, so a real stat there answers no for
-    // every one of them.
-    isFile: (String) -> Boolean = { File(it).isFile },
+    published: List<String>, sensitive: List<String>,
+    /**
+     * Already reduced to a directory by whoever supplied it.
+     *
+     * Reducing needs a `stat`, because a `.code-workspace` is a workspace only
+     * when it is a FILE, and this function runs once per intercepted resource
+     * request. `MainActivity.openWorkspaceRoot` therefore does it once per
+     * navigation and both suppliers hand the answer, which keeps the stat off
+     * this path and keeps a momentarily absent file from silently unpublishing
+     * the root. Reducing here as well would be wrong and not merely wasteful: a
+     * directory whose own name ends in `.code-workspace` would be reduced twice
+     * and publish its parent.
+     */
+    workspaceRoot: String?,
 ): List<String> {
-    // Normalised here and not at the two suppliers, because both converge on this
-    // and `ServiceWorkerRetentionTest` refuses a supplier written as anything but
-    // `self.get()?....`: wrapping one would either capture the Activity or widen
-    // a check whose own message says not to. A `.code-workspace` names a file,
-    // and a root is matched by path prefix, so publishing the file publishes only
-    // itself and refuses every resource beside it.
-    val candidate = workspaceDirectoryInForce(workspaceOrFolder, isFile)
+    val candidate = workspaceRoot
     val workspace = workspaceRootOrNull(candidate, sensitive)
     if (candidate != null && workspace == null) {
         if (candidate != lastRefusedWorkspace) {
@@ -1005,9 +1006,14 @@ class VSCodroidWebViewClient(
         // without going through Kotlin, and then the URL is the only notice
         // there is. A redacted copy would lose the folder on exactly those loads.
         //
-        // This log statement is at `Logger.i`, which is not gated on a debuggable
-        // build, so it was the leak that shipped.
-        Logger.i(tag, "Page loaded: ${redactToken(url)}")
+        // Labelled rather than redacted, because this statement is at `Logger.i`,
+        // which is not gated on a debuggable build. `redactToken` removes the
+        // token and nothing else, so the folder rode out in release logcat on
+        // every load and every folder switch, on a channel READ_LOGS can read.
+        // That is the same reason the refusals inside `interceptResourceRequest`
+        // are at `Logger.d`. The label keeps what this line is for, saying a load
+        // finished, and `onPageLoaded` below still receives the URL whole.
+        Logger.i(tag, "Page loaded: ${urlLogLabel(url)}")
         onPageLoaded(url)
     }
 

--- a/android/app/src/main/kotlin/com/vscodroid/webview/VSCodroidWebViewClient.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/webview/VSCodroidWebViewClient.kt
@@ -1106,7 +1106,12 @@ class VSCodroidWebViewClient(
      * `ViewRootImpl.dispatchUnhandledInputEvent`, which queues the event with
      * `FLAG_UNHANDLED`. `deliverInputEvent` sends anything carrying that flag to
      * `mSyntheticInputStage` INSTEAD of the view tree, and that stage is the only
-     * caller of `KeyCharacterMap.getFallbackAction` in the framework. Some
+     * caller of `KeyCharacterMap.getFallbackAction` reached by an event carrying
+     * that flag. It is not the only caller in the platform, and the other one is
+     * the whole reason the Activity keeps an override of its own:
+     * `PhoneWindowManager.dispatchUnhandledKey` calls it too, in the system
+     * server, for a key the app reported unhandled. The two are answered
+     * separately and neither substitutes for the other. Some
      * keyboards answer `ESCAPE` there with `fallback BACK` (AOSP ships one:
      * `Vendor_18d1_Product_5018.kcm`, the Pixel C keyboard, which reads
      * `base: fallback BACK` on a stock API 33 image where `Generic.kcm` reads

--- a/android/app/src/test/kotlin/com/vscodroid/WorkspaceUrlRoundTripTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/WorkspaceUrlRoundTripTest.kt
@@ -213,6 +213,44 @@ class WorkspaceUrlRoundTripTest {
         )
     }
 
+    /**
+     * Where the reduction happens, which no pure function can pin.
+     *
+     * `workspaceDirectoryInForce` needs a `stat`, and the resource interceptor
+     * runs once per request, so the reduction was moved to the one navigation-time
+     * writer and both suppliers hand the result. Nothing else notices if that
+     * moves back: the interceptor would still be handed a path, the roots would
+     * still be a list, and every case above would stay green while a workspace
+     * session paid a `stat` per request and a momentarily absent file silently
+     * unpublished the root.
+     *
+     * Read from the source because the writer is an Activity method and the
+     * suppliers are lambdas closing over its fields, neither of which a plain JVM
+     * test can drive. See [SourceScan] for the ceiling that reading carries.
+     */
+    @Test
+    fun `the workspace root is reduced once at navigation, not per request`() {
+        val source = SourceScan.read("src/main/kotlin/com/vscodroid/MainActivity.kt")
+        val writer = SourceScan.withoutComments(
+            SourceScan.body(source, "private fun rememberWorkspaceFolder("),
+        )
+
+        assertTrue(writer.contains("openWorkspaceRoot = workspaceDirectoryInForce(")) {
+            "rememberWorkspaceFolder no longer derives the published root, so either " +
+                "nothing does and a workspace file publishes only itself, or the " +
+                "interceptor went back to reducing per request"
+        }
+
+        val body = SourceScan.withoutComments(source)
+        assertTrue(body.contains("openFolder = { openWorkspaceRoot }")) {
+            "the webview client is handed the unreduced folder again"
+        }
+        assertTrue(body.contains("{ self.get()?.openWorkspaceRoot }")) {
+            "the service worker is handed the unreduced folder again, and it is the " +
+                "entry point that does not go through the client"
+        }
+    }
+
     @Test
     fun `the directory in force for a directory named like a workspace is itself`() {
         assertEquals(

--- a/android/app/src/test/kotlin/com/vscodroid/webview/WebviewResourceRootsTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/WebviewResourceRootsTest.kt
@@ -484,28 +484,31 @@ class ResourceRootsInForceTest {
 
     /**
      * A multi-root workspace is named by its `.code-workspace` file, and a root
-     * is matched by path prefix, so publishing the file publishes only itself.
+     * is matched by path prefix, so publishing the file would publish only
+     * itself. The reduction to the directory holding it happens once per
+     * navigation, in `MainActivity.openWorkspaceRoot`, because it needs a `stat`
+     * and this function runs once per intercepted request; what arrives here is
+     * already a directory. `WorkspaceUrlRoundTripTest` covers the reduction
+     * itself, including the directory that merely ends in `.code-workspace`.
      *
-     * Catches: taking the open-workspace value through to the roots unchanged
-     * now that it can be a file. Every resource beside the workspace file would
-     * be refused, and only for a workspace held outside the statically published
-     * trees, which is the case nothing else here covers.
+     * Catches: a root that is a single file reaching the interceptor. Every
+     * resource beside the workspace would be refused, and only for a workspace
+     * held outside the statically published trees, which is the case nothing
+     * else here covers.
      */
     @Test
-    fun `a workspace file publishes the directory holding it`() {
-        val roots = resourceRootsInForce(
-            ROOTS, SENSITIVE, "$FILES/home/projects/app/app.code-workspace",
-            // The premise of this case, and it has to be said rather than assumed:
-            // the reduction to the holding directory is for a workspace FILE. A
-            // directory spelled the same way publishes itself, because its
-            // siblings are not the workspace's content.
-            isFile = { true },
-        )
+    fun `the directory holding a workspace publishes its siblings`() {
+        val roots = resourceRootsInForce(ROOTS, SENSITIVE, "$FILES/home/projects/app")
 
         assertTrue(roots.containsAll(ROOTS), "the static roots must survive")
         assertNotNull(
             resolveWebviewResource("$FILES/home/projects/app/docs/diagram.png", roots),
             "a file beside the workspace, which is what the workspace's own roots hold",
+        )
+        assertNull(
+            resolveWebviewResource("$FILES/home/projects/app.code-workspace", roots),
+            "and nothing above it: publishing the holding directory must not reach " +
+                "the directory that holds THAT",
         )
     }
 

--- a/docs/DEVICE_TEST_CHECKLIST.md
+++ b/docs/DEVICE_TEST_CHECKLIST.md
@@ -55,7 +55,8 @@
 | KB-15 | Ctrl+Enter from the key row | Put the caret in the MIDDLE of a line, tap Ctrl on the key row, then press Enter on the soft keyboard | A new line opens below and the caret moves to it, leaving the line under the caret unsplit (Insert Line Below). A split line means the latch was spent without being applied: the soft keyboard reports Enter as an edit rather than as a key, so this is a different path from every other row key | | |
 | KB-17 | Latched Ctrl and a composed word on the EditContext path | On a WebView 121 or newer device with Gboard suggestions on (KB-11's check says which path), latch Ctrl on the row, type a word, then space | The word is inserted plainly and the row's Ctrl clears as the word starts; the space is inserted and no suggest widget opens. Latch Ctrl and type `s` with a non-composing commit (suggestions off, or Samsung keyboard) as the control: the file still saves (KB-7) | | |
 | KB-18 | Latched modifier and a frame | Latch Ctrl on the row, tap into a Simple Browser page or an extension webview and type, then tap back into the editor and type `a` | The row's Ctrl clears within a moment of focus entering the frame, and `a` is inserted rather than run as a chord | | |
-| KB-19 | Escape on a hardware keyboard | Connect a BT/USB keyboard, open a terminal, start `vi`, press `i` for insert mode, then press Esc | vi leaves INSERT and the app stays in the foreground. Only hardware answers this row, and unusually it is the key character map rather than the dispatch that has to be real: an injected Escape carries `Virtual.kcm` and the emulator's own keyboard resolves to `qwerty2.kcm`, and neither declares the `ESCAPE base: fallback BACK` that turns the key into a back press. Record the keyboard model, since only some maps carry it | | |
+| KB-19 | Escape on a hardware keyboard | FIRST establish the precondition, because without it this row cannot fail on any build: with the keyboard connected, run `adb shell dumpsys input`, find its `KeyCharacterMapFile`, and confirm that file contains `ESCAPE` with `base: fallback BACK`. Record the keyboard model and the map. Then open a file in the editor, click in it so the editor and not a terminal has focus, and press Esc once | The app stays in the foreground. Only hardware answers this row: an injected Escape carries `Virtual.kcm` and the emulator's own keyboard resolves to `qwerty2.kcm`, and neither declares the fallback. The editor is the target on purpose, and a terminal is not: xterm consumes the Escape keydown and writes `0x1b`, so a terminal never leaves the key unhandled and the route this row exists to test is never entered. Only the keyup leaks with the editor focused, which is enough, because the synthesised press carries the same action | | |
+| KB-20 | Escape still reaches the page | Same keyboard and the same editor file, then a terminal: press Esc in the editor with a suggest widget open, and press Esc in a terminal running `cat -v` | The widget closes, and `^[` appears under `cat -v`. This is the control for KB-19: refusing to hand Escape back to Android must not take it from the page, and the two rows fail in opposite directions | | |
 | KB-16 | Narrow phone paging | On a device or emulator whose portrait width is 360dp or less, bring the keyboard up and swipe through every page. `adb shell wm size` and `adb shell wm density` give the width in dp: pixels times 160, divided by density | There are more pages than the five a 411dp phone shows: six at 360dp, seven at 320dp. Every key still fills a comfortable target, no label is clipped, and the keys appear in the same order, only broken across more pages. The dots say how many there are | | |
 
 ## 4. Screen & Orientation
@@ -231,7 +232,7 @@ first launch of a build that has this line, so the row to run instead is TC-8.
 |----------|-------|------|------|------|
 | Device Matrix | 4 | | | |
 | Android Versions | 4 | | | |
-| Keyboard Input | 19 | | | |
+| Keyboard Input | 20 | | | |
 | Screen & Orientation | 6 | | | |
 | Editor Operations | 12 | | | |
 | Extensions | 6 | | | |
@@ -241,7 +242,7 @@ first launch of a build that has this line, so the row to run instead is TC-8.
 | Toolchains | 7 | | | |
 | Terminal & Tools | 11 | | | |
 | SAF & Files | 11 | | | |
-| **Total** | **102** | | | |
+| **Total** | **103** | | | |
 
 **Overall Result**: [ ] PASS / [ ] FAIL
 


### PR DESCRIPTION
Prepares the 1.3.0 tag, corrects three things in the record it would otherwise ship with, and closes two defects rather than carrying them past the tag.

Fixes #389
Fixes #390

## The bump

`versionCode` 14 and `versionName` 1.3.0. Minor rather than patch because the range adds two entries under **Added**: a device folder holding one `.code-workspace` opens as that workspace, and **VSCodroid: Open Recent Folder** reaches the remote indicator.

`## [Unreleased]` becomes `## [1.3.0] - 2026-09-04` with a fresh empty heading above it, and the compare-link block gains `[1.3.0]` and repoints `[Unreleased]` at `compare/v1.3.0...HEAD`. That block is worth calling out because nothing gates it: `release.yml` greps only for the `## [<version>]` heading, so a release can otherwise publish a version whose link resolves to nothing.

Simulated the three tag gates against this commit with the workflow's own commands: `versionName` extracts as `1.3.0`, `versionCode` 14 is greater than v1.2.0's 13, and the `## [1.3.0]` heading is present.

## Corrections

**The changelog promised more than the code delivers.** The Escape entry said pressing Esc on a hardware keyboard no longer sends the app to the background. What the code does is narrower and is now what the entry says: an Escape the editor leaves unhandled is no longer handed back to Android.

**A comment stated a falsehood that would get the wrong code deleted.** The override's documentation said the synthetic input stage is the only caller of `KeyCharacterMap.getFallbackAction` in the framework. `PhoneWindowManager.dispatchUnhandledKey` calls it too, in the system server, for a key the app reported unhandled, and that call is precisely the route the Activity's own override exists to close. The file therefore contradicted itself eight lines later, and a reader trusting the sentence would have removed an override that is load-bearing.

**A device-test row could not fail.** KB-19 asked for vi to leave INSERT mode and for the app to stay in the foreground. Leaving INSERT means xterm consumed the key and called `preventDefault`, so `onUnhandledKeyEvent` never fires and no fallback is ever synthesised, on a fixed build and an unfixed one alike. The row now establishes its precondition first, that the connected keyboard's character map really carries `ESCAPE base: fallback BACK`, since without that nothing can fire, and it targets the editor rather than a terminal. KB-20 is added as the control in the opposite direction: refusing to hand Escape back must not take it from the page.

## Two fixes that were nearly deferred

**The published resource root was derived on the request path.** `resourceRootsInForce` runs once per intercepted resource request and reduced a `.code-workspace` to its holding directory there, which needs a `stat`. `MainActivity`'s own documentation says that is the wrong place: the workbench issues hundreds of those during a cold load, which is what `openWorkspaceFolder` exists to keep a stat away from. The correctness half is worse than the cost: a workspace file momentarily absent, during a save-replace or a mirror re-sync, answered "not a file", so the reduction did not happen and the published root became the workspace file itself, refusing every resource beside it until something navigated again. The root is now derived once beside the folder it comes from and both suppliers hand it over, which also removes a double-reduction that a pre-reduced value would otherwise hit for a directory ending in `.code-workspace`.

**The page-load log carried the folder path.** It sits at `Logger.i`, which is not gated on a debuggable build, and `redactToken` removes the connection token and nothing else, so the absolute path shipped in release logcat on every load. It now logs the address label; `onPageLoaded` still receives the URL whole, which is what the callback exists for. The refusal line beside it keeps its path on purpose: `WorkspaceRefusalLogTest` records that its concern was volume, bounded to once per folder, not content, and that decision is not this change's to overturn.

## Verification

- Full JVM suite green, 2289 tests, 0 failures, 0 errors, 0 skipped.
- The root move is pinned by a source-scanning case, and both halves of it were confirmed red under mutation: dropping the reduction, and handing a supplier the unreduced folder. No pure function can see which side of the boundary the stat sits on, so nothing else would have noticed.
- Every `scripts/check-*.py` that runs without arguments passes, including the checklist-totals gate after the new row.
- `minifyReleaseWithR8` and `lintVitalRelease` both run clean.
- `check-patch-fingerprints.py --self-test` passes, and the full check against the packaged server tree is ok through patch 0017.

## Not covered

The Escape fix still has no end-to-end device evidence and cannot get any on an emulator: an injected Escape carries `Virtual.kcm`, and the emulator's own keyboard resolves to `qwerty2.kcm`, neither of which declares the fallback. What was confirmed on a device is that the interception point is live: a virtual keyboard created through `uinput` produces `onUnhandledKeyEvent` with `KEYCODE_ESCAPE`, and with the editor focused only the keyup arrives, which is what the override reads. KB-19 is the row that closes the rest, and it needs real hardware.
