### PR TITLE
chore: reopen the changelog and undo the version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.3.0] - 2026-09-04
-
 ### Added
 
 - A device folder holding one `.code-workspace` now opens as that workspace. Android's picker can only hand back a folder, so a workspace on device storage was reachable only by finding the file in the explorer and opening it from there.
@@ -893,8 +891,7 @@ This release represents the cumulative work across milestones M0 through M5, bri
 - Health check polling for server readiness
 - Android intent handling for "Open with VSCodroid"
 
-[Unreleased]: https://github.com/rmyndharis/VSCodroid/compare/v1.3.0...HEAD
-[1.3.0]: https://github.com/rmyndharis/VSCodroid/compare/v1.2.0...v1.3.0
+[Unreleased]: https://github.com/rmyndharis/VSCodroid/compare/v1.2.0...HEAD
 [1.2.0]: https://github.com/rmyndharis/VSCodroid/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/rmyndharis/VSCodroid/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/rmyndharis/VSCodroid/compare/v0.2.9...v1.0.0

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -136,8 +136,8 @@ android {
         // browser simply times out.
         @Suppress("OldTargetApi")
         targetSdk = 36
-        versionCode = 14
-        versionName = "1.3.0"
+        versionCode = 13
+        versionName = "1.2.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
The changelog heading was renamed to `## [1.3.0]` and the version fields raised to `versionCode = 14` / `versionName = "1.3.0"` without a release having been called for. Both of those belong to the cut, not to ordinary work on main, and this repository already does them together: `874e576c` is "release: bump to 1.2.0 and close the changelog", a single commit made at the moment of tagging.

Two things were wrong with doing it early.

Between releases, the version fields matching the last published tag is the normal state rather than a defect. Treating it as something to fix is what produced the premature bump.

Closing the section early files an entry describing something nobody can install yet as shipped. Anything landing afterwards then has to choose between a section that claims to be released and an empty one above it, and I hit exactly that twice while adding entries.

## What this restores

- Every entry back under a single `## [Unreleased]`, with the `## [1.3.0] - 2026-09-04` heading removed.
- The compare-link block back to `[Unreleased]: compare/v1.2.0...HEAD`, with the `[1.3.0]` line dropped. Nothing gates that block, which is why it is easy to leave inconsistent in either direction.
- `versionCode = 13` and `versionName = "1.2.0"`, byte-identical to `git show v1.2.0:android/app/build.gradle.kts`.

With this, `release.yml`'s three gates go back to refusing a tag: the versionName equality, the versionCode monotonicity, and the `## [<version>]` heading check. That refusal is the wanted behaviour until a cut is deliberately called for.

The fixes themselves are untouched. Only the release mechanics move.