### PR TITLE
fix: read the device trust store, fix the key row chords, and find a LAN dev server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - VSCodroid's own commands, settings and the Get Started walkthrough are translated into the same thirteen languages as the editor.
 - The user guide covers installing an extension from a VSIX file, and what running and debugging does and does not do on the device.
 - The user guide explains why a Python package carrying compiled code cannot be installed, `pygame` among them, why `turtle` and `tkinter` are absent, and how to put a drawing on screen without either.
+- The user guide covers the two Python surprises that read as broken installs: a command installed by `pip` that will not start, and a named time zone that raises.
 
 ### Fixed
 
+- **Serve on Network** finds a dev server bound to the phone's own address. A server started as `vite --host 192.168.1.50` was reported as not running at all, in the list and when the port was typed in, although it was already answering other devices.
+- Python reaches HTTPS sites. The bundled interpreter loaded no certificates at all, so any script using `urllib`, `requests` or `ssl` failed to verify every site it tried. A certificate authority you installed on the device also reaches `pip` now, so a private package index behind one works.
+- Holding Ctrl or Alt on the key row and typing a capital letter sends the chord you asked for. The capital lost its Shift on the way, so Ctrl+Shift+P opened Quick Open instead of the Command Palette, and every other Ctrl+Shift shortcut reached the wrong command.
+- The alternates that appear when you hold a key on the key row go away with it. Turning the phone over left them floating over the keyboard, and letting the keyboard go left them over the editor, until you tapped somewhere else.
+- A sign-in you finish while the editor is restarting now says so instead of hanging. The callback was handed to the loading page, which cannot receive one.
+- A device folder opened twice at once no longer risks the file the second open skipped. Where two syncs of one folder met, the one that stepped aside kept no record that it had not read the document, so a later save could overwrite it.
+- The key row notices again when the page takes a modifier it was holding, after a reply that never arrives. One lost answer used to stop it asking for the rest of the session.
+- A file downloaded through the app's proxy is no longer reported as complete when the site it came from died halfway. The transfer either finished or hung with no error at all, depending on how the site framed it.
 - A device folder you waited for is no longer lost when the server dies while it is being copied. The page the app puts up to carry the new folder could be stopped by the editor's own "changes you made may not be saved" prompt, because the app had not said the navigation was its own doing; cancelling it left the old folder open and the new one forgotten after minutes of copying.
 - A folder opened after the editor's page has crashed several times comes back with its Android features working. The editor could be loaded over a rebuilt page whose bridge had not been restored, so Open Folder from Device, the toolchain screen, Open in Browser and every download quietly did nothing, with nothing on screen to say why.
 - The editor no longer offers to uninstall VSCodroid's own extensions. Removing one took the device folder picker, the toolchain screen and the storage tools with it, nothing in the editor could put it back, and the only way out was clearing app data.

--- a/android/app/src/main/assets/dns-proxy.js
+++ b/android/app/src/main/assets/dns-proxy.js
@@ -263,7 +263,33 @@ function start(log) {
                 // one here.
                 req.on('error', () => {});
                 res.on('error', () => {});
-                res.writeHead(407, { 'Proxy-Authenticate': CHALLENGE }).end();
+                // "Connection: close" is what keeps an unauthenticated peer
+                // inside the bound HEADER_PHASE_MS exists to impose. That sweep
+                // watches the header phase only, and a peer that finishes its
+                // headers steps out of its reach: the request body is never read
+                // here, so the connection sits in Node's request phase, where the
+                // only bound left is requestTimeout at its 300 s default.
+                //
+                // Measured against the shipped file, on the same socket that
+                // sends complete headers and then dribbles one body byte every
+                // 2 s: with keep-alive it was still holding its slot at 30 s and
+                // the timer never advanced, because each byte resets it; with
+                // this header it is gone in 3 ms. A peer that sends nothing after
+                // the headers was already closed at 6 s (keepAliveTimeout plus
+                // Node's 1 s buffer), so the header is not what bounds that one --
+                // it is the dribble, where the difference is a slot held for as
+                // long as the peer cares to hold it against 128 of them being the
+                // whole cap.
+                //
+                // A challenge-response client is unaffected: it opens a fresh
+                // connection for the retry, which on loopback costs nothing. This
+                // is not the CONNECT leg's reason for the same header, where the
+                // FIN is already sent by hand and the header is what stops git
+                // retrying into a dead socket.
+                res.writeHead(407, {
+                    'Proxy-Authenticate': CHALLENGE,
+                    Connection: 'close',
+                }).end();
                 return;
             }
             // Addressed to this proxy, so they stop here. See HOP_BY_HOP_HEADERS.
@@ -351,6 +377,30 @@ function start(log) {
                     // middle by a timer meant for one that never started.
                     upstream.setTimeout(0);
                     res.writeHead(upstreamRes.statusCode || 502, upstreamRes.headers);
+                    // An origin that dies part-way through its body raises the
+                    // failure HERE, on the response, and not on the request that
+                    // the handler below watches. Measured on node v22.23.2
+                    // against an origin that writes a header and destroys the
+                    // socket 50 ms later: the client sees `res:aborted`,
+                    // `res:error(ECONNRESET)`, `res:close` and the request object
+                    // gets only `close`. With nothing listening here, pipe never
+                    // reaches 'end', so `res` is never finished and the client
+                    // waits forever -- both legs held, no timeout left in the
+                    // response phase to cut it. npm and git hang rather than
+                    // retry.
+                    //
+                    // destroy(), not end(). Chunked is the framing at issue: on
+                    // a truncated chunked body end() writes the terminating
+                    // chunk, and the client reads a complete 200 carrying half a
+                    // tarball (measured: complete=true, body "SHORT" of a longer
+                    // stream). destroy() sends no terminator, so it surfaces as
+                    // ECONNRESET, which is what it is. Under Content-Length the
+                    // two agree, because Node refuses to under-deliver a declared
+                    // length and resets either way.
+                    upstreamRes.on('error', (err) => {
+                        log('warn', `dns-proxy: ${target.hostname} died mid-response: ${reason(err)}`);
+                        res.destroy();
+                    });
                     upstreamRes.pipe(res);
                 },
             );
@@ -362,9 +412,16 @@ function start(log) {
                 // relayed; writeHead would then throw ERR_HTTP_HEADERS_SENT,
                 // and an uncaught throw here takes this process down, and this
                 // process is now the editor server.
-                if (!res.headersSent) {
-                    res.writeHead(502);
+                //
+                // Past the headers there is no status left to send and no honest
+                // way to finish the body, so the connection goes down instead --
+                // same reason as the response-side handler above, and stated
+                // once there.
+                if (res.headersSent) {
+                    res.destroy();
+                    return;
                 }
+                res.writeHead(502);
                 res.end();
             });
             // A client that vanishes mid-transfer must tear down the upstream
