### PR TITLE
fix: paste what you copied, open a preview, and find the Python formatter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -296,6 +296,7 @@ jobs:
           node scripts/test-download-capture.js
           node scripts/test-serve-network.js
           node scripts/test-welcome.js
+          node scripts/test-xdg-open.js
 
       - name: Run lint
         working-directory: android

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -414,6 +414,7 @@ jobs:
           node scripts/test-download-capture.js
           node scripts/test-serve-network.js
           node scripts/test-welcome.js
+          node scripts/test-xdg-open.js
 
       - name: Install system dependencies
         # See build.yml: the runner's baked apt index goes stale as Ubuntu drops

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Opening a Python file offers to install Black Formatter. It is the formatter that works without installing anything with pip, and no marketplace search returns it, so it could not be found by looking.
+
 ### Fixed
 
 - Paste works again, in the editor, the terminal, the Command Palette and anything an extension pastes into. Copying put text on the device clipboard and pasting it back raised "Unable to read from the browser's clipboard", asking for a permission a WebView has no way to grant.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Paste works again, in the editor, the terminal, the Command Palette and anything an extension pastes into. Copying put text on the device clipboard and pasting it back raised "Unable to read from the browser's clipboard", asking for a permission a WebView has no way to grant.
+- Signing in to GitHub no longer goes through a confirmation dialog first. The sign-in ends by opening github.com, and every address outside the extension marketplace was treated as untrusted.
+- A confirmation dialog fits a phone screen. It was drawn wider than the screen and centred, so the button that proceeds hung off the right edge with a letter of it showing.
+- The editor keeps a usable height in landscape with the keyboard up. The extra key row took the last of the space the keyboard left, so the file being renamed and the line being typed were both off screen.
+- An extension that opens a preview in your browser now opens one. Live Server and everything like it reported "Could not open the default browser" and left the address to be copied by hand.
+
 ## [1.3.0] - 2026-09-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A confirmation dialog fits a phone screen. It was drawn wider than the screen and centred, so the button that proceeds hung off the right edge with a letter of it showing.
 - The editor keeps a usable height in landscape with the keyboard up. The extra key row took the last of the space the keyboard left, so the file being renamed and the line being typed were both off screen.
 - An extension that opens a preview in your browser now opens one. Live Server and everything like it reported "Could not open the default browser" and left the address to be copied by hand.
+- A command installed with `pip` runs. `black`, `pytest`, `ruff`, `httpie` and anything else that brings a command with it installed successfully and then refused to start, because Android will not run a script out of the app's own storage. A command installed while the app is running becomes available the next time you open it.
 
 ## [1.3.0] - 2026-09-06
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -319,6 +319,7 @@ checkouts differed.
 | `test-process-monitor.js` | Points a scan at a fixture `/proc` and checks the snapshot: that the language servers that ship are recognised, that an unrelated user process carrying a server's name in its path is not, and that the count includes the process the monitor runs inside | exit status |
 | `test-platform-fix.js` | Runs the platform override under a faked `process.platform` and checks it engages for node-gyp and for nothing that merely mentions it in a path or an argument | exit status |
 | `test-server-bootstrap.js` | Boots the server bootstrap against a fixture tree and checks the `product.json` rewrite: overrides applied, a truncated file named rather than thrown, an unwritable directory leaving the existing file intact | exit status |
+| `test-xdg-open.js` | Runs the browser opener against a stand-in for the editor's CLI socket and checks it sends the `openExternal` message that handler actually reads, and that it refuses an address the handler would have skipped in silence while still answering 200 | exit status |
 | `test-process-monitor-extension.js` | Drives the process monitor extension against two snapshots that differ in every count and checks its notifications read the same either way. A notification cannot be edited once open, so any number baked into one freezes while the status bar beside it keeps moving | exit status |
 | `test-bridge-relay.js` | Extracts the bridge relay from the Kotlin raw string it lives in and runs it against a stub bridge, driving the real bundled extension, so what is asserted is the message a user is shown. Nothing else reads that script: it is neither compiled nor linted, so a bridge change can be reverted with every suite green. Also refuses a command an extension sends that the relay has no branch for, whose only symptom is a five-second timeout naming neither the command nor the cause | exit status |
 | `test-download-capture.js` | Exercises the download-capture script, which is JavaScript inside a Kotlin raw string handed to `evaluateJavascript`, so nothing compiles or lints it and no Kotlin test reaches past the bridge methods it calls. What it pins is the deferred `revokeObjectURL`: the workbench revokes a `blob:` URL on the next task, and choosing a destination takes seconds, so without the deferral every save finds nothing to write while the Kotlin suite, lint and the build all stay green | exit status |
@@ -866,7 +867,7 @@ override silently removes it from the running product.
 
 ### JavaScript / Node.js
 
-- `assets/server.js`, `assets/process-monitor.js`, `assets/platform-fix.js`, `assets/dns-proxy.js` and the four `assets/extensions/vscodroid.*` trees are hand-written JavaScript (not minified) and are the only parts of `assets/` in git. Keep them readable.
+- `assets/server.js`, `assets/process-monitor.js`, `assets/platform-fix.js`, `assets/dns-proxy.js`, `assets/xdg-open.js` and the four `assets/extensions/vscodroid.*` trees are hand-written JavaScript (not minified) and are the only parts of `assets/` in git. Keep them readable.
 - Use `const`/`let`, not `var`.
 - No TypeScript -- these run directly on the bundled Node.js.
 

--- a/android/app/src/androidTest/kotlin/com/vscodroid/keyboard/KeyRowAccessibilityInstrumentedTest.kt
+++ b/android/app/src/androidTest/kotlin/com/vscodroid/keyboard/KeyRowAccessibilityInstrumentedTest.kt
@@ -444,10 +444,12 @@ class KeyRowAccessibilityInstrumentedTest {
 
         var idle = 0
         var latched = 0
+        var derived = 0
         var ctrl: ExtraKeyButton? = null
         onMain {
             val row = ExtraKeyRow(context)
             idle = heightOf(row)
+            derived = row.rowHeightPx
             row.layout(0, 0, widthPx, idle)
             ctrl = findKey(row, "Ctrl")
             ctrl?.performAccessibilityAction(AccessibilityNodeInfo.ACTION_CLICK, null)
@@ -465,6 +467,16 @@ class KeyRowAccessibilityInstrumentedTest {
                 "WebView above it is resized every time one is pressed or spent",
             idle,
             latched,
+        )
+        // The inset listener decides whether the page can afford this row before the
+        // row has been measured, so it spends a derived figure rather than a real
+        // one. The two drifting apart is silent: the row would go on being shown
+        // where it does not fit, or stand down where it would have.
+        assertEquals(
+            "the height the page-height decision spends, ${derived}px, is not the height " +
+                "the row measures, ${idle}px",
+            idle,
+            derived,
         )
     }
 

--- a/android/app/src/main/assets/server.js
+++ b/android/app/src/main/assets/server.js
@@ -31,6 +31,26 @@ const REH_DIR = path.join(SERVER_DIR, 'vscode-reh');
 // hex so it cannot run past the object it belongs to.
 const CALLBACK_PAYLOAD = /JSON\.stringify\(\{ id: id, uri: uri(?:, nonce: '[0-9a-f]*')? \}\)/;
 
+// Which external addresses open without the "Do you want VSCodroid to open the
+// external website?" confirmation.
+//
+// github.com is not a convenience. The GitHub sign-in this build can run is the
+// device-code flow, and it ends in env.openExternal("https://github.com/login/device"),
+// so without this entry the one screen between a user and a signed-in editor is a
+// confirmation dialog. Everything else the workbench opens keeps the prompt.
+//
+// Loopback is deliberately absent. The matcher answers for localhost, *.localhost,
+// 127.0.0.1 and [::1] on any port before it ever consults this list, so a dev-server
+// preview already opens without a prompt and an entry here would only look like it
+// was doing the work.
+//
+// Written with the scheme, so a bare host cannot also match plain http.
+const TRUSTED_LINK_DOMAINS = ['https://open-vsx.org', 'https://github.com'];
+
+// What says the workbench page has already been given the list above, so a second
+// start does not stack a second copy of the same script into it.
+const TRUSTED_DOMAINS_MARKER = 'vscodroid-trusted-domains';
+
 /**
  * Replaces a file in one step, the way the product.json rewrite below does.
  *
@@ -72,7 +92,7 @@ const productOverrides = {
         controlUrl: '',
         nlsBaseUrl: ''
     },
-    linkProtectionTrustedDomains: ['https://open-vsx.org'],
+    linkProtectionTrustedDomains: TRUSTED_LINK_DOMAINS,
     telemetryOptIn: false,
     enableTelemetry: false,
     // Where the page is told to fetch its translated interface strings.
@@ -243,6 +263,75 @@ if (!fs.existsSync(rehEntryPoint)) {
         log('error', 'Sign-in still works, but a callback is matched by request id alone.');
     }
 
+    // Give the page the trusted-domain list, which the product.json rewrite above
+    // cannot reach.
+    //
+    // That rewrite reaches THIS process's IProductService and stops there. The page
+    // never reads the file: the product object is inlined into the workbench bundle
+    // at build time, and the only product the server hands the page at runtime is a
+    // three-key object that does not carry this list. So what the confirmation
+    // dialog consults is branding/product.json as it stood at the last server build,
+    // and widening it there alone would reach a device only after a ~30 minute
+    // rebuild and a new server release.
+    //
+    // The workbench adds `additionalTrustedDomains` from its web construction
+    // options to whatever the product lists, and those options are JSON in a meta
+    // element of a page this server rebuilds FROM A TEMPLATE ON EVERY REQUEST. So a
+    // script added to that template arrives with an ordinary app update, where
+    // editing the bundle would not: /static is served `max-age=31536000` with no
+    // ETag and no Last-Modified under a URL that does not change between runs, so a
+    // WebView that has loaded this build once would keep its cached bundle for a
+    // year and never see the edit. The document carries no caching headers at all.
+    //
+    // Safe against the page's own policy without touching it: the server hashes
+    // every bare <script> in the HTML it has just built and puts those hashes into
+    // the Content-Security-Policy it sends with it, so a script inserted here is
+    // covered by construction. It must stay a bare <script> for that to hold.
+    //
+    // branding/product.json carries the same list for the next server build. After
+    // it, this adds entries the page already has, which is a no-op by the membership
+    // test below rather than by luck.
+    //
+    // Guarded on the file existing rather than reporting its absence: a tree with
+    // no workbench page is not a tree this could fix, and a missing server tree is
+    // already a failed start above and a build-time gate in verify-server-tree.py.
+    const workbenchHtmlPath = path.join(REH_DIR, 'out/vs/code/browser/workbench/workbench.html');
+    try {
+        const html = fs.existsSync(workbenchHtmlPath) ? fs.readFileSync(workbenchHtmlPath, 'utf8') : null;
+        if (html !== null && !html.includes(TRUSTED_DOMAINS_MARKER)) {
+            const anchor =
+                '<meta id="vscode-workbench-web-configuration" data-settings="{{WORKBENCH_WEB_CONFIGURATION}}">';
+            if (!html.includes(anchor)) {
+                throw new Error('the workbench page does not carry the configuration element this extends');
+            }
+            const script = [
+                '',
+                '\t\t<script>',
+                `\t\t\t/* ${TRUSTED_DOMAINS_MARKER} */`,
+                '\t\t\t(function () {',
+                "\t\t\t\tvar el = document.getElementById('vscode-workbench-web-configuration');",
+                '\t\t\t\tif (!el) { return; }',
+                '\t\t\t\ttry {',
+                "\t\t\t\t\tvar settings = JSON.parse(el.getAttribute('data-settings'));",
+                '\t\t\t\t\tvar trusted = settings.additionalTrustedDomains || [];',
+                `\t\t\t\t\tvar wanted = ${JSON.stringify(TRUSTED_LINK_DOMAINS)};`,
+                '\t\t\t\t\tfor (var i = 0; i < wanted.length; i++) {',
+                '\t\t\t\t\t\tif (trusted.indexOf(wanted[i]) === -1) { trusted.push(wanted[i]); }',
+                '\t\t\t\t\t}',
+                '\t\t\t\t\tsettings.additionalTrustedDomains = trusted;',
+                "\t\t\t\t\tel.setAttribute('data-settings', JSON.stringify(settings));",
+                '\t\t\t\t} catch (e) { /* a broken configuration is the workbench own report to make */ }',
+                '\t\t\t})();',
+                '\t\t</script>',
+            ].join('\n');
+            writeThroughRename(workbenchHtmlPath, html.replace(anchor, () => anchor + script));
+            log('info', 'Trusted link domains given to the workbench page');
+        }
+    } catch (e) {
+        log('error', `Could not widen the trusted link domains: ${e.message}`);
+        log('error', 'External links still open, behind the confirmation dialog.');
+    }
+
     // Build server arguments.
     //
     // No connection-token flag of any kind, and that absence is the security
@@ -263,6 +352,17 @@ if (!fs.existsSync(rehEntryPoint)) {
         '--host', HOST,
         '--port', String(PORT),
         '--accept-server-license-terms',
+        // Stops the server pointing BROWSER at a script that cannot run.
+        //
+        // Without the flag the extension host is handed
+        // BROWSER=<appRoot>/bin/helpers/browser.sh, and every Node helper that
+        // opens a browser prefers $BROWSER over anything else. That script is a
+        // shebang file under filesDir, which SELinux refuses to execve, and it
+        // execs a `$ROOT/node` the packaged tree does not carry, so it could never
+        // have worked. Leaving it set means the helpers stop at a dead end instead
+        // of falling through to `xdg-open`, which is the name this build now
+        // answers to through the execution trampoline.
+        '--without-browser-env-var',
         // Without this every folder opens in Restricted Mode, which blocks most
         // extensions from activating.
         //

--- a/android/app/src/main/assets/server.js
+++ b/android/app/src/main/assets/server.js
@@ -51,6 +51,37 @@ const TRUSTED_LINK_DOMAINS = ['https://open-vsx.org', 'https://github.com'];
 // start does not stack a second copy of the same script into it.
 const TRUSTED_DOMAINS_MARKER = 'vscodroid-trusted-domains';
 
+// The extensions the editor offers to install, and the reason this list exists at
+// all rather than leaving people to search.
+//
+// Open VSX does not return ms-python.black-formatter for any text search, its own
+// /api/-/search included, so the Extensions view cannot surface it however the
+// query is phrased. Looking it up by identifier does return it, which is the route
+// a recommendation takes, so a recommendation reaches an extension a search cannot.
+// The one a search does return, mikoz.black-py, formats only once black has been
+// installed separately with pip and stays silent when it has not.
+//
+// `languages` rather than a `**/*.py` glob: it also catches a file the editor knows
+// is Python without the suffix saying so, and the workbench re-evaluates it when the
+// language of an open file changes. `whenNotInstalled` names the extension itself so
+// the offer stops once it is accepted, stated here rather than left to the
+// notification service's own filtering, which is not measured.
+const EXTENSION_RECOMMENDATIONS = {
+    'ms-python.black-formatter': {
+        onFileOpen: [
+            {
+                languages: ['python'],
+                important: true,
+                whenNotInstalled: ['ms-python.black-formatter'],
+            },
+        ],
+    },
+};
+
+// What says the page already carries the recommendations. Separate from the marker
+// above so either script can be added to a page that already has the other.
+const RECOMMENDATIONS_MARKER = 'vscodroid-extension-recommendations';
+
 /**
  * Replaces a file in one step, the way the product.json rewrite below does.
  *
@@ -68,6 +99,53 @@ function writeThroughRename(target, contents, mode) {
         try { fs.unlinkSync(tmp); } catch { /* nothing was written */ }
         throw e;
     }
