### PR TITLE
fix: ask the bytes before replacing an interrupted upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A file you changed on the device is no longer overwritten when the app reopens the folder after an upload was cut short. The app took its own record of the unfinished write as proof that nothing else had touched the file, and replaced it.
 - The storage message asks for the amount your device actually reports. It was counted in binary megabytes and labelled MB, so freeing exactly what it asked for left you about 5 percent short and refused again.
 - An Escape the editor leaves unhandled is no longer handed back to Android. Some keyboard layouts answer it with a Back press, which sends the app to the background mid-keystroke.
 - Opening a workspace file no longer costs a filesystem check on every resource the editor loads, and a workspace file that is briefly absent while it is saved no longer cuts off every resource beside it.

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
@@ -385,12 +385,14 @@ class SafSyncEngine(private val context: Context) {
                 localPath.mkdirs()
             } else {
                 // The one thing no timestamp comparison can see: this app was
-                // writing this path back when it stopped, so a newer, shorter
-                // document here is this app's own truncated copy rather than a
-                // device edit. The mirror is kept, it is the only complete
-                // version, and the upload attempted again, which is also the
-                // repair. The record is consumed by the sync that acted on it;
-                // the re-upload re-marks it if it is cut short again.
+                // writing this path back when it stopped. A newer, shorter
+                // document here is CONSISTENT with this app's own truncated copy,
+                // which is not the same as being one, so the bytes are asked
+                // rather than assumed below. Where they answer yes the mirror is
+                // kept, it is the only complete version, and the upload is
+                // attempted again, which is also the repair. The record is
+                // consumed by the sync that acted on it; the re-upload re-marks
+                // it if it is cut short again.
                 //
                 // Repaired here rather than queued: the queue belongs to the
                 // watcher's lifecycle, and [startWatching] opens by calling
@@ -399,9 +401,48 @@ class SafSyncEngine(private val context: Context) {
                 // is discarded before anything executes it. The sync already
                 // owns this moment; it is on the IO dispatcher and mid-copy.
                 if (localPath.exists() && localPath.absolutePath in unfinishedUploads) {
+                    // The journal line is not the licence the comment above reads
+                    // it as. It says a write started here and did not finish; it
+                    // says nothing about what touched the document between then
+                    // and now, and the window is as long as the app was away. A
+                    // user who edits that file on the device before opening the
+                    // app again, or another app that rewrites it, leaves a
+                    // document this branch used to overwrite with `"wt"`, which
+                    // truncates at open. The bytes were gone and nothing had been
+                    // kept.
+                    //
+                    // [deviceIsTruncatedMirror] is what the comment above assumed
+                    // rather than checked: the interrupted write leaves a strict
+                    // prefix of the mirror, so anything else came from somewhere
+                    // else. In the expected case it costs one provider read and
+                    // no copy, which is why it is asked before the set-aside
+                    // rather than instead of it: routing every repair through
+                    // [setAsideDeviceCopy] would keep a `.device-` copy of this
+                    // app's own half-written bytes, and phase 2b would then put
+                    // that copy on the device.
+                    val ownPartialWrite = deviceIsTruncatedMirror(doc.uri, localPath, doc.size)
+                    if (!ownPartialWrite && !setAsideDeviceCopy(doc, localPath)) {
+                        // Held back, not abandoned, and the record is deliberately
+                        // NOT consumed: the mirror keeps the only complete copy,
+                        // unvouched, and the next open tries the whole repair
+                        // again. Writing anyway would be the loss this guard
+                        // exists to prevent.
+                        keptLocal++
+                        Logger.w(
+                            tag,
+                            "Not replacing ${doc.relativePath}: its device copy is not the " +
+                                "unfinished upload this app left and could not be read to " +
+                                "set aside, so the mirror keeps its copy and the next open " +
+                                "tries again",
+                        )
+                        filesDone++
+                        onProgress(filesDone, totalFiles)
+                        continue
+                    }
                     unfinishedUploads.remove(localPath.absolutePath)
                     consumeStaleUploadRecord(localPath.absolutePath)
                     keptLocal++
+                    if (!ownPartialWrite) setAside++
                     Logger.i(
                         tag,
                         "Kept the mirror of ${doc.relativePath}: its device copy was an " +
@@ -1786,6 +1827,59 @@ class SafSyncEngine(private val context: Context) {
      * mirror kept and unrecorded, which is what happens today, while a true this could
      * not justify would vouch for bytes nobody compared.
      */
+    /**
+     * Whether the device document is exactly what this app's own interrupted
+     * write-back leaves behind: a STRICT PREFIX of the mirror.
+     *
+     * The upload journal records that a write started and did not finish. It does
+     * not record that nothing touched the document afterwards, and the two are
+     * only the same thing if the app was the last writer. `"wt"` truncates at
+     * open and the copy runs forward from zero, so a write cut short leaves the
+     * document holding the mirror's leading bytes and nothing else. Any other
+     * content, longer, shorter with different bytes, or the same length, was
+     * written by something that is not that interrupted write, and the caller
+     * must preserve it rather than overwrite it.
+     *
+     * Strict, because equal length is [deviceMatchesMirror]'s question and means
+     * the write finished after all.
+     *
+     * One provider read, the same one [setAsideDeviceCopy] would pay, and it
+     * spends it on the question that decides whether a copy is worth keeping
+     * rather than on the copy itself. Answering false on any failure is the safe
+     * direction: the caller then preserves the document before replacing it.
+     */
+    private fun deviceIsTruncatedMirror(safDocUri: Uri, localFile: File, deviceSize: Long): Boolean {
+        if (deviceSize <= 0L || deviceSize >= localFile.length()) return false
+        return try {
+            context.contentResolver.openInputStream(safDocUri)?.use { device ->
+                localFile.inputStream().use { mirror ->
+                    val a = ByteArray(COPY_BUFFER_SIZE)
+                    val b = ByteArray(COPY_BUFFER_SIZE)
+                    var compared = 0L
+                    while (true) {
+                        val read = device.readNBytes(a, 0, a.size)
+                        if (read == 0) return@use compared == deviceSize
+                        // The mirror is the longer side, so a short read from it
+                        // means the two disagree about their own lengths and the
+                        // prefix cannot hold.
+                        if (mirror.readNBytes(b, 0, read) != read) return@use false
+                        if (!java.util.Arrays.equals(a, 0, read, b, 0, read)) return@use false
+                        compared += read
+                        if (compared > deviceSize) return@use false
+                    }
+                    @Suppress("UNREACHABLE_CODE") false
+                }
+            } ?: false
+        } catch (e: Exception) {
+            Logger.w(
+                tag,
+                "Could not compare ${localFile.name} with its device copy: " +
+                    e.javaClass.simpleName,
+            )
+            false
+        }
+    }
+
     private fun deviceMatchesMirror(safDocUri: Uri, localFile: File, deviceSize: Long): Boolean {
         if (deviceSize != localFile.length()) return false
         return try {

--- a/android/app/src/test/kotlin/com/vscodroid/storage/InitialSyncWiringTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/InitialSyncWiringTest.kt
@@ -127,6 +127,111 @@ class InitialSyncWiringTest {
         every { context.contentResolver } returns resolver
     }
 
+    /**
+     * The upload journal, which is a plain list of absolute paths in `filesDir`.
+     *
+     * Seeded rather than produced, because producing one means killing the
+     * process mid-write. `context.filesDir` is stubbed per case rather than in
+     * `setUp` so the cases that do not care keep the relaxed mock they have
+     * always had.
+     */
+    private fun journalHolding(path: String, into: File) {
+        every { context.filesDir } returns into
+        File(into, SafSyncEngine.UPLOADS_IN_FLIGHT_FILE).writeText(path + "\n")
+    }
+
+    private fun journalEntries(into: File): List<String> =
+        File(into, SafSyncEngine.UPLOADS_IN_FLIGHT_FILE)
+            .takeIf { it.isFile }?.readLines()?.filter { it.isNotBlank() } ?: emptyList()
+
+    private fun setAsideCopies(): List<String> =
+        mirror.list().orEmpty().filter { SafSyncEngine.DEVICE_COPY_SUFFIX in it }
+
+    /**
+     * What the journal actually licenses, which is narrower than it was read as.
+     *
+     * A line says a write started at this path and did not finish. The repair
+     * took that to mean the device document is this app's own truncated copy and
+     * pushed the mirror over it with a truncating open. The two are only the same
+     * thing when nothing touched the document afterwards, and the window is as
+     * long as the app was away.
+     *
+     * These three are the whole decision: the bytes say which case it is, a copy
+     * is kept only when they say the document came from somewhere else, and a
+     * document that cannot be read holds the repair back rather than overwriting
+     * it. Each asserts on the journal too, because consuming the record is what
+     * makes a held-back repair permanent.
+     */
+    @Test
+    fun `a device copy that is this app's own truncated write is replaced without a copy`(
+        @TempDir files: File,
+    ) {
+        val local = mirrorHolding("notes.txt", "the whole file, saved", 1_700_000_060_000)
+        // A strict prefix: exactly what "wt" plus a copy cut short leaves behind.
+        deviceFolderHolding("notes.txt", "the whole file", 1_700_000_090_000)
+        journalHolding(local.absolutePath, files)
+
+        sync()
+
+        assertTrue(
+            writtenDocuments.contains("notes.txt"),
+            "the repair is the re-upload, so the mirror still has to reach the device",
+        )
+        assertEquals(
+            emptyList<String>(), setAsideCopies(),
+            "these are this app's own half-written bytes, and a copy of them is not a " +
+                "rescue: phase 2b would put it in the user's folder and nothing removes it",
+        )
+        assertEquals(
+            emptyList<String>(), journalEntries(files),
+            "the record was acted on, so it has to be consumed or every later open " +
+                "repeats the repair",
+        )
+    }
+
+    @Test
+    fun `a device edit made while the app was away is kept before the mirror replaces it`(
+        @TempDir files: File,
+    ) {
+        val local = mirrorHolding("notes.txt", "the whole file, saved", 1_700_000_060_000)
+        // Not a prefix, and that is the only thing separating it from the case
+        // above: something other than the interrupted write produced these bytes.
+        deviceFolderHolding("notes.txt", "typed on the phone instead", 1_700_000_090_000)
+        journalHolding(local.absolutePath, files)
+
+        sync()
+
+        assertEquals(
+            1, setAsideCopies().size,
+            "the device bytes were overwritten with nothing kept, which is the loss this " +
+                "guard exists to prevent. Found: ${mirror.list().orEmpty().toList()}",
+        )
+    }
+
+    @Test
+    fun `a device copy that cannot be read holds the repair back`(
+        @TempDir files: File,
+    ) {
+        val local = mirrorHolding("notes.txt", "the whole file, saved", 1_700_000_060_000)
+        deviceFolderHolding("notes.txt", "typed on the phone instead", 1_700_000_090_000)
+        journalHolding(local.absolutePath, files)
+        // After the fixture, so it replaces the reader the fixture installed.
+        every { resolver.openInputStream(any()) } throws IOException("the provider refused")
+
+        sync()
+
+        assertEquals(
+            emptyList<String>(), writtenDocuments,
+            "the document could not be read, so what it holds is unknown, and writing " +
+                "over an unknown is the loss itself",
+        )
+        assertEquals(
+            listOf(local.absolutePath), journalEntries(files),
+            "the record has to survive a held-back repair, or the next open has no reason " +
+                "to try again and the mirror keeps the only complete copy for ever",
+        )
+    }
+
     @Test
     fun `an unsaved local edit survives reopening the folder`() {
         // Newer AND a different length: the pairing the size-first rule overwrote.

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafUploadInterruptionTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafUploadInterruptionTest.kt
@@ -117,6 +117,13 @@ class SafUploadInterruptionTest {
             row = -1
             cursor
         }
+        // A real stream, and not decoration. The repair path reads the document
+        // before it replaces it, and a relaxed mock answers 0 from `read`, which
+        // `InputStream.copyTo` treats as "keep going": its loop is
+        // `while (bytes >= 0)`, so the copy spins for ever and takes the test JVM
+        // with it. A real stream ends at -1, and the fixture has to keep the
+        // contract the engine is entitled to rely on.
+        every { resolver.openInputStream(any()) } answers { ByteArrayInputStream(ByteArray(0)) }
     }
 
     /** One event, and the write-back thread's pass over what it queued. */
@@ -241,13 +248,17 @@ class SafUploadInterruptionTest {
 
     @Test
     fun `a sync prefers the mirror of a file whose upload was cut short`() {
-        // The device's copy is newer and shorter: exactly what a truncation looks
-        // like, and exactly what an edit made on the device looks like. The
-        // journal is the only thing that can tell them apart.
+        // The device's copy is newer and shorter, and its bytes are a PREFIX of
+        // the mirror's, which is what `"wt"` plus a copy cut short leaves: the
+        // open truncates and the copy runs forward from zero. Length alone is not
+        // the shape, and this fixture said "TRUNC" until it was pointed at the
+        // bytes: an edit made on the device is also newer and shorter, and telling
+        // the two apart is the whole job. The journal says a write started here;
+        // the bytes say whether it is still the thing that finished last.
         val local = File(mirror, "notes.txt").apply { writeText("the whole edit") }
         local.setLastModified(1_000_000_000_000L)
         journal.writeText(local.absolutePath)
-        val byDocId = mapOf("doc:notes.txt" to "TRUNC")
+        val byDocId = mapOf("doc:notes.txt" to "the wh")
 
         val cursor = mockk<Cursor>(relaxed = true)
         var row = -1
@@ -265,7 +276,7 @@ class SafUploadInterruptionTest {
         every { cursor.getString(0) } returns "doc:notes.txt"
         every { cursor.getString(1) } returns "notes.txt"
         every { cursor.getString(2) } returns "text/plain"
-        every { cursor.getLong(3) } returns 5L
+        every { cursor.getLong(3) } returns 6L
         every { cursor.getLong(4) } returns 2_000_000_000_000L
         every { resolver.query(any(), any(), any(), any(), any()) } returns cursor
         every { resolver.openInputStream(any()) } answers {


### PR DESCRIPTION
Fixes #391

`initialSync`'s repair for an unfinished upload pushed the mirror over the device document with a truncating open, on the strength of a journal line alone. That line says a write started at this path and did not finish. It does not say the document was untouched since, and the window is as long as the app was away. A user who edits that file on the device before opening the app again, or another app that rewrites it, left bytes this branch overwrote with nothing kept.

## The change

The bytes are asked rather than assumed. `"wt"` truncates at open and the copy runs forward from zero, so an interrupted write leaves a **strict prefix** of the mirror; anything else came from somewhere other than that write.

- A prefix is replaced as before, with no copy kept.
- Anything else is set aside first.
- If it cannot be read, the write is held back and the record is deliberately left in the journal, so the next open tries the whole repair again rather than the mirror keeping the only complete copy for ever.

Routing every repair through `setAsideDeviceCopy` would have been simpler and wrong. It keeps a copy whenever the bytes differ, so the expected case would leave a `.device-` copy of this app's own half-written bytes, and phase 2b would then upload that into the user's folder. The prefix test is what separates the two, and it costs the same single provider read the set-aside would have paid.

## Two fixture faults surfaced with it

**The cut-short case was not modelling a truncation.** It used contents that were merely shorter (`"TRUNC"` against a mirror of `"the whole edit"`), so the case never exercised the shape it describes. It now uses a genuine prefix.

**The harness could hang the test JVM.** `deviceHolding` left `openInputStream` to the relaxed resolver, which answers `0` from `read()`, and Kotlin's `InputStream.copyTo` loops `while (bytes >= 0)`. Any case where the engine reads a document therefore spun until the JVM died, and it surfaced as `Could not initialize class org.junit.platform.commons.util.ExceptionUtils` rather than as a test failure. The fixture now returns a stream that ends, which is the contract a real `InputStream` keeps.

## Tests

Three cases, in the file that already owns this behaviour and in `InitialSyncWiringTest` for the sync-level wiring: the own-truncated-write case that must leave no copy, the foreign-edit case that must keep one, and the unreadable case that must hold the write back and keep the record.

Two mutations confirm they discriminate:

- Removing the guard entirely turns the foreign-edit and unreadable cases red.
- The naive fix, routing every repair through `setAsideDeviceCopy`, turns the own-truncated-write case red. That is the one that matters: it is the patch a reader would reach for first.

Full JVM suite: 2293 tests, 0 failures, 0 errors, 0 skipped.

## Scope

This lands before the 1.3.0 tag, so the entry sits in the 1.3.0 section. The defect is not a regression from this release: the branch is identical at `v1.2.0`, and what changed around it is that the sibling write-back arm gained a set-aside, which is what made the asymmetry visible.

The related loose end is not addressed here and is worth its own change: `.device-<time>` copies are written inside the mirror, phase 2b does not exclude them, so they reach the device folder and nothing removes them.
