### PR TITLE
fix: keep a folder the sync could not read, and prove a sign-in is ours

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,10 @@ permissions:
 # that means unpublishing or deleting the release before the run, which takes it
 # out of `releases/latest` for the duration, and that is where every non-Play
 # install resolves its toolchain ZIPs. So it stays open deliberately: it needs a
-# tag to move, while the pointer is read on every sideloaded install.
+# tag to move, while the pointer is read on every sideloaded install. What
+# reaches it is narrower than it was: the version gate below refuses a tag
+# re-aimed at a different commit, so a second run is one re-pushed at the same
+# commit, which rebuilds the same tree.
 # `draft: true` is no shortcut to it either, because `finalizeRelease` returns
 # early when that input is set and the release would never be published at all.
 #
@@ -120,6 +123,14 @@ jobs:
         if: github.event_name == 'push'
         env:
           TAG: ${{ github.ref_name }}
+          # What the ref pointed at before this push and what it points at now.
+          # Every other check here compares this tree against OTHER tags, so none
+          # of them can see the tag itself being re-aimed: by the time the runner
+          # has the checkout, the tag is simply on this commit and git holds no
+          # record of where it used to be. The push event does, and reading it
+          # costs neither a token nor a call to the API.
+          TAG_WAS: ${{ github.event.before }}
+          TAG_NOW: ${{ github.event.after }}
         run: |
           # Through the environment and validated before use: the tag reaches a
           # git command below, and the workflow's v* filter is a match rule, not
@@ -127,6 +138,39 @@ jobs:
           case "$TAG" in
             v[0-9]*) ;;
             *) echo "::error::Refusing tag $TAG; expected vMAJOR.MINOR.PATCH"; exit 1 ;;
+          esac
+
+          # A tag that already existed and now names a different commit satisfies
+          # every check below, because all of them still describe the release that
+          # was cut from the old commit: versionName still matches the tag,
+          # versionCode still beats the version before it, and the three CHANGELOG
+          # rules were all satisfied when the tag was first taken. The run then
+          # rebuilds, re-signs and replaces the assets of a release that is
+          # already public, with a tree of everything merged since, still
+          # labelled the same versionName and versionCode.
+          # FirstRunSetup.setupIsStale compares
+          # exactly those two fields, so every device already on that version
+          # installs the new tree and skips extraction and migrations entirely.
+          #
+          # Forty zeros means the tag is new. TAG_WAS equal to TAG_NOW means it
+          # was re-pushed at the same commit, which rebuilds the same tree and is
+          # how a run cancelled or killed midway is retried. A push event
+          # carrying no `before` at all is allowed through rather than blocking a
+          # release on the shape of a payload.
+          #
+          # This is a guardrail and not a wall, deliberately: deleting the tag and
+          # pushing it again presents as a new tag and is allowed, which is the
+          # right way back when the earlier run never published anything. What it
+          # stops is the one-line accident, `git tag -f` followed by `git push
+          # -f`, which is indistinguishable from a normal release everywhere else.
+          case "$TAG_WAS" in
+            ""|0000000000000000000000000000000000000000|"$TAG_NOW") ;;
+            *) echo "::error::Tag $TAG pointed at $TAG_WAS and now points at $TAG_NOW." \
+                    "Re-aiming a tag republishes the assets of a release users already" \
+                    "have, under a versionName and versionCode that did not change, so" \
+                    "their next install skips setup. Cut a new version; if nothing was" \
+                    "published, delete the tag and push it again."
+               exit 1 ;;
           esac
 
           gradle_file=android/app/build.gradle.kts
@@ -161,11 +205,23 @@ jobs:
           fi
 
           # versionCode is what migrations threshold against; a repeat means a
-          # migration written for this release runs for nobody. --match keeps
-          # build-vscode-oss.yml's server-* tags out of "previous": those land on
-          # arbitrary commits, and comparing against one either fails a
-          # legitimate tag or lets a repeated versionCode through.
-          previous=$(git describe --tags --abbrev=0 --match 'v[0-9]*' "$TAG^" 2>/dev/null || echo "")
+          # migration written for this release runs for nobody. The 'v[0-9]*'
+          # filter keeps build-vscode-oss.yml's server-* tags out of "previous":
+          # those land on arbitrary commits, and comparing against one either
+          # fails a legitimate tag or lets a repeated versionCode through.
+          #
+          # The highest released version, not the nearest tag behind this commit.
+          # `git describe ... "$TAG^"` answered a question about ancestry, and a
+          # tag does not have to be cut on top of the last one: aim v1.3.0 at a
+          # branch taken before v1.2.0 and the nearest tag behind it is v1.1.0,
+          # so v1.2.0's versionCode is never compared against and the store gets
+          # a build it will refuse or a device gets one whose migrations do not
+          # run. Play requires versionCode to rise across every upload, not along
+          # one line of history, so the whole tag list is the right comparison.
+          # The tag being placed is excluded because it is already on this commit
+          # by the time the runner sees it, and comparing a tree against itself
+          # would fail every release.
+          previous=$(git tag --list 'v[0-9]*' --sort=-v:refname | grep -vFx "$TAG" | head -1 || true)
           if [ -n "$previous" ]; then
             previous_code=$(git show "$previous:$gradle_file" 2>/dev/null \
               | grep -m1 -E '^[[:space:]]*versionCode = ' | sed 's/[^0-9]*//g' || echo "")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Serve on Network** finds a dev server bound to the phone's own address. A server started as `vite --host 192.168.1.50` was reported as not running at all, in the list and when the port was typed in, although it was already answering other devices.
-- Python reaches HTTPS sites. The bundled interpreter loaded no certificates at all, so any script using `urllib`, `requests` or `ssl` failed to verify every site it tried. A certificate authority you installed on the device also reaches `pip` now, so a private package index behind one works.
+- Python reaches HTTPS sites. The bundled interpreter loaded no certificates at all, so anything relying on OpenSSL's default trust failed to verify every site it tried: `ssl`, `urllib` and the scripts you write yourself. `pip` and `requests` were unaffected, each verifying against a certificate bundle vendored inside it. A certificate authority you installed on the device also reaches `pip` now, so a private package index behind one works.
 - Holding Ctrl or Alt on the key row and typing a capital letter sends the chord you asked for. The capital lost its Shift on the way, so Ctrl+Shift+P opened Quick Open instead of the Command Palette, and every other Ctrl+Shift shortcut reached the wrong command.
 - The alternates that appear when you hold a key on the key row go away with it. Turning the phone over left them floating over the keyboard, and letting the keyboard go left them over the editor, until you tapped somewhere else.
 - A sign-in you finish while the editor is restarting now says so instead of hanging. The callback was handed to the loading page, which cannot receive one.

--- a/android/app/src/main/assets/dns-proxy.js
+++ b/android/app/src/main/assets/dns-proxy.js
@@ -424,6 +424,33 @@ function start(log) {
                 res.writeHead(502);
                 res.end();
             });
+            // A 101 never reaches the response callback above. Node routes an
+            // upgrade response to this event and to nothing else, and when
+            // nothing is listening for it the runtime destroys the socket
+            // without raising a failure anywhere: measured on node v22.23.2
+            // against an origin that answers an ordinary GET with a 101, the
+            // request object gets 'close' and no 'error', so the handler above
+            // never runs either. `res` was then neither written nor ended and
+            // the client waited with no status and no error at all, holding one
+            // socket at each end for as long as it cared to wait, with nothing
+            // logged. The setup bound cannot collect that: destroying a socket
+            // takes its timer with it.
+            //
+            // The socket is ours to close once this fires, because listening is
+            // what stops the runtime closing it. Nothing here speaks whatever
+            // protocol the origin switched to, and the client asked for none,
+            // so the leg reports the origin as failed by the same rule the
+            // handler above follows, headersSent branch included.
+            upstream.on('upgrade', (_upstreamRes, socket) => {
+                socket.destroy();
+                log('warn', `dns-proxy: ${target.hostname} switched protocols on a request that did not ask`);
+                if (res.headersSent) {
+                    res.destroy();
+                    return;
+                }
+                res.writeHead(502);
+                res.end();
+            });
             // A client that vanishes mid-transfer must tear down the upstream
             // leg, not surface as an unhandled 'error' -- same contract as the
             // CONNECT handler below.
@@ -623,7 +650,16 @@ function start(log) {
                     if (HOP_BY_HOP_HEADERS.includes(req.rawHeaders[i].toLowerCase())) continue;
                     lines.push(`${req.rawHeaders[i]}: ${req.rawHeaders[i + 1]}`);
                 }
-                upstream.write(`${lines.join('\r\n')}\r\n\r\n`);
+                // latin1, which is the encoding a header block is bytes in and
+                // the one Node used to hand these lines back: a header byte
+                // above 0x7F arrives here as one char, and the default encoding
+                // would put it back on the wire as the two bytes of its UTF-8
+                // form. A cookie, a Sec-WebSocket-Protocol or any signed value
+                // carrying such a byte then reached the origin altered, and the
+                // handshake it fails is one with nothing in it naming a proxy.
+                // The plain leg never had this: it hands its headers to
+                // http.request, which encodes them itself.
+                upstream.write(Buffer.from(`${lines.join('\r\n')}\r\n\r\n`, 'latin1'));
                 if (head && head.length) {
                     upstream.write(head);
                 }

--- a/android/app/src/main/assets/server.js
+++ b/android/app/src/main/assets/server.js
@@ -7,6 +7,7 @@
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
+const crypto = require('crypto');
 
 // Parse command-line arguments
 const args = {};
@@ -21,6 +22,33 @@ const LOG_LEVEL = args.log || 'info';
 
 const SERVER_DIR = path.dirname(__filename);
 const REH_DIR = path.join(SERVER_DIR, 'vscode-reh');
+
+// The payload `callback.html` hands to the Android side, as it is built before a
+// nonce is bound into it and as it is built afterwards. Both shapes are matched so
+// the rewrite below is idempotent across restarts: on the second start the page on
+// disk already carries the previous run's nonce, and a pattern that only knew the
+// pristine form would silently stop binding. The nonce alternative is anchored to
+// hex so it cannot run past the object it belongs to.
+const CALLBACK_PAYLOAD = /JSON\.stringify\(\{ id: id, uri: uri(?:, nonce: '[0-9a-f]*')? \}\)/;
+
+/**
+ * Replaces a file in one step, the way the product.json rewrite below does.
+ *
+ * This process is killed as a matter of routine, by the OOM killer and by
+ * Android's phantom-process limit, so an in-place write interrupted partway
+ * leaves a truncated file. rename(2) lands either side of a kill and never
+ * inside it, and a write that cannot finish leaves the existing file untouched.
+ */
+function writeThroughRename(target, contents, mode) {
+    const tmp = `${target}.${process.pid}.tmp`;
+    try {
+        fs.writeFileSync(tmp, contents, mode === undefined ? undefined : { mode });
+        fs.renameSync(tmp, target);
+    } catch (e) {
+        try { fs.unlinkSync(tmp); } catch { /* nothing was written */ }
+        throw e;
+    }
+}
 
 // How long the editor server gets to answer a SIGTERM before it is SIGKILLed.
 // Bounded from outside: ProcessManager force-kills this process a second after
@@ -166,6 +194,53 @@ if (!fs.existsSync(rehEntryPoint)) {
             log('error', 'A truncated product.json is repaired by the asset extraction that ' +
                 'runs on the next app update, or by clearing app data.');
         }
+    }
+
+    // Bind the sign-in callback to a secret only this server's own page can know.
+    //
+    // The `vscodroid://callback` intent-filter is exported and BROWSABLE, so any
+    // app on the device and any page in any browser can fire it. Everything the
+    // Android side could check before this was guessable: the request id is a
+    // counter the workbench starts at one per page, and the window around it is
+    // ten minutes. A page that knew a sign-in was in flight could therefore forge
+    // the callback, hand the signing-in extension an OAuth code of its choosing
+    // with the confirmation prompt suppressed, and take the pending id with it so
+    // the user's real callback was dropped.
+    //
+    // `callback.html` is served from this server's own origin, so no other origin
+    // can read what is written into it. The nonce goes into the intent payload the
+    // page builds and into a file inside the app sandbox; the Android side accepts
+    // a callback only when the two match.
+    //
+    // Rewritten on every start, like product.json above and through the same
+    // temporary file and rename: the value has to be new for each run, and the
+    // pattern matches the page whether it is pristine or still carries the
+    // previous run's nonce.
+    //
+    // The nonce file is removed first and written last, so no window exists in
+    // which the page carries a secret the Android side cannot check. If any of
+    // this fails there is simply no file, and the Android side falls back to the
+    // matching it did before, which is what keeps a page this cannot rewrite from
+    // costing the user their ability to sign in at all.
+    const callbackHtmlPath = path.join(REH_DIR, 'out/vs/code/browser/workbench/callback.html');
+    const noncePath = path.join(SERVER_DIR, 'auth-callback.nonce');
+    try { fs.unlinkSync(noncePath); } catch { /* nothing to clear */ }
+    try {
+        const html = fs.readFileSync(callbackHtmlPath, 'utf8');
+        if (!CALLBACK_PAYLOAD.test(html)) {
+            throw new Error('the callback page does not build the payload this binds to');
+        }
+        const nonce = crypto.randomBytes(32).toString('hex');
+        const bound = html.replace(
+            CALLBACK_PAYLOAD,
+            `JSON.stringify({ id: id, uri: uri, nonce: '${nonce}' })`
+        );
+        writeThroughRename(callbackHtmlPath, bound);
+        writeThroughRename(noncePath, nonce, 0o600);
+        log('info', 'Sign-in callbacks bound to this run');
+    } catch (e) {
+        log('error', `Could not bind the sign-in callback: ${e.message}`);
+        log('error', 'Sign-in still works, but a callback is matched by request id alone.');
     }
 
     // Build server arguments.

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -32,6 +32,7 @@ import android.widget.ScrollView
 import android.widget.TextView
 import android.widget.Toast
 import java.io.File
+import java.security.MessageDigest
 import java.io.OutputStream
 import java.lang.ref.WeakReference
 import java.util.concurrent.CountDownLatch