+}
+
+/**
+ * Adds one script to the workbench page, once. Answers whether it added it.
+ *
+ * Everything the page needs that `product.json` cannot carry arrives this way, so
+ * the shape is shared rather than written out per caller. The caller supplies the
+ * lines that read and mutate `settings`; the wrapper around them, the marker that
+ * makes a second start a no-op, and the write are the same every time.
+ *
+ * The tag has to stay a BARE `<script>`: the server hashes exactly that shape out
+ * of the page it has just built and puts the hashes into the Content-Security-Policy
+ * it serves with it, so a tag carrying any attribute is one the page's own policy
+ * then refuses to run.
+ *
+ * A page that is not there is not a page this can fix, and a missing server tree is
+ * already a failed start and a build-time gate in verify-server-tree.py. A page that
+ * is there but carries no configuration element is a tree this does not understand,
+ * and that is worth reporting rather than passing over.
+ */
+function extendWorkbenchPage(pagePath, marker, lines) {
+    const html = fs.existsSync(pagePath) ? fs.readFileSync(pagePath, 'utf8') : null;
+    if (html === null || html.includes(marker)) {
+        return false;
+    }
+    const anchor =
+        '<meta id="vscode-workbench-web-configuration" data-settings="{{WORKBENCH_WEB_CONFIGURATION}}">';
+    if (!html.includes(anchor)) {
+        throw new Error('the workbench page does not carry the configuration element this extends');
+    }
+    const script = [
+        '',
+        '\t\t<script>',
+        `\t\t\t/* ${marker} */`,
+        '\t\t\t(function () {',
+        "\t\t\t\tvar el = document.getElementById('vscode-workbench-web-configuration');",
+        '\t\t\t\tif (!el) { return; }',
+        '\t\t\t\ttry {',
+        "\t\t\t\t\tvar settings = JSON.parse(el.getAttribute('data-settings'));",
+        ...lines,
+        "\t\t\t\t\tel.setAttribute('data-settings', JSON.stringify(settings));",
+        '\t\t\t\t} catch (e) { /* a broken configuration is the workbench own report to make */ }',
+        '\t\t\t})();',
+        '\t\t</script>',
+    ].join('\n');
+    writeThroughRename(pagePath, html.replace(anchor, () => anchor + script));
+    return true;
 }
 
 // How long the editor server gets to answer a SIGTERM before it is SIGKILLed.