@@ -407,9 +464,10 @@ function start(log) {
                 // Measured: adding this one header is what makes git work, and
                 // Content-Length: 0 in its place does not.
                 //
-                // The plain-HTTP 407 above needs no equivalent: it goes through
-                // Node's own response framing, which keeps that connection
-                // alive for the retry.
+                // The plain-HTTP 407 above carries the same header for an
+                // unrelated reason, spelled out there: Node frames that response
+                // itself and would keep the connection alive, which is what let
+                // an unauthenticated peer hold a slot indefinitely.
                 closeWith(
                     clientSocket,
                     `HTTP/1.1 407 Proxy Authentication Required\r\n` +

--- a/android/app/src/main/assets/extensions/vscodroid.vscodroid-serve-network-1.3.0/extension.js
+++ b/android/app/src/main/assets/extensions/vscodroid.vscodroid-serve-network-1.3.0/extension.js
@@ -76,11 +76,25 @@ function canConnect(host, port, timeoutMs = PROBE_TIMEOUT_MS) {
  * Which of [ports] are listening, and from which of this device's addresses each
  * of them answers.
  *
- * Two probes, because one cannot tell the difference and the difference is the
- * point of the command. Loopback finds the server; the device's own addresses
- * decide whether anyone else can reach it. A server bound to 127.0.0.1 answers
- * the first and refuses the second, which is exactly the distinction reading
- * /proc used to give for free.
+ * Two kinds of probe, because one cannot tell the difference and the difference
+ * is the point of the command: loopback says the server is only reachable here,
+ * the device's own addresses say another device can reach it. A server bound to
+ * 127.0.0.1 answers the first and refuses the second, which is exactly the
+ * distinction reading /proc used to give for free.
+ *
+ * Neither is a gate, and loopback used to be one. It was asked first and a
+ * refusal ended the port there, which reads as "is anything listening at all"
+ * and is not what it answers: `vite --host 192.168.1.50`, the invocation Vite
+ * documents for binding a single address and the one this command's own advice
+ * leads to, binds that address alone, so loopback refuses and the port was
+ * dropped before any address was tried. The quick pick then offered no entry for
+ * it and typing the port in answered "Nothing is listening on port 5173" about a
+ * server that was up and already reachable from the other device.
+ *
+ * Asking everything at once costs less wall clock, not more: the loopback probe
+ * and the address probes used to be sequential, so a scan could take two
+ * PROBE_TIMEOUT_MS and now takes one. What rises is the number of sockets open
+ * at once, and every one of them is dialled at this device.
  *
  * Every address, not the first one. A phone routinely has more than one: a VPN
  * puts up tun0 and mobile data puts up rmnet beside wlan0, and this probed
@@ -95,17 +109,23 @@ function canConnect(host, port, timeoutMs = PROBE_TIMEOUT_MS) {
  * which is what makes the answer meaningful.
  *
  * Returns a Map of port to the addresses that answered, which is empty for a
- * port only loopback reaches.
+ * port only loopback reaches. A port nothing answered at all is absent, which is
+ * a different thing from present with an empty list.
  */
 async function scanPorts(ports, lanAddresses, connect = canConnect) {
     const addresses = lanAddresses || [];
     const results = await Promise.all(
         ports.map(async (port) => {
-            if (!(await connect('127.0.0.1', port))) return null;
-            const answered = await Promise.all(
-                addresses.map(async (address) => ((await connect(address, port)) ? address : null)),
-            );
-            return [port, answered.filter(Boolean)];
+            const [loopback, ...answers] = await Promise.all([
+                connect('127.0.0.1', port),
+                ...addresses.map(async (address) => ((await connect(address, port)) ? address : null)),
+            ]);
+            const answered = answers.filter(Boolean);
+            // Absent only when nothing anywhere answered. An empty list is not
+            // the same verdict: it is a port loopback reached and no address
+            // did, which is the "this device only" entry the quick pick shows.
+            if (!loopback && answered.length === 0) return null;
+            return [port, answered];
         }),
     );
     return new Map(results.filter(Boolean));

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -162,8 +162,12 @@ class MainActivity : AppCompatActivity() {
     /**
      * Whether a workbench page is loaded and able to receive an auth callback.
      *
-     * Reset by [recreateWebView], because the replacement is a new page: the ids
-     * the workbench is waiting on live in memory and do not survive it. See
+     * Cleared by every path that puts a page of this app's own in front of the
+     * workbench, because none of them can consume a callback: [recreateWebView],
+     * whose replacement is a new page and does not carry the ids the workbench is
+     * waiting on, since those live in its memory; [showErrorPage]; and
+     * [retryServerStart], whose loading page is a `data:` document. Set again
+     * only where the workbench itself has finished loading. See
      * [receiveCallbackIntent].
      */
     private var workbenchLoaded = false
@@ -2438,6 +2442,15 @@ class MainActivity : AppCompatActivity() {
      * again anyway. Only the start is missing, and only the start is sent.
      */
     private fun retryServerStart() {
+        // The page about to replace the workbench is a `data:` loading page, and
+        // it can consume nothing: an auth callback relayed into it writes
+        // `vscode-web.url-callbacks` into that document's own localStorage and
+        // dispatches a StorageEvent no listener exists for, inside a try/catch
+        // that only reaches the console. The sign-in then hangs with nothing said,
+        // where a false flag raises the notice that names the restart.
+        // [showErrorPage] and [recreateWebView] clear it for the same reason; this
+        // site loads over the workbench exactly as they do and was left out.
+        workbenchLoaded = false
         // The loading page promises the editor once the server answers, and the
         // readiness that follows has to be allowed to keep that promise.
         rendererCrashLoopShown = false

--- a/android/app/src/main/kotlin/com/vscodroid/keyboard/ExtraKeyRow.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/keyboard/ExtraKeyRow.kt
@@ -152,7 +152,10 @@ class ExtraKeyRow @JvmOverloads constructor(
          * a fresh query every 200 ms with nothing waiting on the last one, for as
          * long as a modifier stayed latched. Asking again only once the previous
          * answer is in restores exactly one outstanding query, without making the
-         * poll depend on an answer arriving.
+         * poll depend on an answer arriving. Only once, or after a bounded silence:
+         * a reply lost while the injector that owes it is still this row's is
+         * displaced by nothing, and a slot with no way out of that is a poll that
+         * ticks forever without ever asking again.
          *
          * On the runnable rather than on the row, because it is the poll's own
          * bookkeeping and no other member reads it. It is deliberately not a
@@ -316,6 +319,24 @@ class ExtraKeyRow @JvmOverloads constructor(
 
             visibility = if (imeVisible) View.VISIBLE else View.GONE
             if (!imeVisible) {
+                // The popup is a window of its own and the row going GONE does
+                // not take it with it: nothing here is its parent. Measured on an
+                // API 37 emulator, long press `{}`, then let the keyboard go: the
+                // row disappears and the two alternates are left floating over
+                // the middle of the editor, with no key under them and nothing to
+                // say what they belong to. Dismissing it here is the same
+                // reasoning as the modifier reset beside it: the row is leaving,
+                // so everything it put on the screen leaves with it.
+                //
+                // It cannot fire while a popup is legitimately open, and that is
+                // measured rather than assumed: the popup sets
+                // INPUT_METHOD_NOT_NEEDED so the IME goes on targeting the
+                // activity window, and on an API 37 emulator a Ctrl latched on
+                // the row was still latched with the alternates up, which the
+                // reset on this same branch would have cleared had the branch
+                // run.
+                longPressPopup?.dismiss()
+                longPressPopup = null
                 resetModifiersIfNeeded()
             }
             Logger.d(tag, "IME visible=$imeVisible, bottomInset=$bottomInset")
@@ -487,13 +508,24 @@ class ExtraKeyRow @JvmOverloads constructor(
      */
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
-        val repacked = KeyPages.forSmallestWidthDp(newConfig.smallestScreenWidthDp)
-        if (repacked == pages) return
-        // The popup is a window anchored to a key that is about to be destroyed
-        // with the page holding it, and nothing tears it down with that key: the
-        // same reason [onDetachedFromWindow] dismisses it.
+        // Before the early return below, not after it, and that ordering is the
+        // whole of it. `smallestScreenWidthDp` is by definition the SMALLER of
+        // the two dimensions, so it does not move when the phone is turned over:
+        // a rotation always repacks to the same pages and always takes that
+        // return. The dismiss therefore never ran on the one configuration change
+        // every user performs. Measured on an API 37 emulator: long press `{}` in
+        // portrait, rotate, and the alternates are left sitting in the middle of
+        // the soft keyboard, a screen's width from the key they belong to, until
+        // the user taps somewhere else.
+        //
+        // The popup is a window anchored to a key that a repack destroys with the
+        // page holding it, and nothing tears it down with that key: the same
+        // reason [onDetachedFromWindow] dismisses it. A rotation that changes
+        // nothing else still moves the key out from under it.
         longPressPopup?.dismiss()
         longPressPopup = null
+        val repacked = KeyPages.forSmallestWidthDp(newConfig.smallestScreenWidthDp)
+        if (repacked == pages) return
         val ctrl = ctrlActive
         val alt = altActive
         val shift = shiftActive
@@ -617,10 +649,22 @@ internal fun latchedModifierLabel(ctrl: Boolean, alt: Boolean, shift: Boolean): 
  * Asked against the injector, that cannot happen: a claim by an injector other
  * than the one owing an answer displaces it, because an answer nobody can
  * deliver is an answer nobody is waiting for. The record is therefore released
- * on three occasions and can be stuck on none of them: [claim] by a new
- * injector, [release] by the answer arriving, [abandon] when the row is left
- * with no injector at all. Bounded at one reference, and that reference is
- * replaced or dropped rather than accumulated.
+ * on four occasions and can be stuck on none of them: [claim] by a new injector,
+ * [release] by the answer arriving, [abandon] when the row is left with no
+ * injector at all, and [claim] again by the SAME injector once it has stayed
+ * silent for [UNANSWERED_TICKS] of them. Bounded at one reference, and that
+ * reference is replaced or dropped rather than accumulated.
+ *
+ * That fourth one is the case the other three cannot reach: a reply lost while
+ * the injector it was asked of is still the row's. Nothing then displaces the
+ * claim and nothing abandons it, so every later tick returned at the guard and
+ * the poll went silent for the life of the page while going on ticking. It is
+ * the same end state the plain flag had, arrived at by a narrower door, and the
+ * cost is the same: a modifier the page has spent stays lit on the row and the
+ * next key goes out as a chord. Giving the slot up after a bounded silence
+ * closes it without giving back the bound, which is the whole reason the slot
+ * exists: a renderer that never answers is asked once a second instead of five
+ * times.
  *
  * Main thread only, which is where both writers run: the tick is a
  * `View.postDelayed` and the answer is an `evaluateJavascript` callback.
@@ -636,14 +680,33 @@ internal class OutstandingModifierQuery {
     private var askedOf: KeyInjector? = null
 
     /**
+     * How many claims [askedOf] has refused since it was taken.
+     *
+     * Zero whenever the slot is free, so it never has to be read together with
+     * [askedOf] to mean anything.
+     */
+    private var unanswered = 0
+
+    /**
      * Takes the single outstanding slot for [injector], reporting whether the
-     * caller may now ask. False only while that same injector already owes an
-     * answer, which is the back-pressure; a different injector always takes it,
-     * displacing a claim whose answer can no longer arrive.
+     * caller may now ask. False while that same injector already owes an answer
+     * and has owed it for fewer than [UNANSWERED_TICKS] calls, which is the
+     * back-pressure; a different injector always takes it, displacing a claim
+     * whose answer can no longer arrive.
+     *
+     * The count is what keeps the back-pressure from becoming a deadlock. It is
+     * kept in calls and not in milliseconds because this has no clock: the caller
+     * is a 200 ms tick, so five of them is the second the class doc names, and a
+     * caller that ticked at some other rate would get its own five ticks rather
+     * than a wrong second.
      */
     fun claim(injector: KeyInjector): Boolean {
-        if (askedOf === injector) return false
+        if (askedOf === injector) {
+            unanswered += 1
+            if (unanswered < UNANSWERED_TICKS) return false
+        }
         askedOf = injector
+        unanswered = 0
         return true
     }
 
@@ -656,11 +719,30 @@ internal class OutstandingModifierQuery {
     fun release(injector: KeyInjector): Boolean {
         if (askedOf !== injector) return false
         askedOf = null
+        unanswered = 0
         return true
     }
 
     /** Gives up on the answer entirely, for a row left with no injector. */
     fun abandon() {
         askedOf = null
+        unanswered = 0
+    }
+
+    private companion object {
+        /**
+         * How many ticks one injector may stay silent before it is asked again.
+         *
+         * Inside the class rather than beside it: a file-level `const` written
+         * above the declaration lands between this class's KDoc and the class,
+         * which orphans thirty lines explaining the whole invariant onto a
+         * number.
+         *
+         * Five, against the poll's 200 ms tick, so a lost reply costs about a
+         * second of a row painted stale rather than the rest of the page's life,
+         * and a renderer that answers nothing is asked once a second rather than
+         * five times.
+         */
+        const val UNANSWERED_TICKS = 5
     }
 }

--- a/android/app/src/main/kotlin/com/vscodroid/keyboard/KeyInjector.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/keyboard/KeyInjector.kt
@@ -340,6 +340,29 @@ class KeyInjector(
                         code = /[a-zA-Z]/.test(ch) ? 'Key' + upper :
                                /[0-9]/.test(ch) ? 'Digit' + ch : '';
                         keyCode = upper.charCodeAt(0);
+                        // A capital is a shifted key, and the table above says so
+                        // for punctuation and cannot for letters: it carries no
+                        // letters at all, so `def` is null here and shiftKey kept
+                        // whatever the ROW's Shift said, which for a capital typed
+                        // on the soft keyboard is false.
+                        //
+                        // What that costs is the chord. Measured on an API 37
+                        // emulator against the shipped build: latch Ctrl on the
+                        // row, type a capital P, and the page receives
+                        // {key:"P", code:"KeyP", ctrl:true, shift:false} and opens
+                        // Quick Open, "Search files by name". The same event with
+                        // shift true opens the Command Palette, "Type the name of
+                        // a command to run". So Ctrl+Shift+anything was
+                        // unreachable from this row by the one route a phone
+                        // offers for it, and it failed by doing something else
+                        // plausible rather than nothing.
+                        //
+                        // [A-Z] and not `ch !== ch.toLowerCase()`: a capital
+                        // outside ASCII gets no `code` two lines up, so there is
+                        // no chord for a modifier to belong to, and claiming
+                        // Shift for it would describe a US layout that has no such
+                        // key.
+                        if (/[A-Z]/.test(ch)) shiftKey = true;
                     }
 
                     init = {

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
@@ -152,6 +152,17 @@ class SafSyncEngine(private val context: Context) {
      *
      * Absolute paths and scoped per mirror in [initialSync], next to [unfetched] and for
      * the same reason: one engine serves every folder in turn.
+     *
+     * "One notice per path" is therefore per ENGINE, not per device, and the
+     * difference is reachable: an activity recreated mid-open leaves two engines
+     * over one mirror, both of them announcing through a lambda that closes over
+     * the application context, so one file can be announced twice. That is left
+     * as it is deliberately. Moving the set to the companion object, the shape
+     * [mirrorCopiesInFlight] and its siblings use, would let the engine whose
+     * notice the manager's own per-activity throttle swallowed spend the other
+     * engine's budget, and the failure would be silence about a save that is not
+     * reaching the device folder. A duplicate of the same sentence is the cheaper
+     * way to be wrong, and two is not the wall this set exists to stop.
      */
     private val refusalsAnnounced = ConcurrentHashMap.newKeySet<String>()
 
@@ -712,10 +723,34 @@ class SafSyncEngine(private val context: Context) {
                 // the other, whose remaining bytes then landed inside the finished
                 // mirror file that [recordIdentity] had already vouched for.
                 if (!mirrorCopiesInFlight.add(localPath.absolutePath)) {
+                    // Armed for the same reason every other refusal in this loop
+                    // arms it: THIS sync did not read the device document, which
+                    // is the whole of what the set means. Leaving it to the other
+                    // sync is right for the copy and says nothing about the guard,
+                    // and the two engines do not share one: the claim above is in
+                    // the companion object precisely because two engines meet
+                    // over one mirror, while [unfetched] is per engine.
+                    //
+                    // Which engine is left holding the folder makes it worse, not
+                    // academic. The routine way two syncs meet here is an activity
+                    // recreated mid-open: the claim belongs to the engine of the
+                    // activity being destroyed, so the winner is the one going
+                    // away and the LOSER is the engine whose watcher goes on
+                    // serving saves. A copy the winner never finished then leaves
+                    // the mirror holding a stub, and the first save writes it over
+                    // the device document with "wt", which truncates at open.
+                    //
+                    // It can only add refusals, never a write, and a refusal here
+                    // is a deferral the next open clears: [initialSync] scrubs the
+                    // mirror's prefix out of the set before phase 2. The cost when
+                    // the winner did finish is one save deferred to the next open
+                    // of that folder; the cost of not arming it is the document.
+                    unfetched.add(localPath.absolutePath)
                     Logger.w(
                         tag,
                         "Another sync of this folder is already copying " +
-                            "${doc.relativePath}; leaving it to that one",
+                            "${doc.relativePath}; leaving it to that one, and not " +
+                            "vouching for a device copy this sync never read",
                     )
                     filesDone++
                     onProgress(filesDone, totalFiles)
@@ -3991,8 +4026,11 @@ class SafSyncEngine(private val context: Context) {
          * network or MTP provider has no timeout, so waiting would trade a race for an
          * unbounded stall of a folder open behind a dialog with `setCancelable(false)`.
          * What the loser gives up is one copy of a document the winner is already
-         * copying, and it records nothing for that path, which is the direction that
-         * costs disk rather than work.
+         * copying, and it vouches for nothing at that path, which is the direction
+         * that costs disk rather than work. It does record the path as one it did
+         * not read: this set is shared between the two engines and `unfetched` is
+         * not, so the loser is the only thing that can arm its own write-back
+         * guard, and the loser is routinely the engine that outlives the winner.
          */
         private val mirrorCopiesInFlight = ConcurrentHashMap.newKeySet<String>()
 

--- a/android/app/src/main/kotlin/com/vscodroid/util/Environment.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/util/Environment.kt
@@ -134,12 +134,37 @@ object Environment {
             // any certificate; CAPATH alone does not satisfy it, measured on
             // device. setupGitCaBundle() writes this on every launch it has
             // changed, from the system trust store plus any CA the device owner
-            // installed themselves through Settings. That second half reaches
-            // git and nothing else: SSL_CERT_DIR below names the system store
-            // directly, so python, ruby and curl still see system roots only,
-            // and the WebView and the toolchain downloader go through the
-            // platform trust manager, which this file cannot influence.
+            // installed themselves through Settings.
             "GIT_SSL_CAINFO" to "$filesDir/usr/etc/tls/cert.pem",
+            // The same bundle for everything else that links OpenSSL, and this
+            // used to say the directory below was enough for them. It is not,
+            // and the reason is a hash algorithm.
+            //
+            // A directory trust store is not scanned, it is looked up: OpenSSL
+            // hashes the issuer name and opens `<hash>.0`. Android names its
+            // files with the OpenSSL 0.9.8 hash, and everything since 1.0 uses a
+            // different one. Measured against a cert out of
+            // /system/etc/security/cacerts on the emulator: the file is
+            // 01419da9.0, `openssl x509 -subject_hash_old` answers 01419da9, and
+            // `-hash` answers 8d89cda1, which is the name OpenSSL 3 goes looking
+            // for and which is not there. So SSL_CERT_DIR alone leaves a store
+            // that can be listed and never read.
+            //
+            // What that cost, measured on device before this line existed: the
+            // bundled Python loaded zero certificates and `urllib.request` on
+            // https://pypi.org failed with CERTIFICATE_VERIFY_FAILED. With the
+            // file named here it loads 120 and the same request answers 200.
+            // Ruby's OpenSSL reads the same variable and was in the same state.
+            //
+            // pip is NOT the client this rescues, and saying so was the first
+            // wrong version of this comment: it verifies against the certifi
+            // bundle vendored inside itself, so it worked throughout. What was
+            // broken is everything that asks OpenSSL for the default trust,
+            // which is any ordinary script a user writes.
+            //
+            // The directory stays beside it. It costs nothing, and a client that
+            // does resolve the old hashes keeps working.
+            "SSL_CERT_FILE" to "$filesDir/usr/etc/tls/cert.pem",
             "SSL_CERT_DIR" to getSystemCaCertsPath(),
             "NPM_CONFIG_PREFIX" to "$filesDir/usr",
             "NPM_CONFIG_CACHE" to "$cacheDir/npm-cache",
@@ -155,7 +180,27 @@ object Environment {
             "VSCODROID_VERSION" to getVersionName(context),
         )
 
-        return base + toolchainEnv
+        // The name pip actually reads, and what makes a CA the device owner
+        // installed count for a private index. It is requests' variable rather
+        // than pip's own PIP_CERT, so the one row also reaches a user's own
+        // `requests` code.
+        //
+        // Conditional, and the guard is the whole reason this is not a row in
+        // the map above. requests treats a bundle it cannot open as fatal
+        // instead of falling back to its vendored certifi: measured on an API 37
+        // emulator, pointing it at a missing path stops pip with "Could not find
+        // a suitable TLS CA certificate bundle". setupGitCaBundle() gives up on
+        // a device with no system CA directory and after a failed write, so
+        // naming a file it never wrote would take away the one Python HTTPS
+        // client that works without any of this. SSL_CERT_FILE above wants no
+        // such guard: with a path that does not exist OpenSSL loads nothing and
+        // verification fails, which is where this started rather than worse.
+        val caBundle = File("$filesDir/usr/etc/tls/cert.pem")
+        val requestsCa =
+            if (caBundle.isFile) mapOf("REQUESTS_CA_BUNDLE" to caBundle.absolutePath)
+            else emptyMap()
+
+        return base + requestsCa + toolchainEnv
     }
 
     private fun getToolchainEnvironment(context: Context): MutableMap<String, String> {

--- a/android/app/src/test/kotlin/com/vscodroid/keyboard/ExtraKeyQueryOwnershipTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/keyboard/ExtraKeyQueryOwnershipTest.kt
@@ -4,6 +4,7 @@ import android.webkit.WebView
 import io.mockk.mockk
 import io.mockk.unmockkAll
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -89,6 +90,92 @@ class ExtraKeyQueryOwnershipTest {
         )
         assertTrue(query.release(injector), "the answer that arrived is the one being waited for")
         assertTrue(query.claim(injector), "with the answer in, the next tick must ask again")
+    }
+
+    /**
+     * The reply that is simply lost, with the injector that owes it still the
+     * row's.
+     *
+     * Nothing displaces the claim: no replacement injector arrives, so [claim]
+     * never sees a different one, and the row still has an injector, so the poll
+     * never reaches [abandon]. Without a way out, the guard above turns from
+     * back-pressure into a stop: every later tick returns without asking, and the
+     * row never again learns that the page has spent a latched modifier. It is
+     * the plain-flag failure this class was written to remove, reached by the one
+     * door the class did not close.
+     *
+     * NEGATIVE CONTROL: restore the old `if (askedOf === injector) return false`
+     * and this goes red on the last assertion, on every tick after it.
+     */
+    @Test
+    fun `an injector that never answers is asked again after a bounded silence`() {
+        val query = OutstandingModifierQuery()
+        val silent = injector()
+
+        assertTrue(query.claim(silent), "the first tick must be allowed to ask")
+
+        // The bound is still a bound: it is not given up on the very next tick,
+        // or a slow renderer is back to being asked five times a second.
+        assertFalse(query.claim(silent), "the tick right after the question must not re-ask")
+
+        // Ticks on, with nothing ever answering. This is deliberately not a
+        // spelled count: what the case is about is that the silence ENDS, and
+        // pinning the number here would make a change to it a two-file edit for
+        // no gain. The floor below is what keeps it from being unbounded.
+        var asked = 1
+        var ticks = 1
+        while (ticks < 20 && asked < 2) {
+            ticks += 1
+            if (query.claim(silent)) asked += 1
+        }
+
+        assertTrue(
+            asked >= 2,
+            "twenty ticks went by and the poll never asked again, so one lost reply " +
+                "silences it for the life of the page: the row goes on painting a modifier " +
+                "the page has already spent, and the next key goes out as a chord",
+        )
+        assertTrue(
+            ticks >= 3,
+            "the slot was given up almost immediately, which is the bound gone rather than " +
+                "closed: a renderer slow to answer is asked again while its first reply is " +
+                "still in the air",
+        )
+    }
+
+    /**
+     * That the reprieve is spent, not carried.
+     *
+     * A silence already counted against one query must not be counted against
+     * the next: carried forward, the bound decays over the life of a page until
+     * every tick asks, which is the back-pressure gone by degrees rather than
+     * visibly. Compared between two rounds rather than against a spelled number,
+     * for the reason the case above gives.
+     */
+    @Test
+    fun `a silence is not counted against the query after it`() {
+        val query = OutstandingModifierQuery()
+        val injector = injector()
+
+        fun refusalsBeforeReasking(): Int {
+            var refusals = 0
+            while (refusals < 20 && !query.claim(injector)) refusals += 1
+            return refusals
+        }
+
+        assertTrue(query.claim(injector), "the first tick must be allowed to ask")
+        val first = refusalsBeforeReasking()
+        assertTrue(first in 1..19, "the first round never re-asked, so there is nothing to compare")
+
+        // This round's query is answered, and then the injector goes silent again.
+        assertTrue(query.release(injector), "the answer arrived")
+        assertTrue(query.claim(injector), "with the answer in, the next tick must ask again")
+
+        assertEquals(
+            first, refusalsBeforeReasking(),
+            "a query that follows an answered one gets a shorter reprieve than the one " +
+                "before it, so the bound wears away over the life of a page",
+        )
     }
 
     /**

--- a/android/app/src/test/kotlin/com/vscodroid/keyboard/ExtraKeyRowPopupTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/keyboard/ExtraKeyRowPopupTest.kt
@@ -76,6 +76,57 @@ class ExtraKeyRowPopupTest {
     }
 
     @Test
+    fun `a configuration change closes the popup before deciding it changed nothing`() {
+        val lines = code()
+        val start = lines.indexOfFirst { it.contains("override fun onConfigurationChanged(") }
+        assertTrue(start >= 0, "onConfigurationChanged is no longer where this test looks")
+
+        val body = lines.drop(start).take(12)
+        val dismiss = body.indexOfFirst { it.contains("longPressPopup?.dismiss()") }
+        val earlyReturn = body.indexOfFirst { it.contains("if (repacked == pages) return") }
+
+        // The control. Both landmarks have to be in the window this reads, or a
+        // renamed guard would leave the case passing on an empty comparison.
+        assertTrue(dismiss >= 0, "the config-change path no longer dismisses the popup at all")
+        assertTrue(
+            earlyReturn >= 0,
+            "the repack guard is no longer where this test looks, so the ordering below is " +
+                "being asserted about nothing",
+        )
+
+        assertTrue(
+            dismiss < earlyReturn,
+            "the popup is dismissed only after the repack guard has decided the pages did " +
+                "not change, and on a rotation they never do: smallestScreenWidthDp is the " +
+                "smaller dimension by definition, so turning the phone over always takes " +
+                "that return and leaves the alternates floating over the new layout",
+        )
+    }
+
+    @Test
+    fun `the popup goes down with the keyboard`() {
+        val lines = code()
+        val start = lines.indexOfFirst { it.contains("visibility = if (imeVisible)") }
+        assertTrue(
+            start >= 0,
+            "the row no longer drives its visibility from the IME insets, so this case is " +
+                "reading nothing",
+        )
+
+        val body = lines.drop(start).take(8).joinToString("\n")
+        assertTrue(
+            body.contains("resetModifiersIfNeeded()"),
+            "the hidden-IME branch is no longer where this test looks. It reads:\n$body",
+        )
+        assertTrue(
+            body.contains("longPressPopup?.dismiss()"),
+            "the row goes GONE with the keyboard and leaves the alternates window standing " +
+                "over the editor, with no key under it and nothing to say what it belongs " +
+                "to. It reads:\n$body",
+        )
+    }
+
+    @Test
     fun `a row leaving its window takes the popup with it`() {
         val lines = code()
         val start = lines.indexOfFirst { it.contains("override fun onDetachedFromWindow()") }

--- a/android/app/src/test/kotlin/com/vscodroid/keyboard/KeyInjectorShiftTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/keyboard/KeyInjectorShiftTest.kt
@@ -131,6 +131,68 @@ class KeyInjectorShiftTest {
         )
     }
 
+    /**
+     * The branch the listener takes for a character the table does not carry,
+     * which is every letter.
+     *
+     * Sliced by its own `} else {` rather than searched for across the script:
+     * the branch above it assigns the same three variables from the table, so a
+     * whole-script search for an assignment to `shiftKey` is satisfied by that
+     * copy while this one leaves it alone.
+     */
+    private fun letterBranch(): String {
+        KeyInjector(webView).setupModifierInterceptor()
+        val installed = script.captured
+        val marker = "var upper = ch.toUpperCase();"
+        val start = installed.indexOf(marker)
+        assertTrue(
+            start >= 0,
+            "the listener no longer derives a key from the character itself, so this test " +
+                "is reading nothing and its verdict is worth nothing. It reads:\n$installed",
+        )
+        // The closing brace on a line of its own, found by shape rather than by
+        // a counted indent: the script is trimIndent'ed on its way out, so the
+        // column it sits in is a property of the Kotlin file around it and not of
+        // the JS. Nothing inside this branch closes a block, so the first one is
+        // the branch's own.
+        val end = Regex("\\n\\s*\\}").find(installed, start)
+        assertTrue(end != null, "the branch is never closed")
+        return installed.substring(start, end!!.range.first)
+    }
+
+    @Test
+    fun `a capital typed on the soft keyboard carries Shift`() {
+        // The one route a phone has to Ctrl+Shift+letter: latch Ctrl on the row,
+        // then use the soft keyboard's own Shift for the letter. The table this
+        // branch falls back from carries no letters, so nothing else can say the
+        // character was shifted, and a chord that loses it is not a chord that
+        // does nothing. Measured on an API 37 emulator: Ctrl with a capital P
+        // arrived as {key:"P", code:"KeyP", ctrl:true, shift:false} and opened
+        // Quick Open; the same event with shift true opens the Command Palette.
+        val branch = letterBranch()
+
+        assertTrue(
+            branch.contains("shiftKey = true"),
+            "a capital reaches the page as an unshifted keystroke, so Ctrl with a capital " +
+                "resolves to the unshifted chord: Ctrl+Shift+P opens Quick Open instead of " +
+                "the Command Palette. It reads: $branch",
+        )
+    }
+
+    @Test
+    fun `a lowercase letter is not given a Shift it never had`() {
+        // The other half, and the reason the test above is not satisfied by
+        // forcing the flag on: an ordinary letter typed with Ctrl latched has to
+        // stay the unshifted chord, or Ctrl+c becomes Ctrl+Shift+C.
+        val branch = letterBranch()
+
+        assertTrue(
+            branch.contains("/[A-Z]/"),
+            "the branch decides Shift from something other than the character being an " +
+                "upper-case letter, so it cannot tell `p` from `P`. It reads: $branch",
+        )
+    }
+
     @Test
     fun `a character that needs Shift is sent with Shift held`() {
         // `{` rather than a letter: a letter is unshifted, so it would pass

--- a/android/app/src/test/kotlin/com/vscodroid/setup/TerminalTrustStoreTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/TerminalTrustStoreTest.kt
@@ -1,0 +1,156 @@
+package com.vscodroid.setup
+
+import android.content.Context
+import android.content.pm.ApplicationInfo
+import com.google.android.play.core.assetpacks.AssetPackManagerFactory
+import com.vscodroid.util.Environment
+import com.vscodroid.util.Logger
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+/**
+ * That everything in the terminal which speaks TLS is given a trust store it can
+ * actually read, and not only git.
+ *
+ * A directory trust store is not scanned, it is looked up: OpenSSL hashes the
+ * issuer name and opens `<hash>.0`. Android names its files with the OpenSSL
+ * 0.9.8 hash and everything since 1.0 uses a different one, so pointing
+ * `SSL_CERT_DIR` at the system store yields a directory that can be listed and
+ * never read. Measured against a certificate out of
+ * `/system/etc/security/cacerts` on an API 37 emulator: the file is `01419da9.0`,
+ * `openssl x509 -subject_hash_old` answers `01419da9`, and `-hash` answers
+ * `8d89cda1`, which is the name OpenSSL 3 goes looking for and which is not
+ * there.
+ *
+ * What that cost, measured on device before the file variable existed: the
+ * bundled Python loaded zero certificates and every HTTPS request failed with
+ * CERTIFICATE_VERIFY_FAILED, so `pip install` could not reach PyPI at all, on a
+ * command the user guide documents and the Get Started walkthrough advertises as
+ * ready. git was unaffected the whole time, because it had been handed the file
+ * form separately, which is exactly why nothing noticed.
+ */
+class TerminalTrustStoreTest {
+
+    @TempDir
+    lateinit var filesDir: File
+
+    private lateinit var context: Context
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(Logger)
+        every { Logger.d(any(), any()) } just Runs
+        every { Logger.i(any(), any()) } just Runs
+        every { Logger.w(any(), any()) } just Runs
+        every { Logger.w(any(), any(), any()) } just Runs
+        every { Logger.e(any(), any(), any()) } just Runs
+
+        mockkStatic(AssetPackManagerFactory::class)
+        every { AssetPackManagerFactory.getInstance(any()) } returns mockk(relaxed = true)
+
+        context = mockk(relaxed = true)
+        every { context.filesDir } returns filesDir
+        every { context.cacheDir } returns File(filesDir, "cache")
+        every { context.applicationInfo } returns ApplicationInfo().apply {
+            nativeLibraryDir = "/data/app/~~hash==/com.vscodroid-hash==/lib/arm64"
+        }
+        every { context.getExternalFilesDir(null) } returns File(filesDir, "external")
+
+        File(filesDir, "home/.vscodroid").mkdirs()
+    }
+
+    @AfterEach
+    fun tearDown() = unmockkAll()
+
+    private fun env(): Map<String, String> = Environment.buildProcessEnvironment(context, 1234)
+
+    @Test
+    fun `the bundle reaches everything that speaks TLS, not only git`() {
+        val environment = env()
+        val bundle = "${filesDir.absolutePath}/usr/etc/tls/cert.pem"
+
+        assertEquals(
+            bundle, environment["GIT_SSL_CAINFO"],
+            "git no longer names the bundle the app builds; this case reads both halves",
+        )
+        assertEquals(
+            bundle, environment["SSL_CERT_FILE"],
+            "nothing but git is given a readable trust store. The directory store beside " +
+                "this is named with the pre-1.0 OpenSSL hash, so OpenSSL 3 looks up a name " +
+                "that is not there and finds no issuer: pip install fails at TLS against " +
+                "PyPI, on a command the guide documents as working",
+        )
+    }
+
+    /**
+     * pip does not read SSL_CERT_FILE. It verifies against the certifi bundle
+     * vendored inside itself, so it kept working throughout and the row above
+     * does nothing for it. This is the name it does read, and without it a CA
+     * the device owner installed reaches git and never reaches a private index.
+     */
+    @Test
+    fun `pip is given the bundle under the name it reads`() {
+        File(filesDir, "usr/etc/tls").mkdirs()
+        File(filesDir, "usr/etc/tls/cert.pem").writeText("-----BEGIN CERTIFICATE-----\n")
+
+        assertEquals(
+            "${filesDir.absolutePath}/usr/etc/tls/cert.pem", env()["REQUESTS_CA_BUNDLE"],
+            "pip and a user's own requests code are back on the vendored certifi, so a CA " +
+                "the device owner installed does not reach a private index",
+        )
+    }
+
+    /**
+     * And only when the file is there.
+     *
+     * requests treats a bundle it cannot open as fatal rather than falling back,
+     * so naming one `setupGitCaBundle` never wrote would stop pip outright: it
+     * is the one Python HTTPS client that works without any of this, and taking
+     * it away to improve trust would be the worse trade.
+     */
+    @Test
+    fun `no bundle on disk means the variable is not set at all`() {
+        assertTrue(
+            !File(filesDir, "usr/etc/tls/cert.pem").exists(),
+            "this case has to run with no bundle written, or it proves nothing",
+        )
+
+        assertTrue(
+            env()["REQUESTS_CA_BUNDLE"] == null,
+            "pip is pointed at a bundle that does not exist, which it treats as fatal: " +
+                "every install stops with \"Could not find a suitable TLS CA certificate " +
+                "bundle\" instead of falling back to the one vendored inside it",
+        )
+    }
+
+    /**
+     * The directory stays. It costs nothing, and a client that does resolve the
+     * old hashes keeps working; dropping it would be a change nobody measured.
+     */
+    @Test
+    fun `the system store is still offered alongside the bundle`() {
+        val environment = env()
+
+        assertTrue(
+            environment["SSL_CERT_DIR"]?.startsWith("/") == true,
+            "SSL_CERT_DIR no longer names an absolute system path: ${environment["SSL_CERT_DIR"]}",
+        )
+        assertTrue(
+            environment["SSL_CERT_DIR"] != environment["SSL_CERT_FILE"],
+            "the directory and the file variables now name the same thing, so one of them " +
+                "is being used for something it is not",
+        )
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafUnfetchedDocumentTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafUnfetchedDocumentTest.kt
@@ -52,6 +52,7 @@ class SafUnfetchedDocumentTest {
     lateinit var filesDir: File
 
     private lateinit var resolver: ContentResolver
+    private lateinit var context: Context
     private lateinit var engine: SafSyncEngine
     private lateinit var treeUri: Uri
     private val uris = mutableMapOf<String, Uri>()
@@ -89,7 +90,7 @@ class SafUnfetchedDocumentTest {
         every { DocumentsContract.renameDocument(any(), any(), any()) } returns mockk(relaxed = true)
 
         resolver = mockk(relaxed = true)
-        val context = mockk<Context>(relaxed = true)
+        context = mockk<Context>(relaxed = true)
         every { context.contentResolver } returns resolver
         every { context.filesDir } returns filesDir
         engine = SafSyncEngine(context)
@@ -713,6 +714,72 @@ class SafUnfetchedDocumentTest {
             announced,
             "the write was refused and nothing said so, which is the silence this " +
                 "guard was supposed to end rather than create",
+        )
+    }
+
+    /**
+     * The refusal that is not a skip and not a failure: this sync did not read the
+     * document because another sync of the same mirror was already reading it.
+     *
+     * The claim is in the companion object because two engines routinely meet over
+     * one mirror; `unfetched` is per engine, so the loser is the only thing that
+     * can arm its own guard, and the loser is routinely the engine that outlives
+     * the winner. An activity recreated mid-open leaves the claim with the engine
+     * of the activity being destroyed, so the survivor, the one whose watcher goes
+     * on serving saves, is exactly the one that walked away with no record.
+     *
+     * Built reentrantly and single-threaded rather than with two threads: the
+     * second engine's whole `initialSync` runs inside the first engine's answer to
+     * `openInputStream`, which is precisely the window in which the first engine
+     * holds the claim. Nothing here can flake and nothing can hang.
+     */
+    @Test
+    fun `a sync that lost the copy to another engine still guards the document`() {
+        deviceHolding("notes.md", size = 64)
+        val loser = SafSyncEngine(context)
+        val announced = mutableListOf<String>()
+        loser.onWriteBackFailed = { announced.add(it.name) }
+
+        var writes = 0
+        every { resolver.openOutputStream(any(), "wt") } answers {
+            writes++
+            java.io.ByteArrayOutputStream()
+        }
+
+        var reentered = false
+        every { resolver.openInputStream(any()) } answers {
+            if (!reentered) {
+                reentered = true
+                // Inside the winner's read, so the claim is held: this sync meets
+                // it, loses, and walks away without the file.
+                runBlocking { loser.initialSync(treeUri, mirror) { _, _ -> } }
+            }
+            // And then the winner's own copy fails, which is what leaves the
+            // mirror without the document and the device holding the only one.
+            throw IOException("the provider refused the read")
+        }
+
+        runBlocking { engine.initialSync(treeUri, mirror) { _, _ -> } }
+        assertTrue(reentered, "the second sync never ran, so no claim was ever contested")
+
+        // Counted from here, because the reentrant sync above is a whole sync of
+        // its own and a bare `exactly = 0` would be answering for both.
+        val before = writes
+
+        File(mirror, "notes.md").writeText("stub")
+        loser.handleMirrorEvent(FileObserver.CREATE, File(mirror, "notes.md"), mirror, treeUri)
+        loser.runWriteBackLoop { false }
+
+        assertEquals(
+            before, writes,
+            "the engine that lost the copy wrote a local file over a device document it " +
+                "never read, opening it with \"wt\": the device copy is truncated to " +
+                "whatever the mirror happened to hold",
+        )
+        assertEquals(
+            listOf("notes.md"), announced,
+            "the write was refused and nothing said so, which is the silence the guard " +
+                "exists to end rather than create",
         )
     }
 

--- a/android/app/src/test/kotlin/com/vscodroid/storage/UnreadDocumentGuardTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/UnreadDocumentGuardTest.kt
@@ -14,15 +14,22 @@ import org.junit.jupiter.api.Test
  * path missing from it means the save truncates whatever the device holds.
  *
  * The set is therefore a contract, not a cache, and the contract is "the device
- * holds a document this sync did not read". Phase 2 has five branches that end
- * that way, and for a long time only three of them said so. The two that did not
- * were the refusals over a device copy that could not be set aside, which are
- * precisely the branches whose own comment reads "Writing anyway would be the
- * loss this guard exists to prevent": they protected the document for exactly as
- * long as the sync ran, and the first save afterwards did what they refused.
+ * holds a document this sync did not read". Phase 2 has six branches that end
+ * that way, and for a long time only three of them said so. Two of the missing
+ * ones were the refusals over a device copy that could not be set aside, which
+ * are precisely the branches whose own comment reads "Writing anyway would be
+ * the loss this guard exists to prevent": they protected the document for
+ * exactly as long as the sync ran, and the first save afterwards did what they
+ * refused.
+ *
+ * The sixth was the loser of a race for the copy, which the count below is what
+ * found: two syncs of one mirror meet at a claim held in the companion object,
+ * and the one that steps aside has its own `unfetched`, so it alone can arm its
+ * own guard. It is also routinely the survivor, since the claim belongs to the
+ * engine of the activity being destroyed.
  *
  * Counted rather than named, because what matters is that no branch is left out;
- * a case naming one line would pass while a sixth arrived unrecorded.
+ * a case naming one line would pass while a seventh arrived unrecorded.
  */
 class UnreadDocumentGuardTest {
 
@@ -77,9 +84,9 @@ class UnreadDocumentGuardTest {
     }
 
     /**
-     * Five branches end with the device holding something this sync did not read.
-     * The count is the assertion: naming lines would pass while a sixth arrived
-     * unrecorded, which is exactly how the two refusals came to be missing.
+     * Six branches end with the device holding something this sync did not read.
+     * The count is the assertion: naming lines would pass while a seventh arrived
+     * unrecorded, which is exactly how the three that were missing went unnoticed.
      */
     @Test
     fun `every branch that declines to read records it`() {
@@ -87,10 +94,11 @@ class UnreadDocumentGuardTest {
             .findAll(engine()).count()
 
         assertEquals(
-            5, adds,
-            "phase 2 has five branches that leave a device document unread: the confine " +
-                "refusal, the size skip, a failed copy, and the two refusals over a " +
-                "device copy that could not be set aside. Found $adds recording it",
+            6, adds,
+            "phase 2 has six branches that leave a device document unread: the confine " +
+                "refusal, the size skip, a failed copy, the two refusals over a device " +
+                "copy that could not be set aside, and the sync that lost the copy to " +
+                "another engine. Found $adds recording it",
         )
     }
 }

--- a/android/app/src/test/kotlin/com/vscodroid/webview/AppNavigationMarkingTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/AppNavigationMarkingTest.kt
@@ -27,8 +27,32 @@ import org.junit.jupiter.api.Test
  * the Activity instead. What is still out of reach is a member declared in a
  * shape the scan does not match, and the floor inside the case is what exposes a
  * scan that has stopped matching.
+ *
+ * The same scan carries a second rule that is not about marking, and the file is
+ * not renamed for it deliberately: the scan is the shared asset, and the way this
+ * has failed twice is a per-rule copy of it that stopped matching on its own. The
+ * second rule is [workbenchLoaded], which every page of this app's own has to
+ * clear before it loads over the workbench, and which `retryServerStart` also
+ * missed, so both rules have now been broken by the same site for the same
+ * reason: a page-replacing member added without the two lines its neighbours
+ * carry.
  */
 class AppNavigationMarkingTest {
+
+    private companion object {
+        /**
+         * A WebView load. The receiver dot is what separates one from this file's
+         * own method of a similar name, so `.loadVSCode(` is not one of these.
+         */
+        val NAVIGATION = Regex("""\.load(Url|Data)|(webView\?|wv)\.reload\(\)""")
+
+        /**
+         * A page this app renders itself, in both the forms MainActivity uses:
+         * `loadData` for the loading page and `loadDataWithBaseURL` for the error
+         * page. The workbench is never one of these; it is loaded by URL.
+         */
+        val OWN_PAGE = Regex("""\.loadData""")
+    }
 
     private fun mainActivity(): String =
         SourceScan.withoutComments(SourceScan.read("src/main/kotlin/com/vscodroid/MainActivity.kt"))
@@ -42,30 +66,13 @@ class AppNavigationMarkingTest {
      * The order is asserted as well as the presence, and it is not pedantry: the
      * veto is asked during the load, so a mark written afterwards changes nothing.
      *
-     * `setupWebView` is skipped by name, and it is the only site with nothing to
-     * veto: it loads the placeholder into a WebView holding no document at all,
-     * either the one `onCreate` inflated or the replacement `recreateWebView`
-     * built after destroying the crashed one.
+     * `setupWebView` is skipped by [sitesLoading], which gives the reason both
+     * rules share it: nothing is in front of the page it loads.
      */
     @Test
     fun `every navigation this app starts marks itself first`() {
         val source = mainActivity()
-        // The receiver dot is what separates a WebView load from this file's own
-        // method of a similar name, so `.loadVSCode(` is not one of these.
-        val navigation = Regex("""\.load(Url|Data)|(webView\?|wv)\.reload\(\)""")
-
-        // Any run of modifiers, not a spelled list of them. Written as
-        // `(?:private |internal |override )?` this missed `private suspend fun`,
-        // which MainActivity already declares: a suspend function that navigates
-        // would have been invisible to the one check written to find it.
-        val sites = Regex("""\n    (?:\w+ )*fun \w+\(""")
-            .findAll(source)
-            .map { it.value.trim() }
-            .distinct()
-            .filterNot { it.endsWith("fun setupWebView(") }
-            .map { it to SourceScan.body(source, it) }
-            .filter { (_, body) -> navigation.containsMatchIn(body) }
-            .toList()
+        val sites = sitesLoading(source, NAVIGATION)
 
         // The control for the case itself. A scan that matches nothing passes
         // every assertion below it, which is the one way a derived list is weaker
@@ -78,7 +85,7 @@ class AppNavigationMarkingTest {
 
         sites.forEach { (declaration, body) ->
             val marked = body.indexOf("markAppNavigation()")
-            val navigates = navigation.find(body)!!.range.first
+            val navigates = NAVIGATION.find(body)!!.range.first
             assertTrue(marked >= 0) {
                 "`$declaration` navigates the WebView without calling markAppNavigation first, " +
                     "so onJsBeforeUnload treats a navigation this app decided on as one the " +
@@ -87,6 +94,77 @@ class AppNavigationMarkingTest {
             assertTrue(marked < navigates) {
                 "`$declaration` marks the navigation after starting it, which is too late: " +
                     "the veto is asked during the load"
+            }
+        }
+    }
+
+    /**
+     * Every member of the Activity whose body loads through [what], paired with
+     * that body.
+     *
+     * `setupWebView` is skipped by name in both rules, and for one reason: it is
+     * the only site with no workbench in front of it. It loads the placeholder
+     * into a WebView holding no document at all, either the one `onCreate`
+     * inflated or the replacement `recreateWebView` built after destroying the
+     * crashed one, and `recreateWebView` has already cleared the flag by then.
+     *
+     * Any run of modifiers, not a spelled list of them. Written as
+     * `(?:private |internal |override )?` this missed `private suspend fun`,
+     * which MainActivity already declares: a suspend function that navigates
+     * would have been invisible to the one check written to find it.
+     */
+    private fun sitesLoading(source: String, what: Regex): List<Pair<String, String>> =
+        Regex("""\n    (?:\w+ )*fun \w+\(""")
+            .findAll(source)
+            .map { it.value.trim() }
+            .distinct()
+            .filterNot { it.endsWith("fun setupWebView(") }
+            .map { it to SourceScan.body(source, it) }
+            .filter { (_, body) -> what.containsMatchIn(body) }
+            .toList()
+
+    /**
+     * That a page of this app's own says so before it lands on top of the
+     * workbench.
+     *
+     * `workbenchLoaded` gates one thing, `receiveCallbackIntent`: false is "no
+     * workbench left to receive this", which raises the notice naming the
+     * restart, and true sends the callback on to be written into the loaded
+     * document's `localStorage`. Over one of these pages that write reaches a
+     * `data:` document with no listener, inside a try/catch that only console
+     * .errors, so the sign-in hangs and nothing anywhere says why.
+     *
+     * Derived off the same scan as the rule above rather than listed, because a
+     * list is exactly what let `retryServerStart` be added without either line.
+     * `loadData` in both its forms is what identifies these pages: the workbench
+     * is loaded by URL, and everything this app renders itself is loaded from
+     * bytes it built.
+     */
+    @Test
+    fun `every page of this app's own clears the workbench flag before it loads`() {
+        val source = mainActivity()
+        val sites = sitesLoading(source, OWN_PAGE)
+
+        // The control, on the same grounds the other rule's floor stands on: a
+        // scan matching nothing passes every assertion under it. Two is what
+        // MainActivity holds today, showErrorPage and retryServerStart.
+        assertTrue(sites.size >= 2) {
+            "found ${sites.size} functions rendering a page of this app's own, so this scan " +
+                "has stopped matching them and would pass by looking at nothing"
+        }
+
+        sites.forEach { (declaration, body) ->
+            val cleared = body.indexOf("workbenchLoaded = false")
+            val loads = OWN_PAGE.find(body)!!.range.first
+            assertTrue(cleared >= 0) {
+                "`$declaration` puts a page of this app's own over the workbench and leaves " +
+                    "workbenchLoaded true, so an auth callback arriving afterwards is relayed " +
+                    "into a document that cannot consume it and the sign-in hangs with nothing " +
+                    "said"
+            }
+            assertTrue(cleared < loads) {
+                "`$declaration` clears workbenchLoaded after starting the load, and a callback " +
+                    "arriving in between is relayed into the page being replaced"
             }
         }
     }

--- a/docs/04-TECHNICAL_SPEC.md
+++ b/docs/04-TECHNICAL_SPEC.md
@@ -351,6 +351,15 @@ val env = mapOf(
     "GIT_SSH_COMMAND"         to "${nativeLibDir}/libssh.so -F ${filesDir}/home/.ssh/config",
     "GIT_SSL_CAPATH"          to "<system trust store>",
     "GIT_SSL_CAINFO"          to "${filesDir}/usr/etc/tls/cert.pem",   // curl needs the bundle, not the dir
+    "SSL_CERT_FILE"           to "${filesDir}/usr/etc/tls/cert.pem",   // and so does everything else: Android
+                                                                       // names its store files with the pre-1.0
+                                                                       // OpenSSL hash, so the dir below is a
+                                                                       // store OpenSSL 3 cannot look anything up in
+    "REQUESTS_CA_BUNDLE"      to "${filesDir}/usr/etc/tls/cert.pem",   // the name pip reads; it verifies
+                                                                       // against its own vendored certifi and
+                                                                       // never looks at SSL_CERT_FILE. Set only
+                                                                       // when the bundle exists: requests treats
+                                                                       // one it cannot open as fatal
     "SSL_CERT_DIR"            to "<system trust store>",
     "NPM_CONFIG_PREFIX"       to "${filesDir}/usr",
     "NPM_CONFIG_CACHE"        to "${cacheDir}/npm-cache",

--- a/docs/DEVICE_TEST_CHECKLIST.md
+++ b/docs/DEVICE_TEST_CHECKLIST.md
@@ -61,6 +61,8 @@
 | KB-21 | Keyboard only for text | Tap the Explorer icon, open a file from the tree, then tap a line of text | Stays down for the first two, comes up on the third with the caret where the tap landed | | |
 | KB-22 | Deleting after a paste does not multiply a word | The report this exists for is a word repeated many times while deleting pasted code. It did not reproduce on an emulator across four attempts, and the emulator is not the reason: tapping Gboard's own key coordinates with `adb shell input tap` produces a real composing region, a tap on a key row coordinate drives the real `dispatchKeyEvent` path, and `adb shell input swipe X Y X Y 2000` drives Gboard's own backspace auto-repeat, so every ingredient is reachable there. What an emulator cannot vary is the reporter's Gboard build and a WebView old enough to use the textarea path, which is what a real device is for. Open a file, paste a block of code from the clipboard, then type a word with Gboard so a composition is pending (the underlined, uncommitted characters), tap a punctuation key on the extra key row, and hold backspace until the paste is gone. Watch Gboard's suggestion strip while you type, not only the file | Backspace removes one character per repeat and the file only shrinks. The thing to watch for on the way is the suggestion strip offering a word the file does not contain, for example the composed word doubled: that is the keyboard's buffer and the page disagreeing, and it was seen on an emulator without the file ever multiplying, so it is the state the report would grow out of rather than the report itself. Record the device, the Gboard version, the keyboard language and the WebView version | | |
 | KB-23 | Control for KB-22 | The same file and the same paste, but type the punctuation from Gboard's own symbol page instead of the extra key row, and delete the same way | Identical behaviour. If KB-22 multiplies and this does not, the row's injected key event is what desynchronised the keyboard; if both do, it belongs to Monaco or to the WebView and not to this app | | |
+| KB-24 | Ctrl with a capital typed on the soft keyboard | Tap **ctrl** on the key row so it lights, then use the soft keyboard's own Shift to type a capital `P` | The Command Palette opens, "Type the name of a command to run". Quick Open, "Search files by name", is the failure: it means the capital reached the page without its Shift, so `Ctrl+Shift+P` resolved as `Ctrl+P`. Measured on an API 37 emulator before the fix: the page received `{key:"P", code:"KeyP", ctrl:true, shift:false}`. Try `Ctrl` with a lower-case `s` as the control, which must still be Save and not Save As | | |
+| KB-25 | The alternates go away with the row | Hold `{}` on the key row until `[` and `<` appear. With them up, turn the phone over; then hold `{}` again and let the keyboard go, by tapping outside a text area or with the keyboard's own hide key | Both times the alternates disappear with the row. Before the fix they stayed: after the rotation they sat over the middle of the soft keyboard, a screen's width from the key, and after the keyboard went down they sat over the editor with nothing under them, until the user tapped elsewhere. `smallestScreenWidthDp` does not change on rotation, so this is the case the popup's own teardown could not see | | |
 
 ## 4. Screen & Orientation
 
@@ -257,7 +259,7 @@ first launch of a build that has this line, so the row to run instead is TC-8.
 |----------|-------|------|------|------|
 | Device Matrix | 4 | | | |
 | Android Versions | 4 | | | |
-| Keyboard Input | 23 | | | |
+| Keyboard Input | 25 | | | |
 | Screen & Orientation | 10 | | | |
 | Editor Operations | 14 | | | |
 | Extensions | 6 | | | |
@@ -268,7 +270,7 @@ first launch of a build that has this line, so the row to run instead is TC-8.
 | Terminal & Tools | 11 | | | |
 | SAF & Files | 16 | | | |
 | Display Language | 6 | | | |
-| **Total** | **123** | | | |
+| **Total** | **125** | | | |
 
 **Overall Result**: [ ] PASS / [ ] FAIL
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -483,9 +483,11 @@ Plain `http://` is the answer for a local preview: cleartext is permitted here p
 because that is what dev servers speak. Installing your own CA through Android Settings
 does not help for a page, and this is the one place where it makes a difference which
 part of the app is asking. Pages are rendered by the system WebView, which trusts the
-device's system roots and nothing else. git does read a CA you installed, because the
-app builds git's certificate bundle from both halves of the device trust store. So the
-same certificate can clone fine in the terminal and still be refused in a preview tab.
+device's system roots and nothing else. The terminal does read a CA you installed,
+because the app builds a certificate bundle from both halves of the device trust store
+and hands it to git, to Python and to everything else there that speaks TLS. So the same
+certificate can clone or `pip install` fine in the terminal and still be refused in a
+preview tab.
 
 #### Opening in the device's browser instead
 
@@ -739,6 +741,62 @@ PNG or an SVG in the workspace acts as a display you can watch while you edit.
 Python's own `zlib` is enough to write a PNG with no packages at all. For
 anything interactive, serve it: `python3 -m http.server` and open the address, as
 in [Dev Server Preview](#dev-server-preview) above.
+
+### Python Command-Line Tools
+
+Some packages install a command as well as a module: `pytest`, `black`, `httpie`,
+`cowsay`. The install succeeds and the command still does not run.
+
+```
+$ pip install cowsay
+$ cowsay -t hi
+bash: /data/.../usr/bin/cowsay: /data/.../usr/bin/python3: bad interpreter: Permission denied
+```
+
+The command pip writes is a short text file starting with `#!` and the path to
+the interpreter. Android does not let an app run a program out of its own
+storage, which is why VSCodroid's own tools live in a directory the system does
+allow, and a file pip writes has nowhere else to go. The message names `python3`,
+so it reads as a broken Python; Python is fine, and the interpreter it names runs
+perfectly when you call it yourself. It is the one-line launcher that cannot
+start.
+
+Run the module instead. Every one of these packages is importable, which is what
+the command was starting anyway:
+
+```bash
+python3 -m pytest
+python3 -m black .
+python3 -m cowsay -t hi
+```
+
+`pip` itself is the same shape and is already handled: `pip` and `pip3` are set up
+as shell functions that call `python3 -m pip`, so they work in the terminal
+without anything on your part. A build task that runs outside a shell does not see
+those functions, so write `python3 -m pip` in `tasks.json` and in any script.
+
+### Time Zones In Python
+
+A named time zone raises instead of resolving:
+
+```python
+>>> from zoneinfo import ZoneInfo
+>>> ZoneInfo("Asia/Jakarta")
+zoneinfo._common.ZoneInfoNotFoundError: 'No time zone found with key Asia/Jakarta'
+```
+
+`zoneinfo` reads the operating system's time zone database, from
+`/usr/share/zoneinfo` and three sibling paths. Android keeps its own database
+somewhere else entirely and ships none of those, so the lookup finds nothing.
+
+Install the database as a package and it works from then on, including for
+`pandas`, `croniter` and anything else that asks `zoneinfo` for a zone:
+
+```bash
+pip install tzdata
+```
+
+`datetime.now()`, `time.time()` and UTC never needed this. It is named zones only.
 
 ### Packages With Prebuilt Binaries
 
@@ -1010,10 +1068,15 @@ If `npm install` fails with errors:
 - **Unsupported platform errors** come from a package whose prebuilt binaries have no Android build, so there is nothing to install (see [Known Limitations](#packages-with-prebuilt-binaries)).
 - **Network timeout** -- check your internet connection. npm uses `--prefer-offline` by default, so cached packages install without network.
 
+### Python: Installed, and Then Something Fails
+
+- **`bad interpreter: Permission denied`** after installing a package that brings a command with it (`pytest`, `black`, `httpie`). Run it as a module instead: `python3 -m pytest`. See [Python Command-Line Tools](#python-command-line-tools) for why the message names `python3` when Python is not the problem.
+- **`ZoneInfoNotFoundError`** from `zoneinfo`, `pandas` or anything that resolves a named time zone. `pip install tzdata` and it works from then on; see [Time Zones In Python](#time-zones-in-python).
+
 ### Git Push/Pull Fails
 
 - **Permission denied (publickey)** -- generate an SSH key with `ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519` in the terminal and add it to your GitHub/GitLab account. The `-f` is required; see [Generating an SSH Key](#generating-an-ssh-key) for why.
-- **SSL certificate error** -- the CA bundle git uses is built from your device's own trust store: the system roots, plus any certificate authority you installed yourself through Android Settings, under the CA-certificate flow in the device's security settings. So a private or corporate CA does work for git, from the next time you open the app -- the bundle is rebuilt at launch, not while the app is running. If you would rather not install a CA on the device, an SSH remote (`git@`) instead of `https://` is still the shortest route to an internal host. Two things that bundle does not reach: npm, which has its own trust store, and pages loaded inside the editor, which use the system roots only.
+- **SSL certificate error** -- the CA bundle the terminal uses is built from your device's own trust store: the system roots, plus any certificate authority you installed yourself through Android Settings, under the CA-certificate flow in the device's security settings. git and Python are both given it, so a private or corporate CA works for `git clone` and for `pip install` alike, from the next time you open the app -- the bundle is rebuilt at launch, not while the app is running. If you would rather not install a CA on the device, an SSH remote (`git@`) instead of `https://` is still the shortest route to an internal host. Two things that bundle does not reach: npm, which has its own trust store, and pages loaded inside the editor, which use the system roots only.
 
 ### App Uses Too Much Storage
 

--- a/scripts/test-dns-proxy.js
+++ b/scripts/test-dns-proxy.js
@@ -248,6 +248,51 @@ async function main() {
     const wrongToken = await proxiedGet(proxyPort, `http://127.0.0.1:${originPort}/`, 'vscodroid:not-the-token');
     assert.strictEqual(wrongToken.status, 407, 'a wrong token was accepted');
 
+    // The plain 407 has to close the connection, and for a different reason
+    // than the CONNECT one below: the request body is never read, so the socket
+    // stays in Node's request phase, where the header sweep no longer reaches it
+    // and only requestTimeout's 300 s default is left. Complete headers, a
+    // declared body and one byte every couple of seconds then hold a slot for as
+    // long as the peer likes, out of a cap of 128 shared with git, npm and the
+    // gallery. Sending nothing after the headers is not the case that matters:
+    // keepAliveTimeout collects that one at 6 s either way.
+    const heldOpen = await new Promise((resolve, reject) => {
+        const t0 = process.hrtime.bigint();
+        const socket = net.connect(proxyPort, '127.0.0.1', () => {
+            socket.write(
+                `POST http://127.0.0.1:${originPort}/ HTTP/1.1\r\nHost: 127.0.0.1:${originPort}\r\n` +
+                    'Content-Length: 1000000\r\n\r\n',
+            );
+            // Inside the 5 s keep-alive window, so each byte resets the only
+            // timer that would otherwise reclaim the socket.
+            const dribble = setInterval(() => !socket.destroyed && socket.write('x'), 500);
+            socket.on('close', () => clearInterval(dribble));
+        });
+        let received = '';
+        socket.on('data', (chunk) => (received += chunk));
+        socket.on('error', reject);
+        socket.on('close', () =>
+            resolve({ received, ms: Number(process.hrtime.bigint() - t0) / 1e6 }));
+        // A wall-clock timer, not socket.setTimeout: that one measures
+        // inactivity, and the dribble above is activity, so it would never fire
+        // in exactly the case this is here to catch.
+        setTimeout(() => {
+            socket.destroy();
+            resolve({ received, ms: Infinity });
+        }, 4000).unref();
+    });
+    assert.match(heldOpen.received, /^HTTP\/1\.1 407 /, `the dribbling peer was not challenged: ${heldOpen.received}`);
+    assert.match(
+        heldOpen.received,
+        /Connection: close/i,
+        `the plain 407 omits "Connection: close": ${heldOpen.received}`,
+    );
+    assert.ok(
+        heldOpen.ms < 1000,
+        `an unauthenticated peer still held its connection ${heldOpen.ms} ms after the 407, so ` +
+            'it can hold one of 128 slots indefinitely by dribbling a body nothing reads',
+    );
+
     const authenticated = await proxiedGet(proxyPort, `http://127.0.0.1:${originPort}/`, goodCredentials);
     assert.strictEqual(authenticated.status, 200, 'a correct token was rejected');
 
@@ -610,6 +655,48 @@ async function main() {
     // If either abort had killed the proxy, this would not answer.
     const stillAlive = await proxiedGet(proxyPort, `http://127.0.0.1:${originPort}/`, goodCredentials);
     assert.strictEqual(stillAlive.status, 200, 'the proxy died after a client aborted mid-transfer');
+
+    // --- an origin that dies mid-body ------------------------------------
+    // The other half of the same abort: the client behaves and the origin goes
+    // away, which on a mobile network is the ordinary case. Node raises that on
+    // the response object, not on the request the plain leg's error handler
+    // watches, so it has to be caught there and it has to tear the client leg
+    // down rather than finish it. Both wrong answers are quiet: with no handler
+    // the pipe never reaches 'end' and the client waits forever, and with end()
+    // the terminating chunk goes out and a half-downloaded tarball reads as a
+    // complete 200.
+    const dyingOrigin = net.createServer((sock) =>
+        sock.once('data', () => {
+            sock.write('HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nSHORT\r\n');
+            setTimeout(() => sock.destroy(), 50);
+        }));
+    const dyingPort = await listen(dyingOrigin);
+    const truncated = await new Promise((resolve) => {
+        const req = http.request({
+            host: '127.0.0.1', port: proxyPort, path: `http://127.0.0.1:${dyingPort}/x`, agent: false,
+            headers: { 'proxy-authorization': `Basic ${Buffer.from(goodCredentials).toString('base64')}` },
+        }, (res) => {
+            let body = '';
+            res.on('data', (chunk) => (body += chunk));
+            res.on('end', () => resolve({ outcome: 'end', body, complete: res.complete }));
+            res.on('error', (err) => resolve({ outcome: `error:${err.code || err.message}` }));
+        });
+        req.on('error', (err) => resolve({ outcome: `error:${err.code || err.message}` }));
+        req.end();
+        setTimeout(() => {
+            req.destroy();
+            resolve({ outcome: 'hung' });
+        }, 4000).unref();
+    });
+    dyingOrigin.close();
+    assert.ok(
+        truncated.outcome.startsWith('error:'),
+        truncated.outcome === 'hung'
+            ? 'an origin that died mid-body left the client waiting with no error and no end, ' +
+                'holding both legs for as long as the client is willing to wait'
+            : `a truncated body was framed as a complete response (complete=${truncated.complete}, ` +
+                `body=${JSON.stringify(truncated.body)}), so a half-downloaded file reads as whole`,
+    );
 
     // --- a rejected CONNECT must not pin a descriptor ---------------------
     // The response text is identical whether or not the socket is released, so

--- a/scripts/test-serve-network.js
+++ b/scripts/test-serve-network.js
@@ -121,13 +121,38 @@ async function closedPortIsAbsent() {
     assert.strictEqual(found.size, 0, 'ports nothing answers are not reported at all');
 }
 
-async function lanProbeSkippedWhenNothingListens() {
-    const { connect, dialled } = fakeConnector(new Set());
-    await ext.scanPorts([3000], [LAN], connect);
+/**
+ * The case the loopback gate lost outright: a server bound to one LAN address
+ * and nothing else.
+ *
+ * `vite --host 192.168.1.50` binds that address alone, so loopback refuses. The
+ * scan used to end the port there and the command reported no dev server, both
+ * in the list and for a port typed in by hand, about a server that was up and
+ * already answering the other device.
+ */
+async function boundToTheLanAddressAloneIsFound() {
+    const { connect } = fakeConnector(new Set([`${LAN}:5173`]));
+    const found = await ext.scanPorts([5173], [LAN], connect);
     assert.deepStrictEqual(
-        dialled,
-        ['127.0.0.1:3000'],
-        'the LAN probe is not dialled for a port loopback already refused',
+        [...found],
+        [[5173, [LAN]]],
+        'a server bound to the LAN address alone is reported as reachable',
+    );
+}
+
+/**
+ * Every probe goes out for every port, loopback included, and the port is
+ * dropped only when all of them refuse. Dialling is asserted as a set: they are
+ * issued together now, so the order is the scheduler's and pinning it would fail
+ * for a reason that is not a defect.
+ */
+async function everyAddressIsProbedEvenWhenLoopbackRefuses() {
+    const { connect, dialled } = fakeConnector(new Set());
+    await ext.scanPorts([3000], [VPN, LAN], connect);
+    assert.deepStrictEqual(
+        [...dialled].sort(),
+        ['10.8.0.2:3000', '127.0.0.1:3000', '192.168.1.50:3000'],
+        `a loopback refusal still ends the port before its addresses are tried: ${dialled.join(', ')}`,
     );
 }
 
@@ -169,15 +194,16 @@ async function main() {
     await localOnlyWhenLanRefuses();
     await eachAddressGetsItsOwnVerdict();
     await closedPortIsAbsent();
-    await lanProbeSkippedWhenNothingListens();
+    await boundToTheLanAddressAloneIsFound();
+    await everyAddressIsProbedEvenWhenLoopbackRefuses();
     await noLanAddressMeansLocalOnly();
     candidatesMergeAndSort();
     defaultsAreSane();
 
     say(
         `  ok     reachable/local-only split holds over ${ext.COMMON_DEV_PORTS.length} default ports, ` +
-            'each address is judged on its own probe, and the LAN probe is skipped when ' +
-            'loopback refuses\n',
+            'each address is judged on its own probe, a server bound only to the LAN ' +
+            'address is found, and a port is dropped only once every probe has refused\n',
     );
 }
 


### PR DESCRIPTION
Nine defects, each with a regression test that was watched fail against the current code first. Most were measured on an API 37 emulator; the two proxy ones were measured on Node v22.23.2, the bundled runtime's line.

## Terminal TLS

`SSL_CERT_DIR` named Android's own certificate store, whose files are named with the OpenSSL 0.9.8 issuer hash while everything since 1.0 looks up a different one. That is a directory OpenSSL can list and never read: the bundled Python loaded zero certificates and every HTTPS request failed with `CERTIFICATE_VERIFY_FAILED`. git was unaffected the whole time, because it had been handed the bundle as a file separately, which is why nothing noticed.

`SSL_CERT_FILE` now names the same bundle. Measured on device: 0 certificates loaded before, 120 after, and `https://pypi.org` goes from a verification failure to 200.

pip is a separate case and was never broken; it verifies against the certifi bundle vendored inside itself. It reads `REQUESTS_CA_BUNDLE`, which is now also set, so a certificate authority the device owner installed reaches a private index as well as `git clone`. Guarded on the file existing, because requests treats a bundle it cannot open as fatal rather than falling back.

## Extra key row

**A capital typed on the soft keyboard lost its Shift.** The key table carries no letters, so a capital fell to the fallback branch and kept whatever the row's own Shift said. Measured: Ctrl latched on the row plus a capital `P` reached the page as `{key:"P", code:"KeyP", ctrl:true, shift:false}` and opened Quick Open; the same event with `shift: true` opens the Command Palette. `Ctrl+Shift+anything` was unreachable by the one route a phone offers for it, and it failed by running a different command rather than none.

**The alternates popup outlived the row.** It was dismissed on a configuration change only after the guard deciding the pages did not need repacking, and a rotation never does need one: `smallestScreenWidthDp` is the smaller dimension by definition, so that guard always returns first. Rotating with `[` and `<` up left them over the middle of the soft keyboard, a screen's width from the key. Letting the keyboard go left them over the editor, because the row going `GONE` does not take a window with it.

**The modifier poll could stop asking.** It keeps one query outstanding per injector, and had no way out of a reply that never arrives while that injector is still the row's: nothing displaces the claim and nothing abandons it, so it ticked on without ever asking again and the row went on painting a modifier the page had already spent. The claim is now given up after a bounded silence, which keeps the back-pressure the slot exists for.

## Device folders

Two syncs of one mirror meet at a claim held in the companion object, and the one that steps aside skipped the file without recording that it had not read the device document. Every sibling refusal in that loop records it, and that record is the only thing stopping a later save from opening the device copy with `"wt"`.

Which engine is left holding the folder makes it worse. The routine way two syncs meet is an activity recreated mid-open, so the claim belongs to the engine going away and the loser is the engine whose watcher goes on serving saves. A copy the winner never finished leaves the mirror holding a stub, and the first save writes it over the device document. The test reproduces this single-threaded, by running the second engine's whole sync inside the first engine's answer to `openInputStream`.

## Serve on Network

The scan probed loopback first and dropped the port on a refusal, which reads as "is anything listening at all" and is not what it answers. `vite --host 192.168.1.50`, the invocation Vite documents for binding a single address and the one this command's own advice leads to, refuses loopback: the port never appeared in the quick pick, and typing it in answered "Nothing is listening on port 5173" about a server that was up and already reachable from the other device. Every address is now probed at once and a port is dropped only when all of them refuse, which also halves the worst case, since the two rounds used to be sequential.

## Local proxy

**An unauthenticated request could hold a connection indefinitely.** The plain leg answered 407 with keep-alive, and the request body is never read there, so the socket sat in Node's request phase, where the header sweep no longer reaches it and only `requestTimeout`'s 300 s default is left. Measured: complete headers plus one body byte every two seconds was still holding one of 128 slots at 30 s, and is gone in 3 ms with `Connection: close`.

**An origin that died mid-body was not handled.** Node raises that on the response object, not the request the error handler watched, so nothing ended the client leg and the transfer hung. Ending it with `end()` is worse under chunked framing: the terminating chunk goes out and a half-downloaded file reads as a complete 200. Both legs are torn down instead, so it surfaces as `ECONNRESET`.

## Sign-in during a restart

`retryServerStart` puts a `data:` loading page over the workbench and left `workbenchLoaded` true, so a callback arriving afterwards was relayed into a document that cannot consume it: the write goes into that page's own `localStorage` and the `StorageEvent` reaches no listener, inside a `try`/`catch` that only reaches the console. The sign-in hung with nothing said, where a false flag raises the notice naming the restart. The derived scan that already holds the navigation-marking rule now holds this one too, since the same site broke both.

## Verification

- `:app:testDebugUnitTest`: 372 classes, 2411 tests, 0 failures. `:app:lintDebug` clean.
- Every Node harness CI runs, and every `--self-test` and `check-*.py` in the lint workflow.
- Each new test was run against the unfixed code first and observed to fail on the assertion it exists for.
- Emulator work is backed by screenshots that were actually opened: the wrong quick pick, the popup over the keyboard after rotation, the popup over the editor after the keyboard went down, and the terminal probes for the Python cases.

Two rows are added to the device checklist for the key row changes, which need a build on hardware to confirm.
