### PR TITLE
fix: let a menu be used once it is open, and stop timing out a prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Editor tabs and status bar entries fit their strips again. Both were drawn taller than the area holding them, by 5px and 10px.
 - A long press opens a menu that stays open while the keyboard is up. The menu took focus from the text, the keyboard went down, and the workbench answered the resize by closing the menu about 60ms after it appeared, so it read as flickering or dead. Esc on the key row still closes it.
 - Menus no longer list keyboard shortcuts beside their items on a touch screen. The items run on a tap; the chord was width taken from a phone to advertise a key it does not have.
-- A long press with the keyboard down opens its menu instead of raising the keyboard. The press was read as a tap, so the keyboard came up, the window resized, and the workbench closed the menu that the press had just opened.
-- Esc on the key row closes a terminal or explorer menu again. The key was forwarded to a menu that did not hold focus, and the forwarded press was picked up by the same forwarder, so it never arrived.
+- A long press opens the editor menu whether the keyboard is up or down, and using it leaves the keyboard where it was. Tapping an item runs it, a submenu opens, Esc closes one level and tapping away closes the menu.
 - Paste works again, in the editor, the terminal, the Command Palette and anything an extension pastes into. Copying put text on the device clipboard and pasting it back raised "Unable to read from the browser's clipboard", asking for a permission a WebView has no way to grant.
 - Signing in to GitHub no longer goes through a confirmation dialog first. The sign-in ends by opening github.com, and every address outside the extension marketplace was treated as untrusted.
 - A confirmation dialog fits a phone screen. It was drawn wider than the screen and centred, so the button that proceeds hung off the right edge with a letter of it showing.