@@ -283,53 +361,61 @@ if (!fs.existsSync(rehEntryPoint)) {
     // WebView that has loaded this build once would keep its cached bundle for a
     // year and never see the edit. The document carries no caching headers at all.
     //
-    // Safe against the page's own policy without touching it: the server hashes
-    // every bare <script> in the HTML it has just built and puts those hashes into
-    // the Content-Security-Policy it sends with it, so a script inserted here is
-    // covered by construction. It must stay a bare <script> for that to hold.
-    //
     // branding/product.json carries the same list for the next server build. After
     // it, this adds entries the page already has, which is a no-op by the membership
-    // test below rather than by luck.
-    //
-    // Guarded on the file existing rather than reporting its absence: a tree with
-    // no workbench page is not a tree this could fix, and a missing server tree is
-    // already a failed start above and a build-time gate in verify-server-tree.py.
+    // test below rather than by luck. How the script is inserted, and why it stays a
+    // bare <script>, is at [extendWorkbenchPage].
     const workbenchHtmlPath = path.join(REH_DIR, 'out/vs/code/browser/workbench/workbench.html');
     try {
-        const html = fs.existsSync(workbenchHtmlPath) ? fs.readFileSync(workbenchHtmlPath, 'utf8') : null;
-        if (html !== null && !html.includes(TRUSTED_DOMAINS_MARKER)) {
-            const anchor =
-                '<meta id="vscode-workbench-web-configuration" data-settings="{{WORKBENCH_WEB_CONFIGURATION}}">';
-            if (!html.includes(anchor)) {
-                throw new Error('the workbench page does not carry the configuration element this extends');
-            }
-            const script = [
-                '',
-                '\t\t<script>',
-                `\t\t\t/* ${TRUSTED_DOMAINS_MARKER} */`,
-                '\t\t\t(function () {',
-                "\t\t\t\tvar el = document.getElementById('vscode-workbench-web-configuration');",
-                '\t\t\t\tif (!el) { return; }',
-                '\t\t\t\ttry {',
-                "\t\t\t\t\tvar settings = JSON.parse(el.getAttribute('data-settings'));",
-                '\t\t\t\t\tvar trusted = settings.additionalTrustedDomains || [];',
-                `\t\t\t\t\tvar wanted = ${JSON.stringify(TRUSTED_LINK_DOMAINS)};`,
-                '\t\t\t\t\tfor (var i = 0; i < wanted.length; i++) {',
-                '\t\t\t\t\t\tif (trusted.indexOf(wanted[i]) === -1) { trusted.push(wanted[i]); }',
-                '\t\t\t\t\t}',
-                '\t\t\t\t\tsettings.additionalTrustedDomains = trusted;',
-                "\t\t\t\t\tel.setAttribute('data-settings', JSON.stringify(settings));",
-                '\t\t\t\t} catch (e) { /* a broken configuration is the workbench own report to make */ }',
-                '\t\t\t})();',
-                '\t\t</script>',
-            ].join('\n');
-            writeThroughRename(workbenchHtmlPath, html.replace(anchor, () => anchor + script));
+        const added = extendWorkbenchPage(workbenchHtmlPath, TRUSTED_DOMAINS_MARKER, [
+            '\t\t\t\t\tvar trusted = settings.additionalTrustedDomains || [];',
+            `\t\t\t\t\tvar wanted = ${JSON.stringify(TRUSTED_LINK_DOMAINS)};`,
+            '\t\t\t\t\tfor (var i = 0; i < wanted.length; i++) {',
+            '\t\t\t\t\t\tif (trusted.indexOf(wanted[i]) === -1) { trusted.push(wanted[i]); }',
+            '\t\t\t\t\t}',
+            '\t\t\t\t\tsettings.additionalTrustedDomains = trusted;',
+        ]);
+        if (added) {
             log('info', 'Trusted link domains given to the workbench page');
         }
     } catch (e) {
         log('error', `Could not widen the trusted link domains: ${e.message}`);
         log('error', 'External links still open, behind the confirmation dialog.');
+    }
+
+    // Give the page the extension recommendations, which reach it the same way and
+    // for the same reason: the product the workbench consults is inlined into its
+    // bundle at build time, and the three-key product this server hands the page at
+    // runtime does not carry them.
+    //
+    // Merged under `productConfiguration` rather than set over it. The page deep
+    // merges that object into the inlined product, so an entry added here joins the
+    // built one instead of replacing it, and an identifier the page already carries
+    // is left alone by the membership test below.
+    //
+    // Deliberately NOT also in branding/product.json, where the trusted-domain list
+    // above does live. That list is read by this process too, through the
+    // product.json rewrite; recommendations are read only by the page, so a build-time
+    // copy would buy nothing and give the two places to drift. It would also have to
+    // be added to the locked product.json key set that build-vscode-oss.sh checks.
+    // The membership test still holds if a later build inlines them anyway.
+    try {
+        const added = extendWorkbenchPage(workbenchHtmlPath, RECOMMENDATIONS_MARKER, [
+            '\t\t\t\t\tvar product = settings.productConfiguration || {};',
+            '\t\t\t\t\tvar have = product.extensionRecommendations || {};',
+            `\t\t\t\t\tvar wanted = ${JSON.stringify(EXTENSION_RECOMMENDATIONS)};`,
+            '\t\t\t\t\tfor (var id in wanted) {',
+            '\t\t\t\t\t\tif (!Object.prototype.hasOwnProperty.call(have, id)) { have[id] = wanted[id]; }',
+            '\t\t\t\t\t}',
+            '\t\t\t\t\tproduct.extensionRecommendations = have;',
+            '\t\t\t\t\tsettings.productConfiguration = product;',
+        ]);
+        if (added) {
+            log('info', 'Extension recommendations given to the workbench page');
+        }
+    } catch (e) {
+        log('error', `Could not add the extension recommendations: ${e.message}`);
+        log('error', 'The editor still works; a formatter is just never suggested.');
     }
 
     // Build server arguments.

--- a/android/app/src/main/assets/xdg-open.js
+++ b/android/app/src/main/assets/xdg-open.js
@@ -1,0 +1,75 @@
+'use strict';
+
+/**
+ * `xdg-open` for this device: hands a URL to the editor, which hands it to Android.
+ *
+ * Node's "open a browser" helpers spawn the LITERAL command `xdg-open` on Linux,
+ * and Android counts as Linux to every one of them. Nothing on this device's PATH
+ * answered to that name: `setupToolSymlinks` puts ten commands in `usr/bin` and
+ * none of them opens anything. So a preview server printed its own abort line and
+ * the user copied the address into a browser by hand.
+ *
+ * This is reached by its bare name through the execution trampoline, which is what
+ * makes it runnable at all. A file under `filesDir` cannot be `execve`d, so there
+ * is no shebang here to be refused: the table names `libnode.so` in
+ * `nativeLibraryDir` as the interpreter and this file as its argument.
+ *
+ * The URL travels over the CLI socket the editor is already listening on. The
+ * extension host publishes it as VSCODE_IPC_HOOK_CLI, every process an extension
+ * spawns inherits it, and `{"type":"openExternal"}` is the same message VS Code's
+ * own remote CLI sends for `--openExternal`. From there the editor calls
+ * `env.openExternal`, which reaches the page, the `window.open` override, the
+ * Android bridge and a Custom Tab. Nothing new is invented to carry it.
+ *
+ * `file:` URIs are refused here rather than sent. The handler on the other end
+ * skips them silently and answers 200, so forwarding one would report success for
+ * an address nothing opened. Opening a path is a different job with a different
+ * message, and is deliberately not this one.
+ */
+
+const http = require('http');
+
+const socketPath = process.env.VSCODE_IPC_HOOK_CLI;
+const args = process.argv.slice(2).filter((arg) => arg !== '');
+
+function fail(message) {
+    process.stderr.write(`xdg-open: ${message}\n`);
+    process.exit(1);
+}
+
+if (args.length === 0) {
+    fail('no address given');
+}
+
+const unopenable = args.filter((arg) => !/^https?:\/\//i.test(arg));
+if (unopenable.length > 0) {
+    fail(`only http and https addresses can be opened, not ${unopenable[0]}`);
+}
+
+if (!socketPath) {
+    fail('no editor to open this with (VSCODE_IPC_HOOK_CLI is unset)');
+}
+
+const body = JSON.stringify({ type: 'openExternal', uris: args });
+const request = http.request(
+    {
+        socketPath,
+        path: '/',
+        method: 'POST',
+        headers: {
+            'content-type': 'application/json',
+            'content-length': Buffer.byteLength(body),
+        },
+    },
+    (response) => {
+        response.resume();
+        response.on('end', () => {
+            if (response.statusCode === 200) {
+                process.exit(0);
+            }
+            fail(`the editor answered ${response.statusCode}`);
+        });
+    },
+);
+request.on('error', (err) => fail(err.message));
+request.end(body);

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -3132,6 +3132,8 @@ class MainActivity : AppCompatActivity() {
         injectKeyboardGuard()
         // Fix #7: Override window.open() to route through AndroidBridge
         injectWindowOpenOverride()
+        // Answers a paste out of Android's clipboard, which the WebView will not
+        injectClipboardReadFallback()
         // Keeps a downloaded blob readable long enough to be saved, and names it
         injectDownloadCapture()
         // Open in Browser, SSH keys and About are contributed by the bundled bridge
@@ -3516,6 +3518,33 @@ class MainActivity : AppCompatActivity() {
                     // there because that strip is already far wider than 12px, but
                     // narrow it and this rule starts deciding its width.
                     '  .slider { min-width: 12px !important; }',
+                    // A modal dialog is 480px wide on a 411px phone, and the
+                    // overflow is not shared: `.monaco-dialog-modal-block` centres
+                    // the box, so 34.5px hangs off each side and the left half is
+                    // simply unreachable. `min-width` beats `max-width` in CSS, so
+                    // the `max-width:90vw` sitting beside it in the same rule never
+                    // binds and cannot.
+                    //
+                    // Which button is lost is not luck. `rearrangeButtons` takes
+                    // its Linux branch here, because the WebView's user agent says
+                    // Linux, and that branch puts the PRIMARY action last in DOM
+                    // order against a right-aligned row: the affirmative button is
+                    // the one off the screen. On the external-link prompt that is
+                    // "Open", which is the whole point of the dialog, and on the
+                    // GitHub device-code sign-in it is the only way forward.
+                    //
+                    // `min()` rather than 0, so nothing changes where there is room:
+                    // a tablet keeps the 480px this reads as the designed width, and
+                    // only a viewport narrower than that is clamped to fit.
+                    '  .monaco-dialog-box { min-width: min(480px, 90vw) !important; }',
+                    // Clamping the box alone still loses buttons: the row is
+                    // `white-space:nowrap` with `overflow:hidden`, so four actions
+                    // that no longer fit are clipped rather than moved. Wrapping is
+                    // what makes the narrower box actually show them, and the 67px
+                    // indent that aligns them under the message is worth more as
+                    // width on a phone than as alignment.
+                    '  .monaco-dialog-box > .dialog-buttons-row > .dialog-buttons { flex-wrap: wrap !important; }',
+                    '  .monaco-dialog-box:not(.align-vertical) > .dialog-buttons-row > .dialog-buttons { margin-left: 0 !important; }',
                     '  .quick-input-list .monaco-list-row { min-height: 36px !important; }',
                     // The chrome's own text, which no setting in this build can reach.
                     // `editor.fontSize` governs the editor and nothing else; the
@@ -3608,6 +3637,89 @@ class MainActivity : AppCompatActivity() {
                     }
                     return orig.apply(window, arguments);
                 };
+            })();
+            """.trimIndent(),
+            null
+        )
+    }
+
+    /**
+     * Answers the workbench's clipboard READ out of Android's clipboard.
+     *
+     * Copy works and paste does not, and the asymmetry is the WebView's: it
+     * grants the page `clipboard-write` and refuses `clipboard-read`. There is
+     * no site-permission UI in a WebView to grant it in, and
+     * `WebChromeClient.onPermissionRequest` has no clipboard resource to grant
+     * even if there were, so nothing the user can do makes the read succeed.
+     *
+     * What the workbench does with the rejection is the visible half. Its one
+     * `IClipboardService.readText` catches it and raises a STICKY notification
+     * telling the user to grant a permission that does not exist here, and the
+     * promise only settles when they dismiss it, resolving the empty string. So
+     * every paste costs a modal that cannot be acted on and pastes nothing.
+     *
+     * [ClipboardBridge.readFromClipboard] has been able to answer this the whole
+     * time. It is token-validated, it declines to open a `content://` URI through
+     * our own ContentResolver, and it is unit-tested. It simply had no caller in
+     * the page: the only hits outside the built tree were the bridge itself and
+     * its test. This is that caller.
+     *
+     * On the prototype rather than on `navigator.clipboard`, because the call
+     * site resolves the method off the ACTIVE window's navigator on every paste
+     * rather than capturing it once, and the prototype is what every one of those
+     * lookups ends at. The instance is patched instead only where the interface
+     * global is missing, which is not this WebView but costs two lines to be sure
+     * of.
+     *
+     * Injected after load, which is soon enough and provably so: nothing captures
+     * `readText` at bundle-evaluation time. The one thing read that early is a
+     * capability probe that tests the method for truthiness to decide whether to
+     * register the terminal's paste command, and a wrapper is still a function,
+     * so the probe answers the same either way.
+     *
+     * The original is tried FIRST and this only answers its rejection. A WebView
+     * that one day grants the permission then keeps its own answer, and the
+     * fallback costs a rejected promise per paste until it does.
+     *
+     * A null answer is the empty string, not an error: the bridge returns null
+     * for a clipboard holding no text, and pasting nothing is the correct outcome
+     * there. A missing bridge or a missing token rethrows instead, so a genuine
+     * failure still reaches the user as the error it is rather than as a paste
+     * that silently did nothing.
+     *
+     * Fixes the editor, the terminal, the command palette and every extension's
+     * `vscode.env.clipboard.readText()` at once: all of them are that one service.
+     */
+    private fun injectClipboardReadFallback() {
+        webView?.evaluateJavascript(
+            """
+            (function() {
+                if (window.__vscodroidClipboardPatched) return;
+                function fallback(reason) {
+                    var t = (window.__vscodroid || {}).authToken;
+                    if (!t || typeof AndroidBridge === 'undefined') { throw reason; }
+                    var text = AndroidBridge.readFromClipboard(t);
+                    return (text === null || text === undefined) ? '' : text;
+                }
+                function wrap(orig) {
+                    return function() {
+                        var self = this, args = arguments;
+                        try {
+                            return Promise.resolve(orig.apply(self, args)).catch(fallback);
+                        } catch (e) {
+                            return Promise.reject(e).catch(fallback);
+                        }
+                    };
+                }
+                var proto = window.Clipboard && window.Clipboard.prototype;
+                if (proto && typeof proto.readText === 'function') {
+                    proto.readText = wrap(proto.readText);
+                } else if (navigator.clipboard && typeof navigator.clipboard.readText === 'function') {
+                    navigator.clipboard.readText = wrap(navigator.clipboard.readText.bind(navigator.clipboard));
+                } else {
+                    return;
+                }
+                window.__vscodroidClipboardPatched = true;
             })();
             """.trimIndent(),
             null

--- a/android/app/src/main/kotlin/com/vscodroid/keyboard/ExtraKeyRow.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/keyboard/ExtraKeyRow.kt
@@ -25,6 +25,44 @@ import com.vscodroid.util.Logger
  */
 private const val DOT_SIZE_DP = 8
 
+/**
+ * Height of the swipeable key pages, which is the larger half of what this row
+ * costs the page below it. Named because [ExtraKeyRow.rowHeightPx] has to agree
+ * with the layout parameter it is derived from.
+ */
+private const val PAGER_HEIGHT_DP = 56
+
+/**
+ * How much page has to survive this row before it is allowed to take any.
+ *
+ * The row takes its height OUT of the WebView rather than covering it, which is
+ * the whole point of the vertical layout it sits in, and until now it took that
+ * height whatever was left. On a landscape phone there is nothing left to take:
+ * measured on an API 36 emulator at 1080x2424, density 2.625, the keyboard's own
+ * inset is 662px of a 1080px window and the status bar another 137px, so with this
+ * row's 197px the page was handed 84px, about 32dp. The title bar and the status
+ * bar overlapped and no line of the file showed at all, so the row was offering
+ * keys for an editor nobody could see.
+ *
+ * This is a threshold for taking, NOT a promise of what is left. Landscape on a
+ * phone gives the page 107dp once the row stands down, which is still cramped:
+ * the keyboard alone is 61% of that window and nothing here can change it. What
+ * the number says is that a row costing 75dp is not worth paying for out of a
+ * page that would then hold less than a title bar, a tab strip and a line. Above
+ * the threshold nothing changes at all, which is every phone in portrait and every
+ * tablet in either orientation.
+ *
+ * Suppressing the row rather than shrinking it, because there is no shrink worth
+ * having. The pages are already at [MIN_TOUCH_TARGET_DP], the accessibility floor
+ * every key is sized against, so the only height that could be given back without
+ * going under it is the page-indicator band, about 19dp against a shortfall near
+ * 90. What suppression costs is real and is not softened here: Tab, Escape, the
+ * modifiers, the arrows and every bracket go with it, and in a terminal that
+ * includes Ctrl+C. It buys the only thing that makes any of them useful, which is
+ * being able to see what they did.
+ */
+private const val MIN_PAGE_HEIGHT_DP = 120
+
 class ExtraKeyRow @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
@@ -254,7 +292,7 @@ class ExtraKeyRow @JvmOverloads constructor(
 
         // ViewPager2 for swipeable key pages
         viewPager = ViewPager2(context).apply {
-            layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, dpToPx(56))
+            layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, dpToPx(PAGER_HEIGHT_DP))
             offscreenPageLimit = 1
         }
         addView(viewPager)
@@ -297,6 +335,37 @@ class ExtraKeyRow @JvmOverloads constructor(
         setupPageChangeCallback()
     }
 
+    /**
+     * What this row costs the page, decided before it has ever been measured.
+     *
+     * The inset listener has to know the cost while the row is still GONE, when
+     * its measured height is zero, so this is derived from the same three figures
+     * the views above are built from rather than read back off them. The band's
+     * floor is [android.view.View.getMinimumHeight] rather than a literal because
+     * the badge grows with the user's font scale, which is exactly why the floor
+     * is derived from paint metrics up there.
+     *
+     * Pinned against the real measurement by
+     * `KeyRowAccessibilityInstrumentedTest.latchingAModifierDoesNotChangeTheHeightOfTheRow`,
+     * so this copy cannot drift from the row it is describing without a test
+     * saying so.
+     */
+    val rowHeightPx: Int =
+        dpToPx(PAGER_HEIGHT_DP) + dotContainer.minimumHeight + dpToPx(2) + dpToPx(4)
+
+    /**
+     * Whether the row has stood down because the page had no height to spare.
+     *
+     * Latched for as long as the keyboard is up, rather than recomputed per
+     * dispatch. Insets are re-dispatched on every change in the keyboard's own
+     * height, and a phone landscape sits far enough below [MIN_PAGE_HEIGHT_DP]
+     * that no ordinary change crosses back over it; but an emoji panel or a voice
+     * panel can move the boundary, and a row appearing and disappearing under a
+     * user's thumb would relayout the workbench and resize every PTY with it each
+     * time. That is the same cost the band floor above exists to prevent.
+     */
+    private var suppressedForHeight = false
+
     fun setupWithRootView(rootView: View) {
         ViewCompat.setOnApplyWindowInsetsListener(rootView) { v, insets ->
             // The display cutout is its own inset type, not part of systemBars().
@@ -317,8 +386,27 @@ class ExtraKeyRow @JvmOverloads constructor(
             val bottomInset = maxOf(bars.bottom, ime.bottom)
             v.setPadding(bars.left, bars.top, bars.right, bottomInset)
 
-            visibility = if (imeVisible) View.VISIBLE else View.GONE
+            // What the page would be left with if this row took its height too.
+            //
+            // The window's own height, not the root view's: this runs during the
+            // inset dispatch, before the traversal that would give the view a
+            // height for this configuration, so reading the view here would answer
+            // for the previous one. `displayMetrics` is window-scoped and is
+            // already updated, which is the same source `dpToPx` resolves against
+            // and the same one `pages` is packed from a few lines up.
+            val pageHeightPx =
+                resources.displayMetrics.heightPixels - bars.top - bottomInset - rowHeightPx
             if (!imeVisible) {
+                suppressedForHeight = false
+            } else if (pageHeightPx < dpToPx(MIN_PAGE_HEIGHT_DP)) {
+                suppressedForHeight = true
+            }
+            val showRow = imeVisible && !suppressedForHeight
+
+            visibility = if (showRow) View.VISIBLE else View.GONE
+            // Standing down for height leaves through the same door the keyboard
+            // going away already used, and needs everything that is done there.
+            if (!showRow) {
                 // The popup is a window of its own and the row going GONE does
                 // not take it with it: nothing here is its parent. Measured on an
                 // API 37 emulator, long press `{}`, then let the keyboard go: the
@@ -339,7 +427,11 @@ class ExtraKeyRow @JvmOverloads constructor(
                 longPressPopup = null
                 resetModifiersIfNeeded()
             }
-            Logger.d(tag, "IME visible=$imeVisible, bottomInset=$bottomInset")
+            Logger.d(
+                tag,
+                "IME visible=$imeVisible, bottomInset=$bottomInset, " +
+                    "pageHeight=${pageHeightPx}px, row=${if (showRow) "shown" else "hidden"}"
+            )
             insets
         }
     }

--- a/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/FirstRunSetup.kt
@@ -544,7 +544,13 @@ class FirstRunSetup(
             if (!extracted) incomplete += "vscode-reh"
 
             reportProgress(context.getString(R.string.setup_step_bootstrap), 60)
-            for (script in listOf("server.js", "process-monitor.js", "platform-fix.js", "dns-proxy.js")) {
+            // xdg-open.js is not a bootstrap script and is never required by one:
+            // it is the program the execution trampoline runs for the command
+            // `xdg-open`, and it lands here because this is where the trampoline's
+            // table is told to look for it.
+            for (script in listOf(
+                "server.js", "process-monitor.js", "platform-fix.js", "dns-proxy.js", "xdg-open.js",
+            )) {
                 if (!extractAssetFile(script, "server/$script")) incomplete += script
             }
 

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
@@ -3085,6 +3085,14 @@ class ToolchainManager(private val context: Context) {
         var added = 0
         for (name in names.sorted()) {
             if (name in rows) continue
+            // A tab or a newline in the name is a torn record: the trampoline
+            // splits a row on its tabs and would read what follows as a path the
+            // user never chose. These names come from a directory anyone can write
+            // to, unlike the toolchain manifests the rows above are built from.
+            if (name.any { it == '\t' || it == '\n' }) {
+                Logger.w(tag, "No row for a command whose name the table cannot carry")
+                continue
+            }
             val script = File(binDir, name)
             // readlink succeeds only for a symlink, which is how a bundled tool is
             // told apart from a script without reaching for OsConstants.

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
@@ -2919,11 +2919,9 @@ class ToolchainManager(private val context: Context) {
             Logger.w(tag, "toolchains.json is unreadable; keeping the exec table as it stands")
             return
         }
-        if (installed.length() == 0) {
-            if (execTable.exists()) execTable.delete()
-            refreshTrampolineLinks(emptySet())
-            return
-        }
+        // No early return for an empty record any more. The table is no longer
+        // only about toolchains: the row this app owns below has to exist on a
+        // device that has never installed one, which is most devices.
 
         // Insertion-ordered so the file is stable between runs: a table that
         // reordered itself on every launch would make every diff of it
@@ -2995,6 +2993,24 @@ class ToolchainManager(private val context: Context) {
                 }
             }
         }
+
+        // The one row this app owns rather than a toolchain. `putIfAbsent`, and
+        // after the loop, so a toolchain shipping its own `xdg-open` keeps the
+        // name: rows are keyed by command and the toolchain's went in first, and
+        // an opener that came with a toolchain knows more about it than this does.
+        //
+        // Node's browser helpers spawn the literal command `xdg-open` on Android,
+        // and nothing on PATH answered to it, so a preview server could only print
+        // that it had given up. The interpreter form is used rather than a plain
+        // path because the program is a JavaScript file under `filesDir`, which
+        // SELinux will not `execve`; naming `libnode.so` in `nativeLibraryDir` as
+        // its interpreter is the same shape the script wrappers above use, and the
+        // reason this launch pass has to rewrite the table at all is that Android
+        // hands out a new `nativeLibraryDir` on every reinstall.
+        rows.putIfAbsent(
+            "xdg-open",
+            "xdg-open\t${Environment.getNodePath(context)}\t$filesDir/server/xdg-open.js",
+        )
 
         val body = (envRows.values + rows.values).joinToString("\n", postfix = "\n")
         execTable.parentFile?.mkdirs()

--- a/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/setup/ToolchainManager.kt
@@ -273,6 +273,16 @@ class ToolchainManager(private val context: Context) {
         private const val KEY_EXEC_REPAIRED = "execBitsChecked"
 
         /**
+         * How much of a file in `usr/bin` is read to find out what runs it.
+         *
+         * A `#!` line is the first thing in the file and a console script's is well
+         * under this, so the whole answer is always in the first read. Bounded
+         * because this runs over every name in that directory on every launch and
+         * nothing stops a user putting an enormous file there.
+         */
+        private const val SHEBANG_HEAD_BYTES = 256
+
+        /**
          * Serialises every read-modify-write cycle on `toolchains.json` and the
          * env file generated from it.
          *
@@ -3011,6 +3021,7 @@ class ToolchainManager(private val context: Context) {
             "xdg-open",
             "xdg-open\t${Environment.getNodePath(context)}\t$filesDir/server/xdg-open.js",
         )
+        addPipInstalledScriptRows(rows)
 
         val body = (envRows.values + rows.values).joinToString("\n", postfix = "\n")
         execTable.parentFile?.mkdirs()
@@ -3025,6 +3036,92 @@ class ToolchainManager(private val context: Context) {
         refreshTrampolineLinks(rows.keys)
         Logger.i(tag, "Regenerated toolchain-exec.tsv (${rows.size} commands, " +
             "${envRows.size} variables)")
+    }
+
+    /**
+     * Gives every command `pip` has installed a row, so it can actually run.
+     *
+     * `pip install black` succeeds, reports success, and writes an executable
+     * `usr/bin/black` that is already on PATH, and then the command does not run:
+     *
+     *     bash: .../usr/bin/black: .../usr/bin/python3: bad interpreter: Permission denied
+     *
+     * Measured in the app's own terminal, which is the only place it can be
+     * measured: `run-as` runs in the `runas_app` SELinux domain rather than
+     * `untrusted_app`, and there the same command succeeds. A shebang script has
+     * to be `execve`d on its own inode to reach its interpreter, and the kernel
+     * refuses that for anything under `filesDir`. This is the same wall the npm
+     * and pip shell functions were written for, and those cover exactly two names
+     * and only for bash; a formatter extension spawning a command reaches neither.
+     *
+     * The interpreter form settles it: the trampoline is a real binary in
+     * `nativeLibraryDir`, so it starts, and it then runs the bundled Python ELF
+     * with the script as an argument. Nothing is `execve`d under `filesDir` at any
+     * point, which is why this works where the shebang does not.
+     *
+     * Only `usr/bin`, because that is where pip puts a console script when the
+     * interpreter's prefix is the one the app ships, and only regular files there:
+     * every other name in that directory is a symlink [FirstRunSetup.setupToolSymlinks]
+     * made onto an ELF that already runs.
+     *
+     * Only a Python shebang. A script naming some other interpreter is not one
+     * this can help, and handing it to Python would turn a command that does not
+     * start into one that starts and does the wrong thing.
+     *
+     * Rows already present win, so a toolchain's own command and the app's own
+     * `xdg-open` keep their meaning.
+     *
+     * The table is rewritten by the launch pass, so a command installed while the
+     * app is running becomes reachable on the next launch rather than at once.
+     * Worth knowing before reading a bug report that says a fresh `pip install`
+     * still is not found.
+     */
+    private fun addPipInstalledScriptRows(rows: LinkedHashMap<String, String>) {
+        val binDir = File(context.filesDir, "usr/bin")
+        val names = binDir.list() ?: return
+        val interpreter = "${context.applicationInfo.nativeLibraryDir}/libpython.so"
+        if (!File(interpreter).exists()) return
+
+        var added = 0
+        for (name in names.sorted()) {
+            if (name in rows) continue
+            val script = File(binDir, name)
+            // readlink succeeds only for a symlink, which is how a bundled tool is
+            // told apart from a script without reaching for OsConstants.
+            val isSymlink = try {
+                Os.readlink(script.absolutePath); true
+            } catch (_: Exception) {
+                false
+            }
+            if (isSymlink || !script.isFile) continue
+            if (!namesPythonInShebang(script)) continue
+            rows[name] = "$name\t$interpreter\t${script.absolutePath}"
+            added++
+        }
+        if (added > 0) Logger.i(tag, "Exec table carries $added pip-installed commands")
+    }
+
+    /**
+     * Whether [script] starts with a `#!` line naming a Python interpreter.
+     *
+     * Reads a bounded head rather than the file: a console script is a few hundred
+     * bytes, but nothing stops a user putting something enormous in this directory,
+     * and this runs on every launch.
+     */
+    private fun namesPythonInShebang(script: File): Boolean = try {
+        script.inputStream().use { stream ->
+            val head = ByteArray(SHEBANG_HEAD_BYTES)
+            val read = stream.read(head)
+            if (read < 3) {
+                false
+            } else {
+                val first = String(head, 0, read, Charsets.ISO_8859_1).substringBefore('\n')
+                first.startsWith("#!") && first.contains("python")
+            }
+        }
+    } catch (e: Exception) {
+        Logger.d(tag, "Could not read ${script.name} to see what runs it: ${e.message}")
+        false
     }
 
     /**

--- a/android/app/src/main/kotlin/com/vscodroid/util/Environment.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/util/Environment.kt
@@ -66,9 +66,12 @@ object Environment {
         // Behind nativeLibDir, because that is where bash, node, git and rg
         // live as real executables and no toolchain may shadow them.
         //
-        // Absent for anyone who has installed no toolchain: the generator only
-        // creates it when there is something to put in it, and a PATH entry that
-        // does not exist costs one failed lookup per command.
+        // Present on every device, which it was not until `xdg-open` moved in.
+        // The generator used to create this directory only when a toolchain had
+        // put something in it, so on a device with none the entry named nothing
+        // and cost one failed lookup per command. It now always carries at least
+        // the browser opener, which is a command the editor needs whether or not
+        // a toolchain was ever installed.
         val basePath = "$nativeLibDir:${getTrampolineBinDir(context)}:$filesDir/usr/bin"
         val path = if (extraPath != null)
             "$basePath:$extraPath:/system/bin"

--- a/android/app/src/test/kotlin/com/vscodroid/keyboard/ExtraKeyRowPopupTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/keyboard/ExtraKeyRowPopupTest.kt
@@ -106,14 +106,25 @@ class ExtraKeyRowPopupTest {
     @Test
     fun `the popup goes down with the keyboard`() {
         val lines = code()
-        val start = lines.indexOfFirst { it.contains("visibility = if (imeVisible)") }
+        val start = lines.indexOfFirst { it.contains("visibility = if (showRow)") }
         assertTrue(
             start >= 0,
             "the row no longer drives its visibility from the IME insets, so this case is " +
                 "reading nothing",
         )
 
-        val body = lines.drop(start).take(8).joinToString("\n")
+        // Bounded by the line that ends the listener's decision rather than by a
+        // line count. The branch below the anchor carries most of the reasoning
+        // that keeps it correct, so any window written as a number is a window a
+        // comment can push the code out of, silently.
+        val length = lines.drop(start).indexOfFirst { it.contains("Logger.d(") }
+        assertTrue(
+            length > 0,
+            "the listener no longer logs what it decided, so this case cannot tell where " +
+                "the decision it is reading ends",
+        )
+
+        val body = lines.drop(start).take(length).joinToString("\n")
         assertTrue(
             body.contains("resetModifiersIfNeeded()"),
             "the hidden-IME branch is no longer where this test looks. It reads:\n$body",

--- a/android/app/src/test/kotlin/com/vscodroid/keyboard/ExtraKeyToggleStateTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/keyboard/ExtraKeyToggleStateTest.kt
@@ -103,9 +103,30 @@ class ExtraKeyToggleStateTest {
                 "the field check below is not looking at a row that reads the shared store",
         )
 
+        // The one boolean this row is allowed to keep, named here because the KDoc
+        // above asks for exactly that rather than for the ban to be widened.
+        //
+        // `suppressedForHeight` is not modifier state and cannot drift the way a
+        // modifier can. Nothing paints it, the adapter never reads it, and the inset
+        // listener that owns it recomputes the decision from the window on every
+        // dispatch and clears the flag whenever the keyboard goes away. What it
+        // holds is that the row already stood down because the page had no height
+        // to spare, so the answer does not flip while the keyboard changes its own
+        // height under the user's thumb.
+        val notModifierState = setOf("suppressedForHeight")
+
+        // Control: an allowance for a field that no longer exists hides nothing and
+        // would quietly excuse the next boolean that took the same name.
+        assertTrue(
+            row.declaredFields.any { it.name in notModifierState },
+            "the exception named in this test is no longer a field on the row, so the " +
+                "allowance below should go with it",
+        )
+
         val ownState = row.declaredFields
             .filter { it.type == java.lang.Boolean.TYPE }
             .map { it.name }
+            .filterNot { it in notModifierState }
 
         assertEquals(
             emptyList<String>(), ownState,

--- a/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainExecTableTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainExecTableTest.kt
@@ -1,6 +1,8 @@
 package com.vscodroid.setup
 
 import android.content.Context
+import android.system.Os
+import android.system.StructStat
 import com.google.android.play.core.assetpacks.AssetPackManagerFactory
 import com.vscodroid.util.Logger
 import io.mockk.Runs
@@ -18,6 +20,9 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
+import java.nio.file.Files
+import java.nio.file.LinkOption
+import java.nio.file.Path
 
 /**
  * What `toolchain-exec.tsv` has to contain for a toolchain command to work when
@@ -45,6 +50,7 @@ class ToolchainExecTableTest {
     private lateinit var stateFile: File
     private lateinit var execTable: File
     private lateinit var envFile: File
+    private lateinit var nativeLibDir: File
 
     @BeforeEach
     fun setUp() {
@@ -60,8 +66,37 @@ class ToolchainExecTableTest {
         mockkStatic(AssetPackManagerFactory::class)
         every { AssetPackManagerFactory.getInstance(any()) } returns mockk(relaxed = true)
 
+        // Backed by the real filesystem, so a symlink in usr/bin is told apart
+        // from a script the way the generator tells them apart on a device.
+        mockkStatic(Os::class)
+        every { Os.lstat(any()) } answers {
+            val path = Path.of(firstArg<String>())
+            if (!Files.exists(path, LinkOption.NOFOLLOW_LINKS)) {
+                throw java.io.FileNotFoundException(path.toString())
+            }
+            mockk<StructStat>(relaxed = true)
+        }
+        every { Os.readlink(any()) } answers {
+            Files.readSymbolicLink(Path.of(firstArg<String>())).toString()
+        }
+        every { Os.symlink(any(), any()) } answers {
+            Files.createSymbolicLink(Path.of(secondArg<String>()), Path.of(firstArg<String>()))
+            Unit
+        }
+
         context = mockk(relaxed = true)
         every { context.filesDir } returns filesDir
+        // The only directory this app may execve from, and the one every
+        // interpreter row has to name. Real files, because the generator declines
+        // to write a row naming an interpreter that is not there.
+        nativeLibDir = File(filesDir, "nativeLib").apply { mkdirs() }
+        File(nativeLibDir, "libnode.so").writeText("elf")
+        File(nativeLibDir, "libpython.so").writeText("elf")
+        every { context.applicationInfo } answers {
+            android.content.pm.ApplicationInfo().apply {
+                nativeLibraryDir = this@ToolchainExecTableTest.nativeLibDir.absolutePath
+            }
+        }
 
         File(filesDir, "home/.vscodroid").mkdirs()
         stateFile = File(filesDir, "home/.vscodroid/toolchains.json")
@@ -399,6 +434,101 @@ class ToolchainExecTableTest {
         assertEquals(
             "${filesDir.absolutePath}/server/xdg-open.js", fields[2],
             "the row does not name the opener FirstRunSetup extracts",
+        )
+    }
+
+    /** A console script pip has written, and the two names beside it that are not. */
+    private fun pipBin() = File(filesDir, "usr/bin").apply { mkdirs() }
+
+    /**
+     * What `pip install black` leaves behind, and why it does not run without this.
+     *
+     * pip writes an executable `usr/bin/black` whose first line points at the
+     * interpreter, and that directory is already on PATH, so the command is found.
+     * Running it then fails: reaching the interpreter means execve on the script's
+     * own inode, and SELinux refuses that for anything under filesDir. Measured in
+     * the app's terminal as `bad interpreter: Permission denied`.
+     *
+     * The interpreter form has no such step. The trampoline starts because it lives
+     * in nativeLibraryDir, and it runs the bundled Python with the script as an
+     * argument, so nothing under filesDir is ever execve'd.
+     */
+    @Test
+    fun `a command pip installed gets a row that runs it through Python`() {
+        stateFile.writeText("[]")
+        File(pipBin(), "black").writeText("#!${filesDir.absolutePath}/usr/bin/python3\nprint(1)\n")
+
+        regenerate()
+
+        assertEquals(
+            listOf(
+                "black\t${nativeLibDir.absolutePath}/libpython.so" +
+                    "\t${filesDir.absolutePath}/usr/bin/black"
+            ),
+            tableLines().filter { it.startsWith("black\t") },
+            "nothing runs `black`, so a formatter that spawns it still reports it missing:\n" +
+                execTable.readText(),
+        )
+    }
+
+    /**
+     * The bundled tools in the same directory are symlinks onto ELFs that already
+     * run, and a row for one would send `bash` or `node` through Python.
+     */
+    @Test
+    fun `a bundled tool in the same directory gets no row`() {
+        stateFile.writeText("[]")
+        Files.createSymbolicLink(
+            File(pipBin(), "node").toPath(),
+            File(nativeLibDir, "libnode.so").toPath(),
+        )
+
+        regenerate()
+
+        assertEquals(
+            emptyList<String>(),
+            tableLines().filter { it.startsWith("node\t") },
+            "a bundled tool was given a row, which would run an ELF through Python",
+        )
+    }
+
+    /**
+     * Only a Python shebang. Handing anything else to Python turns a command that
+     * does not start into one that starts and does the wrong thing.
+     */
+    @Test
+    fun `a script naming another interpreter gets no row`() {
+        stateFile.writeText("[]")
+        File(pipBin(), "somesh").writeText("#!/bin/sh\necho hi\n")
+
+        regenerate()
+
+        assertEquals(
+            emptyList<String>(),
+            tableLines().filter { it.startsWith("somesh\t") },
+            "a shell script was routed through the Python interpreter",
+        )
+    }
+
+    /**
+     * A toolchain owns its own names. pip writing a script of the same name must
+     * not take a toolchain's command away from it.
+     */
+    @Test
+    fun `a toolchain keeps a name pip also installed`() {
+        elf("usr/opt/ruby/bin/black")
+        stateFile.writeText(
+            """[{"name":"ruby","installRoot":"usr/opt/ruby",""" +
+                """"binaries":["usr/opt/ruby/bin/black"]}]"""
+        )
+        File(pipBin(), "black").writeText("#!${filesDir.absolutePath}/usr/bin/python3\nprint(1)\n")
+
+        regenerate()
+
+        assertEquals(
+            listOf("black\t${filesDir.absolutePath}/usr/opt/ruby/bin/black"),
+            tableLines().filter { it.startsWith("black\t") },
+            "the pip script displaced the toolchain's own command",
         )
     }
 }

--- a/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainExecTableTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainExecTableTest.kt
@@ -91,6 +91,17 @@ class ToolchainExecTableTest {
     private fun tableLines() = execTable.readText().lines().filter { it.isNotEmpty() }
 
     /**
+     * The table without the row the app owns rather than a toolchain.
+     *
+     * `xdg-open` is written into every table, on a device with no toolchain
+     * installed included, because a browser opener is not a toolchain's to
+     * provide. The cases below are each about one toolchain's own rows and say so
+     * by reading this; the base row has its own case, which is where a change to
+     * it should fail.
+     */
+    private fun toolchainLines() = tableLines().filterNot { it.startsWith("xdg-open\t") }
+
+    /**
      * The trampoline gets no working directory it can trust and no shell to
      * expand anything, so the row has to name the payload outright. The env file
      * writes `$PREFIX/../usr/...` for its own reader, and copying that spelling
@@ -108,7 +119,7 @@ class ToolchainExecTableTest {
 
         assertEquals(
             listOf("ruby\t${filesDir.absolutePath}/usr/opt/ruby/bin/ruby"),
-            tableLines(),
+            toolchainLines(),
             "the trampoline cannot resolve this row, so `ruby` from a task or a " +
                 "make recipe still fails:\n" + execTable.readText(),
         )
@@ -198,7 +209,7 @@ class ToolchainExecTableTest {
 
         regenerate()
 
-        val (envRows, commandRows) = tableLines().partition { it.startsWith("\t") }
+        val (envRows, commandRows) = toolchainLines().partition { it.startsWith("\t") }
         assertEquals(1, envRows.size, "expected one environment row:\n" + execTable.readText())
         assertEquals(
             listOf("ruby\t${filesDir.absolutePath}/usr/bin/ruby"), commandRows,
@@ -321,17 +332,22 @@ class ToolchainExecTableTest {
 
         assertEquals(
             emptyList<String>(),
-            tableLines(),
+            toolchainLines(),
             "a row was written for a binary that is not on disk",
         )
     }
 
     /**
-     * With nothing installed the table goes, rather than being left as the last
-     * record of a toolchain the user has removed.
+     * With nothing installed a removed toolchain's rows go, and the row the app
+     * owns stays.
+     *
+     * The table used to be deleted outright here, which was right while every row
+     * in it belonged to a toolchain. It no longer is: `xdg-open` is what a Node
+     * browser helper spawns, it has to be reachable on a device that has never
+     * installed a toolchain, and that is most devices.
      */
     @Test
-    fun `an empty record removes the table`() {
+    fun `an empty record removes a toolchain's rows and keeps the app's own`() {
         elf("usr/opt/ruby/bin/ruby")
         stateFile.writeText(
             """[{"name":"ruby","installRoot":"usr/opt/ruby",""" +
@@ -339,10 +355,50 @@ class ToolchainExecTableTest {
         )
         regenerate()
         assertTrue(execTable.isFile, "the table was never written, so this proves nothing")
+        assertTrue(toolchainLines().isNotEmpty(), "control: the toolchain never got a row")
 
         stateFile.writeText("[]")
         regenerate()
 
-        assertFalse(execTable.exists(), "the table outlived the last toolchain")
+        assertEquals(
+            emptyList<String>(),
+            toolchainLines(),
+            "a removed toolchain's rows outlived it",
+        )
+        assertTrue(
+            execTable.isFile,
+            "the table went with the last toolchain and took the browser opener with it",
+        )
+    }
+
+    /**
+     * The row the app owns, which no toolchain provides and every device needs.
+     *
+     * Node's browser helpers spawn the literal command `xdg-open`, so the name is
+     * not ours to choose. The interpreter form is: the payload is JavaScript under
+     * `filesDir`, which SELinux will not execve, so the row names `libnode.so` in
+     * `nativeLibraryDir` and hands it the script.
+     */
+    @Test
+    fun `the browser opener gets a row on a device with no toolchain`() {
+        stateFile.writeText("[]")
+
+        regenerate()
+
+        val fields = tableLines().single().split("\t")
+        assertEquals(
+            3, fields.size,
+            "the row is not the interpreter form, so the trampoline would try to execve a " +
+                "JavaScript file:\n" + execTable.readText(),
+        )
+        assertEquals("xdg-open", fields[0], "the command is not the name Node helpers spawn")
+        assertTrue(
+            fields[1].endsWith("/libnode.so"),
+            "the interpreter is not the bundled Node, so nothing can run the payload: ${fields[1]}",
+        )
+        assertEquals(
+            "${filesDir.absolutePath}/server/xdg-open.js", fields[2],
+            "the row does not name the opener FirstRunSetup extracts",
+        )
     }
 }

--- a/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainExecTableTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainExecTableTest.kt
@@ -511,6 +511,35 @@ class ToolchainExecTableTest {
     }
 
     /**
+     * A name that would tear the record gets no row.
+     *
+     * The trampoline splits a row on its tabs, so a tab in a command name would be
+     * read as the row's next field: a path the user never chose. The toolchain rows
+     * above come from a manifest this app ships, but anyone can write a file into
+     * `usr/bin`, so the name has to be checked here.
+     */
+    @Test
+    fun `a command name the table cannot carry gets no row`() {
+        stateFile.writeText("[]")
+        val torn = File(pipBin(), "bad\tname")
+        // Some filesystems refuse the character outright, which is the same outcome
+        // by another route and leaves nothing to assert about.
+        val staged = try {
+            torn.writeText("#!${filesDir.absolutePath}/usr/bin/python3\nprint(1)\n"); torn.isFile
+        } catch (_: Exception) {
+            false
+        }
+        org.junit.jupiter.api.Assumptions.assumeTrue(staged, "the filesystem would not stage the name")
+
+        regenerate()
+
+        assertFalse(
+            execTable.readText().contains("bad\tname"),
+            "a torn record reached the table:\n" + execTable.readText(),
+        )
+    }
+
+    /**
      * A toolchain owns its own names. pip writing a script of the same name must
      * not take a toolchain's command away from it.
      */

--- a/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainTrampolineLinkTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/setup/ToolchainTrampolineLinkTest.kt
@@ -186,9 +186,10 @@ class ToolchainTrampolineLinkTest {
         // rather than as "irb is gone" because this directory is on PATH, so the
         // refresher's own staging files have to leave with the uninstalled names.
         assertEquals(
-            listOf("ruby"),
+            listOf("ruby", "xdg-open"),
             tcBinDir.list()?.sorted(),
-            "the trampoline directory holds something other than the installed commands",
+            "the trampoline directory holds something other than the installed commands " +
+                "and the browser opener the app puts there itself",
         )
     }
 
@@ -203,6 +204,11 @@ class ToolchainTrampolineLinkTest {
      * the row survives, the link survives, and the command the user just removed
      * answers exit 127 from the trampoline instead of the shell's own
      * "command not found".
+     *
+     * What is left behind afterwards is the row the app owns rather than a
+     * toolchain. `xdg-open` is what a Node browser helper spawns and has to be
+     * reachable whether or not a toolchain was ever installed, so the table and
+     * this directory now survive the last uninstall carrying exactly that.
      */
     @Test
     fun `uninstall takes the rows and the links with it`() {
@@ -216,12 +222,14 @@ class ToolchainTrampolineLinkTest {
         uninstallSync.isAccessible = true
         uninstallSync.invoke(manager, "ruby")
 
-        assertFalse(
-            File(filesDir, "home/.vscodroid/toolchain-exec.tsv").exists(),
+        val table = File(filesDir, "home/.vscodroid/toolchain-exec.tsv")
+        assertEquals(
+            emptyList<String>(),
+            table.readText().lines().filter { it.isNotEmpty() && !it.startsWith("xdg-open\t") },
             "the table outlived the toolchain it describes",
         )
         assertEquals(
-            emptyList<String>(),
+            listOf("xdg-open"),
             tcBinDir.list()?.sorted().orEmpty(),
             "a removed toolchain's commands are still on PATH",
         )

--- a/branding/product.json
+++ b/branding/product.json
@@ -67,7 +67,8 @@
     "urlProtocol": "vscodroid",
     "quality": "stable",
     "linkProtectionTrustedDomains": [
-      "https://open-vsx.org"
+      "https://open-vsx.org",
+      "https://github.com"
     ],
     "telemetryOptIn": false,
     "enableTelemetry": false,

--- a/docs/04-TECHNICAL_SPEC.md
+++ b/docs/04-TECHNICAL_SPEC.md
@@ -397,6 +397,11 @@ still does not reach is an absolute-path invocation such as `$JAVA_HOME/bin/java
 forking its own helper by absolute path (the JDK's `lib/jspawnhelper`), and direct execution of a
 shebang script under `filesDir`, whose own inode is refused before its interpreter is consulted.
 
+The table is no longer only about toolchains. One row is the app's own: `xdg-open`, the literal
+command every Node browser helper spawns, mapped through `libnode.so` onto `assets/xdg-open.js`.
+That is why the generator now writes a table and a `tcbin` on a device with no toolchain installed,
+where it used to delete both.
+
 ---
 
 ## 3. Server Bootstrap

--- a/docs/04-TECHNICAL_SPEC.md
+++ b/docs/04-TECHNICAL_SPEC.md
@@ -402,6 +402,14 @@ command every Node browser helper spawns, mapped through `libnode.so` onto `asse
 That is why the generator now writes a table and a `tcbin` on a device with no toolchain installed,
 where it used to delete both.
 
+The generator also scans `usr/bin` for regular files whose `#!` line names Python, which is what
+`pip install` writes for a package that ships a command, and gives each one an interpreter row onto
+`libpython.so`. Without it `pip install black` produced a `black` on PATH that answered
+`bad interpreter: Permission denied`, since reaching the interpreter through a shebang means
+`execve` on the script's own inode. Symlinks in that directory are skipped: those are the bundled
+tools, already pointing at ELFs that run. The rows are written by the launch pass, so a command
+installed while the app is running is reachable on the next launch.
+
 ---
 
 ## 3. Server Bootstrap

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -745,7 +745,8 @@ in [Dev Server Preview](#dev-server-preview) above.
 ### Python Command-Line Tools
 
 Some packages install a command as well as a module: `pytest`, `black`, `httpie`,
-`cowsay`. The install succeeds and the command still does not run.
+`cowsay`. These work, with one delay worth knowing about: a command you have just
+installed starts working the next time you open VSCodroid, not straight away.
 
 ```
 $ pip install cowsay
@@ -753,16 +754,20 @@ $ cowsay -t hi
 bash: /data/.../usr/bin/cowsay: /data/.../usr/bin/python3: bad interpreter: Permission denied
 ```
 
-The command pip writes is a short text file starting with `#!` and the path to
-the interpreter. Android does not let an app run a program out of its own
-storage, which is why VSCodroid's own tools live in a directory the system does
-allow, and a file pip writes has nowhere else to go. The message names `python3`,
-so it reads as a broken Python; Python is fine, and the interpreter it names runs
-perfectly when you call it yourself. It is the one-line launcher that cannot
-start.
+Close VSCodroid, open it again, and the same line works.
 
-Run the module instead. Every one of these packages is importable, which is what
-the command was starting anyway:
+The delay comes from how the command is made to run at all. Android does not let
+an app run a program out of its own storage, and what pip writes is exactly that:
+a short text file starting with `#!` and the path to the interpreter. VSCodroid
+keeps a small table of what each command means and starts the interpreter itself,
+which is allowed. That table is rebuilt when the app starts, so a command
+installed while it is running is not in it yet, and until then you get the message
+above. It names `python3`, so it reads as a broken Python; Python is fine, and the
+interpreter it names runs perfectly when you call it yourself. It is the one-line
+launcher that cannot start.
+
+If you would rather not wait, run the module. It does the same thing and works the
+moment pip finishes:
 
 ```bash
 python3 -m pytest
@@ -1070,7 +1075,7 @@ If `npm install` fails with errors:
 
 ### Python: Installed, and Then Something Fails
 
-- **`bad interpreter: Permission denied`** after installing a package that brings a command with it (`pytest`, `black`, `httpie`). Run it as a module instead: `python3 -m pytest`. See [Python Command-Line Tools](#python-command-line-tools) for why the message names `python3` when Python is not the problem.
+- **`bad interpreter: Permission denied`** after installing a package that brings a command with it (`pytest`, `black`, `httpie`). Open VSCodroid again and the command works; to use it without waiting, run it as a module: `python3 -m pytest`. See [Python Command-Line Tools](#python-command-line-tools) for why the message names `python3` when Python is not the problem.
 - **`ZoneInfoNotFoundError`** from `zoneinfo`, `pandas` or anything that resolves a named time zone. `pip install tzdata` and it works from then on; see [Time Zones In Python](#time-zones-in-python).
 
 ### Git Push/Pull Fails

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -780,6 +780,38 @@ as shell functions that call `python3 -m pip`, so they work in the terminal
 without anything on your part. A build task that runs outside a shell does not see
 those functions, so write `python3 -m pip` in `tasks.json` and in any script.
 
+### The Python Formatter Is Not in Search Results
+
+Searching the Extensions view for `black` returns **Black** by `mikoz`, and not
+the extension most guides mean. That one does format Python, but only once you
+have installed black yourself:
+
+```bash
+pip install black
+```
+
+Until you do, `Format Document` does nothing at all. There is no error and no
+prompt; the status bar shows "Running black" and stays that way.
+
+The extension that works with no setup is `ms-python.black-formatter`, which
+carries its own copy of black. It is in the registry and installs normally, but
+it never comes back from a text search, so you have to ask for it by identifier.
+Type this into the Extensions search box:
+
+```
+@id:ms-python.black-formatter
+```
+
+That returns exactly one result, published by `ms-python`. Install it, accept the
+publisher prompt, and `Format Document` formats Python straight away, on a device
+where pip has installed nothing.
+
+`@id:` works for any extension a search does not surface. The identifier is the
+`publisher.name` pair shown on the extension's page in the registry.
+
+The shortcut for `Format Document` here is **Ctrl+Shift+I**, not the Shift+Alt+F
+used on the desktop.
+
 ### Time Zones In Python
 
 A named time zone raises instead of resolving:
@@ -1076,6 +1108,7 @@ If `npm install` fails with errors:
 ### Python: Installed, and Then Something Fails
 
 - **`bad interpreter: Permission denied`** after installing a package that brings a command with it (`pytest`, `black`, `httpie`). Open VSCodroid again and the command works; to use it without waiting, run it as a module: `python3 -m pytest`. See [Python Command-Line Tools](#python-command-line-tools) for why the message names `python3` when Python is not the problem.
+- **`Format Document` does nothing in a `.py` file** and the status bar sticks on "Running black". The extension a marketplace search finds needs black installed separately (`pip install black`) and says nothing when it is missing. See [The Python Formatter Is Not in Search Results](#the-python-formatter-is-not-in-search-results) for that, and for the formatter that needs no pip step.
 - **`ZoneInfoNotFoundError`** from `zoneinfo`, `pandas` or anything that resolves a named time zone. `pip install tzdata` and it works from then on; see [Time Zones In Python](#time-zones-in-python).
 
 ### Git Push/Pull Fails

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -782,9 +782,24 @@ those functions, so write `python3 -m pip` in `tasks.json` and in any script.
 
 ### The Python Formatter Is Not in Search Results
 
-Searching the Extensions view for `black` returns **Black** by `mikoz`, and not
-the extension most guides mean. That one does format Python, but only once you
-have installed black yourself:
+Open a Python file and VSCodroid offers to install **Black Formatter** by
+`ms-python`. Accept it and `Format Document` works straight away: the extension
+carries its own copy of black, so nothing needs installing with pip.
+
+The offer exists because the extension cannot be found any other way. Open VSX
+does not return it for a text search, its own API included, so the Extensions view
+cannot surface it however you phrase the query. If you dismissed the offer, ask for
+it by identifier instead:
+
+```
+@id:ms-python.black-formatter
+```
+
+That returns exactly one result. `@id:` works for any extension a search does not
+surface; the identifier is the `publisher.name` pair on its registry page.
+
+What a search does return is **Black** by `mikoz`. That one also formats Python,
+but only after you install black yourself:
 
 ```bash
 pip install black
@@ -792,22 +807,6 @@ pip install black
 
 Until you do, `Format Document` does nothing at all. There is no error and no
 prompt; the status bar shows "Running black" and stays that way.
-
-The extension that works with no setup is `ms-python.black-formatter`, which
-carries its own copy of black. It is in the registry and installs normally, but
-it never comes back from a text search, so you have to ask for it by identifier.
-Type this into the Extensions search box:
-
-```
-@id:ms-python.black-formatter
-```
-
-That returns exactly one result, published by `ms-python`. Install it, accept the
-publisher prompt, and `Format Document` formats Python straight away, on a device
-where pip has installed nothing.
-
-`@id:` works for any extension a search does not surface. The identifier is the
-`publisher.name` pair shown on the extension's page in the registry.
 
 The shortcut for `Format Document` here is **Ctrl+Shift+I**, not the Shift+Alt+F
 used on the desktop.
@@ -1108,7 +1107,7 @@ If `npm install` fails with errors:
 ### Python: Installed, and Then Something Fails
 
 - **`bad interpreter: Permission denied`** after installing a package that brings a command with it (`pytest`, `black`, `httpie`). Open VSCodroid again and the command works; to use it without waiting, run it as a module: `python3 -m pytest`. See [Python Command-Line Tools](#python-command-line-tools) for why the message names `python3` when Python is not the problem.
-- **`Format Document` does nothing in a `.py` file** and the status bar sticks on "Running black". The extension a marketplace search finds needs black installed separately (`pip install black`) and says nothing when it is missing. See [The Python Formatter Is Not in Search Results](#the-python-formatter-is-not-in-search-results) for that, and for the formatter that needs no pip step.
+- **`Format Document` does nothing in a `.py` file** and the status bar sticks on "Running black". That is the formatter a marketplace search finds, which needs black installed separately (`pip install black`) and says nothing when it is missing. Opening a Python file offers you one that needs no pip step; see [The Python Formatter Is Not in Search Results](#the-python-formatter-is-not-in-search-results).
 - **`ZoneInfoNotFoundError`** from `zoneinfo`, `pandas` or anything that resolves a named time zone. `pip install tzdata` and it works from then on; see [Time Zones In Python](#time-zones-in-python).
 
 ### Git Push/Pull Fails

--- a/scripts/patch-venv-home.py
+++ b/scripts/patch-venv-home.py
@@ -34,6 +34,25 @@ The one a person hits is a venv created from inside an active venv.
 parent of that does hold a `lib/python3.X/`, containing nothing but
 `site-packages`. So `home` names a directory that looks right and is not.
 
+`-E` REACHES THE SAME SHAPE WITHOUT A VENV. The paragraph above is about how
+venv derives `home`, and there is a second route into that same wrong directory
+that venv has nothing to do with: `-E`, and `-I`, which implies it. getpath.py
+reads PYTHONHOME `if use_environment` only, so under `-E` the prefix is searched
+from `dirname(realpath(executable))`, which resolves the `usr/bin/python3`
+symlink into the native library directory and finds no standard library there.
+The interpreter then dies with `No module named 'encodings'` before running
+anything. `-s` alone is fine; `-E` is the trigger.
+
+Nothing that ships reaches it, which is why there is no code here for it. The
+standard library's call sites only propagate flags the parent already has
+(`subprocess._args_from_interpreter_flags`, `ensurepip` under
+`sys.flags.isolated`), and a parent that could not have started cannot pass them
+on; venv avoids `-I` deliberately for its own reason, quoted below; pip's `-I` is
+its own `--ignore-installed` option and not an interpreter flag; and the Python
+extension matches this exact message and retries without the flag. Recorded
+because a third-party tool that hardcodes `-E` would land here with nothing in
+the error naming the cause.
+
 WHY THE NOTE IS THE ONLY CHANNEL. PYTHONHOME, which `Environment.kt` exports,
 covers for all of this everywhere else. It cannot cover for it here:
 `_call_new_python` copies the environment and pops PYTHONHOME and PYTHONPATH

--- a/scripts/test-server-bootstrap.js
+++ b/scripts/test-server-bootstrap.js
@@ -105,6 +105,9 @@ function boot(dir) {
     return { ...result, output: `${result.stdout || ''}${result.stderr || ''}` };
 }
 
+// The formatter a marketplace search cannot surface; see EXTENSION_RECOMMENDATIONS.
+const BLACK_FORMATTER = 'ms-python.black-formatter';
+
 const UPSTREAM = JSON.stringify({ nameShort: 'Code - OSS', version: '1.133.0', quality: 'oss' }, null, 2);
 
 // 1. A valid file is rewritten with the overrides, and nothing is left beside it.
@@ -492,9 +495,52 @@ async function stoppingTakesTheEditorServerWithIt() {
     // And it has to parse. The script is assembled from string fragments in
     // server.js, where nothing else would notice a missing bracket until a device
     // silently stopped applying the list.
-    const body = once.match(/<script>\n([\s\S]*?)\n\t\t<\/script>/);
-    assert.ok(body, 'the injected script could not be located to check');
-    new Function(body[1]); // eslint-disable-line no-new-func -- a parse check, never run
+    const bodies = [...once.matchAll(/<script>\n([\s\S]*?)\n\t\t<\/script>/g)].map((m) => m[1]);
+    assert.strictEqual(bodies.length, 2, `expected the two injected scripts, got ${bodies.length}`);
+    bodies.forEach((b) => new Function(b)); // eslint-disable-line no-new-func -- a parse check
+
+    // The page is also given the extension recommendations, and they have to land
+    // UNDER productConfiguration: the workbench deep merges that object into the
+    // product inlined in its bundle, and a recommendation written anywhere else in
+    // the settings is read by nothing.
+    assert.ok(once.includes(BLACK_FORMATTER), `${BLACK_FORMATTER} did not reach the page`);
+
+    // Run both scripts the way the page would, rather than trusting the text. A
+    // recommendation that parses but writes to the wrong key would pass a string
+    // check and reach a device suggesting nothing.
+    {
+        const settings = { additionalTrustedDomains: ['https://example.invalid'] };
+        const el = {
+            getAttribute: () => JSON.stringify(settings),
+            setAttribute: (_name, value) => Object.assign(settings, JSON.parse(value)),
+        };
+        const document = { getElementById: (id) => (id === 'vscode-workbench-web-configuration' ? el : null) };
+        bodies.forEach((b) => new Function('document', b)(document)); // eslint-disable-line no-new-func
+
+        assert.ok(
+            settings.additionalTrustedDomains.includes('https://example.invalid'),
+            'the trusted-domain script dropped a domain the page already carried',
+        );
+        assert.ok(
+            settings.additionalTrustedDomains.includes('https://github.com'),
+            'the trusted-domain script did not add github.com',
+        );
+        const recommended = settings.productConfiguration?.extensionRecommendations;
+        assert.ok(recommended, 'no extensionRecommendations under productConfiguration');
+        const entry = recommended[BLACK_FORMATTER];
+        assert.ok(entry, `${BLACK_FORMATTER} is not among the recommendations`);
+        // The shape the workbench actually reads: it keeps `onFileOpen` and then
+        // tests `languages`, so an entry without both is carried and never fires.
+        assert.ok(Array.isArray(entry.onFileOpen) && entry.onFileOpen.length, 'the entry carries no onFileOpen');
+        assert.ok(
+            entry.onFileOpen.every((c) => Array.isArray(c.languages) && c.languages.length),
+            'an onFileOpen condition names no language, so the workbench never matches it',
+        );
+        assert.ok(
+            entry.onFileOpen.some((c) => c.languages.includes('python')),
+            'nothing recommends the formatter for Python',
+        );
+    }
 
     const twice = boot(dir);
     assert.strictEqual(twice.status, 0, `a second start should boot cleanly:\n${twice.output}`);

--- a/scripts/test-server-bootstrap.js
+++ b/scripts/test-server-bootstrap.js
@@ -458,15 +458,85 @@ async function stoppingTakesTheEditorServerWithIt() {
     }
 }
 
+// The workbench page is given the trusted-domain list, exactly once, and a page
+// that does not carry the element it extends is reported rather than thrown.
+//
+// The page is where this has to land. product.json beside it is read by the
+// bootstrap's own process and never by the browser: the product the workbench
+// consults is inlined into its bundle at build time, so the list that decides
+// whether a link opens without a confirmation reaches the editor only through the
+// construction options in this page.
+{
+    const pageDir = ['vscode-reh', 'out', 'vs', 'code', 'browser', 'workbench'];
+    const anchor =
+        '<meta id="vscode-workbench-web-configuration" data-settings="{{WORKBENCH_WEB_CONFIGURATION}}">';
+    const page = (head) => [
+        '<!DOCTYPE html>', '<html>', '\t<head>', `\t\t${head}`, '\t</head>', '</html>', '',
+    ].join('\n');
+
+    const dir = fixture(UPSTREAM);
+    const pagePath = path.join(dir, ...pageDir, 'workbench.html');
+    fs.mkdirSync(path.dirname(pagePath), { recursive: true });
+    fs.writeFileSync(pagePath, page(anchor));
+
+    const run = boot(dir);
+    assert.strictEqual(run.status, 0, `a tree carrying a workbench page should boot cleanly:\n${run.output}`);
+
+    const once = fs.readFileSync(pagePath, 'utf8');
+    assert.ok(once.includes('additionalTrustedDomains'), 'the page was not given a trusted-domain list');
+    assert.ok(once.includes('https://github.com'), 'github.com did not reach the page');
+    // A BARE <script>. The server hashes exactly that shape out of the page it has
+    // just built and puts the hashes in the CSP it serves with it, so a tag that
+    // carries any attribute is a script the page's own policy then refuses to run.
+    assert.ok(/\n\t\t<script>\n/.test(once), 'the injected script is not the bare form the CSP hashing matches');
+    // And it has to parse. The script is assembled from string fragments in
+    // server.js, where nothing else would notice a missing bracket until a device
+    // silently stopped applying the list.
+    const body = once.match(/<script>\n([\s\S]*?)\n\t\t<\/script>/);
+    assert.ok(body, 'the injected script could not be located to check');
+    new Function(body[1]); // eslint-disable-line no-new-func -- a parse check, never run
+
+    const twice = boot(dir);
+    assert.strictEqual(twice.status, 0, `a second start should boot cleanly:\n${twice.output}`);
+    assert.strictEqual(
+        fs.readFileSync(pagePath, 'utf8'),
+        once,
+        'a second start stacked another copy of the script into the page',
+    );
+
+    const strays = fs.readdirSync(path.dirname(pagePath)).filter((n) => n !== 'workbench.html');
+    assert.deepStrictEqual(strays, [], `the rewrite left files behind: ${strays.join(', ')}`);
+    fs.rmSync(dir, { recursive: true, force: true });
+}
+
+// A page missing the element costs a log line, not a start. The bootstrap is
+// restarted by the watchdog, so a throw here would be a crash loop.
+{
+    const dir = fixture(UPSTREAM);
+    const pagePath = path.join(dir, 'vscode-reh', 'out', 'vs', 'code', 'browser', 'workbench', 'workbench.html');
+    fs.mkdirSync(path.dirname(pagePath), { recursive: true });
+    fs.writeFileSync(pagePath, '<!DOCTYPE html>\n<html></html>\n');
+
+    const run = boot(dir);
+    assert.strictEqual(run.status, 0, `a page without the element should still boot:\n${run.output}`);
+    assert.ok(
+        /Could not widen the trusted link domains/.test(run.output),
+        `a page this cannot extend should be named:\n${run.output}`,
+    );
+    fs.rmSync(dir, { recursive: true, force: true });
+}
+
 preloadRidesAsOneToken()
     .then(proxySurvivesTheBootstrap)
     .then(stoppingTakesTheEditorServerWithIt)
     .then(() => {
         console.log(
             'ok -- product.json survives a truncated file and an unwritable directory, a missing ' +
-                'server tree is a failed start rather than a healthy one, a proxy that does not ' +
-                'parse costs only DNS, the preload rides as one token, the DNS proxy outlives ' +
-                'the bootstrap, and a stop takes the editor server with it',
+                'server tree is a failed start rather than a healthy one, the workbench page is ' +
+                'given the trusted-domain list once and a page without the element it extends is ' +
+                'reported rather than thrown, a proxy that does not parse costs only DNS, the ' +
+                'preload rides as one token, the DNS proxy outlives the bootstrap, and a stop ' +
+                'takes the editor server with it',
         );
     })
     .catch((err) => {

--- a/scripts/test-xdg-open.js
+++ b/scripts/test-xdg-open.js
@@ -1,0 +1,183 @@
+/**
+ * Self-check for the browser opener the execution trampoline runs.
+ *
+ * Node's "open a browser" helpers spawn the literal command `xdg-open`, and until
+ * this file shipped nothing on the device answered to that name. What it sends is
+ * the message VS Code's own remote CLI sends for `--openExternal`, over the socket
+ * the extension host publishes as VSCODE_IPC_HOOK_CLI, so the shape below is not
+ * ours to choose: a field renamed here is a URL the editor drops on the floor.
+ *
+ * The refusals matter as much as the send. The handler on the other end skips a
+ * `file:` URI silently and still answers 200, so an opener that forwarded one
+ * would report success for an address nothing opened.
+ *
+ *   node scripts/test-xdg-open.js
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const http = require('http');
+const os = require('os');
+const path = require('path');
+const { spawn } = require('child_process');
+
+const OPENER = path.resolve(__dirname, '../android/app/src/main/assets/xdg-open.js');
+
+/**
+ * Runs the opener, with the socket it should talk to and the arguments given.
+ *
+ * Asynchronously, and that is not a style choice: the editor these cases stand in
+ * for is an HTTP server in THIS process, so a synchronous spawn would block the
+ * event loop that has to accept the connection and every case would time out
+ * against a server that never answered.
+ */
+function open(args, { socketPath } = {}) {
+    const env = { ...process.env };
+    delete env.VSCODE_IPC_HOOK_CLI;
+    if (socketPath) env.VSCODE_IPC_HOOK_CLI = socketPath;
+    return new Promise((resolve) => {
+        const child = spawn(process.execPath, [OPENER, ...args], { env });
+        const chunks = [];
+        child.stdout.on('data', (c) => chunks.push(c));
+        child.stderr.on('data', (c) => chunks.push(c));
+        const timer = setTimeout(() => child.kill('SIGKILL'), 15_000);
+        child.on('close', (status) => {
+            clearTimeout(timer);
+            resolve({ status, output: chunks.join('') });
+        });
+    });
+}
+
+/** A stand-in for the editor's CLI server, recording what it was sent. */
+function editor(statusCode = 200) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vscodroid-opener-'));
+    const socketPath = path.join(dir, 'cli.sock');
+    const received = [];
+    const server = http.createServer((req, res) => {
+        const chunks = [];
+        req.on('data', (c) => chunks.push(c));
+        req.on('end', () => {
+            received.push({ method: req.method, body: chunks.join('') });
+            res.writeHead(statusCode, { 'content-type': 'application/json' });
+            res.end('null');
+        });
+    });
+    return {
+        socketPath,
+        received,
+        listen: () => new Promise((resolve) => server.listen(socketPath, resolve)),
+        close: () => new Promise((resolve) => {
+            server.close(() => {
+                fs.rmSync(dir, { recursive: true, force: true });
+                resolve();
+            });
+        }),
+    };
+}
+
+async function sendsTheMessageTheEditorAnswers() {
+    const cli = editor();
+    await cli.listen();
+    try {
+        const run = await open(['http://127.0.0.1:5500/index.html'], { socketPath: cli.socketPath });
+        assert.strictEqual(run.status, 0, `opening a preview URL should succeed:\n${run.output}`);
+        assert.strictEqual(cli.received.length, 1, 'the editor was not asked to open anything');
+        assert.strictEqual(cli.received[0].method, 'POST', 'the message did not arrive as a POST');
+        assert.deepStrictEqual(
+            JSON.parse(cli.received[0].body),
+            { type: 'openExternal', uris: ['http://127.0.0.1:5500/index.html'] },
+            'the message is not the one the editor handler reads; it switches on `type` and ' +
+                'iterates `uris`, so a renamed field is silently dropped',
+        );
+    } finally {
+        await cli.close();
+    }
+}
+
+async function severalAddressesRideInOneMessage() {
+    const cli = editor();
+    await cli.listen();
+    try {
+        const run = await open(['https://a.example', 'https://b.example'], { socketPath: cli.socketPath });
+        assert.strictEqual(run.status, 0, `two addresses should still succeed:\n${run.output}`);
+        assert.deepStrictEqual(
+            JSON.parse(cli.received[0].body).uris,
+            ['https://a.example', 'https://b.example'],
+            'only one of the addresses given reached the editor',
+        );
+    } finally {
+        await cli.close();
+    }
+}
+
+async function anEditorThatRefusesIsAFailure() {
+    const cli = editor(500);
+    await cli.listen();
+    try {
+        const run = await open(['https://example.com'], { socketPath: cli.socketPath });
+        assert.notStrictEqual(run.status, 0, 'a refused open reported success');
+        assert.ok(
+            /answered 500/.test(run.output),
+            `the caller should be told what the editor said:\n${run.output}`,
+        );
+    } finally {
+        await cli.close();
+    }
+}
+
+async function whatCannotBeOpenedIsRefusedRatherThanSent() {
+    const cli = editor();
+    await cli.listen();
+    try {
+        // The handler skips a non-http scheme and answers 200 anyway, so forwarding
+        // one would exit 0 for an address that was never opened. Refused here, and
+        // before the connection, so the editor is not asked at all.
+        for (const arg of ['file:///etc/passwd', '/home/user/index.html', 'vscodroid://callback']) {
+            const run = await open([arg], { socketPath: cli.socketPath });
+            assert.notStrictEqual(run.status, 0, `${arg} was not refused`);
+            assert.ok(
+                /only http and https/.test(run.output),
+                `${arg} should be refused by name:\n${run.output}`,
+            );
+        }
+        assert.strictEqual(cli.received.length, 0, 'a refused address still reached the editor');
+    } finally {
+        await cli.close();
+    }
+}
+
+async function nothingToOpenWithIsNamed() {
+    const noArgs = await open([], { socketPath: '/nonexistent.sock' });
+    assert.notStrictEqual(noArgs.status, 0, 'an empty argument list reported success');
+    assert.ok(/no address given/.test(noArgs.output), `an empty call should say so:\n${noArgs.output}`);
+
+    // Reached outside a session there is no editor to hand it to, and saying so
+    // beats a stack trace: this runs where a user is watching a task fail.
+    const noSocket = await open(['https://example.com']);
+    assert.notStrictEqual(noSocket.status, 0, 'opening with no editor reported success');
+    assert.ok(
+        /VSCODE_IPC_HOOK_CLI/.test(noSocket.output),
+        `a missing editor socket should be named:\n${noSocket.output}`,
+    );
+
+    const deadSocket = await open(['https://example.com'], { socketPath: path.join(os.tmpdir(), 'no-such.sock') });
+    assert.notStrictEqual(deadSocket.status, 0, 'a socket nothing is listening on reported success');
+}
+
+sendsTheMessageTheEditorAnswers()
+    .then(severalAddressesRideInOneMessage)
+    .then(anEditorThatRefusesIsAFailure)
+    .then(whatCannotBeOpenedIsRefusedRatherThanSent)
+    .then(nothingToOpenWithIsNamed)
+    .then(() => {
+        console.log(
+            'ok -- the browser opener sends the openExternal message the editor handler reads, ' +
+                'carries every address given, fails when the editor refuses, refuses what the ' +
+                'handler would have skipped silently, and names a missing editor rather than ' +
+                'throwing at one',
+        );
+    })
+    .catch((err) => {
+        console.error(err);
+        process.exit(1);
+    });


### PR DESCRIPTION
Six problems people reported hitting on a phone, plus the formatter that could not be found once the last of them was chased to the end. Each was reproduced on an API 36 emulator against the shipped 1.3.0 build before it was written, and each verified again on device afterwards.

## Paste

Copying put text on the Android clipboard and pasting it back raised "Unable to read from the browser's clipboard", in the editor, the terminal, the Command Palette and anything an extension pasted into. The WebView grants the page `clipboard-write` and refuses `clipboard-read`, and the notification VS Code raises for that rejection asks the user to grant a permission a WebView has no UI to grant. It is sticky, and the paste resolves to the empty string when it is dismissed.

`ClipboardBridge.readFromClipboard` could always have answered this. It is token validated, it declines to open a `content://` URI through our own ContentResolver, and it is unit tested, but it had no caller in the page. `injectClipboardReadFallback` wraps `Clipboard.prototype.readText`, tries the platform first so a WebView that one day grants the permission keeps its own answer, and falls back to the bridge. Every consumer is the one `IClipboardService`, so the editor, the terminal, quick input and `vscode.env.clipboard.readText()` are all fixed at that single point.

## External links and the confirmation dialog

`linkProtectionTrustedDomains` held only the extension marketplace, so every other address raised "Do you want VSCodroid to open the external website?", `github.com` included, which is exactly where the device code sign-in ends. That dialog is `min-width: 480px` against a 411px phone viewport, and `min-width` beats the `max-width: 90vw` sitting beside it, so the box overflowed and the button row is laid out with the primary action last: the button that proceeds was off the right edge with one letter showing.

The list the dialog consults is not read from `product.json`. It is inlined into the workbench bundle at build time, and the only product the server hands the page at runtime carries three keys, none of them this one. Widening `branding/product.json` alone would therefore reach nobody until the next server release. The server now gives the page the same list through `additionalTrustedDomains` in the configuration element, by adding one script to the workbench page template, which it rebuilds on every request; `branding/product.json` carries the same entry for the next server build, after which the injection is a no-op by its own membership test. The bundle itself is deliberately not touched: `/static` is served `max-age=31536000` with no validator under a URL that does not change between runs, so an edit there would not reach a WebView that has already loaded this build.

The width is fixed in the existing coarse-pointer stylesheet: `min(480px, 90vw)`, so nothing changes where there is room, plus wrapping for the button row and dropping the 67px indent that alignment costs on a phone.

## Landscape

With the keyboard up in landscape the workbench collapsed: the title bar and the status bar overlapped and no line of the file showed. The extra key row takes its height out of the WebView rather than covering it, which is deliberate and stays, but it took that height whatever was left. Measured on an API 36 emulator at 1080x2424: the keyboard's inset is 662px of a 1080px window, the status bar another 137px, and this row 197px, leaving the page 84px.

The row now stands down when the page it takes from would fall below 120dp. This is a threshold for taking, not a promise of what is left: landscape still gives the page only 107dp, because the keyboard alone is 61% of that window. Suppressing rather than shrinking, because the pages are already at the 48dp touch target floor and the only height that could be given back without going under it is the page indicator band. The cost is real and is stated in the code: Tab, Escape, the modifiers, the arrows and the brackets go with the row, and in a terminal that includes Ctrl+C.

## Opening a preview in a browser

Node's browser helpers spawn the literal command `xdg-open`, and `setupToolSymlinks` puts exactly ten names in `usr/bin`, none of which opens anything, so Live Server and everything like it could only report "Could not open the default browser".

`xdg-open` is now a row in the execution trampoline's table, in the interpreter form, mapping the name onto the bundled Node and `assets/xdg-open.js`. That script posts `{"type":"openExternal"}` to the CLI socket the extension host already publishes as `VSCODE_IPC_HOOK_CLI`, which is the message VS Code's own remote CLI sends, so the URL travels an existing path to `env.openExternal`, the page, the bridge and a Custom Tab. Nothing new carries it. The server is also started with `--without-browser-env-var`, because otherwise `BROWSER` names `bin/helpers/browser.sh`, a shebang script under `filesDir` that SELinux will not exec and that calls a `$ROOT/node` the packaged tree does not have; helpers prefer `$BROWSER` and stopped there.

One consequence worth reviewing: the exec table and its trampoline directory now survive a device with no toolchain installed, where the generator used to delete both. A browser opener is not a toolchain's to provide, and most devices have no toolchain.

## A command installed with pip

Reported as a Python formatter that never worked. Chasing it took three wrong turns worth recording, because each one is a plausible answer that the device refuted.

It is not the bundled formatter stack against CPython 3.14: `black` 25.1.0, `pygls`, `lsprotocol`, `cattrs` and `attrs` all import cleanly on the 3.14.6 this app ships, and black formats correctly through `python3 -m black`. Nor is it `ms-python.black-formatter`, which installs here and formats with no pip step at all. That one is simply not reachable by searching, which is a separate problem and is addressed below.

What is broken, and is broken for every such tool, is the command itself:

```
$ pip install black
$ black --version
bash: .../usr/bin/black: .../usr/bin/python3: bad interpreter: Permission denied
```

Reaching the interpreter through a shebang means `execve` on the script's own inode, and the kernel refuses that for anything under `filesDir`. The `pip` and `npm` shell functions written for this cover two names and only for bash, so a formatter or a task spawning a command reached neither. `pytest`, `ruff`, `mypy` and `httpie` were all in the same position.

The generator now scans `usr/bin` for regular files whose `#!` line names Python and writes an interpreter row onto `libpython.so` for each, so the trampoline runs Python with the script as an argument and nothing under `filesDir` is exec'd. Symlinks there are skipped, since those are the bundled tools pointing at ELFs that already run. Rows already present win, so a toolchain's own command and `xdg-open` keep their meaning. The table is rebuilt by the launch pass, so a command installed while the app is running is reachable on the next launch; the user guide and the technical spec both described the old behaviour in detail and are updated to say this instead.

## Finding the Python formatter

Open VSX returns nothing for `ms-python.black-formatter` on any text search, its own `/api/-/search` included, so the Extensions view cannot surface it however the query is phrased. Looking it up by identifier does return it. The one a search does return is `mikoz.black-py`, which also registers a Python formatter but shells out to `<interpreter> -m black`, so it formats only once black has been installed separately with pip; until then `Format Document` does nothing, with no error and no prompt, and the status bar stays on "Running black".

Opening a Python file now offers `ms-python.black-formatter`, which carries its own black. A recommendation is resolved by identifier, which is the lookup that works, so it reaches an extension a search cannot.

It has to reach the page rather than `product.json`, for the same reason as the trusted-domain list above, and it goes in through the same injection; the two now share `extendWorkbenchPage` instead of repeating it. Unlike that list it is deliberately not also set at build time, where it would reach only the page, need a second copy to keep in step, and have to be added to the product.json key set `build-vscode-oss.sh` locks.

## Not included

`ContextView` hides itself on every keyboard transition with only iOS exempt, which is a real defect on the phone route to New File. It is not fixed here: it was not reproduced on device, and fixing it needs either a server rebuild or an 18MB runtime rewrite of the workbench bundle that the static asset cache would hide from existing installs.

## Verification

Reproduced first on the shipped 1.3.0 build, then verified on an API 36 emulator with this build: paste inserts the copied text with no notification; the page configuration carries `["https://open-vsx.org","https://github.com"]`; `.monaco-dialog-box` resolves to 370.29px at a 411px viewport with the button row wrapping; the key row logs `pageHeight=84px, row=hidden` in landscape and the tab strip, a line of the file and the status bar are all visible; `xdg-open` resolves by bare name through the trampoline and answers, including refusing a `file:` URI the handler on the other end would have skipped in silence; `BROWSER` is unset in both the server and the extension host process; and `black --version` answers `black, 26.5.1` in the app's own terminal where it previously gave the bad interpreter error.

Opening a Python file raises the recommendation notification, and installing from it lands `ms-python.black-formatter` and leaves `Format Document` working; with the extension's bundled black removed from the picture the same command still formats, so the copy it carries is the one in use.

That last one has to be measured in the app's terminal and nowhere else: `run-as` runs in the `runas_app` SELinux domain rather than `untrusted_app`, and the shebang succeeds there, so a shell test would have reported the bug fixed before anything was changed.

2437 unit tests, the 16 instrumented key row tests, all ten JavaScript self-checks and the repository gates pass. `scripts/test-xdg-open.js` is new and runs in `lint.yml` and `release.yml`; `test-server-bootstrap.js` gains two cases for the page rewrite, including that the injected script parses and that a second start does not stack another copy. Eight existing tests encoded contracts these changes alter and were updated rather than relaxed: the exec table cases now separate the toolchain rows from the app's own, the key row height test pins the derived height against the measured one, and the boolean-field ban on the key row names its one exception with a control that fails if the field goes.

