### PR TITLE
fix: ask for storage in the unit the message names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The storage message asks for the amount your device actually reports. It was counted in binary megabytes and labelled MB, so freeing exactly what it asked for left you about 5 percent short and refused again.
 - An Escape the editor leaves unhandled is no longer handed back to Android. Some keyboard layouts answer it with a Back press, which sends the app to the background mid-keystroke.
 - Opening a workspace file no longer costs a filesystem check on every resource the editor loads, and a workspace file that is briefly absent while it is saved no longer cuts off every resource beside it.
 - The address of the page is no longer written to the system log on every load. It carried the full path of the folder you had open.

--- a/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
@@ -3723,7 +3723,16 @@ claude() {
             // names a figure up to a megabyte short of what the retry measures,
             // so the user frees exactly what was asked and is refused again by
             // the remainder, with nothing on screen to say why.
-            return (bytes + 1_048_575L) / 1_048_576L
+            //
+            // Decimal, and the label says MB, so the two now agree. This divided
+            // by 1_048_576 and called the result MB, which is the same defect the
+            // rounding above exists to prevent, only smaller and harder to see: a
+            // user who freed the number as their storage screen counts it freed
+            // 4.6% too few bytes and was refused again. Android's own storage UI
+            // has been decimal since API 26, and it is what a user checks against,
+            // so the number has to be in its units rather than the machine's.
+            // ToolchainManager already divides by 1_000_000 for the same word.
+            return (bytes + 999_999L) / 1_000_000L
         }
 
         /**

--- a/android/app/src/test/kotlin/com/vscodroid/setup/StoragePreflightTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/StoragePreflightTest.kt
@@ -734,15 +734,46 @@ class StoragePreflightTest {
         assertEquals(FirstRunSetup.SetupResult.LOW_STORAGE, result)
         val required = assetBytes / 2 + largestAssetBytes + slack
         assertEquals(
-            (required - free) / mb,
+            (required - free + 999_999L) / 1_000_000L,
             FirstRunSetup.storageToFreeMb(),
             "the message names the whole demand rather than the shortfall, so a device short " +
-                "by 4 MiB is told to free 70",
+                "by 4 MB is told to free 70",
         )
         assertTrue(
-            FirstRunSetup.storageToFreeMb() < required / mb,
+            FirstRunSetup.storageToFreeMb() < required / 1_000_000L,
             "the shortfall and the demand are the same number here, so this case cannot tell " +
                 "them apart",
+        )
+    }
+
+    /**
+     * The unit the string promises, which neither case above can tell apart.
+     *
+     * `error_storage_full` says MB, the user checks it against Android's storage
+     * screen, and that screen has been decimal since API 26. Dividing by 1 MiB
+     * and calling the answer MB understates the demand by 4.6%, so a user who
+     * frees exactly what was asked is refused again, which is the same failure
+     * the rounding above exists to prevent, only smaller.
+     *
+     * A shortfall chosen so the two units cannot give the same answer: one whole
+     * MiB is 1.048576 MB, which rounds up to 2.
+     */
+    @Test
+    fun `the figure is in the decimal MB the string names`() {
+        stageServerTree(assetBytes / 2)
+        val required = assetBytes / 2 + largestAssetBytes + slack
+        val free = required - mb
+
+        assertEquals(
+            FirstRunSetup.SetupResult.LOW_STORAGE,
+            runBlocking { setup(free = free).runSetup() },
+        )
+        assertEquals(
+            2L,
+            FirstRunSetup.storageToFreeMb(),
+            "a shortfall of one MiB is 1.05 MB, so this is 2 in the unit the string names " +
+                "and 1 in the unit the machine counts in. Reading 1 here means the figure " +
+                "went back to MiB while the string still says MB",
         )
     }
 


### PR DESCRIPTION
`FirstRunSetup.storageToFreeMb` divided by 1 MiB, and `error_storage_full` calls the result MB:

> Not enough storage space. Free at least %1$d MB, then tap Retry.

A user checks that number against Android's own storage screen, which has been decimal since API 26. Freeing exactly what was asked therefore freed about 4.6% too few bytes, and the retry refused them again with nothing on screen to say why.

That is the same failure the rounding in the same function exists to prevent, only smaller and harder to see. The string's own comment records two earlier versions of it: a fixed 500 MB that outlived the tree it was measured against and sent people to free half of what unpacking needs, and quoting the whole demand rather than the shortfall, which told someone 200 MB short to clear 873.

## What changed

- The figure is now decimal, rounded up as before. `ToolchainManager` already divides by `1_000_000` for the same word, so the two agree.
- The gate itself is untouched. It works in bytes, so the threshold that refuses a device is exactly what it was; only the number shown moves.

## Tests

Neither existing case could tell the units apart. `the figure is rounded up so freeing it is enough` is satisfied by either divisor, and `the storage message names what the user has to free` only failed because its fixture happened to be a whole number of MiB, which is luck rather than coverage.

A case with a one MiB shortfall pins it, because that is 2 in the unit the string names and 1 in the unit the machine counts in. Confirmed by mutation: restoring the MiB divisor turns it red, along with the shortfall case.

Full JVM suite: 2290 tests, 0 failures, 0 errors, 0 skipped.

## Scope

This lands before the 1.3.0 tag, so the entry sits in the 1.3.0 section rather than Unreleased.