@@ -886,6 +887,21 @@ class MainActivity : AppCompatActivity() {
             // READ_LOGS on a developer device. No toast either: a message here
             // would be one an outside caller could raise at will.
             Logger.w(tag, "Ignoring a sign-in callback that no sign-in was waiting for")
+            return
+        }
+        // Everything checked so far is guessable from outside. The id is a counter
+        // the workbench starts at one for each page, this filter is exported and
+        // BROWSABLE, and the window below is ten minutes, so proving that this app
+        // armed this id proves nothing about who is answering it.
+        //
+        // The secret the editor server bound into its own callback page this run is
+        // what closes that. It is served from the server's origin, which no other
+        // origin can read, and it is recorded inside the app sandbox. Refused in
+        // the same silence as the branch above and before the window is consulted,
+        // so a forged callback can neither raise a message nor spend the arming the
+        // user's real callback still needs.
+        if (!callbackCarriesOurSecret(uri)) {
+            Logger.w(tag, "Ignoring a sign-in callback that did not come from the editor's own page")
             return
         }
         if (!authCallbackIsExpected(armedAt, SystemClock.elapsedRealtime(), AUTH_TAB_WINDOW_MILLIS)) {
@@ -2940,21 +2956,56 @@ class MainActivity : AppCompatActivity() {
      * because a `beforeunload` only reaches that callback when the workbench has
      * vetoed leaving, and a veto means there is work it cannot yet recover.
      *
-     * A timestamp rather than a flag nobody clears: the callback runs
-     * synchronously inside the load it belongs to, so a few seconds is generous,
-     * and an expiry means a navigation that never happened cannot leave the
-     * answer armed for a page-initiated one minutes later.
+     * Consumed by the first answer it satisfies, not merely aged out. The
+     * callback runs synchronously inside the load [markAppNavigation] precedes
+     * and is raised once for it, so one mark answers for exactly one
+     * `beforeunload`; anything after that is a second navigation and has to
+     * prove itself. The expiry stays as the backstop for a mark whose load
+     * never produced a callback at all, so a navigation that did not happen
+     * cannot leave the answer armed indefinitely.
+     *
+     * Leaving it armed for the whole window was silently answering a
+     * page-initiated veto: the workbench only vetoes when it holds work it
+     * cannot yet recover, so a mark still standing when the user tapped
+     * something the workbench navigates itself discarded whatever had not
+     * reached a backup.
      */
-    @Volatile
-    private var lastAppNavigation = 0L
+    /**
+     * Whether this callback carries the secret `server.js` bound into the editor's
+     * own callback page for this run.
+     *
+     * The file is inside the app sandbox, so its absence means our own binding did
+     * not happen, never that a caller withheld anything; [callbackSecretMatches]
+     * is what turns that into the older, weaker matching rather than into a
+     * refusal of every sign-in.
+     */
+    private fun callbackCarriesOurSecret(uri: Uri): Boolean {
+        val expected = try {
+            val note = File(Environment.getServerDir(this), AUTH_CALLBACK_NONCE_FILE)
+            if (note.isFile) note.readText().trim() else null
+        } catch (e: Exception) {
+            Logger.w(tag, "Could not read the sign-in callback secret: ${e.message}")
+            null
+        }
+        if (expected.isNullOrEmpty()) {
+            Logger.w(
+                tag,
+                "The editor server bound no sign-in secret this run; matching the " +
+                    "callback by request id alone",
+            )
+        }
+        return callbackSecretMatches(callbackNonce(uri.getQueryParameter("data")), expected)
+    }
+
+    private val appNavigation = AppNavigationMark(APP_NAVIGATION_WINDOW_MS)
 
     /** Marks the navigation about to be started as this app's own. */
     private fun markAppNavigation() {
-        lastAppNavigation = SystemClock.elapsedRealtime()
+        appNavigation.mark(SystemClock.elapsedRealtime())
     }
 
     private fun navigationIsOurs(): Boolean =
-        SystemClock.elapsedRealtime() - lastAppNavigation < APP_NAVIGATION_WINDOW_MS
+        appNavigation.consume(SystemClock.elapsedRealtime())
 
     /**
      * The remembered workspace, when reopening it is still the right thing.
@@ -4381,11 +4432,27 @@ class MainActivity : AppCompatActivity() {
          *
          * The `beforeunload` callback runs inside the load it belongs to, so
          * this only has to cover the moment between asking the WebView to go and
-         * the page answering. Generous rather than tight, because being late
-         * here costs one dialog the user did not need, while being early costs
-         * a dialog they did.
+         * the page answering. It is a backstop, not the guard: the mark is
+         * consumed by the answer it satisfies, so the window only ever bounds a
+         * mark whose load produced no callback.
+         *
+         * Tight rather than generous, and the costs are not symmetric. Expiring
+         * too early costs one dialog the user did not need. Staying armed too
+         * long answers a veto the workbench raised because it holds unsaved
+         * work, and that costs the work.
          */
         private const val APP_NAVIGATION_WINDOW_MS = 10_000L
+
+        /**
+         * Where `server.js` records the secret it bound into `callback.html`.
+         *
+         * Beside `editor-server.pid` in the server directory, which is inside the
+         * app sandbox, so nothing else on the device can read it or write it. The
+         * name is shared with `server.js` by convention only; changing it there
+         * without changing it here turns every sign-in back into the matching this
+         * file did before the secret existed.
+         */
+        internal const val AUTH_CALLBACK_NONCE_FILE = "auth-callback.nonce"
 
         /** The preferences file `PortFinder` and `SplashActivity` already use. */
         private const val WORKSPACE_PREFS = "vscodroid"
@@ -4574,6 +4641,50 @@ internal fun callbackRequestId(data: String?): String? {
     } catch (e: JSONException) {
         null
     }
+}
+
+/**
+ * The per-run secret a callback payload carries, if it carries one.
+ *
+ * Written into `callback.html` by `server.js` at every start and read back from
+ * the payload here. Null covers a payload this cannot read, one with no `nonce`,
+ * and one whose `nonce` is not a string, which are the shapes an outside caller
+ * produces and all deserve the same answer.
+ */
+internal fun callbackNonce(data: String?): String? {
+    if (data.isNullOrEmpty()) return null
+    return try {
+        // `opt` and a cast rather than `optString`, which answers for a value
+        // that is not a string by rendering it: a nested object comes back as
+        // its own JSON text, non-empty and therefore a candidate. It could never
+        // match the recorded secret, so nothing turns on it, but this payload is
+        // attacker-shaped by construction and every reading of it here refuses
+        // the shapes it is not for rather than coercing them.
+        (JSONObject(data).opt("nonce") as? String)?.ifEmpty { null }
+    } catch (e: JSONException) {
+        null
+    }
+}
+
+/**
+ * Whether a callback payload proves it came from the editor's own callback page.
+ *
+ * [expected] is what `server.js` recorded for this run, or null when it recorded
+ * nothing. Null means the server could not bind the page, not that a caller
+ * failed a check, so it answers true and leaves the matching where it was before
+ * the binding existed: a server whose page this app cannot rewrite must not cost
+ * the user their ability to sign in at all.
+ *
+ * Compared with [MessageDigest.isEqual] rather than `==`, which is the
+ * comparison this codebase uses for a secret elsewhere and costs nothing here.
+ */
+internal fun callbackSecretMatches(offered: String?, expected: String?): Boolean {
+    if (expected.isNullOrEmpty()) return true
+    if (offered.isNullOrEmpty()) return false
+    return MessageDigest.isEqual(
+        offered.toByteArray(Charsets.UTF_8),
+        expected.toByteArray(Charsets.UTF_8),
+    )
 }
 
 /**
@@ -5252,4 +5363,42 @@ internal fun treeUriLabel(lastPathSegment: String?): String {
     val segment = lastPathSegment.orEmpty()
     val tail = segment.substringAfterLast('/').substringAfterLast(':')
     return tail.ifBlank { segment }
+}
+
+/**
+ * The record of a navigation this app started, good for one answer.
+ *
+ * [VSCodroidWebChromeClient.onJsBeforeUnload] answers a `beforeunload` for the
+ * user only when this says the navigation is the app's own. A `beforeunload`
+ * reaches that callback only when the workbench vetoed leaving, and it vetoes
+ * only while it holds work it has not yet written a backup of, so a wrong "yes"
+ * here throws that work away with nothing on screen.
+ *
+ * One answer per mark, because the callback is raised once for the load
+ * [mark] precedes: a mark left standing for the rest of a window answered for
+ * whatever the page decided to do next, which is the case the veto exists for.
+ * The window survives only as the backstop for a mark whose load never produced
+ * a callback at all.
+ *
+ * Its own class because [MainActivity] cannot be constructed in a unit test,
+ * and a rule whose failure costs unsaved work should not be the one part with
+ * no check on it.
+ */
+internal class AppNavigationMark(private val windowMs: Long) {
+
+    @Volatile
+    private var markedAt = 0L
+
+    /** Says the navigation about to be started is this app's own. */
+    fun mark(now: Long) {
+        markedAt = now
+    }
+
+    /** True at most once per [mark], and only inside the window. */
+    fun consume(now: Long): Boolean {
+        val marked = markedAt
+        if (marked == 0L || now - marked >= windowMs) return false
+        markedAt = 0L
+        return true
+    }
 }

--- a/android/app/src/main/kotlin/com/vscodroid/service/NodeService.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/service/NodeService.kt
@@ -80,13 +80,12 @@ class NodeService : Service() {
     /**
      * When the server last reported ready, on [SystemClock.elapsedRealtime].
      *
-     * Half of Long.MIN_VALUE rather than 0 or the real minimum: the first
-     * readiness of a run has to refill the budget, and subtracting from 0 would
-     * compare against however long the device has been awake, which on an app
-     * started seconds after boot is a smaller number than the window. Halved so
-     * the subtraction cannot overflow.
+     * Written on every readiness and read at exactly one place, [handleServerCrash],
+     * because how long a server lasted is a quantity only at the moment it stops
+     * lasting. See [NEVER_READY_AT] for why a run with no readiness behind it
+     * parks this in the future rather than in the past.
      */
-    private var lastReadyAt = Long.MIN_VALUE / 2
+    private var lastReadyAt = NEVER_READY_AT
     private var isServiceRunning = false
     private var launchJob: Job? = null
 
@@ -129,8 +128,12 @@ class NodeService : Service() {
      * successful start, every later failure in that run was silent, and a run can
      * last days.
      *
-     * Cleared by [endFailureEpisode], at each of the three points an episode is
-     * over: the server became ready, the user stopped it, or the budget ran out.
+     * Cleared by [announceReady] when a server comes up, and by
+     * [endFailureEpisode] at each of the three points a whole episode is over: a
+     * server that had lasted died, the user stopped it, or the budget ran out.
+     * The first of those is the message half alone, because a server coming up
+     * answers the failure before it without having lasted long enough yet to earn
+     * a retry budget back.
      */
     private var failureRaised = false
 
@@ -236,6 +239,29 @@ class NodeService : Service() {
             }
 
             StartCommand.STAND_DOWN -> {
+                // Said out loud, where every other terminal outcome is said.
+                // Nothing was promoted, so there is no notification and therefore
+                // no Stop control, and the activity that asked for this start is
+                // sitting on the loading page: [startAndBindService] catches only
+                // a throw from `startForegroundService`, and a promotion refused
+                // inside the service is not one. Left silent, `bindDecision` reads
+                // no notice, port 0 and not ready, answers Wait, and the page
+                // stays up with no control on it. Nothing clears it either: the
+                // activity is `singleTask`, so relaunching from the launcher
+                // reaches `onNewIntent`, which only relays a sign-in callback.
+                //
+                // Both halves, because they cover different arrivals and neither
+                // is sufficient. The notice is what a client binding AFTER this
+                // reads, and [lastStartupNotice] has exactly one reader, inside
+                // `setupServiceCallbacks`, which runs once per bind; the callback
+                // is what reaches a client already bound, which is the case on the
+                // retry path, where the service is started again without
+                // rebinding and the notice is therefore never read.
+                //
+                // `stopServingRecoverably` is not reusable here: it calls
+                // `startForeground`, which is the call that just failed.
+                reportStartupNotice(getString(R.string.error_server_start), terminal = true)
+                onServerGaveUp?.invoke()
                 stopSelf()
                 START_NOT_STICKY
             }
@@ -297,12 +323,13 @@ class NodeService : Service() {
      * nothing.
      *
      * A notice rather than a failure, which the name and the strings both have
-     * to keep saying. Two of the three messages that reach here are terminal
-     * (a start that could not spawn, and a restart budget spent), and the third
-     * is `status_server_slow_start`, said while the server is still being waited
-     * for and may still come up. Reading them all as failures is what makes a
-     * slow start indistinguishable from a dead one to everything downstream,
-     * which is the thing this whole path exists to avoid.
+     * to keep saying. Most of what reaches here is terminal (a start that could
+     * not spawn, a restart budget spent, a foreground promotion refused), and
+     * the rest is not: `status_server_slow_start` is said while the server is
+     * still being waited for and may still come up. Reading them all as failures
+     * is what makes a slow start indistinguishable from a dead one to everything
+     * downstream, which is the thing this whole path exists to avoid, and the
+     * `terminal` flag rather than the count is what tells them apart.
      *
      * Exists because [onServerError] is a callback and a callback can be raised
      * at a moment when nobody is listening. A start that outlives the activity
@@ -310,9 +337,9 @@ class NodeService : Service() {
      * bind then finds a service that is not ready and waits, with nothing said.
      *
      * Read on the main thread by a newly bound client and written on the main
-     * thread by [launchServer], [awaitLateReadiness] and [enterTerminalState],
-     * so it needs no synchronisation of its own: the same confinement
-     * [restartCount] and [launchJob] rely on.
+     * thread by [launchServer], [awaitLateReadiness], [enterTerminalState] and
+     * the STAND_DOWN arm of [onStartCommand], so it needs no synchronisation of
+     * its own: the same confinement [restartCount] and [launchJob] rely on.
      *
      * Cleared whenever a start begins and whenever one succeeds, so a reader
      * that finds something here is looking at the current attempt.
@@ -485,8 +512,9 @@ class NodeService : Service() {
      * [awaitLateReadiness], whose loop is bounded by whether a server of ours is
      * still there and whose sleep runs to [LATE_READY_SLOW_POLL_MS]; when the new
      * attempt produces one, that answer turns true again and the old loop simply
-     * carries on against it. It is then free to call [announceReady] -- resetting the restart
-     * budget and firing `onServerReady` for an attempt it is not watching -- and
+     * carries on against it. It is then free to call [announceReady] -- clearing
+     * the failure throttle and firing `onServerReady` for an attempt it is not
+     * watching, and moving the instant the next death is judged against -- and
      * free to post `status_server_slow_start` at its own ninety-second mark, over
      * a notice the new attempt had just cleared. `MainActivity` returns without
      * loading when it finds a notice, so that last one shows the user a healthy
@@ -732,23 +760,26 @@ class NodeService : Service() {
 
     /** Records a ready server and tells whoever is listening. */
     private fun announceReady() {
-        // Recovery succeeded, and only then. Future crashes get a fresh retry
-        // budget, and a failure after this point is a new episode that has to be
-        // heard even though an earlier one in the same run already spoke.
-        //
-        // Conditional because an unconditional refill spends nothing: a server
-        // the system kills seconds after it binds would set the count back to
-        // zero on every attempt, so it could never reach [MAX_RESTARTS] and
-        // [enterTerminalState] could never run. See [READY_STABLE_MS].
-        //
-        // Read before the comparison and assigned after it, so the first
-        // readiness of a run always refills: [endFailureEpisode] parks the
-        // instant far enough back that the difference clears the window.
-        val now = SystemClock.elapsedRealtime()
-        if (readinessIsRecovery(now, lastReadyAt)) {
-            endFailureEpisode()
-        }
-        lastReadyAt = now
+        // The instant this server became ready, and deliberately not the retry
+        // budget with it. What earns a fresh budget is a server that LASTED, and
+        // the difference between two readiness announcements is not that: it is
+        // the previous server's uptime PLUS the backoff and the whole start poll
+        // that followed its death, up to sixty-two seconds during which no server
+        // existed at all. Judging recovery here therefore credited a device that
+        // kills the server twenty seconds after every start with having recovered
+        // by the fifth attempt, so the count never reached [MAX_RESTARTS],
+        // [enterTerminalState] was unreachable, and the workbench reloaded every
+        // half minute for as long as the app stayed open. The judgement lives in
+        // [handleServerCrash], where the uptime is a knowable number; this is only
+        // the reading it is judged against. See [READY_STABLE_MS].
+        lastReadyAt = SystemClock.elapsedRealtime()
+        // The message half of an episode does end here, and unconditionally,
+        // which is the half that is not about the budget. Whatever failure was
+        // raised before this server came up has been answered by it coming up, so
+        // the next failure is a new one and has to be heard. Leaving the throttle
+        // set until some later death happens to refill the budget would silence
+        // the first failure of every later episode in the same run.
+        failureRaised = false
         startupNotice = null
         Logger.i(tag, "Server is ready on port ${processManager.port}")
         // Unconditional, and that is the fix for what the guarded version got
@@ -904,17 +935,20 @@ class NodeService : Service() {
      *
      * The two always move together, which is why they are one function rather
      * than a pair repeated three times. Every place that refreshes the budget is
-     * also a place a fresh failure deserves to be heard (the server came up, the
-     * user stopped it, or the budget ran out), and an earlier draft refreshed the
-     * budget at all three and the message key at none of them.
+     * also a place a fresh failure deserves to be heard (a server that had lasted
+     * died, the user stopped it, or the budget ran out), and an earlier draft
+     * refreshed the budget at all three and the message key at none of them.
+     * [announceReady] clears the message half on its own, because a server coming
+     * up answers the failure that preceded it without yet having lasted long
+     * enough to earn anything back.
      */
     private fun endFailureEpisode() {
         restartCount = 0
         failureRaised = false
-        // Parked with the budget, so the next readiness after a stop or a
-        // recoverable shutdown is judged as the first one of a new run rather
-        // than against whenever the last server happened to answer.
-        lastReadyAt = Long.MIN_VALUE / 2
+        // Parked with the budget: whatever server this run had is gone, so there
+        // is no uptime left for the next death to be judged against, and a run
+        // that never gets one must not be credited with an uptime it never had.
+        lastReadyAt = NEVER_READY_AT
     }
 
     /**
@@ -957,14 +991,33 @@ class NodeService : Service() {
             return
         }
 
+        // A server that held for [READY_STABLE_MS] before dying recovered from
+        // whatever episode preceded it, so the death that ends it opens a fresh
+        // budget rather than spending the last of an old one. Judged here because
+        // this is the only moment its uptime exists as a number: everything after
+        // it, the backoff and then the start poll, is time with no server in it,
+        // and folding that waiting into the measurement is what let a server that
+        // lasted twenty seconds pass for one that lasted a minute.
+        //
+        // Not in [retryOrGiveUp], for the same reason [chargeHeapOverride] is not
+        // there either: two paths reach it for one death, and only this one is fed
+        // by a server that ever ran. A start that produced nothing has no uptime
+        // to credit, and [NEVER_READY_AT] is what makes it answer so.
+        if (readinessIsRecovery(SystemClock.elapsedRealtime(), lastReadyAt)) {
+            endFailureEpisode()
+        }
         Logger.w(tag, "Server crashed (exit=$exitCode), restart #${restartCount + 1}")
         chargeHeapOverride(exitCode)
         // The decision and the waiting both live in [retryOrGiveUp], shared with
-        // the start path. Recomputing `crashAction` there costs nothing and reads
-        // the same values. The charge above now suspends, so the two reads are no
-        // longer separated by non-suspending statements alone; what keeps them
-        // reading the same values is that both fields are confined to this
-        // dispatcher and the charge resumes on it before returning.
+        // the start path. Recomputing `crashAction` there costs nothing, and it
+        // is what lets the refill above count: the `action` read at the top of
+        // this function answers only the IGNORE question, which the budget does
+        // not enter into, while the decision that spends an attempt is taken
+        // after a server that lasted has been credited. The charge above
+        // suspends, so the two reads are not separated by non-suspending
+        // statements alone; what keeps them on one thread is that both fields are
+        // confined to this dispatcher and the charge resumes on it before
+        // returning.
         retryOrGiveUp()
     }
 
@@ -1350,14 +1403,35 @@ internal const val MAX_BACKOFF_SHIFT = 4
 internal const val READY_STABLE_MS = 60_000L
 
 /**
- * Whether a server reporting ready has recovered from anything.
+ * What the last-ready instant holds while this run has never had a ready server.
  *
- * Pure, and separate from [NodeService.announceReady] for the reason
+ * In the future rather than in the past, and that direction is the whole of it.
+ * The one question asked of that instant is how long the server that just died
+ * had been ready, so a run with no readiness behind it has to answer "not long
+ * enough". Parked in the past, which is where it sat while readiness itself
+ * asked the question, every crash of a server that never answered would hand out
+ * a fresh budget, and the terminal state would be unreachable for exactly the
+ * run that cannot get a server up at all.
+ *
+ * Half of Long.MAX_VALUE so that subtracting it from a clock reading cannot
+ * overflow.
+ */
+internal const val NEVER_READY_AT = Long.MAX_VALUE / 2
+
+/**
+ * Whether the server that has been ready since [lastReadyAt] lasted long enough
+ * for its readiness to count as a recovery.
+ *
+ * Pure, and separate from [NodeService.handleServerCrash] for the reason
  * [crashAction] and [hasRestartBudget] are: the decision is the part worth
  * pinning, and the caller around it needs a Service to exist.
  *
- * [lastReadyAt] is parked far below zero between runs, so the first readiness
- * of a run always answers true without that having to be a special case here.
+ * The quantity matters as much as the comparison. `now` is the instant the
+ * server DIED, not the instant the next one answered: the gap between two
+ * readiness announcements also contains the backoff and the start poll between
+ * them, which is time with no server in it. [NEVER_READY_AT] is far in the
+ * future, so a run whose server never became ready answers false here without
+ * that having to be a special case.
  */
 internal fun readinessIsRecovery(
     now: Long,

--- a/android/app/src/main/kotlin/com/vscodroid/service/ProcessManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/service/ProcessManager.kt
@@ -551,6 +551,30 @@ class ProcessManager(private val context: Context) {
             // taken, see there for what a note alone lets through, and why the
             // two questions are not interchangeable.
             Logger.i(tag, "Port $_port already served by a server of ours; adopting it")
+            // The same window the spawn below guards, on the branch that has no
+            // Process to destroy, and the decision above is where it opens.
+            // [recordedServerIsServing] spends a second of connect and a second of
+            // read against the port, and [stopServer] runs on the main thread: a
+            // Stop pressed inside that round trip reads `adopted` as false, so it
+            // reaps nothing and returns, and the assignments below would then clear
+            // the flag that stop had just set and record the orphan as this
+            // instance's server. What the user is left with is exactly the state
+            // adoption exists to end, now with the service gone: an editor server
+            // holding the port that nothing is tracking, and the poll
+            // [startAdoptionWatch] would have started over it, both outliving the
+            // stop that was supposed to take them.
+            //
+            // Ended rather than merely declined, for the reason [stopServer]'s own
+            // adopted branch gives: the note names the pid, and a stop is the user
+            // asking for the server to be gone rather than for it to be left
+            // untracked. Placed before every assignment below, because a return
+            // taken after any of them would publish state describing a server this
+            // start is not going to serve.
+            if (isShuttingDown) {
+                Logger.i(tag, "A stop landed while the server was being adopted; ending it instead")
+                reapRecordedEditorServer("a stop landed while it was being adopted")
+                return false
+            }
             // Nothing is warned about here, and that is a change rather than an
             // omission. An adopted server is by construction one whose bootstrap
             // is gone, and while the DNS proxy was bound by that bootstrap the
@@ -566,7 +590,6 @@ class ProcessManager(private val context: Context) {
             // warning back here.
             adopted = true
             clearReadiness()
-            isShuttingDown = false
             // Nothing was spawned, so the flag describes nothing. Cleared rather
             // than left, because it survives in this instance across attempts and
             // a value left over from a previous one is not about this server.

--- a/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
@@ -1018,7 +1018,15 @@ class FirstRunSetup(
      * would see the app ignore it for ever with nothing to indicate why. The
      * fingerprint covers the certificates' own bytes rather than their aliases
      * because a Conscrypt alias is a hash of the subject, so a CA re-issued
-     * under the same name keeps the alias it had.
+     * under the same name keeps the alias it had. It now covers the system half
+     * as well, which is what lets a root the owner turned off rebuild the bundle:
+     * turning one off writes into a store of its own and leaves the certificate
+     * directory's mtime alone, exactly as installing one does.
+     *
+     * Built from the platform's merged store rather than from the certificate
+     * directory plus the owner's additions. See [deviceTrustedCertificates] for
+     * why: the directory keeps the file for a root the owner has distrusted, so
+     * copying it kept trusting what the rest of the phone no longer does.
      */
     fun setupGitCaBundle() {
         val caDir = systemCaCertificateDirs
@@ -1027,8 +1035,8 @@ class FirstRunSetup(
 
         val bundle = File(context.filesDir, "usr/etc/tls/cert.pem")
         val marker = File(context.filesDir, "usr/etc/tls/.user-ca-fingerprint")
-        val userPems = userCertificatePems()
-        val fingerprint = sha256HexOf(userPems.joinToString(""))
+        val storePems = deviceCertificatePems()
+        val fingerprint = sha256HexOf(storePems.joinToString(""))
 
         if (bundle.exists() && bundle.length() > 0 &&
             bundle.lastModified() >= caDir.lastModified() &&
@@ -1049,11 +1057,30 @@ class FirstRunSetup(
             // the wrong side of the cut, with nothing to suggest the file is the
             // problem. An interrupted write now leaves the previous bundle, or
             // no bundle at all, and either one gets rebuilt next time.
+            // The merged store when it answered, the directory when it did not.
+            //
+            // The store is the platform's own view and is the only one of the two
+            // that reflects a root the owner turned off, so where it answers it is
+            // the whole bundle and the directory is not read at all. Where it
+            // answers with nothing -- a provider that threw, a device without it --
+            // the directory is the fallback that keeps HTTPS working at all, which
+            // is worth more than honouring a removal. That is the same trade the
+            // freshness check above makes, and the reason caDir is still resolved
+            // before any of this: its mtime remains the cheap signal that the
+            // system half moved.
             val written = writeAtomically(bundle) { out ->
-                for (cert in certs) {
-                    if (cert.isFile) cert.inputStream().use { it.copyTo(out) }
+                if (storePems.isNotEmpty()) {
+                    for (pem in storePems) out.write(pem.toByteArray())
+                } else {
+                    Logger.w(
+                        tag,
+                        "The device CA store answered with nothing; falling back to " +
+                            "${caDir.path}, which cannot see a root the owner removed",
+                    )
+                    for (cert in certs) {
+                        if (cert.isFile) cert.inputStream().use { it.copyTo(out) }
+                    }
                 }
-                for (pem in userPems) out.write(pem.toByteArray())
             }
             if (!written) {
                 Logger.e(tag, "Could not write the CA bundle; the previous one is unchanged")
@@ -1072,8 +1099,12 @@ class FirstRunSetup(
             }
             Logger.i(
                 tag,
-                "CA bundle: ${certs.size} certificates from ${caDir.path}, " +
-                    "and ${userPems.size} user-installed CA(s)",
+                if (storePems.isNotEmpty()) {
+                    "CA bundle: ${storePems.size} certificates from the device trust store"
+                } else {
+                    "CA bundle: ${certs.size} certificates from ${caDir.path}, " +
+                        "with no device trust store to read"
+                },
             )
         } catch (e: Exception) {
             Logger.e(tag, "Failed to build CA bundle", e)
@@ -1118,9 +1149,9 @@ class FirstRunSetup(
      * there, rather than weakening the fingerprint until the store's changes go
      * unnoticed again.
      */
-    private fun userCertificatePems(): List<String> =
-        runCatching { userTrustedCertificates() }
-            .onFailure { Logger.w(tag, "Could not read the user CA store: ${it.message}") }
+    private fun deviceCertificatePems(): List<String> =
+        runCatching { deviceTrustedCertificates() }
+            .onFailure { Logger.w(tag, "Could not read the device CA store: ${it.message}") }
             .getOrDefault(emptyList())
             .mapNotNull { cert -> runCatching { pemOf(cert) }.getOrNull() }
             .sorted()
@@ -1146,22 +1177,34 @@ class FirstRunSetup(
      *
      * `AndroidCAStore` is the platform's own merged view of both halves, and it
      * is used here rather than the directories underneath it because it is the
-     * documented API and carries no path this app has to keep up to date.
-     * Conscrypt names its entries `system:<hash>.<n>` and `user:<hash>.<n>`, so
-     * the prefix is what separates the owner's own CAs from the roots that
-     * shipped with the device. Measured on an API 33 emulator from inside this
-     * app's process, with one CA installed through Settings: 126 aliases, of
-     * which exactly one began `user:`.
+     * documented API, carries no path this app has to keep up to date, and is
+     * the same view the platform's own trust manager reads. Conscrypt names its
+     * entries `system:<hash>.<n>` and `user:<hash>.<n>`. Measured on an API 33
+     * emulator from inside this app's process, with one CA installed through
+     * Settings: 126 aliases, of which exactly one began `user:`.
+     *
+     * Every alias, not only the `user:` half, and that is the point rather than
+     * a widening. A root the device owner has turned off in Settings > Trusted
+     * credentials leaves this store, and it does not leave
+     * [systemCaCertificateDirs], which still holds the file. Filtering to
+     * `user:` and copying that directory for the rest meant the bundle kept
+     * trusting a root the owner had distrusted, and every other app on the phone
+     * had stopped. That mattered less when only git read the bundle; SSL_CERT_FILE
+     * and REQUESTS_CA_BUNDLE now put it in front of python, pip and curl too.
+     *
+     * The removal is recorded in `/data/misc/user/0/cacerts-removed`, which this
+     * app cannot subtract for itself: the path is hardcoded, carries a user id,
+     * and moved into an APEX on Android 14. Reading the merged store is how the
+     * platform answers the same question, so it is what is asked.
      *
      * A `var` for the same reason as [systemCaCertificateDirs], and more
      * sharply: the provider does not exist on a JVM at all, so every test of
      * the bundle builder replaces this.
      */
-    internal var userTrustedCertificates: () -> List<Certificate> = {
+    internal var deviceTrustedCertificates: () -> List<Certificate> = {
         val store = KeyStore.getInstance("AndroidCAStore")
         store.load(null)
         store.aliases().toList()
-            .filter { it.startsWith("user:") }
             .mapNotNull { alias -> runCatching { store.getCertificate(alias) }.getOrNull() }
     }
 
@@ -5042,6 +5085,24 @@ internal fun bundledIdsToRelist(
         // Its entry was just dropped because the directory it named is gone --
         // an upgrade swapping 1.0.0 for 1.3.0 does exactly this.
         id in droppedIds -> true
+        // Ours, always, and this is the half that used to disagree with itself.
+        // The rule below exists so a downloaded extension the user deliberately
+        // removed does not come back on every update, and that promise is about
+        // marketplace copies. [bundledDirsToExtract] already exempts this prefix
+        // from exactly the same rule, so the directory returned on every update
+        // and then sat unlisted and unloaded, which is the state the comment in
+        // [manifestEntryFor] describes.
+        //
+        // These are not a removable preference: they carry the device folder
+        // picker, the toolchain screen and the editor defaults this app
+        // contributes, so a removed one takes those with it and nothing inside
+        // the editor can put it back. The removal that reached here was possible
+        // on releases that wrote no `isBuiltin`, and `isBuiltin` only stops the
+        // next one; it cannot relist a copy already gone. Without this arm a user
+        // who removed the welcome extension keeps the prune of the app's old
+        // editor overrides, which commits once and for all, while the defaults
+        // that replaced them never load.
+        id.startsWith(OWN_EXTENSION_PREFIX) -> true
         // Never bundled before, so there was no copy for the user to remove.
         else -> id !in previouslyBundledIds
     }

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
@@ -7,6 +7,7 @@ import androidx.annotation.StringRes
 import com.vscodroid.BuildConfig
 import com.vscodroid.R
 import android.system.Os
+import com.google.android.play.core.assetpacks.AssetPackException
 import com.google.android.play.core.assetpacks.AssetPackManagerFactory
 import com.google.android.play.core.assetpacks.AssetPackState
 import com.google.android.play.core.assetpacks.AssetPackStateUpdateListener
@@ -563,7 +564,22 @@ class ToolchainManager(private val context: Context) {
         } else {
             // Ensure listener is registered before fetching
             registerListener()
+            // The Task is answered rather than discarded. A fetch Play refuses
+            // outright delivers no AssetPackState at all, so [handleDownloadState]
+            // never runs for this pack and the queue's downloadNext() is never
+            // reached: the row sits on its last status for the rest of the session,
+            // every pack queued behind it is never even requested, nothing is
+            // written to the log, and the only way out is Cancel.
+            //
+            // Routed through [fail] like every listener-delivered failure, so the
+            // card, the queue and the log all learn about it the same way. A
+            // duplicate terminal report costs nothing: the queue ignores one for a
+            // pack it has already moved past, and the card repaints.
             assetPackManager.fetch(listOf(info.packName))
+                .addOnFailureListener { e ->
+                    Logger.e(tag, "Play refused to fetch ${info.packName}: ${e.message}")
+                    fail(info.packName, playFetchFailure(e))
+                }
         }
     }
 
@@ -3988,6 +4004,22 @@ enum class ToolchainFailure(@param:StringRes val message: Int) {
  * has no constant for and fall through with the rest. Every code that lands in
  * INTERNAL is still in the log line beside this call, raw.
  */
+/**
+ * Why a Play fetch was refused before any state was ever delivered.
+ *
+ * [AssetPackException] carries the same error codes the state listener reports,
+ * so a refusal maps to the same message as the equivalent mid-download failure.
+ * Anything else is an exception the Play library does not classify, and INTERNAL
+ * is the honest answer: the alternative is telling a user to check their
+ * connection for something that was never a network problem.
+ *
+ * Separate from [toolchainFailureFor] because that one takes a code and this one
+ * takes a throwable, and the cast is the whole of the difference.
+ */
+internal fun playFetchFailure(e: Exception): ToolchainFailure =
+    (e as? AssetPackException)?.let { toolchainFailureFor(it.errorCode) }
+        ?: ToolchainFailure.INTERNAL
+
 internal fun toolchainFailureFor(errorCode: Int): ToolchainFailure = when (errorCode) {
     AssetPackErrorCode.NETWORK_ERROR -> ToolchainFailure.NETWORK
     AssetPackErrorCode.INSUFFICIENT_STORAGE -> ToolchainFailure.STORAGE

--- a/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/storage/SafSyncEngine.kt
@@ -1887,6 +1887,18 @@ class SafSyncEngine(private val context: Context) {
 
                     if (isDir && !walkTree(treeUri, docId, relativePath, result, skipped)) {
                         complete = false
+                        // Recorded for the same reason a skipped directory is, and it
+                        // is the same loss: the children could not be enumerated, so
+                        // none of them becomes a DocumentInfo, none reaches phase 2,
+                        // and none reaches an `unfetched.add`. Without this the DELETE
+                        // guard proves "the device holds the only copy" from a set that
+                        // cannot contain them and lets deleteDocument take the whole
+                        // directory on the device, including documents the mirror never
+                        // held. Unlike a skipped name, nothing filters this one out
+                        // earlier: [shouldWriteBack] drops SKIP_DIRECTORIES by name,
+                        // and a directory whose enumeration merely failed has an
+                        // ordinary one.
+                        skipped.add(relativePath)
                     }
                 }
             } ?: return false  // the provider refused to answer at all
@@ -3189,13 +3201,26 @@ class SafSyncEngine(private val context: Context) {
                 }
             }
             SyncType.DELETE -> {
-                // A null uri is the same outcome as a refusal, and deliberately
-                // shares the branch: [findChildDocId] folds a failed provider
-                // query into the null it returns for genuine absence, so "could
-                // not be resolved" and "is not there" arrive here as one answer,
-                // and both leave the device holding what the editor no longer
-                // shows.
-                if (job.safDocUri == null || !deleteFromSaf(job.safDocUri)) {
+                // A null uri is NOT the same outcome as a refusal, though it used to
+                // share the branch: [findChildDocId] folds a failed provider query into
+                // the null it returns for genuine absence, so "could not be resolved"
+                // and "is not there" arrive here as one answer. Only the first leaves
+                // the device holding what the editor no longer shows; for the second
+                // both clauses of the notice are false, and it tells the user to go and
+                // delete a file that is not there.
+                //
+                // [providerHolds] is the three-valued form of the same question and is
+                // what the DELETE guard above already uses. Announce unless the device
+                // positively answers "gone": a provider that cannot answer is still
+                // treated as holding, so a transient failure keeps the warning it used
+                // to give.
+                val refused = if (job.safDocUri == null) {
+                    job.safTreeUri != null &&
+                        providerHolds(job.safTreeUri, job.relativePath) != false
+                } else {
+                    !deleteFromSaf(job.safDocUri)
+                }
+                if (refused) {
                     announceDeleteRefused(File(job.localPath))
                 }
                 // Both cleanups below run whatever the device folder decided.
@@ -3517,8 +3542,10 @@ class SafSyncEngine(private val context: Context) {
         // mirror entry that was never the document, and the document on the device is
         // the only copy of itself.
         //
-        // Matched by prefix for a directory, since a directory holds what is under it
-        // and [unfetched] holds files only, and by exact path for a file, since its own
+        // Matched by prefix and by its own path for a directory, since a directory
+        // holds what is under it and [unfetched] carries a file for each document this
+        // sync did not read plus the directory itself where it read none of them, and
+        // by exact path for a file, since its own
         // path is the only one that names it. The separator is appended so `docs` does
         // not answer for `docs2`, and any depth below counts; on the file side
         // exactness is what stops an unread `notes.md.bak` from keeping `notes.md`.
@@ -3544,7 +3571,13 @@ class SafSyncEngine(private val context: Context) {
         if (type == SyncType.DELETE) {
             val holdsUnread = if (isDirectory) {
                 val below = localFile.absolutePath + File.separator
-                unfetched.any { it.startsWith(below) }
+                // Its own path as well as the prefix. A directory is recorded by its
+                // own mirror path when this sync did not read what is under it, either
+                // because the name is skipped or because enumerating it failed, and
+                // the prefix test alone cannot match that entry: `below` carries a
+                // trailing separator the entry does not have. Deleting the directory
+                // itself is exactly the case those entries exist to refuse.
+                localFile.absolutePath in unfetched || unfetched.any { it.startsWith(below) }
             } else {
                 localFile.absolutePath in unfetched
             }

--- a/android/app/src/main/kotlin/com/vscodroid/util/EditorLocale.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/util/EditorLocale.kt
@@ -97,10 +97,20 @@ object EditorLocale {
             // a Traditional editor, legibly and with nothing on screen to
             // explain it. The mirror case reads correctly by accident, since
             // `zh-Hant-*` is caught by the script before the region is consulted.
+            //
+            // The region is the subtag directly after the language and never the
+            // last one, because a tag is not always two subtags long: Android
+            // carries a Regional preference as a `-u-` Unicode extension on the
+            // default locale, so a Taiwanese phone reports `zh-TW-u-fw-mon` and
+            // reading the last subtag found "mon" there, resolved Simplified and
+            // handed that user an entirely Simplified workbench, extension
+            // manifests included. Taking the first subtag of the rest is exact
+            // for `zh-CN` and `zh-TW`, empty for a bare `zh`, and indifferent to
+            // however many extension, variant or private-use subtags trail behind.
             val traditional = when {
                 rest.startsWith("hans") -> false
                 rest.startsWith("hant") -> true
-                else -> rest.substringAfterLast('-') in TRADITIONAL_CHINESE
+                else -> rest.substringBefore('-') in TRADITIONAL_CHINESE
             }
             val bundle = if (traditional) "zh-hant" else "zh-hans"
             return bundle.takeIf { it in available }

--- a/android/app/src/test/kotlin/com/vscodroid/ExtensionCallbackTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/ExtensionCallbackTest.kt
@@ -1018,16 +1018,26 @@ class NavigationTokenLoggingTest {
         //
         // What still has to be proven is that `leaks` answering empty means
         // "nothing logs one" rather than "the reader can no longer see one". So
-        // the control moves to the reader: the names the workbench URL flows
-        // into must still be recognised.
+        // the control moves to the reader: the name the workbench URL flows into
+        // must still be recognised.
+        //
+        // Named, not counted. `taintedNames` carries the device-folder seed as
+        // well, and four names in this file are written with the type `Uri`
+        // (`syncingFolder`, `destination`, `uri`, `failed`), so the set is
+        // non-empty with every token seed deleted: an `isNotEmpty` control
+        // reports a reader that has gone entirely blind to the token as healthy.
+        // Asking for the one name this file binds the tokened URL to is what
+        // makes the token seeds answer for themselves.
         val tainted = LogTaint.taintedNames(source())
 
         assertTrue(
-            tainted.isNotEmpty(),
-            "LogTaint no longer recognises any token-bearing name in MainActivity, so " +
-                "the case above is passing by looking at nothing. Either the seeds stopped " +
-                "matching where the URL is built, or the declaration reader broke: check " +
-                "`workbenchUrl(` and `getConnectionToken(` against URI_NAME's patterns",
+            "url" in tainted,
+            "LogTaint no longer recognises `url`, which is what MainActivity binds the " +
+                "tokened address to in `val url = workbenchUrl(port, folderPath, token)`, " +
+                "so the case above is passing by looking at nothing. Either the seeds " +
+                "stopped matching where the URL is built, or the declaration reader broke: " +
+                "check `workbenchUrl(` and `getConnectionToken(` against that line. " +
+                "Names seen: $tainted",
         )
     }
 

--- a/android/app/src/test/kotlin/com/vscodroid/service/NodeServiceTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/service/NodeServiceTest.kt
@@ -60,18 +60,84 @@ class RestartBudgetTest {
     }
 
     /**
-     * The first readiness of a run, where nothing has answered yet.
+     * A run whose server never became ready, where the question is asked anyway.
      *
-     * The parked value is far below zero rather than zero because the clock is
-     * time since boot: an app started seconds after boot would otherwise be
-     * compared against a number smaller than the window and refuse to refill,
-     * spending a budget it had never used.
+     * The parked value is read at exactly one place, the death of a server, and
+     * it has to answer "not long enough" there. Parked in the past instead, which
+     * is where it sat while readiness rather than death asked the question, every
+     * crash of a server that never answered at all would hand out a fresh budget:
+     * the five attempts could never be spent and the terminal state would be
+     * unreachable for precisely the run that cannot get a server up.
      */
     @Test
-    fun `the first readiness of a run always counts as recovery`() {
+    fun `a server that was never ready is not credited with having lasted`() {
+        assertFalse(
+            readinessIsRecovery(now = 5_000L, lastReadyAt = NEVER_READY_AT),
+            "a run that never had a ready server refilled the retry budget on a crash",
+        )
+        // And the halving is the part that keeps that true for a real clock
+        // reading rather than only for a small one. `elapsedRealtime` counts from
+        // boot, so the value has to stay above anything a device can reach while
+        // leaving the subtraction room not to overflow; a hundred years of uptime
+        // is the far side of that.
+        assertFalse(
+            readinessIsRecovery(now = 100L * 365 * 24 * 60 * 60 * 1000, lastReadyAt = NEVER_READY_AT),
+            "the parked value is reachable by a clock that has been running a long time",
+        )
+    }
+
+    /**
+     * The instants the service actually produces, rather than two chosen numbers.
+     *
+     * The predicate above is fed by [NodeService] and the numbers it is fed are
+     * the whole defect. Judged at the next readiness, the difference is the dead
+     * server's uptime PLUS everything the service does between the two: the
+     * backoff, which reaches [restartBackoffMs] of the last attempt, and the
+     * start that follows it. On a phone whose memory killer takes the server
+     * twenty seconds after each start, those gaps grow to sixty seconds by the
+     * fifth attempt and the budget refills before it can be spent, so the Retry
+     * page is never offered and the workbench reloads every half minute for as
+     * long as the app is open.
+     *
+     * Judged at the death, which is what [ReadinessRefillSiteTest] pins, none of
+     * that waiting is in the measurement and every one of these attempts spends
+     * an attempt.
+     */
+    @Test
+    fun `the instants a crash loop really produces never refill the budget`() {
+        val uptimeMs = 20_000L
+        // What the service spends getting the next server up: the poll allows
+        // READY_POLL_TIMEOUT_MS and a loaded device uses a good part of it.
+        val startLatencyMs = 8_000L
+
+        var readyAt = 0L
+        for (attempt in 1..MAX_RESTARTS) {
+            assertFalse(
+                readinessIsRecovery(now = readyAt + uptimeMs, lastReadyAt = readyAt),
+                "attempt $attempt: a server that lasted ${uptimeMs}ms was credited with " +
+                    "recovering, so the budget can never be spent",
+            )
+            readyAt = readyAt + uptimeMs + restartBackoffMs(attempt) + startLatencyMs
+        }
+
+        // The same run measured the wrong way, which is the reason this test
+        // names real instants instead of a pair of literals: the last of those
+        // gaps clears the window on its own, with forty of its sixty seconds
+        // spent on a server that did not exist.
+        val gapAcrossTheLastRestart = uptimeMs + restartBackoffMs(MAX_RESTARTS) + startLatencyMs
         assertTrue(
-            readinessIsRecovery(now = 5_000L, lastReadyAt = Long.MIN_VALUE / 2),
-            "the first ready server of a run did not refill the retry budget",
+            readinessIsRecovery(now = gapAcrossTheLastRestart, lastReadyAt = 0L),
+            "the gap between two readiness announcements no longer reaches the window, so " +
+                "this case has stopped telling the two quantities apart",
+        )
+
+        // And the contrast, on the same clock: a server that held for five
+        // minutes and then died has recovered from whatever came before it, and
+        // its death is the moment that says so.
+        val heldFor = 5 * 60_000L
+        assertTrue(
+            readinessIsRecovery(now = readyAt + heldFor, lastReadyAt = readyAt),
+            "a server that lasted ${heldFor}ms was not credited with recovering",
         )
     }
 
@@ -955,9 +1021,12 @@ class NoticeGateKeyTest {
     fun `an episode ends everywhere the retry budget is refreshed`() {
         // The key substitution, pinned as the invariant that makes the key right
         // rather than as the name of a field. Every point that hands out a fresh
-        // budget is a point a fresh failure deserves to be heard: the server came
-        // up, the user stopped it, or the budget ran out. Keying on runId missed
-        // the first of those, because a run does not end when a server comes up.
+        // budget is a point a fresh failure deserves to be heard: a server that
+        // had lasted died, the user stopped it, or the budget ran out. Keying on
+        // runId missed the deaths, because a run does not end when its server
+        // does. Readiness clears the throttle without the budget, which is the
+        // one direction this invariant does not cover and
+        // [ReadinessRefillSiteTest] does.
         val lines = codeLines()
 
         val budget = lines.filter { (_, l) ->
@@ -972,8 +1041,8 @@ class NoticeGateKeyTest {
         val ends = lines.filter { (_, l) -> l.contains("endFailureEpisode()") }
         assertEquals(
             4, ends.size,
-            "expected the declaration plus its three callers -- readiness, stop, and " +
-                "the terminal state:\n" + report(ends),
+            "expected the declaration plus its three callers -- the death of a server " +
+                "that lasted, stop, and the terminal state:\n" + report(ends),
         )
     }
 
@@ -987,6 +1056,124 @@ class NoticeGateKeyTest {
                 "failed, a process that died before answering, and one that could never " +
                 "bind. A failure that speaks on every attempt is the defect, and so is " +
                 "one that never speaks:\n" + report(reported),
+        )
+    }
+}
+
+/**
+ * That the retry budget is refilled where a server's uptime is knowable.
+ *
+ * How long a server lasted is a quantity at exactly one instant: the one it dies
+ * at. Asked on the readiness that follows instead, what gets measured is that
+ * uptime plus everything the service did in between, the backoff and then the
+ * start poll, which on the last attempt is thirty-two seconds and up to thirty
+ * more with no server in them at all. A phone whose memory killer takes the
+ * server twenty seconds after each start therefore cleared the count on the
+ * fifth attempt, [MAX_RESTARTS] was never reached, the terminal state was
+ * unreachable, the Retry page was never offered, and the workbench reloaded
+ * every half minute for as long as the app stayed open.
+ *
+ * The arithmetic is in [RestartBudgetTest] and the two are only worth anything
+ * together: the predicate is right for either set of instants, and which set it
+ * is handed is invisible from inside it.
+ *
+ * Source-reading, and the weaker layer for the reason its neighbours give:
+ * `announceReady` and `handleServerCrash` are private on a `Service`, and this
+ * suite can build neither a `Service` nor its main dispatcher.
+ */
+class ReadinessRefillSiteTest {
+
+    private val nodeService = File("src/main/kotlin/com/vscodroid/service/NodeService.kt")
+
+    private fun codeLines(): List<IndexedValue<String>> {
+        check(nodeService.isFile) {
+            "NodeService.kt not found at ${nodeService.absolutePath} -- this test would " +
+                "otherwise pass by looking at nothing"
+        }
+        return nodeService.readLines().withIndex().filterNot { (_, line) ->
+            val t = line.trimStart()
+            t.startsWith("//") || t.startsWith("*") || t.startsWith("/*")
+        }
+    }
+
+    private fun report(hits: List<IndexedValue<String>>) =
+        hits.joinToString("\n") { (i, l) -> "  NodeService.kt:${i + 1}: ${l.trim()}" }
+
+    /**
+     * One function's body, located by brace depth from its declaration, because
+     * the name of the enclosing function is on none of the lines this looks for.
+     *
+     * Depth is counted over the comment-free lines for the reason [codeLines]
+     * exists: each of these two functions is named in the prose around the other,
+     * so a scan over raw text would read a paragraph as a call and a brace inside
+     * a comment would widen the window without bounding anything.
+     */
+    private fun bodyOf(declaration: String): List<IndexedValue<String>> {
+        val lines = codeLines()
+        val start = lines.indexOfFirst { (_, l) -> l.contains(declaration) }
+        assertTrue(start >= 0, "`$declaration` is gone; this guard names a method")
+        val body = mutableListOf<IndexedValue<String>>()
+        var depth = 0
+        var entered = false
+        for (line in lines.drop(start)) {
+            depth += line.value.count { it == '{' } - line.value.count { it == '}' }
+            if (depth > 0) entered = true
+            body += line
+            if (entered && depth <= 0) break
+        }
+        return body
+    }
+
+    @Test
+    fun `the budget is refilled at the death and not at the readiness`() {
+        val crash = bodyOf("private suspend fun handleServerCrash(")
+        assertTrue(
+            crash.any { (_, l) -> l.contains("readinessIsRecovery(") },
+            "nothing in handleServerCrash judges how long the dead server had been " +
+                "ready, so a server that ran for hours spends an attempt of the same " +
+                "budget as one that ran for seconds",
+        )
+
+        val refill = crash.indexOfFirst { (_, l) -> l.contains("endFailureEpisode()") }
+        assertTrue(refill >= 0, "the crash path judges an uptime and then refills nothing")
+        // And before the retry, which is the call that reads the count: a refill
+        // on the far side of it lands on a decision already made, so the death
+        // that earned the fresh budget still spends the last attempt of the old
+        // one and the give-up it triggers is a whole episode early.
+        val retry = crash.indexOfFirst { (_, l) -> l.contains("retryOrGiveUp()") }
+        assertTrue(retry >= 0, "handleServerCrash no longer hands the death to retryOrGiveUp")
+        assertTrue(
+            refill < retry,
+            "the budget is refilled after the retry decision, which is too late to " +
+                "affect it:\n" + report(crash.slice(minOf(retry, refill)..maxOf(retry, refill))),
+        )
+
+        val ready = bodyOf("private fun announceReady()")
+        val judged = ready.filter { (_, l) ->
+            l.contains("readinessIsRecovery(") || l.contains("endFailureEpisode()")
+        }
+        assertTrue(
+            judged.isEmpty(),
+            "announceReady judges recovery again, and the only interval it can measure " +
+                "is the gap between two announcements, which is the previous server's " +
+                "uptime plus the backoff and the start poll that followed its death:\n" +
+                report(judged),
+        )
+    }
+
+    @Test
+    fun `a readiness still ends the message episode`() {
+        // The half that must not move with the budget. The throttle exists so
+        // that one failure episode produces one toast rather than six, and a
+        // server coming up ends that episode whatever its uptime turns out to be.
+        // Left set until some later death happens to refill the budget, the first
+        // failure of every subsequent episode in the same run is silent, and a
+        // run can last days.
+        val ready = bodyOf("private fun announceReady()")
+        assertTrue(
+            ready.any { (_, l) -> l.contains("failureRaised = false") },
+            "announceReady no longer clears the failure throttle, so the next failure " +
+                "of this run reaches nobody",
         )
     }
 }
@@ -1548,6 +1735,79 @@ class LivenessQuestionCallSiteTest {
             codeLines().any { (_, l) -> l.contains("processManager.heapOverrideIgnored()") },
             "and the card must derive it rather than remember it, or a value the user " +
                 "has since repaired keeps being reported as ignored",
+        )
+    }
+}
+
+/**
+ * That a refused foreground promotion is said out loud somewhere.
+ *
+ * `promoteToForeground` catches the throw and answers false, so
+ * `startForegroundService` at the activity's call site never throws and the
+ * catch around it never runs. Nothing was promoted either, so there is no
+ * notification and therefore no Stop control. Left silent, the activity's bind
+ * reads no notice, port 0 and not ready, decides to wait, and the loading page
+ * stays up with nothing on it and nothing to clear it: the activity is
+ * `singleTask`, so a launcher tap reaches `onNewIntent`, which only relays a
+ * sign-in callback.
+ *
+ * A source scan for the same reason [ReadinessRefillSiteTest] is one: the arm
+ * lives in `onStartCommand` on a `Service`, and both things it has to do are
+ * calls rather than values a unit test can read back.
+ */
+class StandDownIsAnnouncedTest {
+
+    private val nodeService = File("src/main/kotlin/com/vscodroid/service/NodeService.kt")
+
+    /**
+     * The STAND_DOWN arm, from its label to the `}` that closes it, over lines
+     * with the comments taken out. The prose inside this arm names both calls it
+     * is required to make, so a raw scan would find them in the explanation and
+     * pass over an arm that makes neither.
+     */
+    private fun standDownArm(): List<String> {
+        check(nodeService.isFile) {
+            "NodeService.kt not found at ${nodeService.absolutePath} -- this test would " +
+                "otherwise pass by looking at nothing"
+        }
+        val lines = nodeService.readLines().filterNot { line ->
+            val t = line.trimStart()
+            t.startsWith("//") || t.startsWith("*") || t.startsWith("/*")
+        }
+        val start = lines.indexOfFirst { it.contains("StartCommand.STAND_DOWN ->") }
+        assertTrue(start >= 0, "the STAND_DOWN arm is gone; this guard names it")
+        val arm = mutableListOf<String>()
+        var depth = 0
+        var entered = false
+        for (line in lines.drop(start)) {
+            depth += line.count { it == '{' } - line.count { it == '}' }
+            if (depth > 0) entered = true
+            arm += line
+            if (entered && depth <= 0) break
+        }
+        return arm
+    }
+
+    @Test
+    fun `a refused promotion records a terminal notice`() {
+        val arm = standDownArm()
+        assertTrue(
+            arm.any { it.contains("reportStartupNotice(") && it.contains("terminal = true") },
+            "standing down writes no terminal notice, so an activity that binds after it " +
+                "reads nothing, decides to wait, and leaves the user on the loading page " +
+                "with no control and no way back:\n" + arm.joinToString("\n"),
+        )
+    }
+
+    @Test
+    fun `a refused promotion tells a client that is already bound`() {
+        val arm = standDownArm()
+        assertTrue(
+            arm.any { it.contains("onServerGaveUp") },
+            "standing down raises no callback, so a client already bound is never told. " +
+                "The notice alone does not cover it: lastStartupNotice is read inside " +
+                "setupServiceCallbacks, which runs once per bind, and the retry path " +
+                "starts the service again without rebinding:\n" + arm.joinToString("\n"),
         )
     }
 }

--- a/android/app/src/test/kotlin/com/vscodroid/service/ProcessManagerTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/service/ProcessManagerTest.kt
@@ -2367,6 +2367,54 @@ class AdoptionTest {
     }
 
     @Test
+    fun `a stop that lands while the port is being adopted ends the server instead`() {
+        // The counterpart of `a stop that lands while the server is spawning takes
+        // the process with it`, on the branch that has no Process for the stop to
+        // find, and the interleaving is not an exotic one. With the activity gone
+        // nothing is bound, so the service keeps serving; the server crashes,
+        // NodeService restarts it on Dispatchers.IO, an orphan of the previous run
+        // still holds the port, and the start parks inside the adoption round trip
+        // for a second of connect plus a second of read while the notification's
+        // Stop action runs stopServer() on the main thread.
+        //
+        // That stop reads `adopted` as false for the whole of the window, so it
+        // reaps nothing and returns; the branch then cleared isShuttingDown and
+        // marked the server adopted milliseconds later, undoing the stop after
+        // stopSelf() had already been called. What the user was left with is the
+        // state adoption exists to end: an untracked editor server holding the port,
+        // and the adoption watch polling it for the life of the process.
+        //
+        // Fired from the serving thread, between the request being read and the
+        // answer being written, so the stop is inside the round trip by
+        // construction rather than by timing.
+        val killed = mutableListOf<Int>()
+        manager.killRecordedProcess = { killed += it }
+        val holder = serving(200)
+        recordEditorServer(pid = 4242, port = holder.port)
+        holder.beforeAnswer = { manager.stopServer() }
+
+        assertFalse(
+            manager.startServer(),
+            "a start that adopted into a stop reported success, so the caller is told " +
+                "the stop left it a server to serve",
+        )
+        assertFalse(
+            manager.isAdopted(),
+            "a stop must not be undone by the adoption it landed inside",
+        )
+        assertTrue(
+            manager.isShuttingDownField,
+            "clearing the flag the stop set makes the next exit read as a clean one, " +
+                "so nothing recovers from it",
+        )
+        assertEquals(
+            listOf(4242), killed,
+            "the stop asked for the server to be gone, and the orphan it could not see " +
+                "is the only thing left holding the port",
+        )
+    }
+
+    @Test
     fun `the first start in a process adopts the server still holding the remembered port`() {
         // The launch adoption exists for, and the one it could not reach. Every
         // case above puts the port into the field by hand, which is what a RESTART

--- a/android/app/src/test/kotlin/com/vscodroid/setup/BundledManifestReconcileTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/BundledManifestReconcileTest.kt
@@ -31,6 +31,9 @@ class BundledManifestReconcileTest {
     private val safBridge = "vscodroid.vscodroid-saf-bridge"
     private val serveNetwork = "vscodroid.vscodroid-serve-network"
 
+    /** A marketplace extension this app bundles, which the user may remove for good. */
+    private val python = "ms-python.python"
+
     @Test
     fun `an extension bundled for the first time is listed`() {
         val add = bundledIdsToRelist(
@@ -43,16 +46,65 @@ class BundledManifestReconcileTest {
             "an identifier this app has never bundled cannot have been uninstalled")
     }
 
+    /**
+     * The rule's real subject: a marketplace extension this app happens to bundle.
+     * Removing one is an ordinary preference, and bringing it back on every update
+     * would override that choice for ever.
+     */
     @Test
-    fun `an extension the user uninstalled stays uninstalled`() {
+    fun `a fetched extension the user uninstalled stays uninstalled`() {
+        val add = bundledIdsToRelist(
+            bundledIds = listOf(welcome, python),
+            keptIds = setOf(welcome),
+            droppedIds = emptySet(),
+            previouslyBundledIds = setOf(welcome, python),
+        )
+        assertTrue(add.isEmpty(),
+            "the Python extension was bundled before and has no entry, so the user " +
+                "removed it and it must not come back on every update")
+    }
+
+    /**
+     * VSCodroid's own extensions are not a removable preference. They carry the
+     * device folder picker, the toolchain screen and the editor defaults the app
+     * contributes, so a removed one takes those with it and nothing inside the
+     * editor can put it back.
+     *
+     * Releases before `isBuiltin` was written let the editor offer Uninstall, and
+     * `isBuiltin` only refuses the next one; it cannot relist a copy already gone.
+     * Meanwhile `bundledDirsToExtract` exempts this same prefix, so the directory
+     * returned on every update and sat there unlisted and unloaded. The visible
+     * cost is the editor defaults: the pass that removes the app's old overrides
+     * commits once and for all, while the contributed defaults meant to replace
+     * them never load, so word wrap, the minimap and the sash size all revert with
+     * no route back short of clearing app data.
+     */
+    @Test
+    fun `one of this app's own extensions is relisted even after it was removed`() {
         val add = bundledIdsToRelist(
             bundledIds = listOf(welcome, safBridge),
-            keptIds = setOf(welcome),
+            keptIds = emptySet(),
             droppedIds = emptySet(),
             previouslyBundledIds = setOf(welcome, safBridge),
         )
+        assertEquals(listOf(welcome, safBridge), add,
+            "an extension of this app's own, removed under an older release, was left " +
+                "unlisted, so its contributed defaults never load and the screens it " +
+                "carries stay unreachable")
+    }
+
+    /** Even ours does not gain a second entry while it still has a live one. */
+    @Test
+    fun `one of this app's own extensions is not duplicated over a live entry`() {
+        val add = bundledIdsToRelist(
+            bundledIds = listOf(welcome),
+            keptIds = setOf(welcome),
+            droppedIds = emptySet(),
+            previouslyBundledIds = setOf(welcome),
+        )
         assertTrue(add.isEmpty(),
-            "saf-bridge was bundled before and has no entry, so the user removed it")
+            "keptIds must still win for this app's own extensions, or a user's own " +
+                "newer install of the same id is shadowed by the bundled copy")
     }
 
     @Test

--- a/android/app/src/test/kotlin/com/vscodroid/setup/LaunchPassWaitTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/LaunchPassWaitTest.kt
@@ -35,6 +35,21 @@ class LaunchPassWaitTest {
     private companion object {
         /** The pass being started, at statement position rather than quoted. */
         val STARTS_PASS = Regex("""\n\s+\w+\.repairInstalledToolchains\(\)""")
+
+        /**
+         * A case's own declaration, at whatever depth it was written.
+         *
+         * Any indentation rather than the four spaces of a case sitting directly
+         * in its class: a case inside a `@Nested` class is written at eight and
+         * was never looked at, so it could start the pass without waiting and
+         * this file would say nothing. Every case that starts the pass today is
+         * written at four, which is why nothing here noticed.
+         *
+         * Widening it costs nothing downstream because the match is trimmed
+         * before [SourceScan.body] is handed it, and that lookup is by text
+         * rather than by offset, so the indentation dropped is not wanted again.
+         */
+        val DECLARES_CASE = Regex("""\n\s+(?:\w+ )*fun [`\w][^\n(]*\(""")
     }
 
     @Test
@@ -49,7 +64,7 @@ class LaunchPassWaitTest {
             .flatMap { file ->
                 val source = SourceScan.withoutComments(SourceScan.read(file.path))
                 if (!STARTS_PASS.containsMatchIn(source)) return@flatMap emptySequence()
-                Regex("""\n    (?:\w+ )*fun [`\w][^\n(]*\(""")
+                DECLARES_CASE
                     .findAll(source)
                     .map { it.value.trim() }
                     .distinct()
@@ -73,6 +88,46 @@ class LaunchPassWaitTest {
                     "writing into the @TempDir after the case returns, and JUnit's deletion " +
                     "of that directory then fails the whole task"
             }
+        }
+    }
+
+    // --- The scan itself, driven against a source whose answer is known. -----
+    //
+    // The case above derives its list from the suite, and every case in the
+    // suite that starts the pass is written directly in its class today. A scan
+    // that reads only that depth passes it while looking at one shape less than
+    // it claims, and goes on passing until someone puts a `@Nested` class around
+    // the next one, which is when the guard is wanted rather than before.
+    //
+    // Assembled from lines rather than written as a raw string, so the call it
+    // holds never begins a line of this file. [STARTS_PASS] reads a call at
+    // statement position and has no reason to care that it is inside a literal,
+    // which is the same trap the docstring names `LaunchRepairWiringTest` for:
+    // written the other way, this file becomes a case that starts the pass and
+    // never waits for it.
+    private val nestedCase = listOf(
+        "class Outer {",
+        "    @Nested",
+        "    inner class Inner {",
+        "        @Test",
+        "        fun `repairs on launch`() {",
+        "            manager.repairInstalledToolchains()",
+        "        }",
+        "    }",
+        "}",
+    ).joinToString("\n")
+
+    @Test
+    fun `a case inside a nested class is read as a case that starts the pass`() {
+        val found = DECLARES_CASE.findAll(nestedCase)
+            .map { it.value.trim() }
+            .filter { STARTS_PASS.containsMatchIn(SourceScan.body(nestedCase, it)) }
+            .toList()
+
+        assertTrue(found.isNotEmpty()) {
+            "a case written inside a @Nested class is not seen by the declaration scan, " +
+                "so it can start the launch pass without ever being asked whether it waits " +
+                "for the whole of it"
         }
     }
 }

--- a/android/app/src/test/kotlin/com/vscodroid/setup/SettingsPathsTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/SettingsPathsTest.kt
@@ -207,18 +207,30 @@ class SettingsPathsTest {
             // binary. Every other document here gives bash a path of its own, so
             // the lazy span stops before the fence ever matters -- measured: with
             // one profile, widening the fence left all 24 cases green.
-            val result = refreshManagedPaths(before, shell, git, wrapper)
+            //
+            // Null is "nothing needed changing", which is what a correct fence
+            // answers for this document: every managed value in it is already
+            // current, and bash has no path to move. So the document the user is
+            // left with is the one that went in, and reading it that way is what
+            // makes the two assertions below run at all. Guarded by `if (result
+            // != null)` they were skipped in the only state the code is in when
+            // it is right, and the case reduced to whether the call throws.
+            val result = refreshManagedPaths(before, shell, git, wrapper) ?: before
 
-            if (result != null) {
-                assertTrue(
-                    result.contains(""""path": "$zsh""""),
-                    "the zsh profile's path was rewritten:\n$result",
-                )
-                assertTrue(
-                    !result.contains(""""zsh": {\n        "path": "$shell""""),
-                    "bash's binary was written into the zsh profile:\n$result",
-                )
-            }
+            assertTrue(
+                result.contains(""""path": "$zsh""""),
+                "the zsh profile's path was rewritten:\n$result",
+            )
+            // Asked as a shape rather than as a literal. This was written as one
+            // raw string spanning the two lines, `"zsh": {` and its `"path"`,
+            // with the break between them spelled `\n`; a raw string has no
+            // escapes, so it searched for a backslash followed by an `n` and the
+            // assertion could not fail whatever the rewrite had done.
+            assertTrue(
+                !Regex(""""zsh"\s*:\s*\{[^}]*"path"\s*:\s*"${Regex.escape(shell)}"""")
+                    .containsMatchIn(result),
+                "bash's binary was written into the zsh profile:\n$result",
+            )
         }
 
         // bash has a stale path but no args, so the path rewrite fires -- which

--- a/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainInstallTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainInstallTest.kt
@@ -4,8 +4,11 @@ import android.content.Context
 import android.content.pm.InstallSourceInfo
 import android.content.pm.PackageManager
 import android.os.StatFs
+import com.google.android.gms.tasks.OnFailureListener
+import com.google.android.gms.tasks.Task
 import com.google.android.play.core.assetpacks.AssetPackManager
 import com.google.android.play.core.assetpacks.AssetPackManagerFactory
+import com.google.android.play.core.assetpacks.AssetPackStates
 import com.google.android.play.core.assetpacks.model.AssetPackStatus
 import com.vscodroid.util.Logger
 import io.mockk.Runs
@@ -171,6 +174,37 @@ class ToolchainInstallTest {
         // The HTTP branch reports PENDING synchronously, before it queues anything,
         // so an empty list here is what distinguishes the two routes.
         assertEquals(emptyList<Int>(), statuses(), "the HTTP branch ran on a Play install")
+    }
+
+    /**
+     * A fetch Play refuses outright delivers no `AssetPackState` at all, so the
+     * state listener never runs for this pack. The Task was the only place that
+     * refusal was ever reported, and it was discarded: the card sat on its last
+     * status for the rest of the session, every pack queued behind it was never
+     * requested, and nothing reached the log.
+     *
+     * NEGATIVE CONTROL: drop the `addOnFailureListener` from the fetch in
+     * `ToolchainManager.install` and this fails with an empty status list.
+     */
+    @Test
+    fun `a fetch Play refuses is reported instead of leaving the queue stalled`() {
+        installedBy("com.android.vending")
+        val refusal = IllegalStateException("Play refused this fetch")
+        every { packManager.fetch(listOf("toolchain_java")) } returns mockk(relaxed = true) {
+            every { addOnFailureListener(any<OnFailureListener>()) } answers {
+                firstArg<OnFailureListener>().onFailure(refusal)
+                self as Task<AssetPackStates>
+            }
+        }
+
+        manager().install("toolchain_java")
+
+        assertEquals(
+            listOf(AssetPackStatus.FAILED),
+            statuses(),
+            "a fetch Play refused was never reported, so the toolchain screen keeps " +
+                "its last status and the queue behind it never moves",
+        )
     }
 
     /**

--- a/android/app/src/test/kotlin/com/vscodroid/setup/UserCaBundleTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/UserCaBundleTest.kt
@@ -24,29 +24,40 @@ import java.security.cert.X509Certificate
 import java.util.Base64
 
 /**
- * Pins what [FirstRunSetup.setupGitCaBundle] puts in git's certificate bundle,
- * and, more sharply, when it agrees to look again.
+ * Pins what [FirstRunSetup.setupGitCaBundle] puts in the terminal's certificate
+ * bundle, and, more sharply, when it agrees to look again.
  *
- * The bundle used to be system roots only, rebuilt whenever the system store's
- * directory was newer than the file. Folding in the CAs the device owner
- * installed for themselves breaks that test, because installing a CA through
- * Settings writes into a store of its own and leaves the system directory's
- * mtime exactly where it was. So the launch after an install is precisely a
- * launch on which the cheap check says "fresh" and the answer is wrong, and a
- * naive implementation builds the right bundle once and then never again. That
- * failure is silent in both directions -- the user sees the app ignore a
- * certificate they installed, and nothing anywhere says why -- which is what
- * `installing a CA rebuilds a bundle the mtime check calls fresh` exists to
- * catch.
+ * The bundle is the device's own trust store, not a copy of the certificate
+ * directory underneath it, and those are two different answers. A root the
+ * device owner turned off in Settings > Trusted credentials leaves the
+ * platform's merged store, so every other app on the phone stops trusting it,
+ * and its file stays in the certificate directory exactly where it was. A bundle
+ * concatenated from that directory therefore went on trusting a root the owner
+ * had distrusted. It used to matter only for git; SSL_CERT_FILE and
+ * REQUESTS_CA_BUNDLE now put the same file in front of python, pip and curl.
  *
- * The whole method had no unit test before this, so the system half is pinned
- * here too: without it the new cases would be measuring one unmeasured thing
- * against another.
+ * So where the store answers, it is the whole bundle and the certificate
+ * directory is not read at all, which is what `a root the store stops answering
+ * with leaves the bundle` measures. Where the store answers with nothing (a
+ * provider that threw, a device that has none) the directory is concatenated as
+ * before, because a bundle that honours a removal is worth less than a bundle
+ * that exists: this runs inside SplashActivity's per-launch repair block, and
+ * what it writes is the file every HTTPS client in the terminal reads.
  *
- * Certificates are supplied through the [FirstRunSetup.userTrustedCertificates]
+ * Freshness is two conditions and neither is redundant. The certificate
+ * directory's mtime is the cheap one, and it is blind to both halves of what
+ * this measures: installing a CA through Settings and turning a root off both
+ * write into a store of their own and leave that mtime where it was. The
+ * fingerprint over the whole store is the condition that notices, and without it
+ * the right bundle is built on some early launch and then never again. That
+ * failure is silent in both directions: the user sees the terminal ignore a
+ * certificate they installed, or go on trusting one they removed, and nothing
+ * anywhere says why.
+ *
+ * Certificates are supplied through the [FirstRunSetup.deviceTrustedCertificates]
  * seam. `AndroidCAStore` does not exist on a JVM, so there is no version of
  * these tests that reaches the real provider; what the seam's own body does is
- * measured on device instead, through the user-CA count this method logs.
+ * measured on device instead, through the certificate count this method logs.
  */
 class UserCaBundleTest {
 
@@ -61,6 +72,17 @@ class UserCaBundleTest {
 
     /** A file of the shape Android's trust store holds: PEM, one root per file. */
     private val systemPem = "-----BEGIN CERTIFICATE-----\nc3lzdGVtcm9vdA==\n-----END CERTIFICATE-----\n"
+
+    /**
+     * The same root as [systemPem], in the form the store answers with.
+     *
+     * The encoder base64s a certificate's bytes, so one whose encoding is the
+     * ASCII of "systemroot" comes out carrying the body [systemPem] carries.
+     * That is what lets a case have the store answer with a root whose file is
+     * sitting in the certificate directory at the same time, which is the
+     * arrangement the whole change turns on.
+     */
+    private val systemRoot = certificateOf("systemroot".toByteArray())
 
     @BeforeEach
     fun setUp() {
@@ -80,22 +102,29 @@ class UserCaBundleTest {
     @AfterEach
     fun tearDown() = unmockkObject(Logger)
 
-    /** [FirstRunSetup] wired to the fixture store, with [certs] as the user half. */
+    /** [FirstRunSetup] wired to the fixture directory, with [certs] as the store. */
     private fun setupWith(certs: () -> List<Certificate>): FirstRunSetup =
         FirstRunSetup(context).apply {
             systemCaCertificateDirs = listOf(systemCaDir.path)
-            userTrustedCertificates = certs
+            deviceTrustedCertificates = certs
         }
 
+    /**
+     * The store answers with the root every device has, plus [certs].
+     *
+     * The merged store holds both halves, so a case that supplied only its own
+     * certificates would be measuring a device that trusts nothing else, which
+     * is not a device.
+     */
     private fun buildWith(vararg certs: Certificate) =
-        setupWith { certs.toList() }.setupGitCaBundle()
+        setupWith { listOf(systemRoot) + certs }.setupGitCaBundle()
 
     /**
      * Makes the cheap freshness test say "fresh".
      *
-     * This is the state every launch after the first is in, and the state an
-     * install through Settings does not disturb, so it is the state the user-CA
-     * cases have to start from to be measuring anything.
+     * This is the state every launch after the first is in, and the state
+     * neither installing a CA nor turning a root off disturbs, so it is the
+     * state the store cases have to start from to be measuring anything.
      */
     private fun makeMtimeLookFresh() {
         assertTrue(bundle.isFile, "no bundle to age; the harness is wrong")
@@ -105,23 +134,67 @@ class UserCaBundleTest {
 
     private fun bundleText() = bundle.readText()
 
-    // -- the system half, which had no test at all before this --
+    /** How many times [body] occurs in the bundle. */
+    private fun countIn(body: String) = bundleText().split(body).size - 1
+
+    // -- the merged store is the bundle --
 
     @Test
-    fun `the bundle carries every file in the system store`() {
-        File(systemCaDir, "e5f6a7b8.0").writeText("-----BEGIN CERTIFICATE-----\nc2Vjb25k\n-----END CERTIFICATE-----\n")
+    fun `every certificate the store answers with reaches the bundle, exactly once`() {
+        // Exactly once rather than merely present, and that is the whole point of
+        // counting: the certificate directory holds the same root under
+        // a1b2c3d4.0, so a bundle that concatenated the directory as well as the
+        // store would contain every body asserted here and still be wrong.
+        buildWith(certificateOf(byteArrayOf(1, 2, 3, 4)), certificateOf(byteArrayOf(5, 6)))
 
-        buildWith()
+        assertEquals(
+            1,
+            countIn("c3lzdGVtcm9vdA=="),
+            "the system root the store answered with is missing from the bundle, or in it " +
+                "twice because the certificate directory was copied in as well",
+        )
+        assertEquals(1, countIn("AQIDBA=="), "a certificate the store answered with is not in the bundle")
+        assertEquals(1, countIn("BQY="), "a certificate the store answered with is not in the bundle")
+    }
 
-        assertTrue(systemPem in bundleText(), "the first system root is missing from the bundle")
-        assertTrue("c2Vjb25k" in bundleText(), "the second system root is missing from the bundle")
+    /**
+     * The case the change exists for.
+     *
+     * Turning a root off in Settings > Trusted credentials drops it from the
+     * platform's store and leaves its file in the certificate directory, so a
+     * bundle built by copying that directory keeps trusting a root its owner
+     * distrusted and every other app on the phone has already dropped. The mtime
+     * is made to look fresh first because that is the honest arrangement: a
+     * removal does not move it, so the fingerprint over the whole store is the
+     * only thing that can notice.
+     */
+    @Test
+    fun `a root the store stops answering with leaves the bundle`() {
+        val stillTrusted = certificateOf(byteArrayOf(4, 4, 4))
+        buildWith(stillTrusted)
+        makeMtimeLookFresh()
+        assertTrue(
+            File(systemCaDir, "a1b2c3d4.0").isFile,
+            "the removed root's file is gone from the certificate directory; the harness is wrong",
+        )
+
+        setupWith { listOf(stillTrusted) }.setupGitCaBundle()
+
+        assertFalse(
+            "c3lzdGVtcm9vdA==" in bundleText(),
+            "a root the owner turned off is still trusted by everything this bundle feeds, " +
+                "which is git, python, pip and curl. Its file is still in the certificate " +
+                "directory and only the store knows it was distrusted, so a bundle built from " +
+                "that directory cannot honour the removal",
+        )
+        assertTrue("BAQE" in bundleText(), "the rebuild dropped the roots that are still trusted")
     }
 
     @Test
     fun `an unchanged store is not rebuilt`() {
         // The control for every "was rebuilt" assertion below. Without it they
         // would all also hold for a method that rebuilt unconditionally, which
-        // would put a 143-file concatenation on the main thread of every launch.
+        // would rewrite the whole bundle on the main thread of every launch.
         buildWith()
         makeMtimeLookFresh()
         bundle.writeText("sentinel")
@@ -132,8 +205,9 @@ class UserCaBundleTest {
     }
 
     @Test
-    fun `a store that grew a certificate is rebuilt`() {
-        // The other half of that control: the mtime test still has to work.
+    fun `a certificate directory newer than the bundle forces a rebuild`() {
+        // The other half of that control: the mtime test still has to work. It is
+        // the only signal a system update moving the roots underneath us gives.
         buildWith()
         bundle.writeText("sentinel")
         assertTrue(bundle.setLastModified(1_000_000_000_000L), "could not age the bundle")
@@ -144,31 +218,15 @@ class UserCaBundleTest {
         assertTrue(systemPem in bundleText(), "a store newer than the bundle did not force a rebuild")
     }
 
-    // -- the user half --
-
-    @Test
-    fun `a user CA reaches the bundle, after the system roots`() {
-        buildWith(certificateOf(byteArrayOf(1, 2, 3, 4)))
-
-        val text = bundleText()
-        assertTrue(systemPem in text, "the system roots were dropped when a user CA was folded in")
-        assertTrue("AQIDBA==" in text, "the user CA is not in the bundle git reads")
-        assertTrue(
-            text.indexOf(systemPem) < text.indexOf("AQIDBA=="),
-            "the user CA was written before the system roots; the bundle is a concatenation " +
-                "and appending is what keeps the system half byte-identical to the store",
-        )
-    }
-
     /**
-     * The case the whole change turns on.
+     * The other direction of the same blindness.
      *
      * A CA installed through Settings does not touch the mtime of the system
-     * certificate directory, so the check that guarded this method before sees
-     * a bundle newer than the store and returns. Anything that reads only that
-     * clause builds the right bundle on some earlier launch and then ignores
-     * every certificate the owner installs afterwards, for the life of the
-     * install, with nothing on screen or in the log to say so.
+     * certificate directory, so the check that guarded this method before sees a
+     * bundle newer than the store and returns. Anything reading only that clause
+     * builds the right bundle on some earlier launch and then ignores every
+     * certificate the owner installs afterwards, for the life of the install,
+     * with nothing on screen or in the log to say so.
      */
     @Test
     fun `installing a CA rebuilds a bundle the mtime check calls fresh`() {
@@ -196,7 +254,7 @@ class UserCaBundleTest {
             "a CA the owner removed is still trusted by git; the bundle is rewritten rather " +
                 "than appended to, and the fingerprint has to notice a shrinking store too",
         )
-        assertTrue(systemPem in bundleText(), "the rebuild lost the system roots")
+        assertTrue(systemPem in bundleText(), "the rebuild lost the rest of the store")
     }
 
     /**
@@ -248,7 +306,7 @@ class UserCaBundleTest {
         buildWith(certificateOf(byteArrayOf(7, 7, 7)), certificateOf(null))
 
         assertTrue("BwcH" in bundleText(), "a readable certificate was dropped along with a broken one")
-        assertTrue(systemPem in bundleText(), "the system roots were dropped over one broken certificate")
+        assertTrue(systemPem in bundleText(), "the rest of the store was dropped over one broken certificate")
     }
 
     /**
@@ -256,16 +314,51 @@ class UserCaBundleTest {
      *
      * This runs from SplashActivity's per-launch repair block, ahead of the
      * symlink and settings repairs, so an exception escaping here costs work
-     * that matters more than this does. On a device where the provider is
-     * missing or refuses to load, the answer has to be the bundle as it was
-     * before any of this existed.
+     * that matters more than this does. And the bundle is now what git, python,
+     * pip and curl all read, so a device whose provider is missing or refuses to
+     * load has to end up with the bundle as it was before any of this existed:
+     * the certificate directory, concatenated, which cannot see a root the owner
+     * removed but does keep HTTPS working at all. That is the trade, and it is
+     * the right way round.
+     *
+     * Both ways of answering with nothing, because they arrive by different
+     * doors: a provider that throws is caught inside the seam's caller, and an
+     * empty list is a store that loaded and held nothing usable. Only the first
+     * of the two was measured before.
      */
     @Test
-    fun `a trust store that cannot be read leaves the system-only bundle`() {
-        setupWith { throw java.security.KeyStoreException("no such provider") }.setupGitCaBundle()
+    fun `a store that answers with nothing falls back to the certificate directory`() {
+        // Two files, because the fallback has to carry the whole directory: this
+        // is the one path on which what the platform ships is copied through
+        // rather than encoded here, and a bundle holding some roots and not the
+        // rest fails against whichever hosts fall on the wrong side of the cut.
+        val secondPem = "-----BEGIN CERTIFICATE-----\nc2Vjb25k\n-----END CERTIFICATE-----\n"
+        File(systemCaDir, "e5f6a7b8.0").writeText(secondPem)
 
-        assertTrue(bundle.isFile, "the bundle was not written at all")
-        assertEquals(systemPem, bundleText(), "the bundle is not the system-only one")
+        fun assertFallsBack(how: String, store: () -> List<Certificate>) {
+            // Cleared first, or a later pass is answered by the freshness check
+            // rather than by the fallback: a store that answers with nothing
+            // fingerprints to the same hash whichever way it emptied, so a
+            // surviving bundle would satisfy the assertion without the method
+            // having built anything.
+            bundle.parentFile?.deleteRecursively()
+            assertFalse(bundle.exists(), "could not clear the bundle between passes; the harness is wrong")
+
+            setupWith(store).setupGitCaBundle()
+
+            assertTrue(bundle.isFile, "$how left no bundle at all")
+            assertEquals(
+                systemPem + secondPem,
+                bundleText(),
+                "$how left the terminal without the system roots, so HTTPS fails everywhere " +
+                    "the bundle is read: git, python, pip and curl",
+            )
+        }
+
+        assertFallsBack("a provider that cannot be loaded") {
+            throw java.security.KeyStoreException("no such provider")
+        }
+        assertFallsBack("a device with no such store") { emptyList() }
     }
 
     /**
@@ -319,22 +412,24 @@ class UserCaBundleTest {
     // -- the armour itself --
 
     /**
-     * The user half is the only part of the bundle this app encodes; the system
-     * files are copied through byte for byte. So the line wrapping, the header
-     * and footer and the trailing newline are this app's to get right, and the
-     * thing that decides whether it did is a certificate parser rather than a
-     * regular expression of ours. A real self-signed certificate goes in and has
-     * to come back out of the bundle.
+     * Every byte of the normal bundle is now encoded by this app rather than
+     * copied through from a file, so the line wrapping, the header and footer
+     * and the trailing newline are all this app's to get right. The thing that
+     * decides whether it did is a certificate parser rather than a regular
+     * expression of ours: a real self-signed certificate goes in and has to come
+     * back out of the bundle.
+     *
+     * The store answers with that certificate alone, so nothing here depends on
+     * where the sort puts it.
      */
     @Test
     fun `what the bundle carries parses back as the certificate that went in`() {
         val real = realCertificate()
 
-        buildWith(real)
+        setupWith { listOf(real) }.setupGitCaBundle()
 
-        val pem = bundleText().substringAfter(systemPem)
         val parsed = CertificateFactory.getInstance("X.509")
-            .generateCertificate(pem.byteInputStream()) as X509Certificate
+            .generateCertificate(bundleText().byteInputStream()) as X509Certificate
         assertEquals(
             (real as X509Certificate).subjectX500Principal,
             parsed.subjectX500Principal,
@@ -348,19 +443,18 @@ class UserCaBundleTest {
      * Java's certificate factory accepts an unbroken run of base64 quite
      * happily, so a parser is the wrong instrument for this one: measured, an
      * unwrapped encoder passes that test. What reads the bundle in production is
-     * a line-oriented C parser inside a libcurl this suite cannot reach, and
-     * every other entry in the file is a system root copied through byte for
-     * byte at 64 columns. The user half being the one stretch of the file with a
-     * different shape is a difference with no upside and one that costs an
-     * argument to avoid, so it is pinned rather than left to a reader to
-     * rediscover.
+     * a line-oriented C parser inside a libcurl this suite cannot reach, and the
+     * fallback path copies the platform's own root files through byte for byte
+     * at 64 columns. The bundle this app encodes having a different shape from
+     * the bundle it falls back to is a difference with no upside and one that
+     * costs an argument to avoid, so it is pinned rather than left to a reader
+     * to rediscover.
      */
     @Test
-    fun `the user half is wrapped like every other entry in the bundle`() {
-        buildWith(realCertificate())
+    fun `the bundle is wrapped like the root files it stands in for`() {
+        setupWith { listOf(realCertificate()) }.setupGitCaBundle()
 
-        val body = bundleText().substringAfter(systemPem)
-            .lines().filter { it.isNotBlank() && !it.startsWith("-----") }
+        val body = bundleText().lines().filter { it.isNotBlank() && !it.startsWith("-----") }
         assertTrue(body.size > 1, "the certificate was emitted as one unbroken run of base64")
         assertTrue(
             body.all { it.length <= 64 },
@@ -375,7 +469,8 @@ class UserCaBundleTest {
      * Only `getEncoded` is reached: [FirstRunSetup] turns each entry straight
      * into PEM and never asks a certificate anything else. Supplying the bytes
      * directly is what lets a re-issue be expressed as two certificates that
-     * differ in nothing a shortcut would compare.
+     * differ in nothing a shortcut would compare, and what lets a fixture
+     * certificate carry the same body as a file in the certificate directory.
      */
     private fun certificateOf(der: ByteArray?): Certificate = object : Certificate("X.509") {
         override fun getEncoded(): ByteArray =

--- a/android/app/src/test/kotlin/com/vscodroid/storage/SafUnfetchedDocumentTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/storage/SafUnfetchedDocumentTest.kt
@@ -162,13 +162,17 @@ class SafUnfetchedDocumentTest {
      * under it, with `root` as the tree's own. Every file reads as the same short
      * contents, and only ones under [SafSyncEngine.MAX_FILE_SIZE] are ever read.
      */
-    private fun deviceTree(tree: Map<String, List<Entry>>) {
+    private fun deviceTree(tree: Map<String, List<Entry>>, unenumerable: Set<String> = emptySet()) {
         every { DocumentsContract.buildChildDocumentsUriUsingTree(any(), any()) } answers {
             val parent = secondArg<String>()
             mockk<Uri>(relaxed = true).also { every { it.toString() } returns "children:$parent" }
         }
         every { resolver.query(any(), any(), any(), any(), any()) } answers {
             val parent = firstArg<Uri>().toString().removePrefix("children:")
+            // A parent the provider answers for and then will not list: a cloud or SMB
+            // provider momentarily offline, or an MTP bridge hiccup. The walk carries
+            // on from it, which is what leaves the directory in the mirror empty.
+            if (parent in unenumerable) throw IllegalStateException("cannot list $parent")
             cursorOver(tree[parent].orEmpty())
         }
         every { resolver.openInputStream(any()) } answers {
@@ -274,6 +278,38 @@ class SafUnfetchedDocumentTest {
 
         verify(exactly = 1) { DocumentsContract.deleteDocument(any(), uris.getValue("doc:docs")) }
         assertTrue(kept.isEmpty(), "a delete that went through was announced as kept: $kept")
+    }
+
+    /**
+     * The same loss as a skipped directory, with no name to recognise it by. The
+     * provider answered for `docs` itself and then refused to list what is under it,
+     * so the walk carried on and the mirror holds an empty `docs` while the device
+     * holds its documents. A skipped name is filtered out by [SafSyncEngine.shouldWriteBack]
+     * before the guard ever runs; this one has an ordinary name and reaches it, so the
+     * guard is the only thing standing between `rm -r docs` and the device's subtree.
+     */
+    @Test
+    fun `a directory whose enumeration failed is kept on the device`() {
+        val kept = mutableListOf<String>()
+        engine.onKeptOnDevice = { file, _ -> kept.add(file.name) }
+        deviceTree(
+            mapOf(
+                "root" to listOf(Entry("docs", isDirectory = true)),
+                "doc:docs" to listOf(Entry("notes.md")),
+            ),
+            unenumerable = setOf("doc:docs"),
+        )
+        runBlocking { engine.initialSync(treeUri, mirror) { _, _ -> } }
+
+        deleteDirectory("docs")
+
+        verify(exactly = 0) { DocumentsContract.deleteDocument(any(), any()) }
+        assertEquals(
+            listOf("docs"),
+            kept,
+            "a directory the sync could not read was deleted from the device, taking " +
+                "documents the mirror never held",
+        )
     }
 
     /** The unread document sits two levels down; the ancestor is still what holds it. */
@@ -567,6 +603,60 @@ class SafUnfetchedDocumentTest {
             DocumentsContract.deleteDocument(any(), uris.getValue("doc:notes.md"))
         }
         assertTrue(kept.isEmpty(), "notes.md was kept for a document named notes.md.bak: $kept")
+    }
+
+    /**
+     * The device folder was emptied from another app, so the enumeration comes back
+     * with nothing and [SafSyncEngine.reconcileDeletions] leaves the mirror standing.
+     * Deleting one of those entries in the editor resolves to no document, which is not
+     * a refusal: nothing on the device declined anything, and the notice's two clauses
+     * are both false. It would tell the user the file comes back on the next open, when
+     * the next enumeration is still empty, and send them to a file manager to delete a
+     * file that is not there.
+     */
+    @Test
+    fun `deleting a mirror entry the device never held is not announced as a refusal`() {
+        val refused = mutableListOf<String>()
+        engine.onDeleteRefused = { refused.add(it.name) }
+        deviceTree(mapOf("root" to emptyList()))
+        runBlocking { engine.initialSync(treeUri, mirror) { _, _ -> } }
+
+        File(mirror, "notes.md").writeText("only ever in the mirror")
+        deliver(FileObserver.DELETE, "notes.md")
+
+        assertTrue(
+            refused.isEmpty(),
+            "a deletion the device had nothing to refuse was reported as refused, with " +
+                "instructions to go and delete a file that is not there: $refused",
+        )
+    }
+
+    /**
+     * The control for the case above, and the guarantee it must not cost. A provider
+     * that cannot answer at all is not a provider that answered "gone": the document
+     * may well still be there, so the warning still has to be said.
+     */
+    @Test
+    fun `a delete is still announced when the device cannot say whether it holds the file`() {
+        val refused = mutableListOf<String>()
+        engine.onDeleteRefused = { refused.add(it.name) }
+        // Nothing is walked, so nothing is cached and the delete has to resolve the
+        // path live. The folder then stops answering, so the resolution comes back
+        // empty for a reason that is not absence.
+        deviceTree(mapOf("root" to emptyList()))
+        runBlocking { engine.initialSync(treeUri, mirror) { _, _ -> } }
+
+        File(mirror, "notes.md").writeText("saved in the editor")
+        every { resolver.query(any(), any(), any(), any(), any()) } throws
+            IllegalStateException("the provider stopped answering")
+        deliver(FileObserver.DELETE, "notes.md")
+
+        assertEquals(
+            listOf("notes.md"),
+            refused,
+            "a delete the device may still be holding went unannounced, so the file " +
+                "stays on the device with nothing on screen saying so",
+        )
     }
 
     /**

--- a/android/app/src/test/kotlin/com/vscodroid/util/EditorLocaleTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/util/EditorLocaleTest.kt
@@ -80,6 +80,17 @@ class EditorLocaleTest {
             "and the mirror case, which passed before only because the script arm " +
                 "happened to be tested first",
         )
+
+        // A tag is not always language plus region. Android puts a Regional
+        // preference on the default locale as a `-u-` Unicode extension, so these
+        // are what a phone whose owner set one actually reports, and reading the
+        // region as the LAST subtag saw "mon" and "hanidec" instead: Taiwan came
+        // up Simplified, workbench and extension manifests both.
+        assertEquals(
+            "zh-hant", resolve("zh-TW-u-fw-mon"),
+            "the region is the subtag after the language, not whatever trails the tag",
+        )
+        assertEquals("zh-hans", resolve("zh-CN-u-nu-hanidec"))
     }
 
     @Test

--- a/android/app/src/test/kotlin/com/vscodroid/webview/AppNavigationMarkTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/AppNavigationMarkTest.kt
@@ -1,0 +1,90 @@
+package com.vscodroid.webview
+
+import com.vscodroid.AppNavigationMark
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Which `beforeunload` this app is entitled to answer for the user.
+ *
+ * The callback is reached only when the workbench vetoed leaving, and it vetoes
+ * only while it holds an edit it has not written a backup of yet. So answering
+ * one that was not ours discards that edit silently, and the whole value of the
+ * mark is that it stops being true the moment it has done its job.
+ *
+ * The window used to be the only guard. A folder open, or a reload after five
+ * minutes in the background, marked and then left the answer armed for ten
+ * seconds; anything the workbench navigated itself to inside those ten seconds,
+ * a Close Folder or an Open Recent, was confirmed for the user over a veto that
+ * meant unsaved work.
+ */
+class AppNavigationMarkTest {
+
+    private val window = 10_000L
+
+    @Test
+    fun `a navigation this app marked is answered`() {
+        val mark = AppNavigationMark(window)
+        mark.mark(1_000)
+
+        assertTrue(
+            mark.consume(1_050),
+            "the app's own navigation was not recognised, so the user gets a browser " +
+                "modal over something they already chose",
+        )
+    }
+
+    @Test
+    fun `nothing is answered before anything is marked`() {
+        assertFalse(
+            AppNavigationMark(window).consume(0),
+            "an unmarked page-initiated unload was claimed as the app's own",
+        )
+    }
+
+    /**
+     * The case this class exists for. One mark, two unloads: the second is the
+     * page's own and must keep the dialog, however soon it arrives.
+     */
+    @Test
+    fun `a second unload inside the window is not answered`() {
+        val mark = AppNavigationMark(window)
+        mark.mark(1_000)
+
+        assertTrue(mark.consume(1_050), "the marked navigation was refused")
+        assertFalse(
+            mark.consume(1_100),
+            "a page-initiated unload arriving while the mark was still inside its " +
+                "window was confirmed for the user, which discards the unsaved work " +
+                "the workbench vetoed leaving for",
+        )
+    }
+
+    @Test
+    fun `a mark whose load never answered expires`() {
+        val mark = AppNavigationMark(window)
+        mark.mark(1_000)
+
+        assertFalse(
+            mark.consume(1_000 + window),
+            "a mark left by a navigation that never happened stayed armed past its " +
+                "window, so a page-initiated unload much later was answered for",
+        )
+    }
+
+    /** Each navigation gets its own answer; consuming one does not disarm the app. */
+    @Test
+    fun `marking again re-arms the answer`() {
+        val mark = AppNavigationMark(window)
+        mark.mark(1_000)
+        mark.consume(1_050)
+
+        mark.mark(2_000)
+
+        assertTrue(
+            mark.consume(2_050),
+            "the second navigation this app started was treated as the page's own",
+        )
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/webview/AuthCallbackSecretTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/AuthCallbackSecretTest.kt
@@ -1,0 +1,108 @@
+package com.vscodroid.webview
+
+import com.vscodroid.callbackNonce
+import com.vscodroid.callbackSecretMatches
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * What proves a sign-in callback came from the editor's own page.
+ *
+ * The `vscodroid://callback` filter is exported and BROWSABLE, so any app on the
+ * device and any page in any browser can fire it. Everything the gate checked
+ * before this is guessable from outside: the request id is a counter the
+ * workbench starts at one for each page, and the window around it is ten
+ * minutes. So a page that knew a sign-in was in flight could forge the callback,
+ * hand the signing-in extension an OAuth code of its choosing, and take the
+ * pending id with it so the user's own callback was dropped.
+ *
+ * `server.js` binds a fresh secret into `callback.html` on every start and
+ * records it in the app sandbox. The page is served from the server's origin, so
+ * no other origin can read it.
+ */
+class AuthCallbackSecretTest {
+
+    private val ours = "9f2c" + "a".repeat(60)
+
+    @Test
+    fun `a payload carrying the secret is accepted`() {
+        assertTrue(
+            callbackSecretMatches(ours, ours),
+            "the editor's own callback was refused, so a real sign-in never completes",
+        )
+    }
+
+    @Test
+    fun `a payload carrying no secret is refused`() {
+        assertFalse(
+            callbackSecretMatches(null, ours),
+            "a forged callback that simply omitted the secret was accepted",
+        )
+    }
+
+    @Test
+    fun `a payload carrying the wrong secret is refused`() {
+        assertFalse(
+            callbackSecretMatches("9f2c" + "b".repeat(60), ours),
+            "a guessed secret was accepted",
+        )
+    }
+
+    /**
+     * A prefix must not pass. A comparison that stopped at the shorter of the two
+     * would let a caller walk the secret out one character at a time.
+     */
+    @Test
+    fun `a payload carrying a prefix of the secret is refused`() {
+        assertFalse(
+            callbackSecretMatches(ours.take(8), ours),
+            "a prefix of the secret was accepted, so the secret can be guessed a " +
+                "character at a time",
+        )
+    }
+
+    /**
+     * The file lives inside the app sandbox, so its absence means this app's own
+     * binding did not happen, never that a caller withheld anything. Refusing here
+     * would take sign-in away entirely from a build whose page could not be
+     * rewritten, which is a worse outcome than the matching that shipped before.
+     */
+    @Test
+    fun `no recorded secret falls back to the older matching`() {
+        assertTrue(
+            callbackSecretMatches(null, null),
+            "a run where the server bound no secret refused every sign-in",
+        )
+        assertTrue(
+            callbackSecretMatches(null, ""),
+            "an empty secret file refused every sign-in",
+        )
+    }
+
+    @Test
+    fun `the secret is read out of the payload the page builds`() {
+        assertEquals(
+            ours,
+            callbackNonce("""{"id":"1","uri":{"scheme":"vscodroid"},"nonce":"$ours"}"""),
+        )
+    }
+
+    @Test
+    fun `a payload that is not readable carries no secret`() {
+        assertNull(callbackNonce(null), "a missing payload produced a secret")
+        assertNull(callbackNonce(""), "an empty payload produced a secret")
+        assertNull(callbackNonce("not json at all"), "unparseable text produced a secret")
+        assertNull(
+            callbackNonce("""{"id":"1"}"""),
+            "a payload with no nonce produced one, which is the shape every forged " +
+                "callback written before this check has",
+        )
+        assertNull(
+            callbackNonce("""{"id":"1","nonce":{"not":"a string"}}"""),
+            "a non-string nonce was read as a secret",
+        )
+    }
+}

--- a/android/app/src/test/kotlin/com/vscodroid/webview/SafFolderLogCallSiteTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/webview/SafFolderLogCallSiteTest.kt
@@ -50,8 +50,20 @@ class SafFolderLogCallSiteTest {
 
     private val source = SourceScan.read("src/main/kotlin/com/vscodroid/MainActivity.kt")
 
+    /**
+     * `openSafFolder` from its signature line, not from its opening brace.
+     *
+     * [SourceScan.body] starts at the brace, and the `uri: Uri` that makes a tree
+     * URI a source to `LogTaint` is written in the signature above it. Handed the
+     * body alone the reader has nothing to seed from, taints no name, and answers
+     * empty to every question, which is indistinguishable from a body that logs
+     * nothing.
+     */
     private val opened by lazy {
-        SourceScan.withoutComments(SourceScan.body(source, "private fun openSafFolder("))
+        val declaration = "private fun openSafFolder("
+        val body = SourceScan.body(source, declaration)
+        val start = source.indexOf(declaration)
+        SourceScan.withoutComments(source.substring(start, source.indexOf('{', start)) + body)
     }
 
     @Test
@@ -86,11 +98,13 @@ class SafFolderLogCallSiteTest {
         // through `reducedLogs` ties this control to the same machinery, so the
         // two fail together or not at all.
         //
-        // File-scoped, not body-scoped, because that is the scope the reader
-        // works in. MainActivity has exactly one reduced log statement today, the
-        // one at the top of openSafFolder, and `the body being checked was
+        // Scoped to the body this is about, and that scope is the whole of the
+        // control. Read off the file, it cannot fail for the deletion it names:
+        // MainActivity has a second reduced statement, the `urlLogLabel(url)`
+        // line in navigateToFolder, so the file goes on answering yes with the
+        // statement at the top of openSafFolder gone. `the body being checked was
         // actually found` is what still says openSafFolder is the right site.
-        val reduced = LogTaint.reducedLogs(source.lines())
+        val reduced = LogTaint.reducedLogs(opened.lines())
 
         assertTrue(reduced.isNotEmpty()) {
             "nothing in openSafFolder says which folder is being opened, so a bug report " +
@@ -98,8 +112,7 @@ class SafFolderLogCallSiteTest {
                 "folder by the digest the rest of the app already calls it by, not " +
                 "deleting the statement. Found:\n" +
                 opened.lines().filter { it.contains("Logger.") }
-                    .joinToString("\n") { "  ${it.trim()}" } +
-                "\nReduced statements in the whole file: " + reduced
+                    .joinToString("\n") { "  ${it.trim()}" }
         }
     }
 

--- a/docs/04-TECHNICAL_SPEC.md
+++ b/docs/04-TECHNICAL_SPEC.md
@@ -645,6 +645,7 @@ flowchart TD
   P --> P15["0015 menubar: stay open when only the keyboard resized"]
   P --> P16["0016 sidebar: sash travel on narrow viewports"]
   P --> P17["0017 menus: ignore a pan that started in a submenu"]
+  P --> P18["0018 debug terminal: build the command without /usr/bin/env"]
 ```
 
 Five of these are load-bearing in ways their titles understate:

--- a/docs/09-DEVELOPMENT_GUIDE.md
+++ b/docs/09-DEVELOPMENT_GUIDE.md
@@ -15,7 +15,7 @@ of that is how this repository works. There is no submodule and no `.gitmodules`
 `develop` branch, no `scripts/download-vscode-server.sh`, no `server/lib/`, and no script
 under `scripts/` or workflow under `.github/` invokes yarn. The server is built from MIT
 Code - OSS source by `.github/workflows/build-vscode-oss.yml` with the unified diffs in
-`patches/` applied by `git apply` (seventeen today, and the script globs the directory rather
+`patches/` applied by `git apply` (eighteen today, and the script globs the directory rather
 than carrying a list), and app builds fetch the result with `scripts/fetch-vscode-oss.sh`.
 The week-by-week schedule in
 [`12-IMPLEMENTATION_PLAN.md`](./12-IMPLEMENTATION_PLAN.md) still describes that older build,

--- a/docs/PRIVACY_POLICY.md
+++ b/docs/PRIVACY_POLICY.md
@@ -1,7 +1,7 @@
 # VSCodroid Privacy Policy
 
 **Effective Date: February 13, 2026**
-**Last Updated: August 24, 2026**
+**Last Updated: September 6, 2026**
 
 ## Summary
 
@@ -99,7 +99,7 @@ The VS Code editor UI communicates with the local server process over `localhost
 
 ## Android Backup (On by Default)
 
-VSCodroid allows Android's own backup service, so **one directory does leave the device** if you have backup enabled in your Android settings: `~/.vscodroid/data/Machine`, which holds the editor defaults VSCodroid writes for you. Settings and keybindings you change yourself are stored by the editor inside the WebView and are not in the backup. Android uploads it to your Google account, not to us. We never see it.
+VSCodroid allows Android's own backup service, so **one directory does leave the device** if you have backup enabled in your Android settings: `~/.vscodroid/data/Machine`, which holds this device's machine-scoped editor settings (`settings.json`). That file is both what VSCodroid writes there for the device and anything you change yourself on the **Remote** tab of the editor's Settings, and all of it is in the backup. Settings and keybindings you change on the **User** tab are stored by the editor inside the WebView and are not. Android uploads the backup to your Google account, not to us. We never see it.
 
 This is written as an allowlist, so everything not named above is excluded rather than the other way round. In particular these are **not** backed up:
 

--- a/scripts/check-patch-fingerprints.py
+++ b/scripts/check-patch-fingerprints.py
@@ -133,10 +133,19 @@ def introduced_by(pattern, patch_path):
     sufficient -- the same text could coincidentally exist elsewhere in the tree --
     so it catches the mistake actually made (picking a pattern from surrounding
     code) rather than proving the pattern unique.
+
+    The scan reads the diff, not the file. A prose header that quotes the line it
+    is explaining, which is the ordinary way to explain one, puts that line above
+    the diff still carrying its leading `+`, and reading the whole file let it
+    answer for the patch: the fingerprint would then be proven against text git
+    apply never looks at, which is the one thing this exists to refuse. A patch
+    carrying no diff at all is already refused by patch_hashes, and by this
+    returning False for every non-empty pattern, so the empty fallback cannot
+    turn a broken split into a pass.
     """
     added = "".join(
         line[1:]
-        for line in patch_path.read_text(errors="ignore").splitlines()
+        for line in (diff_body(patch_path) or "").splitlines()
         if line.startswith("+") and not line.startswith("+++")
     )
     return squashed(pattern) in squashed(added)
@@ -394,6 +403,31 @@ def self_test():
     with tempfile.TemporaryDirectory() as tmp:
         tree = pathlib.Path(tmp) / "tree"
         tree.mkdir()
+
+        # A header that quotes the line its diff adds, which is how a header
+        # explains what a patch does. The quoted line starts with `+` and is in
+        # no hunk, so a scan reading the whole patch file accepts it as
+        # introduced and the fingerprint ends up proven against text git apply
+        # never reads. The second call is the negative control: a scan that had
+        # stopped finding anything at all would satisfy the first one alone.
+        quoting = pathlib.Path(tmp) / "0000-header-quotes-its-own-diff.patch"
+        quoting.write_text(
+            "Subject: [PATCH] self-test\n\n"
+            "The line it adds is:\n\n"
+            "+only-in-the-prose\n\n"
+            "diff --git a/self-test b/self-test\n"
+            "--- a/self-test\n+++ b/self-test\n"
+            "@@ -1 +1 @@\n-nothing\n+only-in-the-diff\n"
+        )
+        if (introduced_by("only-in-the-prose", quoting)
+                or not introduced_by("only-in-the-diff", quoting)):
+            print("  FAIL   self-test: a fingerprint is provable against the prose "
+                  "above a diff, so introduced_by is reading the patch file rather "
+                  "than the diff in it")
+            return 1
+        print("  ok     self-test: a pattern that appears only in a patch's prose "
+              "header does not count as introduced, and one in its diff does")
+
         for stray in strays + (None,):
             src = pathlib.Path(tmp) / ("stray" if stray else "clean")
             src.mkdir()

--- a/scripts/download-python.sh
+++ b/scripts/download-python.sh
@@ -32,6 +32,12 @@ PYTHON_MAJOR_MINOR=$(echo "$PYTHON_FULL_VER" | grep -oE '^[0-9]+\.[0-9]+')
 REQUIRED_PACKAGES=(
     python
     python-pip
+    # The wheel `python3 -m venv` installs pip from. Termux splits it out of the
+    # python package and nothing depends on it, and resolution here expands no
+    # dependencies anyway, so it has to be named or it never arrives. Without it
+    # every venv create dies in the child that bootstraps pip. Architecture: all,
+    # so it needs no soname entry and no LIB_PACKAGES row.
+    python-ensurepip-wheels
     libffi
     libbz2
     liblzma
@@ -221,6 +227,50 @@ if [ ! -f "$PIP_DST/pip/__main__.py" ]; then
     exit 1
 fi
 echo "  pip installed to site-packages ($(du -sh "$PIP_DST/pip" | cut -f1))"
+
+# --- Step 6b: Place the wheel ensurepip installs pip from ---
+#
+# The pip placed above belongs to the base interpreter and does not cover for
+# this one. `python3 -m venv myenv` bootstraps pip into the new environment by
+# running ensurepip there, and ensurepip installs from a wheel, not from the
+# package in site-packages. Termux builds Python with an empty WHEEL_PKG_DIR, so
+# _find_wheel_pkg_dir_pip() returns None and the only path left is
+# ensurepip/_bundled/pip-<version>-py3-none-any.whl, which the python package
+# does not carry: the wheel lives in a package of its own that nothing depends
+# on. With that directory absent the copy raises FileNotFoundError inside the
+# child and the parent reports a bare non-zero exit status, leaving an
+# environment with no pip in it.
+#
+# Fatal for the same reason the pip placement above is: the failure would arrive
+# on a user's device, on the first thing a beginner does after creating an
+# environment, and it says nothing about what is missing.
+echo ""
+echo "Placing the ensurepip wheel..."
+WHEEL_SRC="extracted/python-ensurepip-wheels/data/data/com.termux/files/usr/lib/python${PYTHON_MAJOR_MINOR}/ensurepip/_bundled"
+WHEEL_DST="$STDLIB_DST/ensurepip/_bundled"
+if [ ! -d "$WHEEL_SRC" ]; then
+    echo "  ERROR: ensurepip wheels not found at $WHEEL_SRC" >&2
+    find "extracted/python-ensurepip-wheels" -name '*.whl' 2>/dev/null | head -3 >&2 || true
+    exit 1
+fi
+mkdir -p "$WHEEL_DST"
+cp "$WHEEL_SRC"/pip-*.whl "$WHEEL_DST/"
+
+# ensurepip spells that filename out of its own _PIP_VERSION rather than globbing
+# the directory, so a wheel whose version has drifted from the ensurepip beside
+# it is exactly as good as no wheel at all and fails on the device in the same
+# silent way. The two packages are versioned together upstream, which is what
+# makes a disagreement worth stopping the build for rather than working around.
+ENSUREPIP_VERSION="$(sed -n 's/^_PIP_VERSION = "\(.*\)"$/\1/p' "$STDLIB_DST/ensurepip/__init__.py")"
+EXPECTED_WHEEL="pip-${ENSUREPIP_VERSION}-py3-none-any.whl"
+if [ ! -f "$WHEEL_DST/$EXPECTED_WHEEL" ]; then
+    echo "  ERROR: ensurepip asks for $EXPECTED_WHEEL and the wheels package placed:" >&2
+    ls "$WHEEL_DST" >&2
+    echo "         An empty version in that name means _PIP_VERSION moved in" >&2
+    echo "         $STDLIB_DST/ensurepip/__init__.py and this read no longer finds it." >&2
+    exit 1
+fi
+echo "  $EXPECTED_WHEEL ($(du -sh "$WHEEL_DST/$EXPECTED_WHEEL" | cut -f1))"
 
 # --- Step 7: Place shared libraries in assets/usr/lib/ ---
 echo ""

--- a/scripts/patch-venv-home.py
+++ b/scripts/patch-venv-home.py
@@ -126,6 +126,18 @@ def patch(path):
 
 def files_under(target):
     """The venv modules to consider, whether given a file or a tree."""
+    # A target that is not there is a broken tree, not a tree with nothing to
+    # do, and both modes have to say so. download-python.sh names one file and
+    # would otherwise print nothing and exit 0 for a Python whose venv module
+    # moved or never arrived, shipping an interpreter where `python3 -m venv`
+    # fails with "No module named venv". The Gradle gate cannot cover for that,
+    # because what arms it is the very file that is missing.
+    if not os.path.exists(target):
+        raise SystemExit(
+            f'{target}: no such file or directory. The bundled Python was '
+            'assembled without its venv module, so nothing was rewritten and '
+            'nothing on device can create an environment.'
+        )
     if os.path.isfile(target):
         return [target]
     found = []
@@ -155,7 +167,7 @@ def _decide(dirname, base_prefix):
 
 
 def self_test():
-    """The three layouts the guard has to tell apart."""
+    """The three layouts the guard has to tell apart, and a target that is absent."""
     stdlib = 'python%d.%d' % sys.version_info[:2]
     with tempfile.TemporaryDirectory() as root:
         base = os.path.join(root, 'usr')
@@ -183,8 +195,22 @@ def self_test():
         # No base prefix to fall back to: better to leave it than to invent one.
         empty = os.path.join(root, 'nowhere')
         assert _decide(native, empty) == native, 'the guard invented a home'
+
+        # A target that is not there is refused in both modes. The write mode is
+        # the one download-python.sh runs, and a silent exit 0 there ships a
+        # Python with no venv module at all, which the Gradle gate cannot notice
+        # because the file it tests to arm itself is the missing one.
+        missing = os.path.join(root, 'absent', 'venv', '__init__.py')
+        for mode in ([], ['--check']):
+            refused = False
+            try:
+                main(mode + [missing])
+            except SystemExit:
+                refused = True
+            assert refused, 'a target that does not exist was accepted'
     print('ok -- venv home decided correctly for an installation, a bare '
-          'directory, an active environment and a missing base prefix')
+          'directory, an active environment and a missing base prefix, and a '
+          'target that does not exist refused in both modes')
 
 
 def main(argv):

--- a/scripts/test-dns-proxy.js
+++ b/scripts/test-dns-proxy.js
@@ -698,6 +698,54 @@ async function main() {
                 `body=${JSON.stringify(truncated.body)}), so a half-downloaded file reads as whole`,
     );
 
+    // --- an origin that switches protocols nobody asked for ---------------
+    // A 101 does not reach the response callback at all. Node routes an upgrade
+    // response to the request's own 'upgrade' event, and when nothing listens
+    // for that it destroys the socket without raising anything: measured on node
+    // v22.23.2 against an origin that answers an ordinary GET with a 101, the
+    // request object gets 'close' and no 'error', so the leg's error handler
+    // never runs either. Both wrong answers are silent, and the one that was
+    // shipped is the quieter: `res` is neither written nor ended, so the client
+    // waits with no status and no error while a socket stays held at each end,
+    // and the setup bound cannot collect them because destroying a socket takes
+    // its timer with it.
+    //
+    // A plain GET on purpose. A client that asks to upgrade is served by the
+    // upgrade leg further down; this is the origin volunteering a switch the
+    // client never requested, which is the case no handler was watching.
+    const switchingOrigin = net.createServer((sock) => {
+        sock.on('error', () => {});
+        sock.once('data', () =>
+            sock.write('HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n'));
+    });
+    const switchingPort = await listen(switchingOrigin);
+    const beforeSwitch = logLines.length;
+    const switched = await Promise.race([
+        proxiedGet(proxyPort, `http://127.0.0.1:${switchingPort}/`, goodCredentials),
+        // The unanswered leg has no bound left on it, so an assertion that
+        // simply waits for the status is a hang for whoever runs this rather
+        // than a failure with a name. Unref'd, so it cannot hold the process
+        // open once the real answer wins the race.
+        new Promise((resolve) => {
+            setTimeout(() => resolve({ status: 'nothing at all within 2000 ms' }), 2000).unref();
+        }),
+    ]);
+    switchingOrigin.close();
+    assert.strictEqual(
+        switched.status, 502,
+        `an origin that answered a plain GET with 101 got the client ${switched.status}; ` +
+            'Node destroys that socket without an error, so the leg answers nothing at all and ' +
+            'both descriptors stay held for as long as the client is willing to wait',
+    );
+    // Silencing it would satisfy the assertion above just as well, and a 502
+    // with nothing behind it is indistinguishable from a refused dial.
+    assert.match(
+        logLines.slice(beforeSwitch).join('\n'),
+        /switched protocols/,
+        `an origin that switched protocols uninvited said nothing: ` +
+            `${logLines.slice(beforeSwitch).join('\n') || '(nothing logged)'}`,
+    );
+
     // --- a rejected CONNECT must not pin a descriptor ---------------------
     // The response text is identical whether or not the socket is released, so
     // this is the one case in the file that has to be asserted by counting.
@@ -766,12 +814,19 @@ async function main() {
     const wsPort = await listen(wsOrigin);
     const upgraded = await new Promise((resolve) => {
         const socket = net.connect(proxyPort, '127.0.0.1', () => {
-            socket.write(
+            // Sent as latin1, which is the encoding a header block is bytes in.
+            // The cookie below carries 0xE9, and with the default encoding this
+            // client would put two bytes on the wire for it, so the byte
+            // assertion after the handshake would be measuring the harness
+            // rather than the proxy.
+            socket.write(Buffer.from(
                 `GET http://127.0.0.1:${wsPort}/socket HTTP/1.1\r\nHost: 127.0.0.1:${wsPort}\r\n` +
                     `Upgrade: websocket\r\nConnection: Upgrade\r\n` +
+                    `Cookie: session=\xe9\r\n` +
                     `Proxy-Connection: Keep-Alive\r\n` +
                     `Proxy-Authorization: Basic ${Buffer.from(goodCredentials).toString('base64')}\r\n\r\n`,
-            );
+                'latin1',
+            ));
         });
         let received = '';
         socket.on('data', (chunk) => {
@@ -809,6 +864,22 @@ async function main() {
             `the upgrade leg forwarded ${header} to the origin: ${JSON.stringify(wsSeen)}`,
         );
     }
+
+    // And the head has to reach the origin as the bytes the client sent. This
+    // leg rebuilds it out of rawHeaders, which Node hands back as latin1: one
+    // char per byte, so 0xE9 is U+00E9. Written back with the default encoding
+    // that char becomes the two bytes 0xC3 0xA9, and a cookie, a
+    // Sec-WebSocket-Protocol or any signed value carrying a byte above 0x7F
+    // arrives altered. The handshake is then rejected by the origin with
+    // nothing anywhere naming a proxy. Asserted at the byte because both
+    // spellings print identically, and read back through latin1 for the same
+    // reason it is written that way.
+    assert.strictEqual(
+        Buffer.from(wsSeen.cookie || '', 'latin1').toString('hex'),
+        Buffer.from('session=\xe9', 'latin1').toString('hex'),
+        `the upgrade leg re-encoded the request head: the origin read Cookie as ` +
+            `${JSON.stringify(Buffer.from(wsSeen.cookie || '', 'latin1').toString('hex'))}`,
+    );
 
     // And the credential still stops at the proxy on this leg too.
     const anonymousUpgrade = await rawExchange(

--- a/scripts/verify-server-tree.py
+++ b/scripts/verify-server-tree.py
@@ -337,6 +337,33 @@ def main(tree):
               "readiness in ProcessManager waits for that line and no spawned "
               "start would ever be reported ready; update SERVER_LISTENING_LINE")
 
+    # server.js binds a per-run secret into callback.html at every start, by
+    # rewriting the payload the page hands to the Android side, and MainActivity
+    # refuses a sign-in callback that does not carry it. That is the only thing
+    # standing between the exported vscodroid://callback filter and a forged
+    # OAuth callback, because the request id it used to be matched on is a
+    # counter the workbench starts at one.
+    #
+    # The rewrite is a pattern match, so a callback.html whose payload is built
+    # differently binds nothing, and the failure is silent by design: the Android
+    # side falls back to the older matching rather than refusing every sign-in.
+    # That fallback is right at runtime and wrong at build time, which is why the
+    # question is asked here. Keep this string in step with CALLBACK_PAYLOAD in
+    # assets/server.js.
+    callback_payload = "JSON.stringify({ id: id, uri: uri })"
+    callback_html = tree / "out/vs/code/browser/workbench/callback.html"
+    try:
+        builds_payload = callback_payload in callback_html.read_text(errors="replace")
+    except OSError as e:
+        builds_payload = False
+        check(False, "out/vs/code/browser/workbench/callback.html is readable", str(e))
+    else:
+        check(builds_payload,
+              "callback.html builds the payload server.js binds a secret into",
+              "server.js could not bind a per-run secret, so MainActivity would "
+              "accept any forged sign-in callback naming an armed request id; "
+              "update CALLBACK_PAYLOAD in assets/server.js to match the page")
+
     # The Mobile CSS block is appended to the packaged workbench.css at server
     # build time, and on 2026-08-15 its content changed (the Accounts/Manage
     # hide was removed) while the idempotency marker stayed the same. The


### PR DESCRIPTION
Eighteen defects, each with a check that was watched fail against the current code first. The trust store and the sign-in callback were measured on an API 33 emulator; the proxy ones on Node v22.23.2, the bundled runtime's line; the rest in the unit suite, which is at 2437 tests.

## Device folders

**A directory the sync could not read was deleted from the device with everything under it.** When a provider will not list a subdirectory, `walkTree` logs it and carries on, so the directory is enumerated, phase 2 does `mkdirs()`, and the editor shows it empty while the device still holds its documents. Deleting it in the terminal reached `deleteDocument` on the directory and took all of them. The guard that exists to refuse exactly this proves "the device holds the only copy" from `unfetched`, and only skipped names and per-file failures ever reached that set. A failed enumeration now records the directory the way a skipped name does, and the guard matches a directory by its own path as well as by prefix, which the trailing separator had made impossible. Both halves are load-bearing: disabling either one on its own lets the delete through, which is how the test was checked.

**A deletion the device had nothing to refuse was announced as a refusal.** `findChildDocId` folds a failed provider query into the null it returns for genuine absence, so "could not be resolved" and "is not there" arrived as one answer and shared a branch. The user was told the file would come back on the next open and to go and delete it in a file manager, and both clauses were false. The three-valued `providerHolds` the delete guard already uses tells them apart; only a device that may still hold the document is announced, so a provider that cannot answer keeps the warning it used to give.

## Sign-in callback

The `vscodroid://callback` filter is exported and BROWSABLE, and everything the gate checked was guessable from outside. The request id is a per-page counter the workbench starts at one, and the window around it is ten minutes, so proving that this app armed an id proves nothing about who is answering it. Any app on the device, or any page in any browser, could forge a callback for a sign-in in flight, hand the signing-in extension an OAuth code of its choosing with the extension-URI confirmation suppressed by `trusted:true`, and take the pending id with it so the user's own callback was silently dropped.

`server.js` now mints a per-run secret, substitutes it into the payload `callback.html` builds, and records it beside the editor server pid. The page is served from the server's own origin, so no other origin can read it, and the file is in the app sandbox, which the backup allowlist does not name. A callback that does not carry it is refused in the same silence as one for a sign-in that was never started, and before the window is consulted, so a forgery can neither raise a message nor spend the arming the real callback still needs.

The rewrite is idempotent by construction, since on the second start the page already carries the previous run's nonce, and it fails open to the older matching rather than refusing every sign-in on a page it cannot rewrite. That fallback is right on a device and wrong in a build, so `verify-server-tree.py` refuses a tree whose callback page the rewrite would not bind.

Measured on device: the nonce file is 64 hex characters at mode 0600, the page carries the matching value, and `Sign-in callbacks bound to this run` appears on both of two consecutive starts.

## Restart budget

The five attempts were refilled on the gap between two readiness announcements. That interval is the dead server's uptime plus the backoff and the whole start poll that followed it, so up to sixty-two of the sixty-second window can be time in which no server existed. A phone whose memory killer takes the server twenty seconds after each start reaches the window on the fifth attempt and gets the budget back, so `MAX_RESTARTS` was unreachable, the Retry page was never offered, and `onServerReady` reloaded the workbench every half minute for as long as the app stayed open.

Uptime is now judged in `handleServerCrash`, the one moment it is a number, and the parked sentinel moved into the future so a run whose server never became ready is credited with nothing. The message throttle had been riding on the same call and is now cleared on every readiness, which is the half that is not about the budget. The test drives the instants the service really produces rather than two literals, and asserts the other direction too: a server that held for five minutes is still credited at its death.

A refused foreground promotion separately told nobody. Nothing is promoted, so there is no notification and no Stop control, and the refusal is not a throw at the activity's call site, so its catch never ran. The loading page stayed up with no control on it, and relaunching reached `onNewIntent`, which only relays a sign-in callback. It now records a terminal notice and raises the callback: the notice is what a later bind reads, the callback is what an already-bound client gets on the retry path, and neither covers the other.

## Bundled Python

`python3 -m venv` could not install pip at all. Termux splits the wheel `ensurepip` installs from into `python-ensurepip-wheels`, which nothing depends on and which was never named, and the build resolves no dependencies of its own. `WHEEL_PKG_DIR` is empty in the shipped `_sysconfigdata`, so `_find_wheel_pkg_dir_pip()` returns None and the only path left is `ensurepip/_bundled/pip-<version>-py3-none-any.whl`, which the tree does not carry. `copy2` raises `FileNotFoundError` in the child and the parent reports a bare exit status, leaving an environment with no pip in it.

The package is fetched and its wheel placed, fatally if the source is absent. Because `ensurepip` spells that filename out of its own `_PIP_VERSION` rather than globbing, the build also stops when the placed wheel's version has drifted from the `ensurepip` beside it; a wheel that does not match is as good as no wheel and fails on the device in the same silent way.

`patch-venv-home.py` exited zero when its target file was absent, and Gradle's `verifyVenvHome` is armed by the very file that would be missing, so a Python assembled without its `venv` module would have shipped green.

## Terminal trust store

The bundle was assembled by copying the system certificate directory and appending the owner's own CAs. A root the owner turns off in Settings leaves the platform's trust store but not that directory, so the bundle kept trusting a certificate authority the rest of the phone had stopped trusting. That was narrower when only git read the bundle; `SSL_CERT_FILE` and `REQUESTS_CA_BUNDLE` now put it in front of python, pip and curl.

It is built from `AndroidCAStore`, which is the merged view the platform's own trust manager reads, and falls back to the directory only where that store answers with nothing, so a device without the provider keeps a working bundle rather than an empty one. The freshness fingerprint now covers the whole store, which is what lets a removal rebuild at all: turning a root off leaves the directory's mtime alone, exactly as installing one does.

Measured on an API 33 emulator, with `AC Camerfirma S.A. / Chambers of Commerce Root - 2008` turned off in Settings. The directory holds 125 files either way. The bundle went from 125 certificates to 124, and diffing the two by subject shows exactly one certificate gone and none added: the root that was turned off. Re-enabling it took the bundle back to 125.

## Editor language

Chinese script was read from the last subtag of the language tag. Android carries a Regional preference as a `-u-` Unicode extension on the default locale, so a Taiwanese phone reports `zh-TW-u-fw-mon`, the last subtag is `mon`, and a Traditional Chinese user got an entirely Simplified workbench with Simplified extension manifests to match. The region is the subtag after the language, which is exact for `zh-CN` and `zh-TW`, empty for a bare `zh`, and indifferent to however many extension subtags trail behind.

## Local proxy

**An origin that answers with 101 hung the client for ever.** Node routes an upgrade response to the `upgrade` event and nothing else, and with no listener it destroys the socket without raising a failure anywhere, so the response was neither written nor ended and one socket stayed pinned at each end with nothing logged. The leg now reports 502 by the same rule the error handler follows. The harness case fails without it with `nothing at all within 2000 ms`.

**The upgrade leg corrupted header bytes above 0x7F.** It reconstructed the request head and wrote it with the default encoding, so a byte that arrived as one latin1 character went back out as the two bytes of its UTF-8 form. A cookie or a signed value carrying one reached the origin altered, and the handshake it fails names no proxy. The plain leg never had this, because it hands its headers to `http.request`.

## Toolchains and adoption

A fetch Play refuses outright delivers no `AssetPackState` at all, and the Task carrying that refusal was discarded, so `handleDownloadState` never ran for the pack, `downloadNext()` was never reached, the row sat on its last status for the rest of the session, and every pack queued behind it was never requested. The refusal is routed through the same `fail` path a listener-delivered one takes.

A stop landing inside the adoption branch of `startServer()` was undone by an `isShuttingDown = false` that could only ever cancel a real stop, since the line above it already clears the flag for any start that is not racing one. `stopServer()` reads `adopted` as false during the round trip and reaps nothing, and the IO thread then marks the server adopted after the service is gone, leaving an untracked editor server holding the port and a poll over it.

## Extensions and defaults

A user who removed one of this app's own extensions under an older release kept the pass that strips the app's former editor overrides while the contributed defaults meant to replace them never loaded. `bundledDirsToExtract` exempts our own prefix from "the user removed it, leave it removed" and `bundledIdsToRelist` did not, so the directory came back on every update and sat unlisted and unloaded. Word wrap, the minimap, the sash size and the rest reverted with no route back short of clearing app data. The two halves now agree, and the rule still holds for the marketplace extensions it was written for, which is what the reworked test measures.

## An unload that was answered for the user

`onJsBeforeUnload` is reached only when the workbench vetoed leaving, and it vetoes only while holding an edit it has not yet written a backup of. The mark that says a navigation is the app's own stayed armed for ten seconds, so anything the workbench navigated itself to inside that window, a Close Folder or an Open Recent, was confirmed on the user's behalf and the edit went with it. The mark is consumed by the first answer it satisfies, since the callback is raised once for the load it belongs to; the window survives as the backstop for a mark whose load produced no callback at all.

## Release and build gates

A release tag re-aimed at a different commit satisfied every version and changelog gate, because all four still describe the release cut from the old commit: the tag matches `versionName`, the predecessor is resolved from `$TAG^` and so cannot see the tag being placed, and the CHANGELOG heading and both links were written at the first cut. The run would have rebuilt, re-signed and replaced the assets of a release that is already public, under a `versionName` and `versionCode` that did not move, and `FirstRunSetup.setupIsStale` compares exactly those two fields, so every device already on that version installs the new tree and skips extraction and migrations. The predecessor is now taken from the tag list by version rather than by ancestry, which also fixes a tag cut off a branch comparing against the wrong release, and a tag that changes where it points is refused outright.

`check-patch-fingerprints.py` scanned the whole patch file for its `+` lines, so a prose header quoting the line it explains, which is the ordinary way to explain one, could prove a fingerprint against text `git apply` never reads. It reads the diff body instead.

## Tests that could not fail

Four, each of which made a real regression invisible. `SafFolderLogCallSiteTest`'s mirror-naming control was widened from a method body to the whole file and passed on the exact deletion it names, because an unrelated statement elsewhere in `MainActivity` answered for it. `LaunchPassWaitTest`'s declaration scan matched only four-space indentation, so a case inside a `@Nested` class could start the launch pass without ever being asked whether it waits for the whole of it. `NavigationTokenLoggingTest`'s liveness control was kept non-empty by a `Uri` seed, so it could not fail for the mutation its own message names. `SettingsPathsTest` searched a Kotlin raw string for a two-character `\n` escape that can never occur.

## Verification

The unit suite is at 2437 tests, 0 failures, run with every asset gate armed against a freshly built eighteen-patch server tree. Each fix has a check that was watched fail against the unfixed code and pass against the fixed one; where a fix had two independent halves, each half was disabled on its own to confirm both are load-bearing.

The trust store and the sign-in callback were measured on an API 33 emulator, on a build produced by the full pipeline rather than a shortcut. The proxy cases run in `scripts/test-dns-proxy.js`, `patch-venv-home.py` refuses a missing target in both of its modes, and `verify-server-tree.py` passes on the rebuilt tree including the new callback-payload assertion.

Not covered by any of this: the `venv` fix changes what `download-python.sh` fetches, so it is exercised for the first time by CI's asset build rather than here.

## Documentation

The privacy policy described the backed-up directory as holding only the app's own defaults; it is the file the Settings editor's Remote tab writes the user's own machine-scoped settings into, and all of it is in the backup. Two documents still described a seventeen-patch set. The CHANGELOG entry for the certificate fix named `requests` among the clients that were broken, where the code's own measurement says it verifies against its vendored certifi and was unaffected.
