### PR TITLE
test: wait for the whole toolchain launch pass, not one effect of it

### DIFF
--- a/android/app/src/test/kotlin/com/vscodroid/setup/AbandonedDownloadSweepTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/AbandonedDownloadSweepTest.kt
@@ -11,12 +11,12 @@ import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
-import java.util.concurrent.TimeUnit
 
 /**
  * The launch pass reclaims staging directories no download owns any more.
@@ -78,20 +78,19 @@ class AbandonedDownloadSweepTest {
         return dir
     }
 
-    /** Waits for the launch pass, which runs on the manager's io executor. */
-    private fun waitUntil(what: String, condition: () -> Boolean) {
-        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10)
-        while (!condition() && System.nanoTime() < deadline) Thread.sleep(20)
-        assertTrue(condition(), what)
-    }
 
     @Test
     fun `a staging directory left by a download that never finished is reclaimed`() {
         val old = abandoned("toolchain_java-1", 3 * ABANDONED_DOWNLOAD_AGE_MS)
 
-        ToolchainManager(context).repairInstalledToolchains()
+        val manager = ToolchainManager(context)
+        manager.repairInstalledToolchains()
+        awaitLaunchPass(manager)
 
-        waitUntil("the abandoned staging directory was never reclaimed: $old") { !old.exists() }
+        assertFalse(
+            old.exists(),
+            "the abandoned staging directory was never reclaimed: $old",
+        )
     }
 
     /**
@@ -105,9 +104,14 @@ class AbandonedDownloadSweepTest {
         val old = abandoned("toolchain_java-1", 3 * ABANDONED_DOWNLOAD_AGE_MS)
         val fresh = abandoned("toolchain_ruby-2", 0)
 
-        ToolchainManager(context).repairInstalledToolchains()
+        val manager = ToolchainManager(context)
+        manager.repairInstalledToolchains()
+        awaitLaunchPass(manager)
 
-        waitUntil("the sweep never ran, so the case below proves nothing") { !old.exists() }
+        assertFalse(
+            old.exists(),
+            "the sweep never ran, so the case below proves nothing",
+        )
         assertTrue(
             fresh.isDirectory && File(fresh, "toolchain_java.zip").isFile,
             "a staging directory a download could still be writing into was deleted",

--- a/android/app/src/test/kotlin/com/vscodroid/setup/LaunchPassWaitTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/LaunchPassWaitTest.kt
@@ -1,0 +1,78 @@
+package com.vscodroid.setup
+
+import com.vscodroid.SourceScan
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * That every case which starts the launch pass waits for the whole of it.
+ *
+ * [awaitLaunchPass] gives the reason: the pass runs on the manager's io executor
+ * and ends by writing into `filesDir`, which every one of these cases puts in a
+ * JUnit `@TempDir`. A case that waits for an earlier effect and returns leaves
+ * those writes racing JUnit's deletion of that directory, and the resulting
+ * `TempDirDeletionStrategy$DeletionException` fails the whole task on a case
+ * whose own assertions passed.
+ *
+ * Derived rather than listed, because a list cannot notice the next case. This
+ * has already been true of two classes at once and neither knew about the other:
+ * one waited for the chmod at step four of five and the other for the sweep at
+ * step two, and the second is the more exposed of the two while being the one
+ * that never failed.
+ *
+ * Read out of each function's own body rather than off the file, so a single
+ * `awaitLaunchPass` somewhere in a class does not vouch for a second case that
+ * does not call it.
+ *
+ * A call at statement position, not the bare name: `LaunchRepairWiringTest`
+ * asserts on the wiring by holding the same call inside string literals, which
+ * `withoutComments` has no reason to strip and which this would otherwise report
+ * as a case that never waits.
+ */
+class LaunchPassWaitTest {
+
+    private companion object {
+        /** The pass being started, at statement position rather than quoted. */
+        val STARTS_PASS = Regex("""\n\s+\w+\.repairInstalledToolchains\(\)""")
+    }
+
+    @Test
+    fun `every case that starts the launch pass waits for the whole of it`() {
+        val root = File("src/test/kotlin/com/vscodroid")
+        assertTrue(root.isDirectory) {
+            "the test sources are not at ${root.absolutePath}, so this case is reading nothing"
+        }
+
+        val sites = root.walkTopDown()
+            .filter { it.isFile && it.extension == "kt" }
+            .flatMap { file ->
+                val source = SourceScan.withoutComments(SourceScan.read(file.path))
+                if (!STARTS_PASS.containsMatchIn(source)) return@flatMap emptySequence()
+                Regex("""\n    (?:\w+ )*fun [`\w][^\n(]*\(""")
+                    .findAll(source)
+                    .map { it.value.trim() }
+                    .distinct()
+                    .map { Triple(file.name, it, SourceScan.body(source, it)) }
+                    .filter { (_, _, body) -> STARTS_PASS.containsMatchIn(body) }
+            }
+            .toList()
+
+        // The control. A scan that matches nothing passes every assertion below
+        // it, which is the one way a derived list is weaker than a written one.
+        // Three is what the suite holds today, across two classes.
+        assertTrue(sites.size >= 3) {
+            "found ${sites.size} cases starting the launch pass, so this scan has stopped " +
+                "matching them and would pass by looking at nothing"
+        }
+
+        sites.forEach { (file, declaration, body) ->
+            assertTrue(body.contains("awaitLaunchPass(")) {
+                "$file `$declaration` starts the launch pass and does not wait for it. " +
+                    "Waiting for the effect it asserts on is not enough: the pass goes on " +
+                    "writing into the @TempDir after the case returns, and JUnit's deletion " +
+                    "of that directory then fails the whole task"
+            }
+        }
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainInterruptedInstallTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainInterruptedInstallTest.kt
@@ -183,12 +183,10 @@ class ToolchainInterruptedInstallTest {
         )
         assertFalse(binary.canExecute(), "the fixture starts from the wrong state")
 
-        manager().repairInstalledToolchains()
+        val manager = manager()
+        manager.repairInstalledToolchains()
+        awaitLaunchPass(manager)
 
-        val deadline = System.currentTimeMillis() + 10_000
-        while (!binary.canExecute() && System.currentTimeMillis() < deadline) {
-            Thread.sleep(20)
-        }
         assertTrue(
             binary.canExecute(),
             "the interpreter of a toolchain the record calls installed has no execute " +
@@ -197,6 +195,16 @@ class ToolchainInterruptedInstallTest {
         assertTrue(
             File(tree, "bin/payload").exists(),
             "the tree of a toolchain the record still names was deleted",
+        )
+        // The barrier's own control, and the reason it is asserted rather than
+        // trusted: the last step of the pass is the one that used to outlive the
+        // case, and waiting for any earlier effect leaves it writing into a
+        // directory JUnit is deleting. Failing here is deterministic; the flake
+        // it replaces was not, and took the whole suite with it when it landed.
+        assertTrue(
+            File(filesDir, "home/.vscodroid/toolchain-env.sh").exists(),
+            "the pass had not reached regenerateDerivedFiles when this case ended, so it " +
+                "is still writing into the @TempDir that is about to be deleted",
         )
     }
 
@@ -311,19 +319,18 @@ class ToolchainInterruptedInstallTest {
      * in that block cannot take it out.
      *
      * `repairInstalledToolchains` hands the work to `ioExecutor`, so this waits
-     * for the effect instead of for the call.
+     * for the pass rather than for the call. See [awaitLaunchPass] for why it is
+     * the whole pass and not the one effect.
      */
     @Test
     fun `the launch repair pass reclaims an interrupted install`() {
         plantMarker("toolchain_java", """{"name":"java","installRoot":"usr/opt/java"}""")
         val tree = plantTree("usr/opt/java")
 
-        manager().repairInstalledToolchains()
+        val manager = manager()
+        manager.repairInstalledToolchains()
+        awaitLaunchPass(manager)
 
-        val deadline = System.currentTimeMillis() + 10_000
-        while (tree.exists() && System.currentTimeMillis() < deadline) {
-            Thread.sleep(20)
-        }
         assertFalse(
             tree.exists(),
             "the launch repair never reclaimed the interrupted install, so the pass " +

--- a/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainLaunchPass.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainLaunchPass.kt
@@ -1,0 +1,45 @@
+package com.vscodroid.setup
+
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.TimeUnit
+
+/**
+ * Waits for the launch pass a manager submitted, not for the one effect a case
+ * asserts on.
+ *
+ * [ToolchainManager.repairInstalledToolchains] submits a single block to the
+ * manager's `ioExecutor` and returns. That block ends with
+ * `regenerateDerivedFiles`, which writes the env file, the exec table and the
+ * trampoline symlinks into `filesDir`, and every case that calls the pass puts
+ * `filesDir` in a JUnit `@TempDir`. Waiting for an earlier step therefore leaves
+ * those writes running after the test method returns, racing JUnit's deletion of
+ * the directory they are inside. The failure is a
+ * `TempDirDeletionStrategy$DeletionException` on a case whose own assertions all
+ * passed, it fails the whole task, and it is rare enough to read as noise: it
+ * appeared once on a CI runner having passed on the same commit's pull request
+ * and on two local runs of the full suite.
+ *
+ * Measured rather than argued. With the effect poll spinning instead of sleeping
+ * 20 ms, so the chmod that `ToolchainInterruptedInstallTest` waits on is seen at
+ * the earliest instant it exists, `toolchain-env.sh` was still absent at the end
+ * of the case on three runs out of three. The sleep is what usually hides this on
+ * a workstation; a loaded runner is what does not.
+ *
+ * A barrier rather than a longer wait: `ioExecutor` is one thread over a FIFO
+ * queue ([toolchainIoExecutor]), so a task submitted after the pass runs only
+ * once the pass has returned. That is exact and needs no number. The timeout is
+ * only so a pass that deadlocks fails as a test rather than hanging the suite.
+ *
+ * Reflection because `ioExecutor` is private and should stay so: nothing in
+ * production has any business reaching it, and the alternative is a seam that
+ * exists for tests alone. The two callers share this one copy rather than
+ * carrying a copy each, which is the shape that lets one of them quietly stop
+ * matching.
+ */
+internal fun awaitLaunchPass(manager: ToolchainManager) {
+    val executor = ToolchainManager::class.java
+        .getDeclaredField("ioExecutor")
+        .apply { isAccessible = true }
+        .get(manager) as ExecutorService
+    executor.submit { }.get(30, TimeUnit.SECONDS)
+}


### PR DESCRIPTION
`ToolchainInterruptedInstallTest` failed on main at 5e68aa95 with a `TempDirDeletionStrategy$DeletionException`, having passed on that commit's pull request and on two local runs of the full suite. The case's own assertions all passed; the failure is in JUnit's teardown, and it fails the whole task.

## What is happening

`repairInstalledToolchains` submits a single block to the manager's `ioExecutor` and returns. That block ends with `regenerateDerivedFiles`, which writes the env file, the exec table and the trampoline symlinks into `filesDir`, and every case that starts the pass puts `filesDir` in a JUnit `@TempDir`. Waiting for an earlier effect and returning leaves those writes running while JUnit deletes the directory they are inside.

Measured rather than argued: with the poll spinning instead of sleeping 20 ms, so the chmod the case waits on is seen at the earliest instant it exists, `toolchain-env.sh` was still absent at the end of the case on three runs out of three. The sleep is what usually hides this on a workstation, and a loaded runner is what does not.

## The change

`awaitLaunchPass` submits a barrier task to the same executor. It is one thread over a FIFO queue, so a task submitted after the pass runs only once the pass has returned: exact, and it needs no number. The 30 s timeout is only so a pass that deadlocks fails as a test rather than hanging the suite.

`AbandonedDownloadSweepTest` had the same shape and waits on an even earlier step, the sweep at two of five, so it is the more exposed of the two while being the one that never failed. Both now use the one shared helper.

`LaunchPassWaitTest` derives the rule instead of listing the two call sites: every test function that starts the pass must also wait for it. It matches the call at statement position rather than by name, because `LaunchRepairWiringTest` asserts on the wiring by holding the same call inside string literals.

## Verification

- `:app:testDebugUnitTest`: 373 classes, 2412 tests, 0 failures.
- Reverting the barrier in either class turns the derived rule red deterministically, and reverting it in `ToolchainInterruptedInstallTest` also turns that case's own new assertion red, which is the one that names the last step of the pass.