--- a/android/app/src/main/assets/xdg-open.js
+++ b/android/app/src/main/assets/xdg-open.js
@@ -52,15 +52,23 @@ if (!socketPath) {
 
 const body = JSON.stringify({ type: 'openExternal', uris: args });
 
-// How long the editor gets to answer before this gives up.
+// NO REPLY TIMEOUT, and that is a correction rather than an omission.
 //
-// Every other failure here is an event: no socket, a stale one, a refused
-// connection. A socket that accepts and then never answers is not, and without
-// this the request waits for as long as the process lives. The caller is a
-// preview server's `open`, which spawns this and waits, so a hang there is a
-// build task that never finishes rather than a browser that did not open. The
-// editor answers in single-digit milliseconds when it answers at all.
-const REPLY_TIMEOUT_MS = 10000;
+// One was added here and taken out again the same day. The reasoning was that a
+// socket which accepts and then never answers is the one failure not covered by
+// an event, so a deadline would turn it into one. What that missed is what the
+// reply is waiting FOR. `server-main.js` answers this request with
+// `case "openExternal": s = await this.openExternal(i)` and only then `n(200, s)`,
+// and `openExternal` awaits `_remoteCLI.openExternal` for every URI. That command
+// puts the trusted-domain confirmation on screen for any address outside the
+// list in `assets/server.js`, and it does not resolve until the person taps Open.
+// A deadline of any length that a user might exceed therefore reports failure for
+// a link that is about to open, on the ordinary path rather than a rare one.
+//
+// The hang it was meant to catch needs a wedged extension host, which is rarer
+// and less costly than breaking every confirmed link. If it is ever worth
+// guarding, guard the CONNECT, which no human is waiting inside of, and leave the
+// reply alone.
 
 const request = http.request(
     {
@@ -83,9 +91,4 @@ const request = http.request(
     },
 );
 request.on('error', (err) => fail(err.message));
-request.setTimeout(REPLY_TIMEOUT_MS, () => {
-    // `destroy` makes the pending request emit 'error', which the handler above
-    // turns into the same one-line diagnostic every other failure produces.
-    request.destroy(new Error(`the editor did not answer in ${REPLY_TIMEOUT_MS}ms`));
-});
 request.end(body);

--- a/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vscodroid/MainActivity.kt
@@ -3408,6 +3408,42 @@ class MainActivity : AppCompatActivity() {
                 }
                 document.addEventListener('pointerdown', function(e) {
                     var target = e.target;
+                    // A touch inside an open context menu decides nothing about the
+                    // keyboard, and letting it decide destroys the menu.
+                    //
+                    // The editor's menu is built in a shadow root whose host is a
+                    // CHILD OF THE EDITOR: `ContextView.setContainer` appends
+                    // `div.shadow-root-host` to the container it was given, and for
+                    // an editor menu that container is the editor's own DOM node.
+                    // A pointer event inside the shadow tree is retargeted to that
+                    // host, so `closest(TEXT)` below matches on the first parent and
+                    // reads a tap on a menu item as a tap on the file. Measured on an
+                    // API 36 emulator with the keyboard down: long press opens the
+                    // 29-item menu with the viewport at 845, then tapping an item
+                    // takes the viewport to 458 and the menu with it, because
+                    // letTheKeyboardUp() blurs and refocuses an editing host that is
+                    // still holding `inputmode="none"`.
+                    //
+                    // It reaches further than the items. The menu renders a
+                    // full-viewport `.context-view-block` to catch a dismissing tap,
+                    // so before this test EVERY point on the screen belonged to the
+                    // editor as far as the line below was concerned.
+                    //
+                    // An early return rather than falling through to the branch under
+                    // it: that branch clears `aimedAtText` and puts `inputmode="none"`
+                    // back on every editing host, which would take the keyboard away
+                    // from a menu opened while the user was typing. Nothing about the
+                    // keyboard should change because a menu was touched.
+                    //
+                    // Both shapes are covered. A shadow-DOM menu retargets to the host
+                    // itself, which carries the class; a light-DOM one (the explorer,
+                    // the terminal, the menubar) leaves the target inside
+                    // `.context-view`, and `closest` reaches it there.
+                    if (target && ((target.classList && target.classList.contains('shadow-root-host')) ||
+                        (target.closest && target.closest('.context-view')))) {
+                        pendingTap = null;
+                        return;
+                    }
                     if (target && target.closest && target.closest(TEXT)) {
                         // Undecided, and that is the point. Dragging inside the
                         // editor is how a phone scrolls a file, and it goes down
@@ -3600,7 +3636,11 @@ class MainActivity : AppCompatActivity() {
                     if (e.__vscodroidForwarded) return;
                     if (e.key !== 'Escape') return;
                     var bars = actionBars();
-                    for (var i = 0; i < bars.length; i++) {
+                    // Innermost first. Escape closes one level, so with a submenu open
+                    // it has to reach the submenu; forwarding to the outermost bar
+                    // instead took the whole stack down in one press, which is not what
+                    // the key means anywhere else.
+                    for (var i = bars.length - 1; i >= 0; i--) {
                         // A menu holding focus handles its own Escape. Asked of the
                         // menu's own root, because `document.activeElement` for a
                         // shadow-DOM menu is the HOST, which the bar does not contain:
@@ -3616,6 +3656,47 @@ class MainActivity : AppCompatActivity() {
                         forwarded.__vscodroidForwarded = true;
                         bars[i].dispatchEvent(forwarded);
                         return;
+                    }
+                }, true);
+
+                // Tapping outside an open menu closes it.
+                //
+                // The menu renders a full-viewport `.context-view-block` to catch a
+                // dismissing click, and on this WebView nothing closes the menu from
+                // it: measured with a real Android tap outside a 29-item menu, and
+                // again with a synthetic mouse press, the menu stayed open both
+                // times. It used to appear to work for the wrong reason. The tap was
+                // read as a tap on the file, the keyboard came up, the window
+                // resized, and the workbench hid every context view; the menu went
+                // away with the user's file half covered by a keyboard they had not
+                // asked for. Excluding those taps from the keyboard guard fixed that
+                // and left the dismissal with nothing behind it, so it is provided
+                // here rather than left to a side effect.
+                //
+                // Decided by geometry, not by containment: a touch anywhere inside a
+                // shadow-DOM menu retargets to the same host, so asking which node
+                // was hit cannot tell the inside of the menu from the outside. Every
+                // open menu is measured, and a point inside any of them is a menu
+                // interaction this leaves alone.
+                //
+                // Innermost first, so a submenu and its parent both close, which is
+                // what tapping away from the whole stack means.
+                window.addEventListener('pointerdown', function (e) {
+                    if (!window.matchMedia(COARSE).matches) return;
+                    if (!inContextView(e.target)) return;
+                    var bars = actionBars();
+                    if (!bars.length) return;
+                    for (var i = 0; i < bars.length; i++) {
+                        var r = bars[i].getBoundingClientRect();
+                        if (e.clientX >= r.left && e.clientX <= r.right &&
+                            e.clientY >= r.top && e.clientY <= r.bottom) {
+                            return;
+                        }
+                    }
+                    for (var j = bars.length - 1; j >= 0; j--) {
+                        var away = new KeyboardEvent('keydown', { key: 'Escape', code: 'Escape', keyCode: 27, bubbles: true });
+                        away.__vscodroidForwarded = true;
+                        bars[j].dispatchEvent(away);
                     }
                 }, true);
 

--- a/android/app/src/test/kotlin/com/vscodroid/KeyboardGuardWiringTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/KeyboardGuardWiringTest.kt
@@ -84,6 +84,25 @@ class KeyboardGuardWiringTest {
      * pointerup branch was written. The three names below are that branch.
      */
     @Test
+    fun `a long press is not a tap`() {
+        val guard = SourceScan.body(mainActivity(), "private fun injectKeyboardGuard(")
+        assertTrue(
+            guard.contains("LONG_PRESS_MS"),
+            "the guard no longer measures how long the finger was down, so a long press is " +
+                "read as a tap again: the keyboard comes up, the window resizes, and the " +
+                "workbench closes the menu the press had just opened. Measured on an API 36 " +
+                "emulator as pointerup at t+985ms, the editor's gesture at t+995ms, the " +
+                "resize at t+1621ms, and no menu.",
+        )
+        assertTrue(
+            guard.contains("e.timeStamp"),
+            "the duration is no longer read from the events themselves. Both timestamps have " +
+                "to come from the same clock; a wall-clock read here would compare two " +
+                "different origins.",
+        )
+    }
+
+    @Test
     fun `a scroll is not a tap`() {
         val source = mainActivity()
 

--- a/android/app/src/test/kotlin/com/vscodroid/TouchContextMenuWiringTest.kt
+++ b/android/app/src/test/kotlin/com/vscodroid/TouchContextMenuWiringTest.kt
@@ -67,6 +67,36 @@ class TouchContextMenuWiringTest {
     }
 
     @Test
+    fun `the keyboard guard ignores a touch that landed in a context menu`() {
+        val guard = body("private fun injectKeyboardGuard(")
+        // The editor's menu is built in a shadow root whose host is a child of the
+        // editor, so a touch inside it retargets to a node that matches the guard's
+        // own TEXT selector. Without this test the guard reads a tap on a menu item
+        // as a tap on the file, raises the keyboard, and the resize takes the menu:
+        // measured on an API 36 emulator as viewport 845 to 458 with the menu gone.
+        assertTrue(
+            guard.contains("shadow-root-host") && guard.contains(".context-view"),
+            "injectKeyboardGuard no longer excludes a touch inside a context view, so " +
+                "tapping a menu item raises the keyboard and the resize closes the menu " +
+                "before the item can be used. A submenu becomes unreachable entirely.",
+        )
+        // It has to leave the keyboard state alone, not reset it: the branch below
+        // the exclusion clears aimedAtText and re-applies inputmode="none", which
+        // would take the keyboard away from a menu opened while the user was typing.
+        val exclusion = guard.substringAfter("shadow-root-host").substringBefore("closest(TEXT)")
+        assertTrue(
+            exclusion.contains("return"),
+            "the context-view exclusion falls through instead of returning, so a touch " +
+                "in a menu still resets the keyboard state it was meant to leave alone",
+        )
+        assertTrue(
+            !exclusion.contains("aimedAtText"),
+            "the context-view exclusion changes aimedAtText; a touch in a menu must " +
+                "decide nothing about the keyboard in either direction",
+        )
+    }
+
+    @Test
     fun `escape still reaches a menu that does not hold focus`() {
         val script = body("private fun injectTouchContextMenu(")
         assertTrue(
@@ -74,6 +104,27 @@ class TouchContextMenuWiringTest {
             "the Escape forwarder is gone. A menu that never took focus never sees Escape, so " +
                 "the key-row Esc button stops closing menus, which is the one keyboard route a " +
                 "phone has.",
+        )
+    }
+
+    @Test
+    fun `tapping away from a menu closes it`() {
+        val script = body("private fun injectTouchContextMenu(")
+        // The menu's own full-viewport dismiss layer closes nothing on this WebView,
+        // measured with a real Android tap and again with a synthetic mouse press.
+        // It only ever appeared to work because the tap was read as a tap on the file
+        // and the keyboard that came up resized the window out from under the menu.
+        // With that excluded from the keyboard guard, this is the dismissal.
+        assertTrue(
+            script.contains("getBoundingClientRect") && script.contains("clientX"),
+            "the tap-away dismissal is gone or no longer decides by geometry. Containment " +
+                "cannot decide it: every touch inside a shadow-DOM menu retargets to the " +
+                "same host, so the inside and the outside of the menu look identical.",
+        )
+        assertTrue(
+            script.contains("bars.length - 1"),
+            "the dismissal no longer walks the menus innermost first, so tapping away " +
+                "from a submenu leaves its parent open",
         )
     }
 

--- a/docs/05-API_SPEC.md
+++ b/docs/05-API_SPEC.md
@@ -851,6 +851,11 @@ and then forwards a **whitelist of exactly four keys**:
 Added by `server.js` itself, not passed from Kotlin:
 
 - `--accept-server-license-terms`
+- `--without-browser-env-var`: without it the server exports `BROWSER` pointing at
+  `bin/helpers/browser.sh`, a shebang script under `filesDir` that SELinux will not
+  exec and that calls a `$ROOT/node` the packaged tree does not have. Node's browser
+  helpers prefer `$BROWSER` over `xdg-open`, so with it set they stop at a script that
+  cannot run; unset, they reach the `xdg-open` row the exec table provides.
 - `--disable-workspace-trust`: without it every folder opens in Restricted Mode and
   most extensions never activate. The `security.workspace.trust.enabled` setting
   cannot substitute: it is APPLICATION-scoped, and the WEB CLIENT takes only the

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -98,6 +98,12 @@ When the soft keyboard is visible, a row of extra keys appears above it. Swipe i
 left or right to change page; the dots underneath show how many pages there are
 and which one you are on.
 
+One exception, and it is deliberate: the row takes its height out of the page
+rather than covering it, so where the keyboard leaves almost nothing behind, the
+row stands down instead of taking the last of it. That is landscape on a phone,
+where the keyboard alone can be two thirds of the screen. Turn back to portrait,
+or put the keyboard away, and the row returns.
+
 How many there are depends on how wide your phone is. The row divides its width
 evenly among the keys on a page, so on a narrower screen it carries fewer keys per
 page and spreads them over more: five pages on a 411dp phone and wider, six at


### PR DESCRIPTION
The previous change made a long press open its menu with the keyboard down. It did not make that menu usable, and this is the other half. Everything below was reproduced on an API 36 emulator before being written and verified on the rebuilt APK afterwards.

## The menu opened and then could not be touched

The editor builds its menu in a shadow root whose host is a **child of the editor**: `ContextView.setContainer` appends `div.shadow-root-host` to the container it was given, and for an editor menu that container is the editor's own DOM node. A touch inside the shadow tree retargets to that host, so the keyboard guard's `closest(TEXT)` matched on the first parent and read a tap on a menu item as a tap on the file.

Measured with the keyboard down, before the change:

```
long press          -> 29-item menu open, viewport 845
host parent         -> "monaco-editor no-user-select ...", matches TEXT selector
tap "Go to Declaration" -> viewport 458, menu gone
```

It reached further than the items. The menu renders a full-viewport dismiss layer, so every point on screen belonged to the editor as far as that test was concerned, and a submenu could not be reached at all.

A touch that lands in a context view now decides nothing about the keyboard. It is an early return rather than a fall-through, because the branch under it clears `aimedAtText` and re-applies `inputmode="none"`, which would take the keyboard away from a menu opened while the user was typing.

## Which left the dismissal with nothing behind it

The menu's own dismiss layer closes nothing on this WebView: measured with a real Android tap outside a 29-item menu, and again with a synthetic mouse press, the menu stayed open both times. Tapping away only ever appeared to work because the tap raised the keyboard and the resize hid every context view, which is the bug above wearing a useful face.

So the dismissal is provided rather than left to a side effect. It decides by geometry, because every touch inside a shadow-DOM menu retargets to the same host and containment cannot tell the inside of the menu from the outside, and it walks innermost first so a submenu and its parent both go. Escape now goes innermost first too: forwarded to the outermost bar it took the whole stack down in one press, which is not what the key means anywhere else.

After, all with the keyboard down and the viewport unchanged at 845: tapping an item runs it, tapping Peek opens its submenu (`2` menus, `[33, 4]` items), Escape closes one level, tapping away closes the menu.

## The xdg-open reply timeout is removed

It was added the same day to guard the one failure there that is not an event, a socket that accepts and never answers. It broke the ordinary path to do it. `server-main.js` answers with `case "openExternal": s = await this.openExternal(i)` and only then `n(200, s)`, and that await does not resolve until the trusted-domain confirmation on screen has been answered by a person. Any deadline a user can exceed reports failure for a link that is about to open. The reasoning is left in the file, including where a timeout would be legitimate (the connect, which nobody is waiting inside of), so it is not added back on the same argument.

## Documents corrected against the code

`05-API_SPEC.md` counted three flags added by `server.js` and listed two; `--without-browser-env-var` is now listed with the reason it exists. The user guide promised the extra key row whenever the keyboard is visible, which landscape has contradicted since the row learned to stand down.

The changelog described three regressions that only ever existed between commits inside this unreleased range. Nobody reading the release notes saw them, so it now describes what the menu does instead of how it got there.

## Tests

`KeyboardGuardWiringTest` pins the duration test, and `TouchContextMenuWiringTest` pins the context-view exclusion, that it returns rather than falling through, and that the tap-away dismissal decides by geometry and walks innermost first. Each was checked by removing the behaviour it guards and watching it fail. Whole unit suite, ten JavaScript self-checks and the repository gates pass.
